### PR TITLE
Type normalize CallsignRecord date and offset fields

### DIFF
--- a/proto/domain/callsign.proto
+++ b/proto/domain/callsign.proto
@@ -54,8 +54,8 @@ message CallsignRecord {
 
   // --- License ---
   optional string license_class    = 40;
-  optional string effective_date   = 41;
-  optional string expiration_date  = 42;
+  optional google.protobuf.Timestamp effective_date   = 41;  // Provider-normalized license date
+  optional google.protobuf.Timestamp expiration_date  = 42;  // Provider-normalized license date
   optional string license_codes    = 43;
 
   // --- Contact ---
@@ -78,7 +78,7 @@ message CallsignRecord {
   optional string dxcc_continent    = 81;  // 2-letter: NA, SA, EU, AF, AS, OC
 
   // --- Metadata ---
-  optional string born           = 90;  // Year of birth
+  optional uint32 birth_year     = 90;   // Operator's year of birth
   optional uint64 qrz_serial    = 91;
   optional google.protobuf.Timestamp last_modified = 92;
   optional uint32 bio_length     = 93;
@@ -86,7 +86,7 @@ message CallsignRecord {
   optional string msa            = 95;   // Metro Service Area
   optional string area_code      = 96;
   optional string time_zone      = 97;
-  optional string gmt_offset     = 98;
+  optional double gmt_offset     = 98;   // Hours offset from GMT, may be fractional
   optional bool   dst_observed   = 99;
   optional uint32 profile_views  = 100;
 }

--- a/src/rust/logripper-server/src/main.rs
+++ b/src/rust/logripper-server/src/main.rs
@@ -233,7 +233,7 @@ fn placeholder_lookup_error(callsign: &str) -> LookupResult {
             iota: None,
             dxcc_country_name: None,
             dxcc_continent: None,
-            born: None,
+            birth_year: None,
             qrz_serial: None,
             last_modified: None,
             bio_length: None,


### PR DESCRIPTION
## Summary
- change `CallsignRecord.effective_date` and `expiration_date` from strings to `google.protobuf.Timestamp`
- rename `born` to `birth_year` and type it as `uint32`
- change `gmt_offset` from string to `double`
- update the Rust placeholder `CallsignRecord` construction to match the new generated fields

## Testing
- `buf lint`
- `cargo test --manifest-path src\rust\Cargo.toml`
- `dotnet build src\dotnet\LogRipper.slnx`

## Notes
- `buf breaking --against '.git#branch=main'` reports the expected field-type/name breaks on `CallsignRecord`.
- There is no checked-in QRZ provider implementation yet, and the only handwritten usage of these fields was the Rust placeholder record, so this is the lowest-risk point to normalize the shared contract.

Fixes #18