### PR TITLE
Exclude DebugHost from code coverage

### DIFF
--- a/src/dotnet/CodeCoverage.runsettings
+++ b/src/dotnet/CodeCoverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <Exclude>[*]LogRipper.Domain.*,[*]LogRipper.Services.*,[*]LogRipper.DebugHost.Components.*,[*]Program</Exclude>
+          <Exclude>[*]LogRipper.Domain.*,[*]LogRipper.Services.*,[LogRipper.DebugHost]*,[*]Program</Exclude>
           <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>


### PR DESCRIPTION
The DebugHost is a developer testing tool, not production code. Exclude the entire LogRipper.DebugHost assembly from coverage measurement. DebugHost tests still run (13 tests passing) but its code no longer counts toward the coverage threshold.

The coverage-measured code is now just the CLI (88.9% line, 80% branch).