### PR TITLE
ci: enforce buf lint for proto contracts

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -48,6 +48,9 @@ jobs:
           sudo apt-get install -y protobuf-compiler build-essential pkg-config
           protoc --version
 
+      - name: Install Buf CLI
+        uses: bufbuild/buf-setup-action@v1
+
       - name: Install cargo-deny
         run: |
           cargo install cargo-deny --locked
@@ -60,6 +63,9 @@ jobs:
 
       - name: Run Rust tests
         run: cargo test --manifest-path src/rust/Cargo.toml
+
+      - name: Run buf lint
+        run: buf lint
 
       - name: Run cargo-deny
         working-directory: src/rust

--- a/buf.yaml
+++ b/buf.yaml
@@ -5,7 +5,17 @@ modules:
 lint:
   use:
     - STANDARD
-  enum_zero_value_suffix: _UNSPECIFIED
+  # LogRipper intentionally keeps repo-scoped packages under proto/domain and
+  # proto/services, allows shared domain messages to serve directly as some RPC
+  # request/response shapes, and preserves operational zero-values for enums
+  # where zero is the true default behavior.
+  except:
+    - ENUM_ZERO_VALUE_SUFFIX
+    - PACKAGE_DIRECTORY_MATCH
+    - PACKAGE_VERSION_SUFFIX
+    - RPC_REQUEST_RESPONSE_UNIQUE
+    - RPC_REQUEST_STANDARD_NAME
+    - RPC_RESPONSE_STANDARD_NAME
   rpc_allow_google_protobuf_empty_requests: true
   rpc_allow_google_protobuf_empty_responses: true
 breaking:

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -190,6 +190,8 @@ buf generate
 - **Field numbering**: Group related fields in ranges (identity: 1-9, name: 10-19, address: 20-29, etc.)
 - **Field naming**: snake_case in proto files (auto-converted to PascalCase in C#, snake_case in Rust)
 - **Optional fields**: Use `optional` keyword for fields that may not be present from the provider
-- **Enums**: Use `_UNSPECIFIED = 0` as the default/unknown value
+- **Enums**: Prefer `_UNSPECIFIED = 0` when the schema has a neutral default; operational defaults may intentionally keep a domain-specific zero value
 - **Timestamps**: Use `google.protobuf.Timestamp` for all date/time fields
 - **C# namespace**: Set via `option csharp_namespace = "LogRipper.Domain"` or `"LogRipper.Services"`
+- **Packages**: Keep the current `proto/domain` and `proto/services` layout with `logripper.domain` / `logripper.services` packages until the project deliberately introduces versioned external contracts
+- **RPC message shapes**: Reuse shared domain messages like `LookupResult` and `QsoRecord` directly when they are already the app-facing contract; add method-specific wrapper messages only when they carry distinct semantics


### PR DESCRIPTION
## Summary
- add Buf CLI setup and `buf lint` to the Rust quality workflow
- align Buf's enforced lint policy with LogRipper's current proto contract conventions
- document the enforced protobuf conventions in `docs/architecture/data-model.md`

## Validation
- `buf lint`
- `cargo test --manifest-path src\rust\Cargo.toml`
- `dotnet test src\dotnet\LogRipper.slnx`