### PR TITLE
Improve Rust Copilot guidance and quality tooling

### DIFF
--- a/.github/agents/code-reviewer.agent.md
+++ b/.github/agents/code-reviewer.agent.md
@@ -13,6 +13,7 @@ You are the code review specialist for LogRipper.
 - Verify changes preserve performance and keyboard-first workflows.
 - Check boundary contracts between core engine, UI, and integrations.
 - Prefer actionable findings with clear impact and suggested remediation.
+- Watch for Rust-specific correctness risks around ownership, async behavior, lint suppressions, tonic/proto contract drift, and stale assumptions about current stable Rust behavior.
 
 ## Review Focus Areas
 
@@ -20,4 +21,5 @@ You are the code review specialist for LogRipper.
 - Regression risk in shortcut-heavy interactions
 - API integration error handling and retry behavior
 - Allocation, latency, and throughput impact on hot paths
-
+- Rust engine/core vs server boundary correctness
+- Generated contract consistency across `proto/`, Rust, and .NET

--- a/.github/agents/implementer.agent.md
+++ b/.github/agents/implementer.agent.md
@@ -13,6 +13,8 @@ You are the primary implementation agent for LogRipper.
 - Favor clear, maintainable designs with low runtime overhead.
 - Reuse existing patterns and avoid unnecessary dependencies.
 - Ensure TUI and GUI integrations consume shared core logic.
+- Treat `src/rust/logripper-core` and `src/rust/logripper-server` as primary implementation surfaces for engine behavior.
+- Verify Rust behavior against current stable guidance when a fix depends on language semantics, lints, or edition-era changes.
 
 ## Implementation Guardrails
 
@@ -20,3 +22,4 @@ You are the primary implementation agent for LogRipper.
 - Avoid introducing Python in core runtime paths.
 - Handle external API failures explicitly and safely.
 - Preserve fast keyboard workflows for high-frequency actions.
+- Keep protobuf and gRPC contracts aligned across Rust and .NET consumers.

--- a/.github/agents/investigator.agent.md
+++ b/.github/agents/investigator.agent.md
@@ -13,6 +13,7 @@ You are the debugging and diagnostics specialist for LogRipper.
 - Trace failures across domain logic, UI interactions, and integrations.
 - Identify root causes, not just surface symptoms.
 - Quantify performance bottlenecks and propose low-risk fixes.
+- Re-check Rust semantics, lint behavior, and undefined-behavior claims against current official guidance before treating them as valid defects.
 
 ## Investigation Workflow
 
@@ -20,3 +21,4 @@ You are the debugging and diagnostics specialist for LogRipper.
 2. Narrow impact area quickly.
 3. Prove the root cause with concrete evidence.
 4. Propose a fix that preserves speed and reliability.
+5. Add a regression test when the defect is confirmed.

--- a/.github/instructions/proto-contract.instructions.md
+++ b/.github/instructions/proto-contract.instructions.md
@@ -1,0 +1,42 @@
+# Proto Contract Instructions
+
+## Purpose
+
+These instructions govern schema and gRPC contract work in `proto/` and any Rust or .NET code generated from those files.
+
+## Source of Truth
+
+- `proto/` is the only source of truth for shared service and domain contracts.
+- Never hand-edit generated Rust or C# code to "fix" a schema issue. Change the `.proto` file and regenerate through the existing build flow.
+- ADIF is an external interchange format only. Internal IPC and cross-process contracts stay on protobuf + gRPC.
+
+## Compatibility Rules
+
+- Prefer additive changes over breaking changes.
+- Preserve existing field numbers and enum numeric values.
+- Keep zero-value enum members as the unspecified/default state.
+- When introducing new fields, think through both Rust (`prost` / `tonic`) and C# (`Grpc.Tools`) consumers.
+- Keep service behavior aligned across the Rust server, .NET CLI, and Debug Workbench.
+
+## Rust/.NET Contract Rules
+
+- Rust server traits and generated message types come from `src/rust/logripper-core/build.rs` generation.
+- .NET clients consume the same contracts through generated gRPC client code under `src/dotnet/`.
+- If a proto change affects logbook or lookup semantics, update both Rust server-side handling and the .NET debugging/client surfaces in the same change when practical.
+
+## Validation
+
+- For schema or service changes, run:
+  - `buf lint`
+  - `cargo test --manifest-path src/rust/Cargo.toml`
+  - `dotnet build src/dotnet/LogRipper.slnx`
+- If the change affects runtime behavior, also smoke-test the live server with:
+  - `cargo run --manifest-path src/rust/Cargo.toml -p logripper-server`
+  - `dotnet run --project src/dotnet/LogRipper.Cli -- status`
+
+## Current References
+
+- Protocol Buffers language guide: https://protobuf.dev/programming-guides/proto3/
+- Buf lint/breaking overview: https://buf.build/docs/
+- tonic docs: https://docs.rs/tonic/latest/tonic/
+- prost docs: https://docs.rs/prost/latest/prost/

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -39,8 +39,8 @@ These instructions govern Rust work in LogRipper, especially under `src/rust/`, 
   - `cargo run --manifest-path src/rust/Cargo.toml -p logripper-server`
   - `dotnet run --project src/dotnet/LogRipper.Cli -- status`
 - When changing Rust dependencies or supply-chain-sensitive infrastructure, also run:
-  - `cargo deny check --manifest-path src/rust/Cargo.toml --config src/rust/deny.toml`
-  - `cargo audit`
+  - `Push-Location src\rust; cargo deny check --config deny.toml; Pop-Location`
+- Treat `cargo audit` as a manual/occasional vulnerability review rather than a per-PR CI requirement unless the team explicitly changes that policy.
 
 ## Authoritative Sources
 

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -1,0 +1,53 @@
+# Rust Instructions
+
+## Purpose
+
+These instructions govern Rust work in LogRipper, especially under `src/rust/`, `proto/`, and the C FFI boundary under `src/c/`.
+
+## Architecture Rules
+
+- `src/rust/logripper-core` owns reusable engine logic, domain mapping, generated proto bindings, and adapter seams.
+- `src/rust/logripper-server` owns runtime hosting and tonic server startup; keep process/bootstrap logic there rather than pushing it into `logripper-core`.
+- Keep ADIF, QRZ, and other external formats/services at the Rust edge. Normalize into project-owned proto/domain types immediately.
+- Do not move engine behavior into .NET debug surfaces; .NET remains a client/inspection layer.
+
+## Current Rust Semantics
+
+- Distinguish the crate **edition** from the installed **compiler version**. `edition = "2021"` does not mean the repo is using an old compiler.
+- This repository should be evaluated against the pinned stable toolchain in `rust-toolchain.toml`, not against stale assumptions from older Rust blog posts or pre-2024 guidance.
+- When a bug report or review comment depends on Rust language semantics, lint behavior, or undefined behavior claims, verify against current official sources before acting.
+- Treat the Rust 2024 edition guide and current stable release notes as the canonical source for edition-era behavior changes.
+
+## Implementation Rules
+
+- Prefer idiomatic, current-stable Rust patterns over bespoke workarounds for language limitations that may no longer apply.
+- Keep filesystem code portable with `Path` and `PathBuf`; do not hardcode separators in Rust source.
+- Keep unsafe usage explicit and narrow. If unsafe behavior is required, document the invariant locally and avoid broad unsafe regions.
+- Prefer narrow lint suppressions with justification. Use `#[expect(...)]` instead of broad `#[allow(...)]` when the lint should stay visible if the underlying issue disappears.
+- Use `thiserror` for typed Rust error surfaces rather than ad hoc stringly errors.
+
+## Validation
+
+- Standard Rust validation starts with:
+  - `cargo fmt --manifest-path src/rust/Cargo.toml --all -- --check`
+  - `cargo test --manifest-path src/rust/Cargo.toml`
+  - `cargo clippy --manifest-path src/rust/Cargo.toml --all-targets -- -D warnings`
+- Rust formatting rules live in `src/rust/rustfmt.toml`; prefer changing that file over arguing style ad hoc.
+- Workspace lint policy lives in `src/rust/Cargo.toml`; keep shared Clippy and rustc lint defaults centralized there.
+- When proto or service contracts change, also run:
+  - `buf lint`
+  - `cargo run --manifest-path src/rust/Cargo.toml -p logripper-server`
+  - `dotnet run --project src/dotnet/LogRipper.Cli -- status`
+- When changing Rust dependencies or supply-chain-sensitive infrastructure, also run:
+  - `cargo deny check --manifest-path src/rust/Cargo.toml --config src/rust/deny.toml`
+  - `cargo audit`
+
+## Authoritative Sources
+
+- Rust Reference: https://doc.rust-lang.org/reference/
+- Rust 2024 Edition Guide: https://doc.rust-lang.org/edition-guide/rust-2024/index.html
+- Rust release notes: https://blog.rust-lang.org/
+- Rust Style Guide: https://doc.rust-lang.org/style-guide/
+- Rust API Guidelines: https://rust-lang.github.io/api-guidelines/
+- Clippy docs: https://rust-lang.github.io/rust-clippy/master/
+- RustSec / cargo-audit: https://rustsec.org/

--- a/.github/prompts/rust-engine-change.prompt.md
+++ b/.github/prompts/rust-engine-change.prompt.md
@@ -1,0 +1,22 @@
+---
+name: rust-engine-change
+description: Implement a Rust engine or tonic/proto change in LogRipper with current-stable Rust guidance and regression-first validation.
+---
+
+# Rust Engine Change
+
+Use this workflow when implementing or reviewing a Rust engine change in LogRipper.
+
+1. Identify whether the change belongs in `logripper-core`, `logripper-server`, or `proto/`.
+2. If the issue depends on Rust semantics, lints, or undefined behavior claims, verify against current official Rust sources before assuming older guidance still applies.
+3. Add or update a failing regression test first when fixing a bug.
+4. Implement the smallest correct fix that preserves engine/UI boundaries.
+5. Run the Rust validation loop:
+   - `cargo fmt --manifest-path src/rust/Cargo.toml --all -- --check`
+   - `cargo test --manifest-path src/rust/Cargo.toml`
+   - `cargo clippy --manifest-path src/rust/Cargo.toml --all-targets -- -D warnings`
+6. If proto or gRPC behavior changed, also run:
+   - `buf lint`
+   - `dotnet build src/dotnet/LogRipper.slnx`
+   - live smoke path through `logripper-server` and `LogRipper.Cli`
+7. Summarize impact, validation, and any remaining contract or migration considerations.

--- a/.github/skills/rust-api-and-idioms/SKILL.md
+++ b/.github/skills/rust-api-and-idioms/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: rust-api-and-idioms
+description: >-
+  Apply current Rust API design and idioms in LogRipper. Use when shaping Rust public APIs,
+  choosing signatures, modeling errors, or checking whether older Rust-era advice still
+  applies to current stable Rust.
+---
+
+# Skill: Rust API and idioms
+
+## When to Use
+
+- Designing new Rust modules or public functions
+- Refactoring Rust APIs for clarity or ergonomics
+- Reviewing error handling and ownership patterns
+- Checking whether an old Rust pattern is still recommended on current stable Rust
+
+## Design Rules
+
+1. Prefer simple, explicit APIs over clever abstractions.
+2. Model domain state with enums and structs rather than stringly flags.
+3. Use typed errors for meaningful failure surfaces; prefer `thiserror` over ad hoc strings.
+4. Avoid unnecessary clones and allocations on hot paths.
+5. Do not keep outdated workarounds just because they were needed in older Rust versions.
+6. Prefer current idioms documented by the Rust API Guidelines and Clippy.
+
+## Review Checklist
+
+- Is this API readable from the caller side?
+- Does ownership/borrowing match actual lifetime needs?
+- Is a clone/allocation happening on a hot path without justification?
+- Is a lint suppression overly broad where `#[expect]` or a redesign would be better?
+- Does the implementation rely on an old-edition limitation that should be rechecked?
+
+## Current References
+
+- Rust API Guidelines: https://rust-lang.github.io/api-guidelines/
+- Clippy docs: https://rust-lang.github.io/rust-clippy/master/
+- Rust Reference: https://doc.rust-lang.org/reference/
+- Rust 2024 Edition Guide: https://doc.rust-lang.org/edition-guide/rust-2024/index.html

--- a/.github/skills/rust-clippy-and-lints/SKILL.md
+++ b/.github/skills/rust-clippy-and-lints/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: rust-clippy-and-lints
+description: >-
+  Enforce current Rust lint, formatting, and dependency-audit practices in LogRipper. Use
+  when enabling or interpreting clippy lints, deciding on lint suppressions, or aligning
+  Rust code with rustfmt, current stable lints, and modern supply-chain checks.
+---
+
+# Skill: Rust Clippy and lints
+
+## When to Use
+
+- Running or fixing `cargo clippy`
+- Running `cargo fmt --check`
+- Working on `src/rust/rustfmt.toml`, `src/rust/deny.toml`, or workspace lint settings in `src/rust/Cargo.toml`
+- Adding dependency-audit checks like `cargo deny` or `cargo audit`
+- Deciding whether to suppress or address a lint
+- Cleaning up Rust style and consistency issues
+- Reviewing unsafe code and modern lint expectations
+
+## Key Rules
+
+1. Use `rustfmt` defaults unless the repository has a strong reason to diverge.
+2. Treat Clippy as a best-practice signal, not just noise to suppress.
+3. Prefer `#[expect(...)]` for narrow, intentional exceptions.
+4. Avoid crate-wide or module-wide `allow` attributes unless there is a strong, documented reason.
+5. Recheck unsafe-related guidance against current stable Rust and edition guidance.
+6. Use `cargo deny` and `cargo audit` for dependency risk and supply-chain checks instead of relying on memory or ad hoc CVE review.
+
+## Standard Commands
+
+```powershell
+cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check
+cargo clippy --manifest-path src\rust\Cargo.toml --all-targets -- -D warnings
+cargo deny check --manifest-path src\rust\Cargo.toml --config src\rust\deny.toml
+cargo audit
+```
+
+## Current References
+
+- Clippy docs: https://rust-lang.github.io/rust-clippy/master/
+- Rust Style Guide: https://doc.rust-lang.org/style-guide/
+- Rust 2024 Edition Guide: https://doc.rust-lang.org/edition-guide/rust-2024/index.html
+- RustSec: https://rustsec.org/

--- a/.github/skills/rust-clippy-and-lints/SKILL.md
+++ b/.github/skills/rust-clippy-and-lints/SKILL.md
@@ -13,7 +13,7 @@ description: >-
 - Running or fixing `cargo clippy`
 - Running `cargo fmt --check`
 - Working on `src/rust/rustfmt.toml`, `src/rust/deny.toml`, or workspace lint settings in `src/rust/Cargo.toml`
-- Adding dependency-audit checks like `cargo deny` or `cargo audit`
+- Adding dependency-audit checks like `cargo deny` or planning a manual `cargo audit` pass
 - Deciding whether to suppress or address a lint
 - Cleaning up Rust style and consistency issues
 - Reviewing unsafe code and modern lint expectations
@@ -25,15 +25,18 @@ description: >-
 3. Prefer `#[expect(...)]` for narrow, intentional exceptions.
 4. Avoid crate-wide or module-wide `allow` attributes unless there is a strong, documented reason.
 5. Recheck unsafe-related guidance against current stable Rust and edition guidance.
-6. Use `cargo deny` and `cargo audit` for dependency risk and supply-chain checks instead of relying on memory or ad hoc CVE review.
+6. Use `cargo deny` for routine dependency risk checks, and reserve `cargo audit` for occasional manual review instead of every CI run.
 
 ## Standard Commands
 
 ```powershell
 cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check
 cargo clippy --manifest-path src\rust\Cargo.toml --all-targets -- -D warnings
-cargo deny check --manifest-path src\rust\Cargo.toml --config src\rust\deny.toml
+Push-Location src\rust
+cargo deny check --config deny.toml
+# Optional manual review
 cargo audit
+Pop-Location
 ```
 
 ## Current References

--- a/.github/skills/rust-engine-workflow/SKILL.md
+++ b/.github/skills/rust-engine-workflow/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: rust-engine-workflow
+description: >-
+  Implement and review Rust engine changes for LogRipper. Use when working in src/rust/,
+  touching logripper-core, logripper-server, build.rs, ADIF/QRZ adapters, or validating
+  current Rust behavior against official language guidance.
+---
+
+# Skill: Rust Engine Workflow
+
+## When to Use
+
+- Editing files under `src/rust/`
+- Adding or changing engine behavior in `logripper-core`
+- Changing tonic server startup or hosting in `logripper-server`
+- Reviewing Rust bugs that may depend on current language semantics or edition behavior
+- Working near `build.rs`, generated proto bindings, or the C DSP boundary
+
+## Core Repo Rules
+
+1. Keep reusable engine logic in `src/rust/logripper-core`.
+2. Keep process startup and tonic host wiring in `src/rust/logripper-server`.
+3. Do not hand-edit generated proto code; change `proto/` and regenerate.
+4. Keep ADIF and provider-specific formats at the edge, normalized into project-owned types.
+5. Favor current stable Rust semantics over workarounds for outdated compiler behavior.
+
+## Validation Loop
+
+```powershell
+cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check
+cargo test --manifest-path src\rust\Cargo.toml
+cargo clippy --manifest-path src\rust\Cargo.toml --all-targets -- -D warnings
+```
+
+If the change affects gRPC or schema behavior:
+
+```powershell
+buf lint
+cargo run --manifest-path src\rust\Cargo.toml -p logripper-server
+dotnet run --project src\dotnet\LogRipper.Cli -- status
+```
+
+## Current Reference Sources
+
+- Rust Reference: https://doc.rust-lang.org/reference/
+- Rust 2024 Edition Guide: https://doc.rust-lang.org/edition-guide/rust-2024/index.html
+- Rust release notes: https://blog.rust-lang.org/
+- Rust Style Guide: https://doc.rust-lang.org/style-guide/
+
+## LogRipper-Specific Paths
+
+- `src/rust/logripper-core/`
+- `src/rust/logripper-server/`
+- `src/rust/logripper-core/build.rs`
+- `proto/`
+- `src/c/logripper-dsp/`

--- a/.github/skills/tonic-proto-contracts/SKILL.md
+++ b/.github/skills/tonic-proto-contracts/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: tonic-proto-contracts
+description: >-
+  Change or review protobuf and tonic contracts for LogRipper. Use when editing proto/,
+  gRPC services, generated Rust bindings, or .NET clients that depend on shared lookup and
+  logbook contracts.
+---
+
+# Skill: tonic/proto contracts
+
+## When to Use
+
+- Editing files under `proto/`
+- Adding or changing `LookupService` or `LogbookService`
+- Reviewing Rust/.NET interoperability risks
+- Updating generated client/server behavior tied to `prost`, `tonic`, or `Grpc.Tools`
+
+## Key Rules
+
+1. `proto/` is the single source of truth for shared contracts.
+2. Preserve field numbers and enum values.
+3. Keep zero-value enums as unspecified/default states.
+4. Prefer additive schema changes over breaking changes.
+5. ADIF is not an internal IPC format; protobuf remains the internal contract.
+
+## Repo-Specific Contract Surfaces
+
+- `proto/domain/*.proto`
+- `proto/services/*.proto`
+- `src/rust/logripper-core/build.rs`
+- `src/rust/logripper-server/`
+- `src/dotnet/LogRipper.Cli/`
+- `src/dotnet/LogRipper.DebugHost/`
+
+## Validation
+
+```powershell
+buf lint
+cargo test --manifest-path src\rust\Cargo.toml
+dotnet build src\dotnet\LogRipper.slnx
+```
+
+Runtime smoke path:
+
+```powershell
+cargo run --manifest-path src\rust\Cargo.toml -p logripper-server
+dotnet run --project src\dotnet\LogRipper.Cli -- status
+```
+
+## Current References
+
+- Protocol Buffers: https://protobuf.dev/programming-guides/proto3/
+- Buf docs: https://buf.build/docs/
+- tonic docs: https://docs.rs/tonic/latest/tonic/
+- prost docs: https://docs.rs/prost/latest/prost/

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,61 @@
+name: "Copilot Setup Steps"
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/copilot-setup-steps.yml"
+      - "rust-toolchain.toml"
+      - "src/rust/rustfmt.toml"
+      - "src/rust/deny.toml"
+  pull_request:
+    paths:
+      - ".github/workflows/copilot-setup-steps.yml"
+      - "rust-toolchain.toml"
+      - "src/rust/rustfmt.toml"
+      - "src/rust/deny.toml"
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: global.json
+
+      - name: Install Rust toolchain and components
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal --component rustfmt --component clippy
+          rustup default 1.88.0
+          rustc --version
+          cargo --version
+
+      - name: Install protobuf and C build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler build-essential pkg-config
+          protoc --version
+
+      - name: Install Buf CLI
+        uses: bufbuild/buf-setup-action@v1
+
+      - name: Install Rust quality tooling
+        run: |
+          cargo install cargo-deny --locked
+          cargo install cargo-audit --locked
+
+      - name: Verify key developer tools
+        run: |
+          cargo fmt --version
+          cargo clippy --version
+          cargo deny --version
+          cargo audit --version
+          buf --version
+          dotnet --version

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -49,13 +49,11 @@ jobs:
       - name: Install Rust quality tooling
         run: |
           cargo install cargo-deny --locked
-          cargo install cargo-audit --locked
 
       - name: Verify key developer tools
         run: |
           cargo fmt --version
           cargo clippy --version
           cargo deny --version
-          cargo audit --version
           buf --version
           dotnet --version

--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -1,0 +1,66 @@
+name: Rust Quality
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/rust-quality.yml"
+      - "rust-toolchain.toml"
+      - "src/c/**"
+      - "src/rust/**"
+      - "proto/**"
+  pull_request:
+    paths:
+      - ".github/workflows/rust-quality.yml"
+      - "rust-toolchain.toml"
+      - "src/c/**"
+      - "src/rust/**"
+      - "proto/**"
+
+permissions:
+  contents: read
+
+jobs:
+  rust-quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        run: |
+          rustup toolchain install 1.88.0 --profile minimal --component rustfmt --component clippy
+          rustup default 1.88.0
+          rustc --version
+          cargo --version
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            src/rust -> target
+
+      - name: Install protobuf and C build prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler build-essential pkg-config
+          protoc --version
+
+      - name: Install cargo-deny
+        run: |
+          cargo install cargo-deny --locked
+
+      - name: Check formatting
+        run: cargo fmt --manifest-path src/rust/Cargo.toml --all -- --check
+
+      - name: Run clippy with warnings denied
+        run: cargo clippy --manifest-path src/rust/Cargo.toml --all-targets -- -D warnings
+
+      - name: Run Rust tests
+        run: cargo test --manifest-path src/rust/Cargo.toml
+
+      - name: Run cargo-deny
+        working-directory: src/rust
+        run: cargo deny check --config deny.toml

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.88.0"
+profile = "minimal"
+components = ["rustfmt", "clippy"]

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -8,6 +8,7 @@ members = [
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.88"
 license = "MIT"
 repository = "https://github.com/rtreit/logripper"
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -17,3 +17,27 @@ prost-types = "0.13"
 tonic = "0.12"
 tokio = { version = "1", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+pedantic = { level = "warn", priority = -1 }
+cast_possible_truncation = "deny"
+cast_sign_loss = "deny"
+cast_precision_loss = "warn"
+cast_lossless = "warn"
+unwrap_used = "warn"
+expect_used = "warn"
+panic = "warn"
+indexing_slicing = "warn"
+inefficient_to_string = "warn"
+large_futures = "warn"
+large_stack_arrays = "warn"
+needless_pass_by_value = "warn"
+cloned_instead_of_copied = "warn"
+manual_string_new = "warn"
+implicit_clone = "warn"
+
+[workspace.lints.rust]
+unsafe_code = "warn"
+missing_docs = "warn"
+unreachable_pub = "warn"

--- a/src/rust/deny.toml
+++ b/src/rust/deny.toml
@@ -4,8 +4,6 @@ all-features = true
 
 [advisories]
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "warn"
 
 [licenses]
 allow = [
@@ -13,9 +11,7 @@ allow = [
   "Apache-2.0",
   "BSD-2-Clause",
   "BSD-3-Clause",
-  "ISC",
   "Unicode-3.0",
-  "Zlib",
 ]
 confidence-threshold = 0.8
 

--- a/src/rust/deny.toml
+++ b/src/rust/deny.toml
@@ -1,0 +1,28 @@
+[graph]
+targets = []
+all-features = true
+
+[advisories]
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+
+[licenses]
+allow = [
+  "MIT",
+  "Apache-2.0",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "ISC",
+  "Unicode-3.0",
+  "Zlib",
+]
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"

--- a/src/rust/logripper-core/Cargo.toml
+++ b/src/rust/logripper-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "logripper-core"
 description = "Core engine for LogRipper ham radio logging system"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 

--- a/src/rust/logripper-core/Cargo.toml
+++ b/src/rust/logripper-core/Cargo.toml
@@ -17,6 +17,9 @@ thiserror = "2"
 chrono = "0.4"
 futures = "0.3"
 
+[lints]
+workspace = true
+
 [build-dependencies]
 tonic-build = "0.12"
 cc = "1"

--- a/src/rust/logripper-core/build.rs
+++ b/src/rust/logripper-core/build.rs
@@ -1,3 +1,5 @@
+//! Build script for generating protobuf bindings and compiling the DSP C library.
+
 use std::path::PathBuf;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/rust/logripper-core/src/adif/mapper.rs
+++ b/src/rust/logripper-core/src/adif/mapper.rs
@@ -1,6 +1,6 @@
-//! Maps difa::Record → proto QsoRecord and back.
+//! Maps `difa::Record` values to the proto `QsoRecord` and back.
 //!
-//! This is the edge adapter between the ADIF file format and LogRipper's
+//! This is the edge adapter between the ADIF file format and `LogRipper`'s
 //! internal domain types. All ADIF-specific logic is contained here.
 
 use crate::domain::band::band_from_adif;
@@ -9,14 +9,16 @@ use crate::domain::qso::{new_local_id, qsl_status_from_adif};
 use crate::proto::logripper::domain::{Band, Mode, QsoRecord, SyncStatus};
 use difa::Record;
 
-/// Maps difa ADIF records to/from proto QsoRecords.
+/// Maps ADIF records to and from proto `QsoRecord` values.
 pub struct AdifMapper;
 
 impl AdifMapper {
-    /// Convert a difa::Record (parsed ADIF QSO) into a proto QsoRecord.
+    /// Convert a `difa::Record` (parsed ADIF QSO) into a proto `QsoRecord`.
     ///
-    /// Recognized ADIF fields are mapped to dedicated QsoRecord fields.
+    /// Recognized ADIF fields are mapped to dedicated `QsoRecord` fields.
     /// Unrecognized fields are stored in `extra_fields` for round-trip fidelity.
+    #[must_use]
+    #[allow(clippy::too_many_lines)]
     pub fn record_to_qso(record: &Record) -> QsoRecord {
         let mut qso = QsoRecord {
             local_id: new_local_id(),
@@ -50,9 +52,6 @@ impl AdifMapper {
                         qso.band = band.into();
                     }
                 }
-                "BAND_RX" => {
-                    qso.extra_fields.insert(key_upper, value_str);
-                }
                 "MODE" => {
                     if let Some(mode) = mode_from_adif(&value_str) {
                         qso.mode = mode.into();
@@ -67,13 +66,9 @@ impl AdifMapper {
                 "SUBMODE" => qso.submode = Some(value_str),
                 "FREQ" => {
                     if let Ok(mhz) = value_str.parse::<f64>() {
-                        qso.frequency_khz = Some((mhz * 1000.0).round() as u64);
+                        qso.frequency_khz = mhz_to_khz(mhz);
                     }
                 }
-                "FREQ_RX" => {
-                    qso.extra_fields.insert(key_upper, value_str);
-                }
-
                 // --- Signal reports ---
                 "RST_SENT" => {
                     qso.rst_sent = Some(crate::proto::logripper::domain::RstReport {
@@ -154,8 +149,10 @@ impl AdifMapper {
         qso
     }
 
-    /// Convert a proto QsoRecord into a list of ADIF field key-value pairs.
+    /// Convert a proto `QsoRecord` into a list of ADIF field key-value pairs.
     /// Suitable for generating ADI output.
+    #[must_use]
+    #[allow(clippy::too_many_lines)]
     pub fn qso_to_adif_fields(qso: &QsoRecord) -> Vec<(String, String)> {
         let mut fields = Vec::new();
 
@@ -169,9 +166,10 @@ impl AdifMapper {
 
         // Timestamp → QSO_DATE + TIME_ON
         if let Some(ref ts) = qso.utc_timestamp {
-            let (date_str, time_str) = format_adif_datetime(ts);
-            fields.push(("QSO_DATE".into(), date_str));
-            fields.push(("TIME_ON".into(), time_str));
+            if let Some((date_str, time_str)) = format_adif_datetime(ts) {
+                fields.push(("QSO_DATE".into(), date_str));
+                fields.push(("TIME_ON".into(), time_str));
+            }
         }
 
         // Band
@@ -191,8 +189,9 @@ impl AdifMapper {
 
         // Frequency
         if let Some(khz) = qso.frequency_khz {
-            let mhz = khz as f64 / 1000.0;
-            fields.push(("FREQ".into(), format!("{mhz:.3}")));
+            let whole_mhz = khz / 1000;
+            let fractional_khz = khz % 1000;
+            fields.push(("FREQ".into(), format!("{whole_mhz}.{fractional_khz:03}")));
         }
 
         // Signal reports
@@ -313,11 +312,18 @@ impl AdifMapper {
     }
 
     /// Generate an ADI-format string from ADIF field pairs.
+    #[must_use]
     pub fn fields_to_adi(fields: &[(String, String)]) -> String {
         let mut out = String::new();
         for (key, value) in fields {
             let len = value.len();
-            out.push_str(&format!("<{key}:{len}>{value}\n"));
+            out.push('<');
+            out.push_str(key);
+            out.push(':');
+            out.push_str(&len.to_string());
+            out.push('>');
+            out.push_str(value);
+            out.push('\n');
         }
         out.push_str("<eor>\n");
         out
@@ -326,8 +332,14 @@ impl AdifMapper {
 
 /// Parse ADIF date (YYYYMMDD) + optional time (HHMM or HHMMSS) into prost Timestamp.
 fn parse_adif_datetime(date_str: &str, time_str: Option<&str>) -> Option<prost_types::Timestamp> {
-    if date_str.len() != 8 {
+    if date_str.len() != 8 || !date_str.is_ascii() {
         return None;
+    }
+
+    if let Some(ts) = time_str {
+        if !ts.is_ascii() {
+            return None;
+        }
     }
 
     let year: i32 = date_str[0..4].parse().ok()?;
@@ -364,16 +376,29 @@ fn parse_adif_datetime(date_str: &str, time_str: Option<&str>) -> Option<prost_t
 }
 
 /// Format a prost Timestamp as ADIF date + time strings.
-fn format_adif_datetime(ts: &prost_types::Timestamp) -> (String, String) {
-    let dt = chrono::DateTime::from_timestamp(ts.seconds, ts.nanos as u32)
-        .unwrap_or_default()
-        .naive_utc();
+fn format_adif_datetime(ts: &prost_types::Timestamp) -> Option<(String, String)> {
+    let nanos = u32::try_from(ts.nanos).ok()?;
+    let dt = chrono::DateTime::from_timestamp(ts.seconds, nanos)?.naive_utc();
     let date = dt.format("%Y%m%d").to_string();
     let time = dt.format("%H%M%S").to_string();
-    (date, time)
+    Some((date, time))
+}
+
+fn mhz_to_khz(mhz: f64) -> Option<u64> {
+    if !mhz.is_finite() || mhz.is_sign_negative() {
+        return None;
+    }
+
+    let rounded = (mhz * 1000.0).round();
+    if rounded < 0.0 {
+        return None;
+    }
+
+    format!("{rounded:.0}").parse().ok()
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use uuid::Uuid;
@@ -537,21 +562,21 @@ mod tests {
 
         let qso = AdifMapper::record_to_qso(&rec);
         assert_eq!(
-            qso.extra_fields.get("MY_RIG").map(|s| s.as_str()),
+            qso.extra_fields.get("MY_RIG").map(String::as_str),
             Some("Icom IC-7300")
         );
         assert_eq!(
-            qso.extra_fields.get("MY_ANTENNA").map(|s| s.as_str()),
+            qso.extra_fields.get("MY_ANTENNA").map(String::as_str),
             Some("Yagi 3-element")
         );
         assert_eq!(
-            qso.extra_fields.get("ANT_AZ").map(|s| s.as_str()),
+            qso.extra_fields.get("ANT_AZ").map(String::as_str),
             Some("045")
         );
         assert_eq!(
             qso.extra_fields
                 .get("APP_LOGRIPPER_SYNC_STATUS")
-                .map(|s| s.as_str()),
+                .map(String::as_str),
             Some("synced")
         );
     }

--- a/src/rust/logripper-core/src/domain/band.rs
+++ b/src/rust/logripper-core/src/domain/band.rs
@@ -11,45 +11,48 @@ pub struct BandRange {
 
 /// All ADIF 3.1.7 band definitions with frequency ranges.
 const BAND_TABLE: &[(&str, Band, f64, f64)] = &[
-    ("2190M",  Band::Band2190m,  0.1357,     0.1378),
-    ("630M",   Band::Band630m,   0.472,      0.479),
-    ("560M",   Band::Band560m,   0.501,      0.504),
-    ("160M",   Band::Band160m,   1.8,        2.0),
-    ("80M",    Band::Band80m,    3.5,        4.0),
-    ("60M",    Band::Band60m,    5.06,       5.45),
-    ("40M",    Band::Band40m,    7.0,        7.3),
-    ("30M",    Band::Band30m,    10.1,       10.15),
-    ("20M",    Band::Band20m,    14.0,       14.35),
-    ("17M",    Band::Band17m,    18.068,     18.168),
-    ("15M",    Band::Band15m,    21.0,       21.45),
-    ("12M",    Band::Band12m,    24.89,      24.99),
-    ("10M",    Band::Band10m,    28.0,       29.7),
-    ("8M",     Band::Band8m,     40.0,       45.0),
-    ("6M",     Band::Band6m,     50.0,       54.0),
-    ("5M",     Band::Band5m,     54.000001,  69.9),
-    ("4M",     Band::Band4m,     70.0,       71.0),
-    ("2M",     Band::Band2m,     144.0,      148.0),
-    ("1.25M",  Band::Band125m,   222.0,      225.0),
-    ("70CM",   Band::Band70cm,   420.0,      450.0),
-    ("33CM",   Band::Band33cm,   902.0,      928.0),
-    ("23CM",   Band::Band23cm,   1240.0,     1300.0),
-    ("13CM",   Band::Band13cm,   2300.0,     2450.0),
-    ("9CM",    Band::Band9cm,    3300.0,     3500.0),
-    ("6CM",    Band::Band6cm,    5650.0,     5925.0),
-    ("3CM",    Band::Band3cm,    10000.0,    10500.0),
-    ("1.25CM", Band::Band125cm,  24000.0,    24250.0),
-    ("6MM",    Band::Band6mm,    47000.0,    47200.0),
-    ("4MM",    Band::Band4mm,    75500.0,    81000.0),
-    ("2.5MM",  Band::Band25mm,   119980.0,   123000.0),
-    ("2MM",    Band::Band2mm,    134000.0,   149000.0),
-    ("1MM",    Band::Band1mm,    241000.0,   250000.0),
-    ("SUBMM",  Band::Submm,      300000.0,   7500000.0),
+    ("2190M", Band::Band2190m, 0.1357, 0.1378),
+    ("630M", Band::Band630m, 0.472, 0.479),
+    ("560M", Band::Band560m, 0.501, 0.504),
+    ("160M", Band::Band160m, 1.8, 2.0),
+    ("80M", Band::Band80m, 3.5, 4.0),
+    ("60M", Band::Band60m, 5.06, 5.45),
+    ("40M", Band::Band40m, 7.0, 7.3),
+    ("30M", Band::Band30m, 10.1, 10.15),
+    ("20M", Band::Band20m, 14.0, 14.35),
+    ("17M", Band::Band17m, 18.068, 18.168),
+    ("15M", Band::Band15m, 21.0, 21.45),
+    ("12M", Band::Band12m, 24.89, 24.99),
+    ("10M", Band::Band10m, 28.0, 29.7),
+    ("8M", Band::Band8m, 40.0, 45.0),
+    ("6M", Band::Band6m, 50.0, 54.0),
+    ("5M", Band::Band5m, 54.000001, 69.9),
+    ("4M", Band::Band4m, 70.0, 71.0),
+    ("2M", Band::Band2m, 144.0, 148.0),
+    ("1.25M", Band::Band125m, 222.0, 225.0),
+    ("70CM", Band::Band70cm, 420.0, 450.0),
+    ("33CM", Band::Band33cm, 902.0, 928.0),
+    ("23CM", Band::Band23cm, 1240.0, 1300.0),
+    ("13CM", Band::Band13cm, 2300.0, 2450.0),
+    ("9CM", Band::Band9cm, 3300.0, 3500.0),
+    ("6CM", Band::Band6cm, 5650.0, 5925.0),
+    ("3CM", Band::Band3cm, 10000.0, 10500.0),
+    ("1.25CM", Band::Band125cm, 24000.0, 24250.0),
+    ("6MM", Band::Band6mm, 47000.0, 47200.0),
+    ("4MM", Band::Band4mm, 75500.0, 81000.0),
+    ("2.5MM", Band::Band25mm, 119980.0, 123000.0),
+    ("2MM", Band::Band2mm, 134000.0, 149000.0),
+    ("1MM", Band::Band1mm, 241000.0, 250000.0),
+    ("SUBMM", Band::Submm, 300000.0, 7500000.0),
 ];
 
 /// Parse an ADIF band string (case-insensitive) into a Band enum value.
 pub fn band_from_adif(s: &str) -> Option<Band> {
     let upper = s.to_uppercase();
-    BAND_TABLE.iter().find(|(name, _, _, _)| *name == upper).map(|(_, band, _, _)| *band)
+    BAND_TABLE
+        .iter()
+        .find(|(name, _, _, _)| *name == upper)
+        .map(|(_, band, _, _)| *band)
 }
 
 /// Convert a Band enum value to its canonical ADIF string representation.
@@ -57,7 +60,10 @@ pub fn band_to_adif(band: Band) -> Option<&'static str> {
     if band == Band::Unspecified {
         return None;
     }
-    BAND_TABLE.iter().find(|(_, b, _, _)| *b == band).map(|(name, _, _, _)| *name)
+    BAND_TABLE
+        .iter()
+        .find(|(_, b, _, _)| *b == band)
+        .map(|(name, _, _, _)| *name)
 }
 
 /// Derive the Band from a frequency in MHz.
@@ -87,10 +93,12 @@ mod tests {
     #[test]
     fn all_bands_round_trip_through_adif_string() {
         for (name, band, _, _) in BAND_TABLE {
-            let parsed = band_from_adif(name).unwrap_or_else(|| panic!("Failed to parse band: {name}"));
+            let parsed =
+                band_from_adif(name).unwrap_or_else(|| panic!("Failed to parse band: {name}"));
             assert_eq!(parsed, *band, "Band mismatch for {name}");
 
-            let back = band_to_adif(parsed).unwrap_or_else(|| panic!("Failed to convert band back: {name}"));
+            let back = band_to_adif(parsed)
+                .unwrap_or_else(|| panic!("Failed to convert band back: {name}"));
             assert_eq!(back, *name, "Round-trip mismatch for {name}");
         }
     }

--- a/src/rust/logripper-core/src/domain/band.rs
+++ b/src/rust/logripper-core/src/domain/band.rs
@@ -4,8 +4,11 @@ use crate::proto::logripper::domain::Band;
 
 /// Frequency range in MHz for a band.
 pub struct BandRange {
+    /// The band associated with the range.
     pub band: Band,
+    /// Lower edge of the band in MHz.
     pub lower_mhz: f64,
+    /// Upper edge of the band in MHz.
     pub upper_mhz: f64,
 }
 
@@ -26,7 +29,7 @@ const BAND_TABLE: &[(&str, Band, f64, f64)] = &[
     ("10M", Band::Band10m, 28.0, 29.7),
     ("8M", Band::Band8m, 40.0, 45.0),
     ("6M", Band::Band6m, 50.0, 54.0),
-    ("5M", Band::Band5m, 54.000001, 69.9),
+    ("5M", Band::Band5m, 54.000_001, 69.9),
     ("4M", Band::Band4m, 70.0, 71.0),
     ("2M", Band::Band2m, 144.0, 148.0),
     ("1.25M", Band::Band125m, 222.0, 225.0),
@@ -40,13 +43,14 @@ const BAND_TABLE: &[(&str, Band, f64, f64)] = &[
     ("1.25CM", Band::Band125cm, 24000.0, 24250.0),
     ("6MM", Band::Band6mm, 47000.0, 47200.0),
     ("4MM", Band::Band4mm, 75500.0, 81000.0),
-    ("2.5MM", Band::Band25mm, 119980.0, 123000.0),
-    ("2MM", Band::Band2mm, 134000.0, 149000.0),
-    ("1MM", Band::Band1mm, 241000.0, 250000.0),
-    ("SUBMM", Band::Submm, 300000.0, 7500000.0),
+    ("2.5MM", Band::Band25mm, 119_980.0, 123_000.0),
+    ("2MM", Band::Band2mm, 134_000.0, 149_000.0),
+    ("1MM", Band::Band1mm, 241_000.0, 250_000.0),
+    ("SUBMM", Band::Submm, 300_000.0, 7_500_000.0),
 ];
 
 /// Parse an ADIF band string (case-insensitive) into a Band enum value.
+#[must_use]
 pub fn band_from_adif(s: &str) -> Option<Band> {
     let upper = s.to_uppercase();
     BAND_TABLE
@@ -56,6 +60,7 @@ pub fn band_from_adif(s: &str) -> Option<Band> {
 }
 
 /// Convert a Band enum value to its canonical ADIF string representation.
+#[must_use]
 pub fn band_to_adif(band: Band) -> Option<&'static str> {
     if band == Band::Unspecified {
         return None;
@@ -68,6 +73,7 @@ pub fn band_to_adif(band: Band) -> Option<&'static str> {
 
 /// Derive the Band from a frequency in MHz.
 /// Returns the first band whose range contains the frequency.
+#[must_use]
 pub fn band_from_frequency_mhz(freq_mhz: f64) -> Option<Band> {
     BAND_TABLE
         .iter()
@@ -76,6 +82,7 @@ pub fn band_from_frequency_mhz(freq_mhz: f64) -> Option<Band> {
 }
 
 /// Get the frequency range (lower, upper) in MHz for a Band.
+#[must_use]
 pub fn band_frequency_range_mhz(band: Band) -> Option<(f64, f64)> {
     if band == Band::Unspecified {
         return None;
@@ -87,6 +94,7 @@ pub fn band_frequency_range_mhz(band: Band) -> Option<(f64, f64)> {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic, clippy::unwrap_used, clippy::float_cmp)]
 mod tests {
     use super::*;
 
@@ -156,8 +164,8 @@ mod tests {
     fn frequency_range_round_trips() {
         for (_, band, lower, upper) in BAND_TABLE {
             let range = band_frequency_range_mhz(*band).unwrap();
-            assert_eq!(range.0, *lower, "Lower bound mismatch for {:?}", band);
-            assert_eq!(range.1, *upper, "Upper bound mismatch for {:?}", band);
+            assert_eq!(range.0, *lower, "Lower bound mismatch for {band:?}");
+            assert_eq!(range.1, *upper, "Upper bound mismatch for {band:?}");
         }
     }
 

--- a/src/rust/logripper-core/src/domain/mode.rs
+++ b/src/rust/logripper-core/src/domain/mode.rs
@@ -62,6 +62,7 @@ const IMPORT_ONLY_MODES: &[(&str, Mode, &str)] = &[
 
 /// Parse an ADIF mode string (case-insensitive) into a Mode enum value.
 /// For import-only modes (C4FM, DSTAR), returns the replacement mode.
+#[must_use]
 pub fn mode_from_adif(s: &str) -> Option<Mode> {
     let upper = s.to_uppercase();
 
@@ -84,6 +85,7 @@ pub fn mode_from_adif(s: &str) -> Option<Mode> {
 /// For import-only modes, returns the submode string that should be set.
 /// E.g., "C4FM" → Some("C4FM"), "DSTAR" → Some("DSTAR").
 /// For standard modes, returns None.
+#[must_use]
 pub fn import_only_submode(mode_str: &str) -> Option<&'static str> {
     let upper = mode_str.to_uppercase();
     IMPORT_ONLY_MODES
@@ -93,6 +95,7 @@ pub fn import_only_submode(mode_str: &str) -> Option<&'static str> {
 }
 
 /// Convert a Mode enum value to its canonical ADIF string representation.
+#[must_use]
 pub fn mode_to_adif(mode: Mode) -> Option<&'static str> {
     if mode == Mode::Unspecified {
         return None;
@@ -107,6 +110,7 @@ pub fn mode_to_adif(mode: Mode) -> Option<&'static str> {
 /// This is a non-exhaustive check for the most common submodes.
 /// Returns true if the submode is known to belong to the given mode,
 /// or if the mode has no known submode list (permissive).
+#[must_use]
 pub fn is_known_submode(mode: Mode, submode: &str) -> bool {
     let upper = submode.to_uppercase();
     match mode {
@@ -119,19 +123,18 @@ pub fn is_known_submode(mode: Mode, submode: &str) -> bool {
 }
 
 #[cfg(test)]
+#[allow(clippy::panic)]
 mod tests {
     use super::*;
 
     #[test]
     fn all_modes_round_trip_through_adif_string() {
         for (name, mode) in MODE_TABLE {
-            let parsed =
-                mode_from_adif(name).unwrap_or_else(|| panic!("Failed to parse mode: {name}"));
-            assert_eq!(parsed, *mode, "Mode mismatch for {name}");
+            let parsed = mode_from_adif(name);
+            assert_eq!(parsed, Some(*mode), "Mode mismatch for {name}");
 
-            let back = mode_to_adif(parsed)
-                .unwrap_or_else(|| panic!("Failed to convert mode back: {name}"));
-            assert_eq!(back, *name, "Round-trip mismatch for {name}");
+            let back = mode_to_adif(*mode);
+            assert_eq!(back, Some(*name), "Round-trip mismatch for {name}");
         }
     }
 

--- a/src/rust/logripper-core/src/domain/mode.rs
+++ b/src/rust/logripper-core/src/domain/mode.rs
@@ -6,58 +6,58 @@ use crate::proto::logripper::domain::Mode;
 /// Submodes are NOT enumerated here — they're stored as freeform strings
 /// since there are 100+ and they change over time.
 const MODE_TABLE: &[(&str, Mode)] = &[
-    ("AM",           Mode::Am),
-    ("ARDOP",        Mode::Ardop),
-    ("ATV",          Mode::Atv),
-    ("CHIP",         Mode::Chip),
-    ("CLO",          Mode::Clo),
-    ("CONTESTI",     Mode::Contesti),
-    ("CW",           Mode::Cw),
+    ("AM", Mode::Am),
+    ("ARDOP", Mode::Ardop),
+    ("ATV", Mode::Atv),
+    ("CHIP", Mode::Chip),
+    ("CLO", Mode::Clo),
+    ("CONTESTI", Mode::Contesti),
+    ("CW", Mode::Cw),
     ("DIGITALVOICE", Mode::Digitalvoice),
-    ("DOMINO",       Mode::Domino),
-    ("DYNAMIC",      Mode::Dynamic),
-    ("FAX",          Mode::Fax),
-    ("FM",           Mode::Fm),
-    ("FSK",          Mode::Fsk),
-    ("FT8",          Mode::Ft8),
-    ("HELL",         Mode::Hell),
-    ("ISCAT",        Mode::Iscat),
-    ("JT4",          Mode::Jt4),
-    ("JT9",          Mode::Jt9),
-    ("JT44",         Mode::Jt44),
-    ("JT65",         Mode::Jt65),
-    ("MFSK",         Mode::Mfsk),
-    ("MTONE",        Mode::Mtone),
-    ("MSK144",       Mode::Msk144),
-    ("OFDM",         Mode::Ofdm),
-    ("OLIVIA",       Mode::Olivia),
-    ("OPERA",        Mode::Opera),
-    ("PAC",          Mode::Pac),
-    ("PAX",          Mode::Pax),
-    ("PKT",          Mode::Pkt),
-    ("PSK",          Mode::Psk),
-    ("Q15",          Mode::Q15),
-    ("QRA64",        Mode::Qra64),
-    ("ROS",          Mode::Ros),
-    ("RTTY",         Mode::Rtty),
-    ("RTTYM",        Mode::Rttym),
-    ("SSB",          Mode::Ssb),
-    ("SSTV",         Mode::Sstv),
-    ("T10",          Mode::T10),
-    ("THOR",         Mode::Thor),
-    ("THRB",         Mode::Thrb),
-    ("TOR",          Mode::Tor),
-    ("V4",           Mode::V4),
-    ("VOI",          Mode::Voi),
-    ("WINMOR",       Mode::Winmor),
-    ("WSPR",         Mode::Wspr),
+    ("DOMINO", Mode::Domino),
+    ("DYNAMIC", Mode::Dynamic),
+    ("FAX", Mode::Fax),
+    ("FM", Mode::Fm),
+    ("FSK", Mode::Fsk),
+    ("FT8", Mode::Ft8),
+    ("HELL", Mode::Hell),
+    ("ISCAT", Mode::Iscat),
+    ("JT4", Mode::Jt4),
+    ("JT9", Mode::Jt9),
+    ("JT44", Mode::Jt44),
+    ("JT65", Mode::Jt65),
+    ("MFSK", Mode::Mfsk),
+    ("MTONE", Mode::Mtone),
+    ("MSK144", Mode::Msk144),
+    ("OFDM", Mode::Ofdm),
+    ("OLIVIA", Mode::Olivia),
+    ("OPERA", Mode::Opera),
+    ("PAC", Mode::Pac),
+    ("PAX", Mode::Pax),
+    ("PKT", Mode::Pkt),
+    ("PSK", Mode::Psk),
+    ("Q15", Mode::Q15),
+    ("QRA64", Mode::Qra64),
+    ("ROS", Mode::Ros),
+    ("RTTY", Mode::Rtty),
+    ("RTTYM", Mode::Rttym),
+    ("SSB", Mode::Ssb),
+    ("SSTV", Mode::Sstv),
+    ("T10", Mode::T10),
+    ("THOR", Mode::Thor),
+    ("THRB", Mode::Thrb),
+    ("TOR", Mode::Tor),
+    ("V4", Mode::V4),
+    ("VOI", Mode::Voi),
+    ("WINMOR", Mode::Winmor),
+    ("WSPR", Mode::Wspr),
 ];
 
 /// ADIF import-only modes that should be mapped to their replacement.
 /// These are deprecated in ADIF 3.1.7 but must be accepted on import.
 const IMPORT_ONLY_MODES: &[(&str, Mode, &str)] = &[
-    ("C4FM",  Mode::Digitalvoice, "C4FM"),   // → DIGITALVOICE + submode C4FM
-    ("DSTAR", Mode::Digitalvoice, "DSTAR"),   // → DIGITALVOICE + submode DSTAR
+    ("C4FM", Mode::Digitalvoice, "C4FM"), // → DIGITALVOICE + submode C4FM
+    ("DSTAR", Mode::Digitalvoice, "DSTAR"), // → DIGITALVOICE + submode DSTAR
 ];
 
 /// Parse an ADIF mode string (case-insensitive) into a Mode enum value.
@@ -66,7 +66,11 @@ pub fn mode_from_adif(s: &str) -> Option<Mode> {
     let upper = s.to_uppercase();
 
     // Check standard modes first
-    if let Some(mode) = MODE_TABLE.iter().find(|(name, _)| *name == upper).map(|(_, mode)| *mode) {
+    if let Some(mode) = MODE_TABLE
+        .iter()
+        .find(|(name, _)| *name == upper)
+        .map(|(_, mode)| *mode)
+    {
         return Some(mode);
     }
 
@@ -93,7 +97,10 @@ pub fn mode_to_adif(mode: Mode) -> Option<&'static str> {
     if mode == Mode::Unspecified {
         return None;
     }
-    MODE_TABLE.iter().find(|(_, m)| *m == mode).map(|(name, _)| *name)
+    MODE_TABLE
+        .iter()
+        .find(|(_, m)| *m == mode)
+        .map(|(name, _)| *name)
 }
 
 /// Validate that a submode string is recognized for the given mode.
@@ -107,7 +114,7 @@ pub fn is_known_submode(mode: Mode, submode: &str) -> bool {
         Mode::Digitalvoice => matches!(upper.as_str(), "C4FM" | "DMR" | "DSTAR" | "FREEDV" | "M17"),
         Mode::Cw => matches!(upper.as_str(), "PCW"),
         Mode::Ft8 | Mode::Wspr | Mode::Msk144 => false, // no submodes
-        _ => true, // permissive for modes with many submodes
+        _ => true,                                      // permissive for modes with many submodes
     }
 }
 
@@ -118,10 +125,12 @@ mod tests {
     #[test]
     fn all_modes_round_trip_through_adif_string() {
         for (name, mode) in MODE_TABLE {
-            let parsed = mode_from_adif(name).unwrap_or_else(|| panic!("Failed to parse mode: {name}"));
+            let parsed =
+                mode_from_adif(name).unwrap_or_else(|| panic!("Failed to parse mode: {name}"));
             assert_eq!(parsed, *mode, "Mode mismatch for {name}");
 
-            let back = mode_to_adif(parsed).unwrap_or_else(|| panic!("Failed to convert mode back: {name}"));
+            let back = mode_to_adif(parsed)
+                .unwrap_or_else(|| panic!("Failed to convert mode back: {name}"));
             assert_eq!(back, *name, "Round-trip mismatch for {name}");
         }
     }

--- a/src/rust/logripper-core/src/domain/qso.rs
+++ b/src/rust/logripper-core/src/domain/qso.rs
@@ -1,9 +1,10 @@
-//! QsoRecord helpers: construction, QSL status mapping, ADIF field mapping.
+//! `QsoRecord` helpers: construction, QSL status mapping, and ADIF field mapping.
 
 use crate::proto::logripper::domain::{Band, Mode, QslStatus, QsoRecord, SyncStatus};
 use uuid::Uuid;
 
-/// Map ADIF QSL Sent/Received status character to QslStatus enum.
+/// Map an ADIF QSL Sent/Received status character to the `QslStatus` enum.
+#[must_use]
 pub fn qsl_status_from_adif(s: &str) -> QslStatus {
     match s.to_uppercase().as_str() {
         "Y" => QslStatus::Yes,
@@ -15,7 +16,8 @@ pub fn qsl_status_from_adif(s: &str) -> QslStatus {
     }
 }
 
-/// Convert QslStatus enum to ADIF character representation.
+/// Convert the `QslStatus` enum to its ADIF character representation.
+#[must_use]
 pub fn qsl_status_to_adif(status: QslStatus) -> Option<&'static str> {
     match status {
         QslStatus::Yes => Some("Y"),
@@ -27,12 +29,13 @@ pub fn qsl_status_to_adif(status: QslStatus) -> Option<&'static str> {
     }
 }
 
-/// Builder for constructing QsoRecord with sensible defaults.
+/// Builder for constructing `QsoRecord` values with sensible defaults.
 pub struct QsoRecordBuilder {
     record: QsoRecord,
 }
 
 impl QsoRecordBuilder {
+    /// Create a builder for a QSO between the local station and the worked station.
     pub fn new(station_callsign: impl Into<String>, worked_callsign: impl Into<String>) -> Self {
         Self {
             record: QsoRecord {
@@ -45,62 +48,84 @@ impl QsoRecordBuilder {
         }
     }
 
+    #[must_use]
+    /// Set the band for the QSO.
     pub fn band(mut self, band: Band) -> Self {
         self.record.band = band.into();
         self
     }
 
+    #[must_use]
+    /// Set the mode for the QSO.
     pub fn mode(mut self, mode: Mode) -> Self {
         self.record.mode = mode.into();
         self
     }
 
+    #[must_use]
+    /// Set the submode for the QSO.
     pub fn submode(mut self, submode: impl Into<String>) -> Self {
         self.record.submode = Some(submode.into());
         self
     }
 
+    #[must_use]
+    /// Set the transmit frequency in kHz.
     pub fn frequency_khz(mut self, khz: u64) -> Self {
         self.record.frequency_khz = Some(khz);
         self
     }
 
+    #[must_use]
+    /// Set the UTC timestamp for the QSO.
     pub fn timestamp(mut self, ts: prost_types::Timestamp) -> Self {
         self.record.utc_timestamp = Some(ts);
         self
     }
 
+    #[must_use]
+    /// Set the contest identifier for the QSO.
     pub fn contest(mut self, contest_id: impl Into<String>) -> Self {
         self.record.contest_id = Some(contest_id.into());
         self
     }
 
+    #[must_use]
+    /// Set the operator comment for the QSO.
     pub fn comment(mut self, comment: impl Into<String>) -> Self {
         self.record.comment = Some(comment.into());
         self
     }
 
+    #[must_use]
+    /// Set operator notes for the QSO.
     pub fn notes(mut self, notes: impl Into<String>) -> Self {
         self.record.notes = Some(notes.into());
         self
     }
 
+    #[must_use]
+    /// Add an extra ADIF field for round-trip preservation.
     pub fn extra_field(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
         self.record.extra_fields.insert(key.into(), value.into());
         self
     }
 
+    #[must_use]
+    /// Finalize and return the built `QsoRecord`.
     pub fn build(self) -> QsoRecord {
         self.record
     }
 }
 
 /// Generate a QSO local ID using the documented UUID format.
+#[must_use]
 pub fn new_local_id() -> String {
     Uuid::new_v4().to_string()
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 
@@ -163,11 +188,11 @@ mod tests {
             .build();
 
         assert_eq!(
-            record.extra_fields.get("MY_RIG").map(|s| s.as_str()),
+            record.extra_fields.get("MY_RIG").map(String::as_str),
             Some("Icom IC-7300")
         );
         assert_eq!(
-            record.extra_fields.get("ANT_AZ").map(|s| s.as_str()),
+            record.extra_fields.get("ANT_AZ").map(String::as_str),
             Some("270")
         );
         assert_eq!(record.extra_fields.len(), 2);
@@ -231,7 +256,7 @@ mod tests {
         assert_eq!(decoded.frequency_khz, Some(7_030));
         assert_eq!(decoded.comment.as_deref(), Some("CW contest"));
         assert_eq!(
-            decoded.extra_fields.get("CHECK").map(|s| s.as_str()),
+            decoded.extra_fields.get("CHECK").map(String::as_str),
             Some("73")
         );
     }

--- a/src/rust/logripper-core/src/ffi/dsp.rs
+++ b/src/rust/logripper-core/src/ffi/dsp.rs
@@ -1,17 +1,25 @@
+#![allow(unsafe_code)]
+
 extern "C" {
     fn lr_dsp_version() -> i32;
     fn lr_dsp_hz_to_khz(freq_hz: u64) -> u64;
     fn lr_dsp_moving_average(samples: *const f64, count: usize) -> f64;
 }
 
+/// Return the version number exposed by the DSP library.
+#[must_use]
 pub fn dsp_version() -> i32 {
     unsafe { lr_dsp_version() }
 }
 
+/// Convert a frequency in Hz to kHz using the DSP helper implementation.
+#[must_use]
 pub fn hz_to_khz(freq_hz: u64) -> u64 {
     unsafe { lr_dsp_hz_to_khz(freq_hz) }
 }
 
+/// Compute the arithmetic mean for the provided sample slice.
+#[must_use]
 pub fn moving_average(samples: &[f64]) -> f64 {
     unsafe { lr_dsp_moving_average(samples.as_ptr(), samples.len()) }
 }

--- a/src/rust/logripper-core/src/ffi/mod.rs
+++ b/src/rust/logripper-core/src/ffi/mod.rs
@@ -1,3 +1,5 @@
+//! FFI boundary for the `LogRipper` DSP helpers.
+
 mod dsp;
 
 pub use dsp::{dsp_version, hz_to_khz, moving_average};

--- a/src/rust/logripper-core/src/lib.rs
+++ b/src/rust/logripper-core/src/lib.rs
@@ -1,4 +1,11 @@
+//! Core Rust engine modules for `LogRipper`.
+#![deny(unsafe_code)]
+
+/// ADIF import/export adapters.
 pub mod adif;
+/// Domain helpers for QSO and lookup-related types.
 pub mod domain;
+/// FFI boundary for DSP helpers.
 pub mod ffi;
+/// Generated protobuf and gRPC bindings.
 pub mod proto;

--- a/src/rust/logripper-core/src/proto/mod.rs
+++ b/src/rust/logripper-core/src/proto/mod.rs
@@ -1,9 +1,17 @@
 //! Re-export generated protobuf types.
 
 pub mod logripper {
+    //! Generated `logripper` protobuf packages.
+
+    /// Generated domain messages and enums.
+    // Generated prost/tonic code is not edited by hand; keep lint signal focused on project code.
+    #[allow(missing_docs, clippy::all, clippy::pedantic)]
     pub mod domain {
         tonic::include_proto!("logripper.domain");
     }
+    /// Generated gRPC service clients and servers.
+    // Generated prost/tonic code is not edited by hand; keep lint signal focused on project code.
+    #[allow(missing_docs, clippy::all, clippy::pedantic)]
     pub mod services {
         tonic::include_proto!("logripper.services");
     }

--- a/src/rust/logripper-core/tests/adif_integration.rs
+++ b/src/rust/logripper-core/tests/adif_integration.rs
@@ -1,4 +1,6 @@
-//! Integration tests: parse real ADI files using `difa` and map to QsoRecord.
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
+
+//! Integration tests: parse real ADI files using `difa` and map to `QsoRecord`.
 
 use difa::RecordStream;
 use futures::StreamExt;
@@ -132,34 +134,34 @@ async fn parse_extra_fields_preserved() {
 
     // MY_ fields and other extras go to extra_fields map
     assert_eq!(
-        q.extra_fields.get("MY_RIG").map(|s| s.as_str()),
+        q.extra_fields.get("MY_RIG").map(String::as_str),
         Some("Icom IC-7300")
     );
     assert_eq!(
-        q.extra_fields.get("MY_ANTENNA").map(|s| s.as_str()),
+        q.extra_fields.get("MY_ANTENNA").map(String::as_str),
         Some("Yagi 3-element")
     );
     assert_eq!(
-        q.extra_fields.get("MY_CITY").map(|s| s.as_str()),
+        q.extra_fields.get("MY_CITY").map(String::as_str),
         Some("Seattle")
     );
     assert_eq!(
-        q.extra_fields.get("MY_STATE").map(|s| s.as_str()),
+        q.extra_fields.get("MY_STATE").map(String::as_str),
         Some("WA")
     );
     assert_eq!(
-        q.extra_fields.get("MY_GRIDSQUARE").map(|s| s.as_str()),
+        q.extra_fields.get("MY_GRIDSQUARE").map(String::as_str),
         Some("CN87up")
     );
     assert_eq!(
-        q.extra_fields.get("ANT_AZ").map(|s| s.as_str()),
+        q.extra_fields.get("ANT_AZ").map(String::as_str),
         Some("045")
     );
-    assert_eq!(q.extra_fields.get("ANT_EL").map(|s| s.as_str()), Some("15"));
+    assert_eq!(q.extra_fields.get("ANT_EL").map(String::as_str), Some("15"));
     assert_eq!(
         q.extra_fields
             .get("APP_LOGRIPPER_SYNC_STATUS")
-            .map(|s| s.as_str()),
+            .map(String::as_str),
         Some("synced")
     );
 }
@@ -213,17 +215,17 @@ async fn round_trip_extra_fields_preserved() {
 
     // Extra fields should survive
     assert_eq!(
-        round_tripped.extra_fields.get("MY_RIG").map(|s| s.as_str()),
-        original.extra_fields.get("MY_RIG").map(|s| s.as_str()),
+        round_tripped.extra_fields.get("MY_RIG").map(String::as_str),
+        original.extra_fields.get("MY_RIG").map(String::as_str),
     );
     assert_eq!(
         round_tripped
             .extra_fields
             .get("APP_LOGRIPPER_SYNC_STATUS")
-            .map(|s| s.as_str()),
+            .map(String::as_str),
         original
             .extra_fields
             .get("APP_LOGRIPPER_SYNC_STATUS")
-            .map(|s| s.as_str()),
+            .map(String::as_str),
     );
 }

--- a/src/rust/logripper-core/tests/adif_integration.rs
+++ b/src/rust/logripper-core/tests/adif_integration.rs
@@ -6,7 +6,9 @@ use logripper_core::adif::AdifMapper;
 use logripper_core::proto::logripper::domain::{Band, Mode, QslStatus};
 
 /// Helper: parse an ADI byte slice and return all QSO records (skip header).
-async fn parse_adi_to_qsos(data: &[u8]) -> Vec<logripper_core::proto::logripper::domain::QsoRecord> {
+async fn parse_adi_to_qsos(
+    data: &[u8],
+) -> Vec<logripper_core::proto::logripper::domain::QsoRecord> {
     let mut stream = RecordStream::new(data, true);
     let mut qsos = Vec::new();
 
@@ -129,15 +131,35 @@ async fn parse_extra_fields_preserved() {
     assert_eq!(q.sat_mode.as_deref(), Some("V"));
 
     // MY_ fields and other extras go to extra_fields map
-    assert_eq!(q.extra_fields.get("MY_RIG").map(|s| s.as_str()), Some("Icom IC-7300"));
-    assert_eq!(q.extra_fields.get("MY_ANTENNA").map(|s| s.as_str()), Some("Yagi 3-element"));
-    assert_eq!(q.extra_fields.get("MY_CITY").map(|s| s.as_str()), Some("Seattle"));
-    assert_eq!(q.extra_fields.get("MY_STATE").map(|s| s.as_str()), Some("WA"));
-    assert_eq!(q.extra_fields.get("MY_GRIDSQUARE").map(|s| s.as_str()), Some("CN87up"));
-    assert_eq!(q.extra_fields.get("ANT_AZ").map(|s| s.as_str()), Some("045"));
+    assert_eq!(
+        q.extra_fields.get("MY_RIG").map(|s| s.as_str()),
+        Some("Icom IC-7300")
+    );
+    assert_eq!(
+        q.extra_fields.get("MY_ANTENNA").map(|s| s.as_str()),
+        Some("Yagi 3-element")
+    );
+    assert_eq!(
+        q.extra_fields.get("MY_CITY").map(|s| s.as_str()),
+        Some("Seattle")
+    );
+    assert_eq!(
+        q.extra_fields.get("MY_STATE").map(|s| s.as_str()),
+        Some("WA")
+    );
+    assert_eq!(
+        q.extra_fields.get("MY_GRIDSQUARE").map(|s| s.as_str()),
+        Some("CN87up")
+    );
+    assert_eq!(
+        q.extra_fields.get("ANT_AZ").map(|s| s.as_str()),
+        Some("045")
+    );
     assert_eq!(q.extra_fields.get("ANT_EL").map(|s| s.as_str()), Some("15"));
     assert_eq!(
-        q.extra_fields.get("APP_LOGRIPPER_SYNC_STATUS").map(|s| s.as_str()),
+        q.extra_fields
+            .get("APP_LOGRIPPER_SYNC_STATUS")
+            .map(|s| s.as_str()),
         Some("synced")
     );
 }
@@ -165,10 +187,14 @@ async fn round_trip_qso_through_adif() {
     assert_eq!(round_tripped.band, original.band);
     assert_eq!(round_tripped.mode, original.mode);
     assert_eq!(round_tripped.frequency_khz, original.frequency_khz);
-    assert_eq!(round_tripped.rst_sent.as_ref().map(|r| r.raw.as_str()),
-               original.rst_sent.as_ref().map(|r| r.raw.as_str()));
-    assert_eq!(round_tripped.rst_received.as_ref().map(|r| r.raw.as_str()),
-               original.rst_received.as_ref().map(|r| r.raw.as_str()));
+    assert_eq!(
+        round_tripped.rst_sent.as_ref().map(|r| r.raw.as_str()),
+        original.rst_sent.as_ref().map(|r| r.raw.as_str())
+    );
+    assert_eq!(
+        round_tripped.rst_received.as_ref().map(|r| r.raw.as_str()),
+        original.rst_received.as_ref().map(|r| r.raw.as_str())
+    );
     assert_eq!(round_tripped.comment, original.comment);
 }
 
@@ -191,7 +217,13 @@ async fn round_trip_extra_fields_preserved() {
         original.extra_fields.get("MY_RIG").map(|s| s.as_str()),
     );
     assert_eq!(
-        round_tripped.extra_fields.get("APP_LOGRIPPER_SYNC_STATUS").map(|s| s.as_str()),
-        original.extra_fields.get("APP_LOGRIPPER_SYNC_STATUS").map(|s| s.as_str()),
+        round_tripped
+            .extra_fields
+            .get("APP_LOGRIPPER_SYNC_STATUS")
+            .map(|s| s.as_str()),
+        original
+            .extra_fields
+            .get("APP_LOGRIPPER_SYNC_STATUS")
+            .map(|s| s.as_str()),
     );
 }

--- a/src/rust/logripper-server/Cargo.toml
+++ b/src/rust/logripper-server/Cargo.toml
@@ -12,3 +12,6 @@ tokio = { workspace = true }
 tonic = { workspace = true }
 tokio-stream = "0.1"
 
+[lints]
+workspace = true
+

--- a/src/rust/logripper-server/Cargo.toml
+++ b/src/rust/logripper-server/Cargo.toml
@@ -3,15 +3,15 @@ name = "logripper-server"
 description = "Runnable gRPC server host for the LogRipper engine"
 version.workspace = true
 edition.workspace = true
+rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 
 [dependencies]
-logripper-core = { path = "../logripper-core" }
+logripper-core = { path = "../logripper-core", version = "0.1.0" }
 tokio = { workspace = true }
 tonic = { workspace = true }
 tokio-stream = "0.1"
 
 [lints]
 workspace = true
-

--- a/src/rust/logripper-server/src/main.rs
+++ b/src/rust/logripper-server/src/main.rs
@@ -1,3 +1,5 @@
+//! Runnable tonic gRPC host for the `LogRipper` Rust engine.
+
 use std::net::SocketAddr;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Server;
@@ -122,7 +124,7 @@ impl LookupService for DeveloperLookupService {
         request: Request<LookupRequest>,
     ) -> Result<Response<LookupResult>, Status> {
         let request = request.into_inner();
-        Ok(Response::new(placeholder_lookup_error(request.callsign)))
+        Ok(Response::new(placeholder_lookup_error(&request.callsign)))
     }
 
     async fn stream_lookup(
@@ -145,7 +147,7 @@ impl LookupService for DeveloperLookupService {
             .await;
 
         let _ = sender
-            .send(Ok(placeholder_lookup_error(queried_callsign)))
+            .send(Ok(placeholder_lookup_error(&queried_callsign)))
             .await;
 
         Ok(Response::new(ReceiverStream::new(receiver)))
@@ -184,18 +186,18 @@ impl LookupService for DeveloperLookupService {
             results: request
                 .callsigns
                 .into_iter()
-                .map(placeholder_lookup_error)
+                .map(|callsign| placeholder_lookup_error(&callsign))
                 .collect(),
         }))
     }
 }
 
-fn placeholder_lookup_error(callsign: String) -> LookupResult {
+fn placeholder_lookup_error(callsign: &str) -> LookupResult {
     LookupResult {
         state: LookupState::Error as i32,
         record: Some(CallsignRecord {
-            callsign: normalize_callsign(&callsign),
-            cross_ref: normalize_callsign(&callsign),
+            callsign: normalize_callsign(callsign),
+            cross_ref: normalize_callsign(callsign),
             aliases: Vec::new(),
             previous_call: String::new(),
             dxcc_entity_id: 0,
@@ -249,7 +251,7 @@ fn placeholder_lookup_error(callsign: String) -> LookupResult {
         ),
         cache_hit: false,
         lookup_latency_ms: 0,
-        queried_callsign: normalize_callsign(&callsign),
+        queried_callsign: normalize_callsign(callsign),
     }
 }
 
@@ -303,6 +305,7 @@ fn print_help() {
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used)]
 mod tests {
     use super::ServerOptions;
 

--- a/src/rust/rustfmt.toml
+++ b/src/rust/rustfmt.toml
@@ -1,0 +1,4 @@
+edition = "2021"
+max_width = 100
+use_field_init_shorthand = true
+use_try_shorthand = true


### PR DESCRIPTION
## Summary
- pin the Rust toolchain, declare workspace MSRV metadata, and add a dedicated Rust quality workflow
- fix the remaining Rust warning backlog and ADIF timestamp edge cases so `cargo clippy -- -D warnings` and Rust tests pass cleanly
- validate `cargo deny` with the current config and keep `cargo-audit` as a manual/occasional review instead of a per-PR CI gate
- keep Rust Copilot setup, instructions, skills, and agent guidance aligned with the enforced workspace validation loop

## Notes
- the automated Rust quality gate is now fmt + clippy `-D warnings` + test + cargo-deny
- `cargo-audit` is still documented for manual vulnerability review, but it is no longer installed or run on every CI/Copilot setup pass
- the `cargo-deny` invocation was corrected to run from `src/rust` with `deny.toml`, matching the current tool behavior

## Issues
Closes #20