### PR TITLE
Add Rust gRPC host and fix QSO local IDs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,6 +59,15 @@ Primary goals:
 - Use `rg` for text search operations.
 - Keep build and test loops fast to support tight iteration.
 
+## Markdown Code Fences
+
+When writing markdown that will be rendered on GitHub, such as PR descriptions, issue bodies, review comments, or other repository comments:
+
+- Never use `bash` as the code fence language for Windows commands.
+- Backslash path separators like `src\dotnet\LogRipper.slnx` can render incorrectly in GitHub-flavored markdown when labeled as `bash`.
+- Use a plain fenced code block with no language tag, or use `powershell` / `cmd` instead.
+- Prefer Windows-style paths in those examples when the command is intended to run on Windows.
+
 ## Cross-Platform
 
 All code must work on both Windows and Linux. The engine is developed on Windows but runs in Linux Docker containers in production.

--- a/.github/instructions/copilot-customization.instructions.md
+++ b/.github/instructions/copilot-customization.instructions.md
@@ -167,6 +167,25 @@ What these instructions govern.
 - Keep each file focused on a single domain (security, performance, UI, etc.).
 - Write rules as actionable directives, not aspirational goals.
 - Reference specific paths, commands, or patterns from the codebase.
+- When documenting Windows commands in markdown that may be rendered on GitHub, never label the code fence as `bash`; use an unlabeled fence or `powershell` / `cmd` so backslash paths render correctly.
+
+## GitHub-Rendered Markdown
+
+GitHub issues, PR descriptions, comments, and review text need an extra Windows-specific rule:
+
+- Do **not** use `bash` code fences for Windows commands.
+- Backslash path separators such as `src\dotnet\LogRipper.slnx` or `src\rust\Cargo.toml` can be rendered as garbled escape sequences when treated like shell escape text.
+- Use one of these instead:
+  - plain fenced block with no language tag
+  - `powershell`
+  - `cmd`
+
+Example:
+
+```powershell
+dotnet build src\dotnet\LogRipper.slnx
+cargo test --manifest-path src\rust\Cargo.toml
+```
 
 ## Common Mistakes
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,15 @@ cargo test
 
 This compiles the C libraries via FFI, generates Rust types from the proto files, and builds the engine. All tests (unit + integration) run with `cargo test`.
 
+**Runnable gRPC server host:**
+
+```
+cd src/rust
+cargo run -p logripper-server
+```
+
+This starts the developer gRPC server on `127.0.0.1:50051` by default so the .NET CLI and debug workbench can validate transport and service wiring against a live Rust host.
+
 **.NET workspace:**
 
 ```

--- a/src/dotnet/LogRipper.Cli.Tests/CliArgumentParserTests.cs
+++ b/src/dotnet/LogRipper.Cli.Tests/CliArgumentParserTests.cs
@@ -32,4 +32,22 @@ public class CliArgumentParserTests
         Assert.True(arguments.ShowHelp);
         Assert.Equal("Missing value for --endpoint.", arguments.Error);
     }
+
+    [Theory]
+    [InlineData("http://localhost:50051", true)]
+    [InlineData("https://example.com:7443", true)]
+    [InlineData("localhost:50051", false)]
+    [InlineData("grpc://localhost:50051", false)]
+    [InlineData("not a uri", false)]
+    public void Endpoint_validator_accepts_only_absolute_http_uris(string endpoint, bool expected)
+    {
+        var isValid = CliEndpointValidator.TryCreateEndpointUri(endpoint, out var uri);
+
+        Assert.Equal(expected, isValid);
+
+        if (expected)
+        {
+            Assert.NotNull(uri);
+        }
+    }
 }

--- a/src/dotnet/LogRipper.Cli/CliEndpointValidator.cs
+++ b/src/dotnet/LogRipper.Cli/CliEndpointValidator.cs
@@ -1,0 +1,15 @@
+namespace LogRipper.Cli;
+
+public static class CliEndpointValidator
+{
+    public static bool TryCreateEndpointUri(string endpoint, out Uri? uri)
+    {
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out uri))
+        {
+            return false;
+        }
+
+        return string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/dotnet/LogRipper.Cli/Program.cs
+++ b/src/dotnet/LogRipper.Cli/Program.cs
@@ -10,10 +10,15 @@ if (arguments.ShowHelp)
     return ShowHelp(arguments.Error);
 }
 
-using var channel = GrpcChannel.ForAddress(arguments.Endpoint);
+if (!CliEndpointValidator.TryCreateEndpointUri(arguments.Endpoint, out var endpointUri))
+{
+    return ShowHelp($"The endpoint '{arguments.Endpoint}' must be a valid absolute http:// or https:// URI.");
+}
 
 try
 {
+    using var channel = GrpcChannel.ForAddress(endpointUri!);
+
     return arguments.Command switch
     {
         "status" => await StatusCommand.RunAsync(channel),

--- a/src/dotnet/LogRipper.DebugHost.Tests/DebugCommandServiceTests.cs
+++ b/src/dotnet/LogRipper.DebugHost.Tests/DebugCommandServiceTests.cs
@@ -17,7 +17,7 @@ public class DebugCommandServiceTests
         var commands = service.GetCommands();
 
         Assert.Contains(commands, static command => command.Key == "cargo-test" && command.RequiresProtoc);
-        Assert.Contains(commands, static command => command.Key == "dotnet-test");
+        Assert.Contains(commands, static command => command.Key == "dotnet-test" && command.Arguments == "test src\\dotnet\\LogRipper.slnx");
         Assert.Contains(commands, static command => command.Key == "buf-lint" && command.RequiredTool == "buf");
     }
 }

--- a/src/dotnet/LogRipper.DebugHost.Tests/RepositoryPathsTests.cs
+++ b/src/dotnet/LogRipper.DebugHost.Tests/RepositoryPathsTests.cs
@@ -11,6 +11,6 @@ public class RepositoryPathsTests
 
         Assert.Equal(@"C:\repo", paths.RepoRoot);
         Assert.Equal(Path.Combine(@"C:\repo", "src", "rust"), paths.RustWorkspaceRoot);
-        Assert.Equal(Path.Combine(@"C:\repo", "src", "dotnet", "LogRipper.Debug.sln"), paths.DebugSolutionPath);
+        Assert.Equal(Path.Combine(@"C:\repo", "src", "dotnet", "LogRipper.slnx"), paths.DotnetWorkspaceSolutionPath);
     }
 }

--- a/src/dotnet/LogRipper.DebugHost/Components/Pages/Engine.razor
+++ b/src/dotnet/LogRipper.DebugHost/Components/Pages/Engine.razor
@@ -43,6 +43,7 @@
                 <ul class="mb-0">
                     <li>The workbench stores endpoint selection per Blazor server circuit.</li>
                     <li>Use <code>http://localhost:50051</code> by default for local Rust gRPC development.</li>
+                    <li>Start the current developer host with <code>cargo run --manifest-path src\rust\logripper-server\Cargo.toml</code>.</li>
                     <li>The lookup page and future logbook pages use this endpoint automatically.</li>
                 </ul>
             </div>

--- a/src/dotnet/LogRipper.DebugHost/Services/DebugCommandService.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/DebugCommandService.cs
@@ -42,10 +42,10 @@ public sealed class DebugCommandService
                 RequiresProtoc: true),
             new(
                 "dotnet-test",
-                "Run debug host tests",
-                "Runs the .NET debug workbench test project through the local debug solution.",
+                "Run .NET workspace tests",
+                "Runs the full .NET workspace test suite through the root src\\dotnet\\LogRipper.slnx solution.",
                 "dotnet",
-                "test src\\dotnet\\LogRipper.Debug.sln",
+                "test src\\dotnet\\LogRipper.slnx",
                 _repositoryPaths.RepoRoot),
             new(
                 "buf-lint",

--- a/src/dotnet/LogRipper.DebugHost/Services/RepositoryPaths.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/RepositoryPaths.cs
@@ -14,7 +14,7 @@ public sealed class RepositoryPaths
         ContentRoot = Path.GetFullPath(contentRootPath);
         RepoRoot = Path.GetFullPath(Path.Combine(ContentRoot, "..", "..", ".."));
         RustWorkspaceRoot = Path.Combine(RepoRoot, "src", "rust");
-        DebugSolutionPath = Path.Combine(RepoRoot, "src", "dotnet", "LogRipper.Debug.sln");
+        DotnetWorkspaceSolutionPath = Path.Combine(RepoRoot, "src", "dotnet", "LogRipper.slnx");
     }
 
     public string ContentRoot { get; }
@@ -23,5 +23,5 @@ public sealed class RepositoryPaths
 
     public string RustWorkspaceRoot { get; }
 
-    public string DebugSolutionPath { get; }
+    public string DotnetWorkspaceSolutionPath { get; }
 }

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 members = [
     "logripper-core",
+    "logripper-server",
 ]
 
 [workspace.package]
@@ -15,3 +16,4 @@ prost = "0.13"
 prost-types = "0.13"
 tonic = "0.12"
 tokio = { version = "1", features = ["full"] }
+uuid = { version = "1", features = ["v4"] }

--- a/src/rust/logripper-core/Cargo.toml
+++ b/src/rust/logripper-core/Cargo.toml
@@ -11,6 +11,7 @@ prost = { workspace = true }
 prost-types = { workspace = true }
 tonic = { workspace = true }
 tokio = { workspace = true }
+uuid = { workspace = true }
 difa = "0.1"
 thiserror = "2"
 chrono = "0.4"

--- a/src/rust/logripper-core/src/adif/mapper.rs
+++ b/src/rust/logripper-core/src/adif/mapper.rs
@@ -5,7 +5,7 @@
 
 use crate::domain::band::band_from_adif;
 use crate::domain::mode::{import_only_submode, mode_from_adif};
-use crate::domain::qso::qsl_status_from_adif;
+use crate::domain::qso::{new_local_id, qsl_status_from_adif};
 use crate::proto::logripper::domain::{Band, Mode, QsoRecord, SyncStatus};
 use difa::Record;
 
@@ -207,50 +207,102 @@ impl AdifMapper {
         }
 
         // Geographic
-        if let Some(ref v) = qso.worked_operator_name { fields.push(("NAME".into(), v.clone())); }
-        if let Some(ref v) = qso.worked_grid { fields.push(("GRIDSQUARE".into(), v.clone())); }
-        if let Some(ref v) = qso.worked_country { fields.push(("COUNTRY".into(), v.clone())); }
-        if let Some(dxcc) = qso.worked_dxcc { fields.push(("DXCC".into(), dxcc.to_string())); }
-        if let Some(ref v) = qso.worked_state { fields.push(("STATE".into(), v.clone())); }
-        if let Some(ref v) = qso.worked_county { fields.push(("CNTY".into(), v.clone())); }
-        if let Some(ref v) = qso.worked_continent { fields.push(("CONT".into(), v.clone())); }
-        if let Some(z) = qso.worked_cq_zone { fields.push(("CQZ".into(), z.to_string())); }
-        if let Some(z) = qso.worked_itu_zone { fields.push(("ITUZ".into(), z.to_string())); }
-        if let Some(ref v) = qso.worked_iota { fields.push(("IOTA".into(), v.clone())); }
+        if let Some(ref v) = qso.worked_operator_name {
+            fields.push(("NAME".into(), v.clone()));
+        }
+        if let Some(ref v) = qso.worked_grid {
+            fields.push(("GRIDSQUARE".into(), v.clone()));
+        }
+        if let Some(ref v) = qso.worked_country {
+            fields.push(("COUNTRY".into(), v.clone()));
+        }
+        if let Some(dxcc) = qso.worked_dxcc {
+            fields.push(("DXCC".into(), dxcc.to_string()));
+        }
+        if let Some(ref v) = qso.worked_state {
+            fields.push(("STATE".into(), v.clone()));
+        }
+        if let Some(ref v) = qso.worked_county {
+            fields.push(("CNTY".into(), v.clone()));
+        }
+        if let Some(ref v) = qso.worked_continent {
+            fields.push(("CONT".into(), v.clone()));
+        }
+        if let Some(z) = qso.worked_cq_zone {
+            fields.push(("CQZ".into(), z.to_string()));
+        }
+        if let Some(z) = qso.worked_itu_zone {
+            fields.push(("ITUZ".into(), z.to_string()));
+        }
+        if let Some(ref v) = qso.worked_iota {
+            fields.push(("IOTA".into(), v.clone()));
+        }
 
         // QSL
         let sent = crate::domain::qso::qsl_status_to_adif(
             crate::proto::logripper::domain::QslStatus::try_from(qso.qsl_sent_status)
                 .unwrap_or(crate::proto::logripper::domain::QslStatus::Unspecified),
         );
-        if let Some(s) = sent { fields.push(("QSL_SENT".into(), s.to_string())); }
+        if let Some(s) = sent {
+            fields.push(("QSL_SENT".into(), s.to_string()));
+        }
 
         let rcvd = crate::domain::qso::qsl_status_to_adif(
             crate::proto::logripper::domain::QslStatus::try_from(qso.qsl_received_status)
                 .unwrap_or(crate::proto::logripper::domain::QslStatus::Unspecified),
         );
-        if let Some(s) = rcvd { fields.push(("QSL_RCVD".into(), s.to_string())); }
+        if let Some(s) = rcvd {
+            fields.push(("QSL_RCVD".into(), s.to_string()));
+        }
 
-        if let Some(true) = qso.lotw_sent { fields.push(("LOTW_QSL_SENT".into(), "Y".into())); }
-        if let Some(true) = qso.lotw_received { fields.push(("LOTW_QSL_RCVD".into(), "Y".into())); }
-        if let Some(true) = qso.eqsl_sent { fields.push(("EQSL_QSL_SENT".into(), "Y".into())); }
-        if let Some(true) = qso.eqsl_received { fields.push(("EQSL_QSL_RCVD".into(), "Y".into())); }
+        if let Some(true) = qso.lotw_sent {
+            fields.push(("LOTW_QSL_SENT".into(), "Y".into()));
+        }
+        if let Some(true) = qso.lotw_received {
+            fields.push(("LOTW_QSL_RCVD".into(), "Y".into()));
+        }
+        if let Some(true) = qso.eqsl_sent {
+            fields.push(("EQSL_QSL_SENT".into(), "Y".into()));
+        }
+        if let Some(true) = qso.eqsl_received {
+            fields.push(("EQSL_QSL_RCVD".into(), "Y".into()));
+        }
 
         // Contest
-        if let Some(ref v) = qso.contest_id { fields.push(("CONTEST_ID".into(), v.clone())); }
-        if let Some(ref v) = qso.serial_sent { fields.push(("STX".into(), v.clone())); }
-        if let Some(ref v) = qso.serial_received { fields.push(("SRX".into(), v.clone())); }
-        if let Some(ref v) = qso.exchange_sent { fields.push(("STX_STRING".into(), v.clone())); }
-        if let Some(ref v) = qso.exchange_received { fields.push(("SRX_STRING".into(), v.clone())); }
+        if let Some(ref v) = qso.contest_id {
+            fields.push(("CONTEST_ID".into(), v.clone()));
+        }
+        if let Some(ref v) = qso.serial_sent {
+            fields.push(("STX".into(), v.clone()));
+        }
+        if let Some(ref v) = qso.serial_received {
+            fields.push(("SRX".into(), v.clone()));
+        }
+        if let Some(ref v) = qso.exchange_sent {
+            fields.push(("STX_STRING".into(), v.clone()));
+        }
+        if let Some(ref v) = qso.exchange_received {
+            fields.push(("SRX_STRING".into(), v.clone()));
+        }
 
         // Propagation
-        if let Some(ref v) = qso.prop_mode { fields.push(("PROP_MODE".into(), v.clone())); }
-        if let Some(ref v) = qso.sat_name { fields.push(("SAT_NAME".into(), v.clone())); }
-        if let Some(ref v) = qso.sat_mode { fields.push(("SAT_MODE".into(), v.clone())); }
+        if let Some(ref v) = qso.prop_mode {
+            fields.push(("PROP_MODE".into(), v.clone()));
+        }
+        if let Some(ref v) = qso.sat_name {
+            fields.push(("SAT_NAME".into(), v.clone()));
+        }
+        if let Some(ref v) = qso.sat_mode {
+            fields.push(("SAT_MODE".into(), v.clone()));
+        }
 
         // Notes
-        if let Some(ref v) = qso.comment { fields.push(("COMMENT".into(), v.clone())); }
-        if let Some(ref v) = qso.notes { fields.push(("NOTES".into(), v.clone())); }
+        if let Some(ref v) = qso.comment {
+            fields.push(("COMMENT".into(), v.clone()));
+        }
+        if let Some(ref v) = qso.notes {
+            fields.push(("NOTES".into(), v.clone()));
+        }
 
         // Extra fields (round-trip overflow)
         for (k, v) in &qso.extra_fields {
@@ -321,17 +373,10 @@ fn format_adif_datetime(ts: &prost_types::Timestamp) -> (String, String) {
     (date, time)
 }
 
-/// Generate a simple local ID. Will be replaced with proper UUID crate later.
-fn new_local_id() -> String {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(1);
-    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    format!("local-{n:012}")
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use uuid::Uuid;
 
     fn make_test_record() -> Record {
         let mut rec = Record::new();
@@ -345,6 +390,13 @@ mod tests {
         rec.insert("RST_RCVD", "57").unwrap();
         rec.insert("STATION_CALLSIGN", "AA7BQ").unwrap();
         rec
+    }
+
+    #[test]
+    fn record_to_qso_generates_uuid_local_id() {
+        let qso = AdifMapper::record_to_qso(&make_test_record());
+
+        assert!(Uuid::parse_str(&qso.local_id).is_ok());
     }
 
     #[test]
@@ -377,7 +429,9 @@ mod tests {
         let qso = AdifMapper::record_to_qso(&rec);
         let ts = qso.utc_timestamp.unwrap();
 
-        let dt = chrono::DateTime::from_timestamp(ts.seconds, 0).unwrap().naive_utc();
+        let dt = chrono::DateTime::from_timestamp(ts.seconds, 0)
+            .unwrap()
+            .naive_utc();
         assert_eq!(dt.format("%Y%m%d").to_string(), "20260115");
         assert_eq!(dt.format("%H%M").to_string(), "1523");
     }
@@ -390,7 +444,9 @@ mod tests {
         rec.insert("CALL", "W1AW").unwrap();
         let qso = AdifMapper::record_to_qso(&rec);
         let ts = qso.utc_timestamp.unwrap();
-        let dt = chrono::DateTime::from_timestamp(ts.seconds, 0).unwrap().naive_utc();
+        let dt = chrono::DateTime::from_timestamp(ts.seconds, 0)
+            .unwrap()
+            .naive_utc();
         assert_eq!(dt.format("%H%M%S").to_string(), "152345");
     }
 
@@ -480,10 +536,24 @@ mod tests {
         rec.insert("APP_LOGRIPPER_SYNC_STATUS", "synced").unwrap();
 
         let qso = AdifMapper::record_to_qso(&rec);
-        assert_eq!(qso.extra_fields.get("MY_RIG").map(|s| s.as_str()), Some("Icom IC-7300"));
-        assert_eq!(qso.extra_fields.get("MY_ANTENNA").map(|s| s.as_str()), Some("Yagi 3-element"));
-        assert_eq!(qso.extra_fields.get("ANT_AZ").map(|s| s.as_str()), Some("045"));
-        assert_eq!(qso.extra_fields.get("APP_LOGRIPPER_SYNC_STATUS").map(|s| s.as_str()), Some("synced"));
+        assert_eq!(
+            qso.extra_fields.get("MY_RIG").map(|s| s.as_str()),
+            Some("Icom IC-7300")
+        );
+        assert_eq!(
+            qso.extra_fields.get("MY_ANTENNA").map(|s| s.as_str()),
+            Some("Yagi 3-element")
+        );
+        assert_eq!(
+            qso.extra_fields.get("ANT_AZ").map(|s| s.as_str()),
+            Some("045")
+        );
+        assert_eq!(
+            qso.extra_fields
+                .get("APP_LOGRIPPER_SYNC_STATUS")
+                .map(|s| s.as_str()),
+            Some("synced")
+        );
     }
 
     #[test]
@@ -567,7 +637,10 @@ mod tests {
         rec.insert("FREQ", "-1.0").unwrap();
 
         let qso = AdifMapper::record_to_qso(&rec);
-        assert_eq!(qso.frequency_khz, None, "Negative frequency should be rejected, not mapped to 0");
+        assert_eq!(
+            qso.frequency_khz, None,
+            "Negative frequency should be rejected, not mapped to 0"
+        );
     }
 
     #[test]
@@ -599,6 +672,9 @@ mod tests {
         // "202ü123" is 8 bytes but byte 4 is inside the ü (continuation byte),
         // so str[0..4] would panic on a char boundary check without a guard.
         let result = parse_adif_datetime("202\u{00fc}123", None);
-        assert!(result.is_none(), "Non-ASCII date should return None, not panic");
+        assert!(
+            result.is_none(),
+            "Non-ASCII date should return None, not panic"
+        );
     }
 }

--- a/src/rust/logripper-core/src/domain/qso.rs
+++ b/src/rust/logripper-core/src/domain/qso.rs
@@ -1,6 +1,7 @@
 //! QsoRecord helpers: construction, QSL status mapping, ADIF field mapping.
 
 use crate::proto::logripper::domain::{Band, Mode, QslStatus, QsoRecord, SyncStatus};
+use uuid::Uuid;
 
 /// Map ADIF QSL Sent/Received status character to QslStatus enum.
 pub fn qsl_status_from_adif(s: &str) -> QslStatus {
@@ -35,7 +36,7 @@ impl QsoRecordBuilder {
     pub fn new(station_callsign: impl Into<String>, worked_callsign: impl Into<String>) -> Self {
         Self {
             record: QsoRecord {
-                local_id: uuid_v4(),
+                local_id: new_local_id(),
                 station_callsign: station_callsign.into(),
                 worked_callsign: worked_callsign.into(),
                 sync_status: SyncStatus::LocalOnly.into(),
@@ -94,15 +95,9 @@ impl QsoRecordBuilder {
     }
 }
 
-/// Generate a simple UUID v4 string.
-/// In production this would use a proper UUID crate; for now, a placeholder.
-fn uuid_v4() -> String {
-    // This will be replaced with a proper UUID crate dependency later.
-    // For now, generate a deterministic placeholder for test builds.
-    format!(
-        "{:08x}-{:04x}-4{:03x}-{:04x}-{:012x}",
-        0u32, 0u16, 0u16, 0u16, 0u64
-    )
+/// Generate a QSO local ID using the documented UUID format.
+pub fn new_local_id() -> String {
+    Uuid::new_v4().to_string()
 }
 
 #[cfg(test)]
@@ -167,9 +162,25 @@ mod tests {
             .extra_field("ANT_AZ", "270")
             .build();
 
-        assert_eq!(record.extra_fields.get("MY_RIG").map(|s| s.as_str()), Some("Icom IC-7300"));
-        assert_eq!(record.extra_fields.get("ANT_AZ").map(|s| s.as_str()), Some("270"));
+        assert_eq!(
+            record.extra_fields.get("MY_RIG").map(|s| s.as_str()),
+            Some("Icom IC-7300")
+        );
+        assert_eq!(
+            record.extra_fields.get("ANT_AZ").map(|s| s.as_str()),
+            Some("270")
+        );
         assert_eq!(record.extra_fields.len(), 2);
+    }
+
+    #[test]
+    fn builder_generates_unique_local_ids() {
+        let first = QsoRecordBuilder::new("AA7BQ", "VK9NS").build();
+        let second = QsoRecordBuilder::new("AA7BQ", "VK9NS").build();
+
+        assert_ne!(first.local_id, second.local_id);
+        assert!(Uuid::parse_str(&first.local_id).is_ok());
+        assert!(Uuid::parse_str(&second.local_id).is_ok());
     }
 
     #[test]
@@ -219,6 +230,9 @@ mod tests {
         assert_eq!(decoded.mode, Mode::Cw as i32);
         assert_eq!(decoded.frequency_khz, Some(7_030));
         assert_eq!(decoded.comment.as_deref(), Some("CW contest"));
-        assert_eq!(decoded.extra_fields.get("CHECK").map(|s| s.as_str()), Some("73"));
+        assert_eq!(
+            decoded.extra_fields.get("CHECK").map(|s| s.as_str()),
+            Some("73")
+        );
     }
 }

--- a/src/rust/logripper-server/Cargo.toml
+++ b/src/rust/logripper-server/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "logripper-server"
+description = "Runnable gRPC server host for the LogRipper engine"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+logripper-core = { path = "../logripper-core" }
+tokio = { workspace = true }
+tonic = { workspace = true }
+tokio-stream = "0.1"
+

--- a/src/rust/logripper-server/src/main.rs
+++ b/src/rust/logripper-server/src/main.rs
@@ -1,0 +1,330 @@
+use std::net::SocketAddr;
+use tokio_stream::wrappers::ReceiverStream;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+use logripper_core::proto::logripper::domain::{
+    BatchLookupRequest, BatchLookupResponse, CachedCallsignRequest, CallsignRecord, DxccEntity,
+    DxccRequest, LookupRequest, LookupResult, LookupState, QsoRecord,
+};
+use logripper_core::proto::logripper::services::{
+    logbook_service_server::{LogbookService, LogbookServiceServer},
+    lookup_service_server::{LookupService, LookupServiceServer},
+    AdifChunk, DeleteQsoRequest, DeleteQsoResponse, ExportRequest, GetQsoRequest, ImportResult,
+    ListQsosRequest, LogQsoRequest, LogQsoResponse, SyncProgress, SyncRequest, SyncStatusRequest,
+    SyncStatusResponse, UpdateQsoRequest, UpdateQsoResponse,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let options = ServerOptions::from_env_and_args(std::env::args().skip(1))?;
+    let address = options.listen_address;
+
+    println!("Starting LogRipper gRPC server on {address}");
+
+    Server::builder()
+        .add_service(LogbookServiceServer::new(DeveloperLogbookService))
+        .add_service(LookupServiceServer::new(DeveloperLookupService))
+        .serve(address)
+        .await?;
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DeveloperLogbookService;
+
+#[tonic::async_trait]
+impl LogbookService for DeveloperLogbookService {
+    type ListQsosStream = ReceiverStream<Result<QsoRecord, Status>>;
+    type SyncWithQrzStream = ReceiverStream<Result<SyncProgress, Status>>;
+    type ExportAdifStream = ReceiverStream<Result<AdifChunk, Status>>;
+
+    async fn log_qso(
+        &self,
+        _request: Request<LogQsoRequest>,
+    ) -> Result<Response<LogQsoResponse>, Status> {
+        Err(Status::unimplemented("LogQso is not implemented yet."))
+    }
+
+    async fn update_qso(
+        &self,
+        _request: Request<UpdateQsoRequest>,
+    ) -> Result<Response<UpdateQsoResponse>, Status> {
+        Err(Status::unimplemented("UpdateQso is not implemented yet."))
+    }
+
+    async fn delete_qso(
+        &self,
+        _request: Request<DeleteQsoRequest>,
+    ) -> Result<Response<DeleteQsoResponse>, Status> {
+        Err(Status::unimplemented("DeleteQso is not implemented yet."))
+    }
+
+    async fn get_qso(
+        &self,
+        _request: Request<GetQsoRequest>,
+    ) -> Result<Response<QsoRecord>, Status> {
+        Err(Status::unimplemented("GetQso is not implemented yet."))
+    }
+
+    async fn list_qsos(
+        &self,
+        _request: Request<ListQsosRequest>,
+    ) -> Result<Response<Self::ListQsosStream>, Status> {
+        Err(Status::unimplemented("ListQsos is not implemented yet."))
+    }
+
+    async fn sync_with_qrz(
+        &self,
+        _request: Request<SyncRequest>,
+    ) -> Result<Response<Self::SyncWithQrzStream>, Status> {
+        Err(Status::unimplemented("SyncWithQrz is not implemented yet."))
+    }
+
+    async fn get_sync_status(
+        &self,
+        _request: Request<SyncStatusRequest>,
+    ) -> Result<Response<SyncStatusResponse>, Status> {
+        Ok(Response::new(SyncStatusResponse {
+            local_qso_count: 0,
+            qrz_qso_count: 0,
+            pending_upload: 0,
+            last_sync: None,
+            qrz_logbook_owner: None,
+        }))
+    }
+
+    async fn import_adif(
+        &self,
+        _request: Request<tonic::Streaming<AdifChunk>>,
+    ) -> Result<Response<ImportResult>, Status> {
+        Err(Status::unimplemented("ImportAdif is not implemented yet."))
+    }
+
+    async fn export_adif(
+        &self,
+        _request: Request<ExportRequest>,
+    ) -> Result<Response<Self::ExportAdifStream>, Status> {
+        Err(Status::unimplemented("ExportAdif is not implemented yet."))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DeveloperLookupService;
+
+#[tonic::async_trait]
+impl LookupService for DeveloperLookupService {
+    type StreamLookupStream = ReceiverStream<Result<LookupResult, Status>>;
+
+    async fn lookup(
+        &self,
+        request: Request<LookupRequest>,
+    ) -> Result<Response<LookupResult>, Status> {
+        let request = request.into_inner();
+        Ok(Response::new(placeholder_lookup_error(request.callsign)))
+    }
+
+    async fn stream_lookup(
+        &self,
+        request: Request<LookupRequest>,
+    ) -> Result<Response<Self::StreamLookupStream>, Status> {
+        let request = request.into_inner();
+        let (sender, receiver) = tokio::sync::mpsc::channel(4);
+        let queried_callsign = normalize_callsign(&request.callsign);
+
+        let _ = sender
+            .send(Ok(LookupResult {
+                state: LookupState::Loading as i32,
+                record: None,
+                error_message: None,
+                cache_hit: false,
+                lookup_latency_ms: 0,
+                queried_callsign: queried_callsign.clone(),
+            }))
+            .await;
+
+        let _ = sender
+            .send(Ok(placeholder_lookup_error(queried_callsign)))
+            .await;
+
+        Ok(Response::new(ReceiverStream::new(receiver)))
+    }
+
+    async fn get_cached_callsign(
+        &self,
+        request: Request<CachedCallsignRequest>,
+    ) -> Result<Response<LookupResult>, Status> {
+        let request = request.into_inner();
+        Ok(Response::new(LookupResult {
+            state: LookupState::NotFound as i32,
+            record: None,
+            error_message: None,
+            cache_hit: false,
+            lookup_latency_ms: 0,
+            queried_callsign: normalize_callsign(&request.callsign),
+        }))
+    }
+
+    async fn get_dxcc_entity(
+        &self,
+        _request: Request<DxccRequest>,
+    ) -> Result<Response<DxccEntity>, Status> {
+        Err(Status::unimplemented(
+            "GetDxccEntity is not implemented yet.",
+        ))
+    }
+
+    async fn batch_lookup(
+        &self,
+        request: Request<BatchLookupRequest>,
+    ) -> Result<Response<BatchLookupResponse>, Status> {
+        let request = request.into_inner();
+        Ok(Response::new(BatchLookupResponse {
+            results: request
+                .callsigns
+                .into_iter()
+                .map(placeholder_lookup_error)
+                .collect(),
+        }))
+    }
+}
+
+fn placeholder_lookup_error(callsign: String) -> LookupResult {
+    LookupResult {
+        state: LookupState::Error as i32,
+        record: Some(CallsignRecord {
+            callsign: normalize_callsign(&callsign),
+            cross_ref: normalize_callsign(&callsign),
+            aliases: Vec::new(),
+            previous_call: String::new(),
+            dxcc_entity_id: 0,
+            first_name: "Developer".into(),
+            last_name: "Placeholder".into(),
+            nickname: None,
+            formatted_name: Some("Developer Placeholder".into()),
+            attention: None,
+            addr1: None,
+            addr2: Some("Local server stub".into()),
+            state: None,
+            zip: None,
+            country: Some("Unavailable".into()),
+            country_code: None,
+            latitude: None,
+            longitude: None,
+            grid_square: None,
+            county: None,
+            fips: None,
+            geo_source: 7,
+            license_class: None,
+            effective_date: None,
+            expiration_date: None,
+            license_codes: None,
+            email: None,
+            web_url: None,
+            qsl_manager: None,
+            eqsl: 0,
+            lotw: 0,
+            paper_qsl: 0,
+            cq_zone: None,
+            itu_zone: None,
+            iota: None,
+            dxcc_country_name: None,
+            dxcc_continent: None,
+            born: None,
+            qrz_serial: None,
+            last_modified: None,
+            bio_length: None,
+            image_url: None,
+            msa: None,
+            area_code: None,
+            time_zone: None,
+            gmt_offset: None,
+            dst_observed: None,
+            profile_views: None,
+        }),
+        error_message: Some(
+            "Lookup transport is live, but provider-backed callsign lookup is not implemented yet."
+                .into(),
+        ),
+        cache_hit: false,
+        lookup_latency_ms: 0,
+        queried_callsign: normalize_callsign(&callsign),
+    }
+}
+
+fn normalize_callsign(callsign: &str) -> String {
+    let trimmed = callsign.trim();
+    if trimmed.is_empty() {
+        "K7DBG".to_string()
+    } else {
+        trimmed.to_ascii_uppercase()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ServerOptions {
+    listen_address: SocketAddr,
+}
+
+impl ServerOptions {
+    fn from_env_and_args<I>(args: I) -> Result<Self, Box<dyn std::error::Error>>
+    where
+        I: IntoIterator<Item = String>,
+    {
+        let mut listen = std::env::var("LOGRIPPER_SERVER_ADDR")
+            .unwrap_or_else(|_| "127.0.0.1:50051".to_string());
+        let mut args = args.into_iter();
+
+        while let Some(arg) = args.next() {
+            match arg.as_str() {
+                "--listen" => {
+                    let value = args.next().ok_or("Missing value for --listen")?;
+                    listen = value;
+                }
+                "--help" | "-h" => {
+                    print_help();
+                    std::process::exit(0);
+                }
+                _ => return Err(format!("Unknown argument: {arg}").into()),
+            }
+        }
+
+        Ok(Self {
+            listen_address: listen.parse()?,
+        })
+    }
+}
+
+fn print_help() {
+    println!(
+        "LogRipper gRPC server\n\nUsage:\n  cargo run -p logripper-server -- [--listen 127.0.0.1:50051]\n\nEnvironment:\n  LOGRIPPER_SERVER_ADDR   Overrides the bind address"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ServerOptions;
+
+    #[test]
+    fn server_options_default_to_localhost_port_50051() {
+        std::env::remove_var("LOGRIPPER_SERVER_ADDR");
+
+        let options = ServerOptions::from_env_and_args(Vec::<String>::new()).unwrap();
+
+        assert_eq!("127.0.0.1:50051", options.listen_address.to_string());
+    }
+
+    #[test]
+    fn server_options_allow_explicit_listen_override() {
+        std::env::remove_var("LOGRIPPER_SERVER_ADDR");
+
+        let options = ServerOptions::from_env_and_args([
+            "--listen".to_string(),
+            "127.0.0.1:60051".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!("127.0.0.1:60051", options.listen_address.to_string());
+    }
+}


### PR DESCRIPTION
## Summary\n- validate CLI endpoints before creating gRPC channels\n- point the debug host .NET validation command at src/dotnet/LogRipper.slnx\n- add a runnable logripper-server crate for local tonic gRPC hosting\n- document local Rust server startup in the README and Engine Session page\n- unify QsoRecord local ID generation on UUIDs across the builder and ADIF mapper\n- add regression coverage for the server host and local ID generation\n\n## Issues\nCloses #5\nCloses #11