### PR TITLE
Wrap GetQso in a response message

### DIFF
--- a/proto/services/logbook_service.proto
+++ b/proto/services/logbook_service.proto
@@ -21,7 +21,7 @@ service LogbookService {
   rpc DeleteQso(DeleteQsoRequest) returns (DeleteQsoResponse);
 
   // Get a single QSO by local ID.
-  rpc GetQso(GetQsoRequest) returns (logripper.domain.QsoRecord);
+  rpc GetQso(GetQsoRequest) returns (GetQsoResponse);
 
   // List QSOs with filtering and pagination.
   rpc ListQsos(ListQsosRequest) returns (stream logripper.domain.QsoRecord);
@@ -83,6 +83,10 @@ message DeleteQsoResponse {
 
 message GetQsoRequest {
   string local_id           = 1;
+}
+
+message GetQsoResponse {
+  logripper.domain.QsoRecord qso = 1;
 }
 
 message ListQsosRequest {

--- a/src/rust/logripper-server/src/main.rs
+++ b/src/rust/logripper-server/src/main.rs
@@ -12,9 +12,9 @@ use logripper_core::proto::logripper::domain::{
 use logripper_core::proto::logripper::services::{
     logbook_service_server::{LogbookService, LogbookServiceServer},
     lookup_service_server::{LookupService, LookupServiceServer},
-    AdifChunk, DeleteQsoRequest, DeleteQsoResponse, ExportRequest, GetQsoRequest,
-    GetQsoResponse, ImportResult, ListQsosRequest, LogQsoRequest, LogQsoResponse, SyncProgress,
-    SyncRequest, SyncStatusRequest, SyncStatusResponse, UpdateQsoRequest, UpdateQsoResponse,
+    AdifChunk, DeleteQsoRequest, DeleteQsoResponse, ExportRequest, GetQsoRequest, GetQsoResponse,
+    ImportResult, ListQsosRequest, LogQsoRequest, LogQsoResponse, SyncProgress, SyncRequest,
+    SyncStatusRequest, SyncStatusResponse, UpdateQsoRequest, UpdateQsoResponse,
 };
 
 #[tokio::main]

--- a/src/rust/logripper-server/src/main.rs
+++ b/src/rust/logripper-server/src/main.rs
@@ -12,9 +12,9 @@ use logripper_core::proto::logripper::domain::{
 use logripper_core::proto::logripper::services::{
     logbook_service_server::{LogbookService, LogbookServiceServer},
     lookup_service_server::{LookupService, LookupServiceServer},
-    AdifChunk, DeleteQsoRequest, DeleteQsoResponse, ExportRequest, GetQsoRequest, ImportResult,
-    ListQsosRequest, LogQsoRequest, LogQsoResponse, SyncProgress, SyncRequest, SyncStatusRequest,
-    SyncStatusResponse, UpdateQsoRequest, UpdateQsoResponse,
+    AdifChunk, DeleteQsoRequest, DeleteQsoResponse, ExportRequest, GetQsoRequest,
+    GetQsoResponse, ImportResult, ListQsosRequest, LogQsoRequest, LogQsoResponse, SyncProgress,
+    SyncRequest, SyncStatusRequest, SyncStatusResponse, UpdateQsoRequest, UpdateQsoResponse,
 };
 
 #[tokio::main]
@@ -66,7 +66,7 @@ impl LogbookService for DeveloperLogbookService {
     async fn get_qso(
         &self,
         _request: Request<GetQsoRequest>,
-    ) -> Result<Response<QsoRecord>, Status> {
+    ) -> Result<Response<GetQsoResponse>, Status> {
         Err(Status::unimplemented("GetQso is not implemented yet."))
     }
 


### PR DESCRIPTION
## Summary
- change `LogbookService.GetQso` to return `GetQsoResponse` instead of a bare `QsoRecord`
- add `GetQsoResponse { QsoRecord qso = 1; }` so the RPC can grow response metadata later without another signature change
- update the Rust server stub to match the new generated service signature

## Testing
- `buf lint`
- `cargo test --manifest-path src\rust\Cargo.toml`
- `dotnet build src\dotnet\LogRipper.slnx`

## Notes
- `buf breaking --against '.git#branch=main'` reports this as a schema break, which is expected because the RPC response type changes.
- `GetQso` is currently unimplemented in the Rust server and unused by the checked-in .NET clients, so this is the lowest-risk point to make the contract correction.

Fixes #15