### PR TITLE
Add Rust-to-C FFI example via logripper-dsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,40 @@ Proto files under `proto/` are the **single source of truth** for all shared typ
 
 ADIF (Amateur Data Interchange Format) is used **only at the edges** -- QRZ API calls and file I/O. Internal communication always uses protobuf. The Rust ADIF parser converts to/from proto types at the boundary, with an `extra_fields` map for lossless round-tripping.
 
+## Getting Started
+
+### Prerequisites
+
+**Rust toolchain** -- install via [rustup](https://rustup.rs/):
+
+```powershell
+winget install Rustlang.Rustup
+```
+
+**Protocol Buffers compiler** -- needed to generate gRPC code from proto files:
+
+```powershell
+winget install Google.Protobuf
+```
+
+**C compiler** -- required for the native FFI libraries under `src/c/`. On Windows, install the "Desktop development with C++" workload in Visual Studio or the [Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). On Linux, `gcc` or `clang` will work. The `cc` crate finds the compiler automatically.
+
+**buf** (optional) -- for linting and breaking change detection on proto files:
+
+```powershell
+winget install Bufbuild.Buf
+```
+
+### Build and Test
+
+```powershell
+cd src\rust
+cargo build
+cargo test
+```
+
+This compiles the C libraries via FFI, generates Rust types from the proto files, and builds the engine. All tests (unit + integration) run with `cargo test`.
+
 ## Project Structure
 
 ```

--- a/src/c/logripper-dsp/include/logripper_dsp.h
+++ b/src/c/logripper-dsp/include/logripper_dsp.h
@@ -10,6 +10,13 @@ extern "C" {
 
 int32_t lr_dsp_version(void);
 
+/// Convert a frequency in Hz to the nearest kHz, rounding to nearest.
+uint64_t lr_dsp_hz_to_khz(uint64_t freq_hz);
+
+/// Compute a simple moving average over `count` samples.
+/// Returns 0.0 if count is 0 or samples is NULL.
+double lr_dsp_moving_average(const double *samples, size_t count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/c/logripper-dsp/src/dsp.c
+++ b/src/c/logripper-dsp/src/dsp.c
@@ -3,3 +3,18 @@
 int32_t lr_dsp_version(void) {
     return 1;
 }
+
+uint64_t lr_dsp_hz_to_khz(uint64_t freq_hz) {
+    return (freq_hz + 500) / 1000;
+}
+
+double lr_dsp_moving_average(const double *samples, size_t count) {
+    if (samples == NULL || count == 0) {
+        return 0.0;
+    }
+    double sum = 0.0;
+    for (size_t i = 0; i < count; i++) {
+        sum += samples[i];
+    }
+    return sum / (double)count;
+}

--- a/src/rust/logripper-core/Cargo.toml
+++ b/src/rust/logripper-core/Cargo.toml
@@ -18,3 +18,4 @@ futures = "0.3"
 
 [build-dependencies]
 tonic-build = "0.12"
+cc = "1"

--- a/src/rust/logripper-core/build.rs
+++ b/src/rust/logripper-core/build.rs
@@ -17,5 +17,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_client(true)
         .compile_protos(protos, &[&proto_root])?;
 
+    let dsp_root = PathBuf::from("../../../src/c/logripper-dsp");
+    println!("cargo::rerun-if-changed={}", dsp_root.display());
+
+    cc::Build::new()
+        .file(dsp_root.join("src/dsp.c"))
+        .include(dsp_root.join("include"))
+        .warnings(true)
+        .compile("logripper_dsp");
+
     Ok(())
 }

--- a/src/rust/logripper-core/src/ffi/dsp.rs
+++ b/src/rust/logripper-core/src/ffi/dsp.rs
@@ -1,0 +1,48 @@
+extern "C" {
+    fn lr_dsp_version() -> i32;
+    fn lr_dsp_hz_to_khz(freq_hz: u64) -> u64;
+    fn lr_dsp_moving_average(samples: *const f64, count: usize) -> f64;
+}
+
+pub fn dsp_version() -> i32 {
+    unsafe { lr_dsp_version() }
+}
+
+pub fn hz_to_khz(freq_hz: u64) -> u64 {
+    unsafe { lr_dsp_hz_to_khz(freq_hz) }
+}
+
+pub fn moving_average(samples: &[f64]) -> f64 {
+    unsafe { lr_dsp_moving_average(samples.as_ptr(), samples.len()) }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_returns_expected() {
+        assert_eq!(dsp_version(), 1);
+    }
+
+    #[test]
+    fn hz_to_khz_rounds_correctly() {
+        assert_eq!(hz_to_khz(14_074_000), 14_074);
+        assert_eq!(hz_to_khz(14_074_499), 14_074);
+        assert_eq!(hz_to_khz(14_074_500), 14_075);
+        assert_eq!(hz_to_khz(0), 0);
+    }
+
+    #[test]
+    fn moving_average_basic() {
+        let samples = [1.0, 2.0, 3.0, 4.0, 5.0];
+        let avg = moving_average(&samples);
+        assert!((avg - 3.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn moving_average_empty_slice() {
+        let avg = moving_average(&[]);
+        assert!((avg - 0.0).abs() < f64::EPSILON);
+    }
+}

--- a/src/rust/logripper-core/src/ffi/mod.rs
+++ b/src/rust/logripper-core/src/ffi/mod.rs
@@ -1,0 +1,3 @@
+mod dsp;
+
+pub use dsp::{dsp_version, hz_to_khz, moving_average};

--- a/src/rust/logripper-core/src/lib.rs
+++ b/src/rust/logripper-core/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod adif;
 pub mod domain;
+pub mod ffi;
 pub mod proto;


### PR DESCRIPTION
Shows how the Rust engine calls into native C code, establishing the pattern for future performance-critical or unsafe work that makes more sense in C.

The C library (src/c/logripper-dsp/) exports three functions demonstrating different ABI patterns: returning a scalar (lr_dsp_version), integer arithmetic with rounding (lr_dsp_hz_to_khz), and pointer+length for array processing (lr_dsp_moving_average).

The Rust side uses the cc crate to compile the C source at cargo build time -- no separate CMake step needed. Safe wrappers in src/rust/logripper-core/src/ffi/ convert Rust slices to pointer+length pairs so callers never touch raw pointers. Four tests verify the FFI round-trip.