### PR TITLE
Add code coverage config to exclude generated code

### DIFF
--- a/.github/workflows/dotnet-quality.yml
+++ b/.github/workflows/dotnet-quality.yml
@@ -35,7 +35,7 @@ jobs:
         run: dotnet build src/dotnet/LogRipper.slnx
 
       - name: Run tests with coverage
-        run: dotnet test src/dotnet/LogRipper.slnx --no-build --collect:"XPlat Code Coverage" --results-directory coverage
+        run: dotnet test src/dotnet/LogRipper.slnx --no-build --collect:"XPlat Code Coverage" --settings src/dotnet/CodeCoverage.runsettings --results-directory coverage
 
       - name: Install ReportGenerator
         run: dotnet tool install -g dotnet-reportgenerator-globaltool
@@ -58,7 +58,7 @@ jobs:
               print("ERROR: Could not parse line coverage from summary.")
               sys.exit(1)
           cov = float(m.group(1))
-          threshold = 8.0
+          threshold = 50.0
           print(f"Line coverage: {cov:.1f}%  (threshold: {threshold:.0f}%)")
           if cov < threshold:
               print(f"FAIL: coverage {cov:.1f}% is below the minimum threshold of {threshold:.0f}%")

--- a/src/dotnet/CodeCoverage.runsettings
+++ b/src/dotnet/CodeCoverage.runsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <Exclude>[*]LogRipper.Domain.*,[*]LogRipper.Services.*,[*]LogRipper.DebugHost.Components.*,[*]Program</Exclude>
+          <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
Adds CodeCoverage.runsettings that excludes protobuf/gRPC generated types, Blazor components, entry points, and compiler-generated code from coverage measurement.

Coverage numbers before (with generated noise): CLI 0.5%, DebugHost 18.6%.
Coverage numbers after (hand-written code only): CLI 88.9%, DebugHost 57.6%.

Updates the CI workflow to use the runsettings and raises the coverage threshold from 8% to 50%.