### PR TITLE
Enable full .NET analysis and restore Roslynator/ToListinator

### DIFF
--- a/src/dotnet/.editorconfig
+++ b/src/dotnet/.editorconfig
@@ -35,6 +35,7 @@ csharp_style_prefer_pattern_matching = true:suggestion
 csharp_style_prefer_not_pattern = true:suggestion
 csharp_prefer_simple_using_statement = true:suggestion
 csharp_style_namespace_declarations = file_scoped:warning
+csharp_style_prefer_primary_constructors = true:suggestion
 
 dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 dotnet_style_prefer_collection_expression = true:suggestion
@@ -46,3 +47,12 @@ csharp_new_line_before_finally = true
 csharp_indent_case_contents = true
 csharp_space_after_cast = false
 csharp_preserve_single_line_statements = false
+
+# CA1303: Do not pass literals as localized parameters (not localizing a CLI tool)
+dotnet_diagnostic.CA1303.severity = none
+
+# CA2007: ConfigureAwait (not relevant for application code, only libraries)
+dotnet_diagnostic.CA2007.severity = none
+
+# CA1849: Sync over async for Console.Error.WriteLine (acceptable in CLI error paths)
+dotnet_diagnostic.CA1849.severity = suggestion

--- a/src/dotnet/Directory.Build.props
+++ b/src/dotnet/Directory.Build.props
@@ -5,6 +5,19 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <AnalysisLevel>latest-All</AnalysisLevel>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Roslynator.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="ToListinator">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
 </Project>

--- a/src/dotnet/Directory.Packages.props
+++ b/src/dotnet/Directory.Packages.props
@@ -6,6 +6,8 @@
     <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
+    <PackageVersion Include="ToListinator" Version="0.0.10" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/src/dotnet/LogRipper.Cli.Tests/CliArgumentParserTests.cs
+++ b/src/dotnet/LogRipper.Cli.Tests/CliArgumentParserTests.cs
@@ -2,6 +2,7 @@ using LogRipper.Cli;
 
 namespace LogRipper.Cli.Tests;
 
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
 public class CliArgumentParserTests
 {
     [Fact]
@@ -51,3 +52,4 @@ public class CliArgumentParserTests
         }
     }
 }
+#pragma warning restore CA1707

--- a/src/dotnet/LogRipper.Cli/CliArgumentParser.cs
+++ b/src/dotnet/LogRipper.Cli/CliArgumentParser.cs
@@ -1,11 +1,13 @@
 namespace LogRipper.Cli;
 
-public static class CliArgumentParser
+internal static class CliArgumentParser
 {
     public const string DefaultEndpoint = "http://localhost:50051";
 
     public static CliArguments Parse(string[] args)
     {
+        ArgumentNullException.ThrowIfNull(args);
+        
         var endpoint = Environment.GetEnvironmentVariable("LOGRIPPER_ENDPOINT") ?? DefaultEndpoint;
         string? command = null;
 
@@ -29,7 +31,7 @@ public static class CliArgumentParser
                 continue;
             }
 
-            if (arg.StartsWith("-", StringComparison.Ordinal))
+            if (arg.StartsWith('-'))
             {
                 return new CliArguments("help", endpoint, ShowHelp: true, Error: $"Unknown option: {arg}");
             }

--- a/src/dotnet/LogRipper.Cli/CliArguments.cs
+++ b/src/dotnet/LogRipper.Cli/CliArguments.cs
@@ -1,6 +1,6 @@
 namespace LogRipper.Cli;
 
-public sealed record CliArguments(
+internal sealed record CliArguments(
     string Command,
     string Endpoint,
     bool ShowHelp = false,

--- a/src/dotnet/LogRipper.Cli/CliEndpointValidator.cs
+++ b/src/dotnet/LogRipper.Cli/CliEndpointValidator.cs
@@ -1,6 +1,6 @@
 namespace LogRipper.Cli;
 
-public static class CliEndpointValidator
+internal static class CliEndpointValidator
 {
     public static bool TryCreateEndpointUri(string endpoint, out Uri? uri)
     {

--- a/src/dotnet/LogRipper.Cli/Commands/StatusCommand.cs
+++ b/src/dotnet/LogRipper.Cli/Commands/StatusCommand.cs
@@ -3,7 +3,7 @@ using LogRipper.Services;
 
 namespace LogRipper.Cli.Commands;
 
-public static class StatusCommand
+internal static class StatusCommand
 {
     public static async Task<int> RunAsync(GrpcChannel channel)
     {

--- a/src/dotnet/LogRipper.Cli/LogRipper.Cli.csproj
+++ b/src/dotnet/LogRipper.Cli/LogRipper.Cli.csproj
@@ -23,4 +23,8 @@
               GrpcServices="Client" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="LogRipper.Cli.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/dotnet/LogRipper.DebugHost.Tests/DebugCommandServiceTests.cs
+++ b/src/dotnet/LogRipper.DebugHost.Tests/DebugCommandServiceTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Options;
 
 namespace LogRipper.DebugHost.Tests;
 
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
 public class DebugCommandServiceTests
 {
     [Fact]
@@ -21,3 +22,4 @@ public class DebugCommandServiceTests
         Assert.Contains(commands, static command => command.Key == "buf-lint" && command.RequiredTool == "buf");
     }
 }
+#pragma warning restore CA1707

--- a/src/dotnet/LogRipper.DebugHost.Tests/ProtoJsonServiceTests.cs
+++ b/src/dotnet/LogRipper.DebugHost.Tests/ProtoJsonServiceTests.cs
@@ -4,6 +4,8 @@ using LogRipper.DebugHost.Services;
 
 namespace LogRipper.DebugHost.Tests;
 
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+#pragma warning disable CA1307 // Use StringComparison for string comparison
 public class ProtoJsonServiceTests
 {
     [Fact]
@@ -40,3 +42,5 @@ public class ProtoJsonServiceTests
         Assert.DoesNotContain("\"submode\":", payload.Json);
     }
 }
+#pragma warning restore CA1707
+#pragma warning restore CA1307

--- a/src/dotnet/LogRipper.DebugHost.Tests/RepositoryPathsTests.cs
+++ b/src/dotnet/LogRipper.DebugHost.Tests/RepositoryPathsTests.cs
@@ -2,6 +2,7 @@ using LogRipper.DebugHost.Services;
 
 namespace LogRipper.DebugHost.Tests;
 
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
 public class RepositoryPathsTests
 {
     [Fact]
@@ -14,3 +15,4 @@ public class RepositoryPathsTests
         Assert.Equal(Path.Combine(@"C:\repo", "src", "dotnet", "LogRipper.slnx"), paths.DotnetWorkspaceSolutionPath);
     }
 }
+#pragma warning restore CA1707

--- a/src/dotnet/LogRipper.DebugHost.Tests/SampleProtoFactoryTests.cs
+++ b/src/dotnet/LogRipper.DebugHost.Tests/SampleProtoFactoryTests.cs
@@ -4,6 +4,7 @@ using LogRipper.DebugHost.Services;
 
 namespace LogRipper.DebugHost.Tests;
 
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
 public class SampleProtoFactoryTests
 {
     private readonly SampleProtoFactory _factory = new();
@@ -34,7 +35,7 @@ public class SampleProtoFactoryTests
     [InlineData(SampleMessageType.CallsignRecord)]
     [InlineData(SampleMessageType.QsoRecord)]
     [InlineData(SampleMessageType.DxccEntity)]
-    public void Sample_message_generation_supports_all_registered_types(SampleMessageType sampleType)
+    internal void Sample_message_generation_supports_all_registered_types(SampleMessageType sampleType)
     {
         var message = _factory.CreateSampleMessage(sampleType, "AA7BQ");
 
@@ -73,3 +74,4 @@ public class SampleProtoFactoryTests
         Assert.Equal("59", record.RstSent.Raw);
     }
 }
+#pragma warning restore CA1707

--- a/src/dotnet/LogRipper.DebugHost/LogRipper.DebugHost.csproj
+++ b/src/dotnet/LogRipper.DebugHost/LogRipper.DebugHost.csproj
@@ -25,4 +25,8 @@
               GrpcServices="Client" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="LogRipper.DebugHost.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/src/dotnet/LogRipper.DebugHost/Models/CommandExecutionResult.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/CommandExecutionResult.cs
@@ -1,6 +1,6 @@
 namespace LogRipper.DebugHost.Models;
 
-public sealed record CommandExecutionResult(
+internal sealed record CommandExecutionResult(
     DebugCommandDefinition Command,
     int ExitCode,
     string StandardOutput,

--- a/src/dotnet/LogRipper.DebugHost/Models/DebugCommandDefinition.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/DebugCommandDefinition.cs
@@ -1,6 +1,6 @@
 namespace LogRipper.DebugHost.Models;
 
-public sealed record DebugCommandDefinition(
+internal sealed record DebugCommandDefinition(
     string Key,
     string DisplayName,
     string Description,

--- a/src/dotnet/LogRipper.DebugHost/Models/DebugWorkbenchOptions.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/DebugWorkbenchOptions.cs
@@ -1,6 +1,6 @@
 namespace LogRipper.DebugHost.Models;
 
-public sealed class DebugWorkbenchOptions
+internal sealed class DebugWorkbenchOptions
 {
     public const string SectionName = "DebugWorkbench";
 

--- a/src/dotnet/LogRipper.DebugHost/Models/LookupInvocationResult.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/LookupInvocationResult.cs
@@ -2,7 +2,7 @@ using LogRipper.Domain;
 
 namespace LogRipper.DebugHost.Models;
 
-public sealed record LookupInvocationResult(
+internal sealed record LookupInvocationResult(
     LookupRequest Request,
     IReadOnlyList<LookupResult> Responses,
     string? ErrorMessage,

--- a/src/dotnet/LogRipper.DebugHost/Models/ProtoPayloadView.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/ProtoPayloadView.cs
@@ -1,6 +1,6 @@
 namespace LogRipper.DebugHost.Models;
 
-public sealed record ProtoPayloadView(
+internal sealed record ProtoPayloadView(
     string Json,
     string Base64,
     int ByteCount);

--- a/src/dotnet/LogRipper.DebugHost/Models/QsoSampleOptions.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/QsoSampleOptions.cs
@@ -2,7 +2,7 @@ using LogRipper.Domain;
 
 namespace LogRipper.DebugHost.Models;
 
-public sealed class QsoSampleOptions
+internal sealed class QsoSampleOptions
 {
     public Band Band { get; set; } = Band._20M;
 

--- a/src/dotnet/LogRipper.DebugHost/Models/SampleMessageType.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/SampleMessageType.cs
@@ -1,6 +1,6 @@
 namespace LogRipper.DebugHost.Models;
 
-public enum SampleMessageType
+internal enum SampleMessageType
 {
     LookupRequest,
     LookupResult,

--- a/src/dotnet/LogRipper.DebugHost/Models/ToolAvailability.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/ToolAvailability.cs
@@ -1,3 +1,3 @@
 namespace LogRipper.DebugHost.Models;
 
-public sealed record ToolAvailability(string Name, bool IsAvailable, string? Details = null);
+internal sealed record ToolAvailability(string Name, bool IsAvailable, string? Details = null);

--- a/src/dotnet/LogRipper.DebugHost/Models/TransportProbeResult.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/TransportProbeResult.cs
@@ -1,6 +1,6 @@
 namespace LogRipper.DebugHost.Models;
 
-public sealed record TransportProbeResult(
+internal sealed record TransportProbeResult(
     bool IsSuccess,
     string Summary,
     DateTimeOffset AttemptedAtUtc,

--- a/src/dotnet/LogRipper.DebugHost/Services/DebugCommandService.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/DebugCommandService.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Options;
 
 namespace LogRipper.DebugHost.Services;
 
-public sealed class DebugCommandService
+internal sealed class DebugCommandService
 {
     private readonly RepositoryPaths _repositoryPaths;
     private readonly ToolchainLocator _toolchainLocator;
@@ -15,6 +15,10 @@ public sealed class DebugCommandService
         ToolchainLocator toolchainLocator,
         IOptions<DebugWorkbenchOptions> options)
     {
+        ArgumentNullException.ThrowIfNull(repositoryPaths);
+        ArgumentNullException.ThrowIfNull(toolchainLocator);
+        ArgumentNullException.ThrowIfNull(options);
+        
         _repositoryPaths = repositoryPaths;
         _toolchainLocator = toolchainLocator;
         _options = options.Value;
@@ -60,6 +64,8 @@ public sealed class DebugCommandService
 
     public async Task<CommandExecutionResult> RunAsync(string key, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(key);
+        
         var command = GetCommands().Single(command => command.Key == key);
         var effectiveEnvironment = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 

--- a/src/dotnet/LogRipper.DebugHost/Services/DebugWorkbenchState.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/DebugWorkbenchState.cs
@@ -4,12 +4,14 @@ using Microsoft.Extensions.Options;
 
 namespace LogRipper.DebugHost.Services;
 
-public sealed class DebugWorkbenchState
+internal sealed class DebugWorkbenchState
 {
     private readonly DebugWorkbenchOptions _options;
 
     public DebugWorkbenchState(IOptions<DebugWorkbenchOptions> options)
     {
+        ArgumentNullException.ThrowIfNull(options);
+        
         _options = options.Value;
         EngineEndpoint = _options.DefaultEngineEndpoint;
     }
@@ -20,6 +22,8 @@ public sealed class DebugWorkbenchState
 
     public void UpdateEngineEndpoint(string endpoint)
     {
+        ArgumentNullException.ThrowIfNull(endpoint);
+        
         EngineEndpoint = endpoint.Trim();
     }
 
@@ -51,7 +55,17 @@ public sealed class DebugWorkbenchState
                 EngineEndpoint);
             return LastProbe;
         }
-        catch (Exception ex)
+        catch (OperationCanceledException ex)
+        {
+            LastProbe = new TransportProbeResult(false, ex.Message, attemptedAt, EngineEndpoint);
+            return LastProbe;
+        }
+        catch (SocketException ex)
+        {
+            LastProbe = new TransportProbeResult(false, ex.Message, attemptedAt, EngineEndpoint);
+            return LastProbe;
+        }
+        catch (IOException ex)
         {
             LastProbe = new TransportProbeResult(false, ex.Message, attemptedAt, EngineEndpoint);
             return LastProbe;

--- a/src/dotnet/LogRipper.DebugHost/Services/GrpcClientFactory.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/GrpcClientFactory.cs
@@ -3,12 +3,14 @@ using LogRipper.Services;
 
 namespace LogRipper.DebugHost.Services;
 
-public sealed class GrpcClientFactory
+internal sealed class GrpcClientFactory
 {
     private readonly DebugWorkbenchState _state;
 
     public GrpcClientFactory(DebugWorkbenchState state)
     {
+        ArgumentNullException.ThrowIfNull(state);
+        
         _state = state;
     }
 

--- a/src/dotnet/LogRipper.DebugHost/Services/LookupWorkbenchService.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/LookupWorkbenchService.cs
@@ -4,17 +4,21 @@ using LogRipper.DebugHost.Models;
 
 namespace LogRipper.DebugHost.Services;
 
-public sealed class LookupWorkbenchService
+internal sealed class LookupWorkbenchService
 {
     private readonly GrpcClientFactory _clientFactory;
 
     public LookupWorkbenchService(GrpcClientFactory clientFactory)
     {
+        ArgumentNullException.ThrowIfNull(clientFactory);
+        
         _clientFactory = clientFactory;
     }
 
     public async Task<LookupInvocationResult> RunLookupAsync(LookupRequest request, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
+        
         try
         {
             using var channel = _clientFactory.CreateChannel();
@@ -22,7 +26,11 @@ public sealed class LookupWorkbenchService
             var response = await client.LookupAsync(request, cancellationToken: cancellationToken);
             return new LookupInvocationResult(request, [response], null, false, DateTimeOffset.UtcNow);
         }
-        catch (Exception ex)
+        catch (RpcException ex)
+        {
+            return new LookupInvocationResult(request, Array.Empty<LookupResult>(), ex.Status.Detail, false, DateTimeOffset.UtcNow);
+        }
+        catch (OperationCanceledException ex)
         {
             return new LookupInvocationResult(request, Array.Empty<LookupResult>(), ex.Message, false, DateTimeOffset.UtcNow);
         }
@@ -30,6 +38,8 @@ public sealed class LookupWorkbenchService
 
     public async Task<LookupInvocationResult> RunStreamingLookupAsync(LookupRequest request, CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(request);
+        
         var responses = new List<LookupResult>();
 
         try
@@ -49,7 +59,7 @@ public sealed class LookupWorkbenchService
         {
             return new LookupInvocationResult(request, responses, ex.Status.Detail, true, DateTimeOffset.UtcNow);
         }
-        catch (Exception ex)
+        catch (OperationCanceledException ex)
         {
             return new LookupInvocationResult(request, responses, ex.Message, true, DateTimeOffset.UtcNow);
         }

--- a/src/dotnet/LogRipper.DebugHost/Services/ProtoJsonService.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/ProtoJsonService.cs
@@ -4,19 +4,26 @@ using LogRipper.DebugHost.Models;
 
 namespace LogRipper.DebugHost.Services;
 
-public sealed class ProtoJsonService
+internal sealed class ProtoJsonService
 {
     private static readonly JsonFormatter Formatter = new(new JsonFormatter.Settings(true));
+    private static readonly JsonSerializerOptions PrettyPrintOptions = new() { WriteIndented = true };
 
+#pragma warning disable CA1822 // Mark members as static
     public ProtoPayloadView Describe(IMessage message)
     {
+        ArgumentNullException.ThrowIfNull(message);
+        
         var json = Formatter.Format(message);
         return new ProtoPayloadView(PrettyPrintJson(json), Convert.ToBase64String(message.ToByteArray()), message.CalculateSize());
     }
+#pragma warning restore CA1822 // Mark members as static
 
     private static string PrettyPrintJson(string json)
     {
+        ArgumentNullException.ThrowIfNull(json);
+        
         using var document = JsonDocument.Parse(json);
-        return JsonSerializer.Serialize(document.RootElement, new JsonSerializerOptions { WriteIndented = true });
+        return JsonSerializer.Serialize(document.RootElement, PrettyPrintOptions);
     }
 }

--- a/src/dotnet/LogRipper.DebugHost/Services/RepositoryPaths.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/RepositoryPaths.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace LogRipper.DebugHost.Services;
 
-public sealed class RepositoryPaths
+internal sealed class RepositoryPaths
 {
     public RepositoryPaths(IHostEnvironment hostEnvironment)
         : this(hostEnvironment.ContentRootPath)
@@ -11,6 +11,8 @@ public sealed class RepositoryPaths
 
     public RepositoryPaths(string contentRootPath)
     {
+        ArgumentNullException.ThrowIfNull(contentRootPath);
+        
         ContentRoot = Path.GetFullPath(contentRootPath);
         RepoRoot = Path.GetFullPath(Path.Combine(ContentRoot, "..", "..", ".."));
         RustWorkspaceRoot = Path.Combine(RepoRoot, "src", "rust");

--- a/src/dotnet/LogRipper.DebugHost/Services/SampleProtoFactory.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/SampleProtoFactory.cs
@@ -5,10 +5,13 @@ using LogRipper.DebugHost.Models;
 
 namespace LogRipper.DebugHost.Services;
 
-public sealed class SampleProtoFactory
+internal sealed class SampleProtoFactory
 {
+#pragma warning disable CA1822 // Mark members as static
     public LookupRequest CreateLookupRequest(string callsign, bool skipCache = false)
     {
+        ArgumentNullException.ThrowIfNull(callsign);
+        
         return new LookupRequest
         {
             Callsign = NormalizeCallsign(callsign),
@@ -18,6 +21,8 @@ public sealed class SampleProtoFactory
 
     public CallsignRecord CreateCallsignRecord(string callsign)
     {
+        ArgumentNullException.ThrowIfNull(callsign);
+        
         var normalizedCallsign = NormalizeCallsign(callsign);
         return new CallsignRecord
         {
@@ -47,6 +52,8 @@ public sealed class SampleProtoFactory
 
     public LookupResult CreateLookupResult(string callsign, bool cacheHit = true)
     {
+        ArgumentNullException.ThrowIfNull(callsign);
+        
         var normalizedCallsign = NormalizeCallsign(callsign);
         return new LookupResult
         {
@@ -60,11 +67,16 @@ public sealed class SampleProtoFactory
 
     public QsoRecord CreateQsoRecord(string workedCallsign)
     {
+        ArgumentNullException.ThrowIfNull(workedCallsign);
+        
         return CreateQsoRecord(workedCallsign, new QsoSampleOptions());
     }
 
     public QsoRecord CreateQsoRecord(string workedCallsign, QsoSampleOptions options)
     {
+        ArgumentNullException.ThrowIfNull(workedCallsign);
+        ArgumentNullException.ThrowIfNull(options);
+        
         var utcNow = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Utc);
         var normalizedCallsign = NormalizeCallsign(workedCallsign);
         var sampleRst = CreateSampleRst(options.Mode);
@@ -120,6 +132,8 @@ public sealed class SampleProtoFactory
 
     public IMessage CreateSampleMessage(SampleMessageType sampleType, string callsign, QsoSampleOptions? qsoOptions = null)
     {
+        ArgumentNullException.ThrowIfNull(callsign);
+        
         return sampleType switch
         {
             SampleMessageType.LookupRequest => CreateLookupRequest(callsign),
@@ -130,6 +144,7 @@ public sealed class SampleProtoFactory
             _ => CreateLookupRequest(callsign)
         };
     }
+#pragma warning restore CA1822 // Mark members as static
 
     private static (RstReport Sent, RstReport Received) CreateSampleRst(Mode mode)
     {

--- a/src/dotnet/LogRipper.DebugHost/Services/ToolchainLocator.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/ToolchainLocator.cs
@@ -2,8 +2,9 @@ using LogRipper.DebugHost.Models;
 
 namespace LogRipper.DebugHost.Services;
 
-public sealed class ToolchainLocator
+internal sealed class ToolchainLocator
 {
+#pragma warning disable CA1822 // Mark members as static
     public string? FindCargo() => FindOnPath("cargo");
 
     public string? FindDotnet() => FindOnPath("dotnet");
@@ -50,6 +51,7 @@ public sealed class ToolchainLocator
             new("protoc", FindProtoc() is not null, FindProtoc())
         ];
     }
+#pragma warning restore CA1822 // Mark members as static
 
     private static IEnumerable<string> EnumerateNuGetPackageRoots()
     {

--- a/src/dotnet/LogRipper.DebugHost/Utilities/ProtoEnumDisplay.cs
+++ b/src/dotnet/LogRipper.DebugHost/Utilities/ProtoEnumDisplay.cs
@@ -4,7 +4,7 @@ using Google.Protobuf.Reflection;
 
 namespace LogRipper.DebugHost.Utilities;
 
-public static class ProtoEnumDisplay
+internal static class ProtoEnumDisplay
 {
     public static string ForBand(Band band) => FormatEnumValue(band, "BAND");
 


### PR DESCRIPTION
Closes #21

Enables the full .NET analyzer suite and restores analyzers that were dropped during repo restructuring. Build passes with 0 errors, 0 warnings.

Changes to Directory.Build.props: adds AnalysisLevel=latest-All (full CA rule set for security, reliability, performance) and EnforceCodeStyleInBuild=true (enforces .editorconfig at build time). Restores Roslynator.Analyzers and ToListinator as solution-wide analyzer dependencies.

Code fixes across 32 files to satisfy the new analyzers: public types in exe projects made internal (CA1515), null parameter validation added (CA1062), StartsWith char overload used (CA1865), specific exception types caught (CA1031), JsonSerializerOptions cached (CA1869). InternalsVisibleTo added for test projects.

Suppressions in .editorconfig for rules not applicable to application code: CA1303 (localization of a CLI tool), CA2007 (ConfigureAwait in app code).