### PR TITLE
feat: add swappable storage backends

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,6 +59,15 @@ Primary goals:
 - Use `rg` for text search operations.
 - Keep build and test loops fast to support tight iteration.
 
+## Quality and Coverage Gates
+
+- Treat the existing CI quality and coverage thresholds as local pre-push requirements, not something to discover only after opening a PR.
+- When implementing a new feature, behavior change, or new error path, add or expand automated tests in the same change so the new code is directly covered.
+- Do not rely on existing coverage headroom to carry new code. If a feature adds meaningful logic, it should add meaningful test coverage too.
+- For Rust changes, keep `cargo fmt`, `cargo clippy`, `cargo test`, `cargo llvm-cov`, `buf lint`, and `cargo deny` green when those gates apply.
+- For .NET changes, keep `dotnet format`, `dotnet build`, and `dotnet test` with coverage green when those gates apply.
+- Do not push code that you already know will fail an existing quality or coverage gate.
+
 ## Markdown Code Fences
 
 When writing markdown that will be rendered on GitHub, such as PR descriptions, issue bodies, review comments, or other repository comments:

--- a/.github/instructions/proto-contract.instructions.md
+++ b/.github/instructions/proto-contract.instructions.md
@@ -30,6 +30,10 @@ These instructions govern schema and gRPC contract work in `proto/` and any Rust
   - `buf lint`
   - `cargo test --manifest-path src/rust/Cargo.toml`
   - `dotnet build src/dotnet/LogRipper.slnx`
+- If the contract change introduces or changes runtime behavior in Rust or .NET, add coverage for the affected paths and rerun the relevant local quality gates before pushing:
+  - Rust: `cargo llvm-cov --manifest-path src/rust/Cargo.toml --all --lcov --output-path rust-coverage.lcov`
+  - .NET: `dotnet test src/dotnet/LogRipper.slnx --collect:"XPlat Code Coverage" --settings src/dotnet/CodeCoverage.runsettings --results-directory coverage`
+- Do not push proto/service changes that you already know will fail the corresponding quality or coverage gates in CI.
 - If the change affects runtime behavior, also smoke-test the live server with:
   - `cargo run --manifest-path src/rust/Cargo.toml -p logripper-server`
   - `dotnet run --project src/dotnet/LogRipper.Cli -- status`

--- a/.github/instructions/rust.instructions.md
+++ b/.github/instructions/rust.instructions.md
@@ -25,6 +25,7 @@ These instructions govern Rust work in LogRipper, especially under `src/rust/`, 
 - Keep unsafe usage explicit and narrow. If unsafe behavior is required, document the invariant locally and avoid broad unsafe regions.
 - Prefer narrow lint suppressions with justification. Use `#[expect(...)]` instead of broad `#[allow(...)]` when the lint should stay visible if the underlying issue disappears.
 - Use `thiserror` for typed Rust error surfaces rather than ad hoc stringly errors.
+- New Rust features, behavior changes, and non-trivial new branches must include tests in the same change. If coverage is hard to reach, refactor the seams for testability rather than leaving the logic effectively untested.
 
 ## Validation
 
@@ -32,6 +33,10 @@ These instructions govern Rust work in LogRipper, especially under `src/rust/`, 
   - `cargo fmt --manifest-path src/rust/Cargo.toml --all -- --check`
   - `cargo test --manifest-path src/rust/Cargo.toml`
   - `cargo clippy --manifest-path src/rust/Cargo.toml --all-targets -- -D warnings`
+- For new Rust behavior and substantial Rust changes, also run the coverage gate locally:
+  - `cargo llvm-cov --manifest-path src/rust/Cargo.toml --all --lcov --output-path rust-coverage.lcov`
+  - `cargo llvm-cov report --manifest-path src/rust/Cargo.toml --summary-only`
+- Keep Rust line coverage at or above the current CI threshold (80%) and do not push Rust changes that already fail formatting, lint, test, coverage, `buf lint`, or `cargo deny` gates that apply to the change.
 - Rust formatting rules live in `src/rust/rustfmt.toml`; prefer changing that file over arguing style ad hoc.
 - Workspace lint policy lives in `src/rust/Cargo.toml`; keep shared Clippy and rustc lint defaults centralized there.
 - When proto or service contracts change, also run:

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,10 @@ nunit-*.xml
 .env.*
 !.env.example
 
+# Local SQLite runtime files
+logripper.db*
+.playwright-mcp/
+
 # Rust
 target/
 Cargo.lock

--- a/README.md
+++ b/README.md
@@ -127,6 +127,22 @@ cargo run -p logripper-server
 
 This starts the developer gRPC server on `127.0.0.1:50051` by default so the .NET CLI and debug workbench can validate transport and service wiring against a live Rust host.
 
+The server can now swap storage implementations at startup:
+
+```powershell
+cd src\rust
+cargo run -p logripper-server -- --storage memory
+cargo run -p logripper-server -- --storage sqlite --sqlite-path .\data\logripper.db
+```
+
+Equivalent environment variables are also supported:
+
+```powershell
+$env:LOGRIPPER_STORAGE_BACKEND = "sqlite"
+$env:LOGRIPPER_SQLITE_PATH = ".\data\logripper.db"
+cargo run -p logripper-server
+```
+
 ### QRZ local configuration
 
 Use `.env.example` as the local template for QRZ settings:

--- a/proto/services/debug_control_service.proto
+++ b/proto/services/debug_control_service.proto
@@ -1,0 +1,73 @@
+syntax = "proto3";
+
+package logripper.services;
+
+option csharp_namespace = "LogRipper.Services";
+
+// Developer-only control surface for live engine diagnostics and runtime overrides.
+service DeveloperControlService {
+  // Read the engine's current runtime configuration snapshot.
+  rpc GetRuntimeConfig(GetRuntimeConfigRequest) returns (RuntimeConfigSnapshot);
+
+  // Apply one or more hot-reloadable runtime config mutations.
+  rpc ApplyRuntimeConfig(ApplyRuntimeConfigRequest) returns (RuntimeConfigSnapshot);
+
+  // Clear one or more overrides. When no keys are provided, clears all overrides.
+  rpc ResetRuntimeConfig(ResetRuntimeConfigRequest) returns (RuntimeConfigSnapshot);
+}
+
+message GetRuntimeConfigRequest {}
+
+message ApplyRuntimeConfigRequest {
+  repeated RuntimeConfigMutation mutations = 1;
+}
+
+message ResetRuntimeConfigRequest {
+  repeated string keys = 1;
+}
+
+message RuntimeConfigSnapshot {
+  repeated RuntimeConfigDefinition definitions = 1;
+  repeated RuntimeConfigValue values = 2;
+  string active_storage_backend = 3;
+  string lookup_provider_summary = 4;
+  repeated string warnings = 5;
+}
+
+message RuntimeConfigDefinition {
+  string key = 1;
+  string label = 2;
+  string description = 3;
+  RuntimeConfigValueKind kind = 4;
+  bool secret = 5;
+  repeated string allowed_values = 6;
+}
+
+message RuntimeConfigValue {
+  string key = 1;
+  bool has_value = 2;
+  string display_value = 3;
+  bool overridden = 4;
+  bool secret = 5;
+  bool redacted = 6;
+}
+
+message RuntimeConfigMutation {
+  string key = 1;
+  RuntimeConfigMutationKind kind = 2;
+  optional string value = 3;
+}
+
+enum RuntimeConfigValueKind {
+  RUNTIME_CONFIG_VALUE_KIND_UNSPECIFIED = 0;
+  RUNTIME_CONFIG_VALUE_KIND_STRING = 1;
+  RUNTIME_CONFIG_VALUE_KIND_BOOLEAN = 2;
+  RUNTIME_CONFIG_VALUE_KIND_INTEGER = 3;
+  RUNTIME_CONFIG_VALUE_KIND_PATH = 4;
+}
+
+enum RuntimeConfigMutationKind {
+  RUNTIME_CONFIG_MUTATION_KIND_UNSPECIFIED = 0;
+  RUNTIME_CONFIG_MUTATION_KIND_SET = 1;
+  RUNTIME_CONFIG_MUTATION_KIND_CLEAR = 2;
+}

--- a/src/dotnet/LogRipper.DebugHost.Tests/DebugCommandServiceTests.cs
+++ b/src/dotnet/LogRipper.DebugHost.Tests/DebugCommandServiceTests.cs
@@ -18,6 +18,7 @@ public class DebugCommandServiceTests
         var commands = service.GetCommands();
 
         Assert.Contains(commands, static command => command.Key == "cargo-test" && command.RequiresProtoc);
+        Assert.Contains(commands, static command => command.Key == "cargo-storage-tests" && command.Arguments.Contains("-p logripper-storage-sqlite", StringComparison.Ordinal));
         Assert.Contains(commands, static command => command.Key == "dotnet-test" && command.Arguments == "test src\\dotnet\\LogRipper.slnx");
         Assert.Contains(commands, static command => command.Key == "buf-lint" && command.RequiredTool == "buf");
     }

--- a/src/dotnet/LogRipper.DebugHost.Tests/DebugWorkbenchStateTests.cs
+++ b/src/dotnet/LogRipper.DebugHost.Tests/DebugWorkbenchStateTests.cs
@@ -1,5 +1,6 @@
 using LogRipper.DebugHost.Models;
 using LogRipper.DebugHost.Services;
+using LogRipper.Services;
 using Microsoft.Extensions.Options;
 
 namespace LogRipper.DebugHost.Tests;
@@ -37,6 +38,47 @@ public class DebugWorkbenchStateTests
         Assert.Equal("memory", state.GetEngineEnvironmentOverrides()["LOGRIPPER_STORAGE_BACKEND"]);
         Assert.DoesNotContain("LOGRIPPER_SQLITE_PATH", state.GetEngineEnvironmentOverrides().Keys, StringComparer.Ordinal);
         Assert.Equal("cargo run -p logripper-server -- --storage memory", state.BuildRustServerCommand());
+    }
+
+    [Fact]
+    public void Update_runtime_config_syncs_active_storage_and_redacts_secret_values()
+    {
+        var state = new DebugWorkbenchState(Options.Create(new DebugWorkbenchOptions()));
+
+        state.UpdateRuntimeConfig(new RuntimeConfigSnapshot
+        {
+            ActiveStorageBackend = "sqlite",
+            LookupProviderSummary = "QRZ XML capture-only via https://xmldata.qrz.com/xml/current/",
+            Values =
+            {
+                new RuntimeConfigValue
+                {
+                    Key = "LOGRIPPER_STORAGE_BACKEND",
+                    HasValue = true,
+                    DisplayValue = "sqlite"
+                },
+                new RuntimeConfigValue
+                {
+                    Key = "LOGRIPPER_SQLITE_PATH",
+                    HasValue = true,
+                    DisplayValue = @".\data\live-logripper.db"
+                },
+                new RuntimeConfigValue
+                {
+                    Key = "LOGRIPPER_QRZ_XML_PASSWORD",
+                    HasValue = true,
+                    DisplayValue = "<redacted>",
+                    Secret = true,
+                    Redacted = true,
+                    Overridden = true
+                }
+            }
+        });
+
+        Assert.Equal(EngineStorageBackend.Sqlite, state.EngineStorageBackend);
+        Assert.Equal(@".\data\live-logripper.db", state.EngineSqlitePath);
+        Assert.Equal("<redacted>", state.GetEngineEnvironmentOverrides()["LOGRIPPER_QRZ_XML_PASSWORD"]);
+        Assert.Contains("--storage sqlite", state.BuildRustServerCommand(), StringComparison.Ordinal);
     }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/LogRipper.DebugHost.Tests/DebugWorkbenchStateTests.cs
+++ b/src/dotnet/LogRipper.DebugHost.Tests/DebugWorkbenchStateTests.cs
@@ -1,0 +1,42 @@
+using LogRipper.DebugHost.Models;
+using LogRipper.DebugHost.Services;
+using Microsoft.Extensions.Options;
+
+namespace LogRipper.DebugHost.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+public class DebugWorkbenchStateTests
+{
+    [Fact]
+    public void Initializes_storage_defaults_from_options()
+    {
+        var state = new DebugWorkbenchState(Options.Create(new DebugWorkbenchOptions
+        {
+            DefaultEngineEndpoint = "http://localhost:60051",
+            DefaultEngineStorageBackend = "sqlite",
+            DefaultEngineSqlitePath = @".\data\test-logripper.db"
+        }));
+
+        Assert.Equal("http://localhost:60051", state.EngineEndpoint);
+        Assert.Equal(EngineStorageBackend.Sqlite, state.EngineStorageBackend);
+        Assert.Equal(@".\data\test-logripper.db", state.EngineSqlitePath);
+        Assert.Contains("--storage sqlite", state.BuildRustServerCommand(), StringComparison.Ordinal);
+        Assert.Contains("--sqlite-path .\\data\\test-logripper.db", state.BuildRustServerCommand(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Update_storage_options_switches_back_to_memory()
+    {
+        var state = new DebugWorkbenchState(Options.Create(new DebugWorkbenchOptions()));
+
+        state.UpdateEngineEndpoint(" http://localhost:50061 ");
+        state.UpdateStorageOptions(EngineStorageBackend.Memory, "   ");
+
+        Assert.Equal("http://localhost:50061", state.EngineEndpoint);
+        Assert.Equal(EngineStorageBackend.Memory, state.EngineStorageBackend);
+        Assert.Equal("memory", state.GetEngineEnvironmentOverrides()["LOGRIPPER_STORAGE_BACKEND"]);
+        Assert.DoesNotContain("LOGRIPPER_SQLITE_PATH", state.GetEngineEnvironmentOverrides().Keys, StringComparer.Ordinal);
+        Assert.Equal("cargo run -p logripper-server -- --storage memory", state.BuildRustServerCommand());
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/LogRipper.DebugHost/Components/Layout/NavMenu.razor
+++ b/src/dotnet/LogRipper.DebugHost/Components/Layout/NavMenu.razor
@@ -34,6 +34,12 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="storage-workbench">
+                Storage Workbench
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="commands">
                 Commands & Tests
             </NavLink>

--- a/src/dotnet/LogRipper.DebugHost/Components/Pages/Engine.razor
+++ b/src/dotnet/LogRipper.DebugHost/Components/Pages/Engine.razor
@@ -1,38 +1,26 @@
 @page "/engine"
 @using LogRipper.DebugHost.Models
+@using LogRipper.Services
 @inject DebugWorkbenchState WorkbenchState
+@inject RuntimeConfigWorkbenchService RuntimeConfigWorkbenchService
 @inject ToolchainLocator ToolchainLocator
 
 <PageTitle>Engine Session</PageTitle>
 
 <h1 class="mb-3">Engine Session</h1>
 <p class="text-muted">
-    Configure the Rust engine endpoint the debug workbench should target. The probe checks TCP reachability then performs a live gRPC call to <code>GetSyncStatus</code> to verify that the engine is actually serving the expected LogRipper services.
+    Configure the Rust engine endpoint the debug workbench should target. The probe checks TCP reachability then performs a live gRPC call to <code>GetSyncStatus</code> to verify that the engine is actually serving the expected LogRipper services. When the host is reachable, this page also lets you hot-apply supported storage and QRZ runtime config overrides without restarting the Rust process.
 </p>
 
 <EditForm Model="this" OnSubmit="SaveEndpointAsync">
     <div class="row g-3 align-items-end">
-        <div class="col-lg-5">
+        <div class="col-lg-8">
             <label class="form-label" for="engine-endpoint">Engine endpoint</label>
             <InputText id="engine-endpoint" class="form-control" @bind-Value="endpoint" />
-        </div>
-        <div class="col-lg-3">
-            <label class="form-label" for="engine-storage-backend">Storage backend</label>
-            <InputSelect id="engine-storage-backend" class="form-select" @bind-Value="storageBackend">
-                <option value="@EngineStorageBackend.Memory">Memory</option>
-                <option value="@EngineStorageBackend.Sqlite">SQLite</option>
-            </InputSelect>
         </div>
         <div class="col-lg-4 d-flex gap-2">
             <button type="submit" class="btn btn-primary">Save endpoint</button>
             <button type="button" class="btn btn-outline-primary" @onclick="ProbeAsync">Probe engine</button>
-        </div>
-    </div>
-    <div class="row g-3 mt-1">
-        <div class="col-lg-8">
-            <label class="form-label" for="engine-sqlite-path">SQLite path</label>
-            <InputText id="engine-sqlite-path" class="form-control" @bind-Value="sqlitePath" />
-            <div class="form-text">Only used when the engine is started with the SQLite backend.</div>
         </div>
     </div>
 </EditForm>
@@ -40,6 +28,11 @@
 @if (!string.IsNullOrWhiteSpace(statusMessage))
 {
     <div class="alert alert-info mt-3">@statusMessage</div>
+}
+
+@if (!string.IsNullOrWhiteSpace(WorkbenchState.RuntimeConfigErrorMessage))
+{
+    <div class="alert alert-warning mt-3">@WorkbenchState.RuntimeConfigErrorMessage</div>
 }
 
 @if (WorkbenchState.LastProbe is not null)
@@ -86,7 +79,7 @@
                 <ul class="mb-0">
                     <li>The workbench stores endpoint selection per Blazor server circuit.</li>
                     <li>Use <code>http://localhost:50051</code> by default for local Rust gRPC development.</li>
-                    <li>Switch storage backend here, restart the Rust host, then rerun the storage workbench against the same endpoint.</li>
+                    <li>Use the live runtime config table below to hot-apply supported storage and QRZ overrides without restarting the engine.</li>
                     <li>The lookup and storage workbench pages use this endpoint automatically.</li>
                 </ul>
             </div>
@@ -126,6 +119,135 @@
 
 <div class="card shadow-sm mt-4">
     <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3 gap-3 flex-wrap">
+            <div>
+                <h2 class="h5 mb-1">Live runtime config</h2>
+                <div class="small text-muted">
+                    Apply hot-reloadable engine settings against the current endpoint. Storage and QRZ overrides take effect for new requests immediately.
+                </div>
+            </div>
+            <div class="d-flex gap-2 flex-wrap">
+                <button class="btn btn-sm btn-outline-primary"
+                        @onclick="RefreshRuntimeConfigAsync"
+                        disabled="@isRuntimeConfigBusy">
+                    Refresh live config
+                </button>
+                <button class="btn btn-sm btn-outline-danger"
+                        @onclick="ResetAllRuntimeOverridesAsync"
+                        disabled="@(isRuntimeConfigBusy || runtimeEntries.Count == 0)">
+                    Reset all overrides
+                </button>
+            </div>
+        </div>
+
+        @if (isRuntimeConfigBusy && runtimeEntries.Count == 0)
+        {
+            <div class="alert alert-info mb-0">Loading live runtime config...</div>
+        }
+        else if (runtimeEntries.Count == 0)
+        {
+            <div class="alert alert-secondary mb-0">
+                No live runtime config is loaded yet. Refresh after the engine endpoint is reachable.
+            </div>
+        }
+        else
+        {
+            <div class="mb-3">
+                <strong>Active storage:</strong> @WorkbenchState.GetStorageBackendDisplayName()<br />
+                <strong>Lookup provider:</strong> @WorkbenchState.RuntimeConfigSnapshot?.LookupProviderSummary
+            </div>
+
+            @if (WorkbenchState.RuntimeConfigSnapshot?.Warnings.Count > 0)
+            {
+                <div class="alert alert-warning">
+                    <ul class="mb-0">
+                        @foreach (var warning in WorkbenchState.RuntimeConfigSnapshot.Warnings)
+                        {
+                            <li>@warning</li>
+                        }
+                    </ul>
+                </div>
+            }
+
+            <div class="table-responsive">
+                <table class="table table-sm align-middle mb-0">
+                    <thead>
+                        <tr>
+                            <th>Setting</th>
+                            <th>Effective value</th>
+                            <th>New override</th>
+                            <th>Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach (var entry in runtimeEntries)
+                        {
+                            <tr>
+                                <td class="w-40">
+                                    <div class="fw-semibold">@entry.Definition.Label</div>
+                                    <div class="small text-muted"><code>@entry.Definition.Key</code></div>
+                                    <div class="small text-muted">@entry.Definition.Description</div>
+                                </td>
+                                <td class="w-25">
+                                    <div>@entry.EffectiveDisplayValue</div>
+                                    <div class="mt-1 d-flex gap-1 flex-wrap">
+                                        @if (entry.IsOverridden)
+                                        {
+                                            <span class="badge text-bg-primary">Override</span>
+                                        }
+                                        @if (entry.CurrentValue?.Redacted == true)
+                                        {
+                                            <span class="badge text-bg-secondary">Redacted</span>
+                                        }
+                                    </div>
+                                </td>
+                                <td class="w-25">
+                                    @if (entry.HasAllowedValues)
+                                    {
+                                        <select class="form-select form-select-sm" @bind="entry.DraftValue">
+                                            @foreach (var allowedValue in entry.Definition.AllowedValues)
+                                            {
+                                                <option value="@allowedValue">@allowedValue</option>
+                                            }
+                                        </select>
+                                    }
+                                    else if (entry.IsSecret)
+                                    {
+                                        <input type="password"
+                                               class="form-control form-control-sm"
+                                               @bind="entry.DraftValue"
+                                               placeholder="Enter new value" />
+                                    }
+                                    else
+                                    {
+                                        <input class="form-control form-control-sm" @bind="entry.DraftValue" />
+                                    }
+                                </td>
+                                <td class="text-nowrap">
+                                    <div class="d-flex gap-2 flex-wrap">
+                                        <button class="btn btn-sm btn-primary"
+                                                disabled="@(!entry.CanSave || isRuntimeConfigBusy)"
+                                                @onclick="() => ApplyRuntimeEntryAsync(entry)">
+                                            Apply
+                                        </button>
+                                        <button class="btn btn-sm btn-outline-secondary"
+                                                disabled="@(!entry.IsOverridden || isRuntimeConfigBusy)"
+                                                @onclick="() => ClearRuntimeEntryAsync(entry)">
+                                            Clear
+                                        </button>
+                                    </div>
+                                </td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        }
+    </div>
+</div>
+
+<div class="card shadow-sm mt-4">
+    <div class="card-body">
         <h2 class="h5">Rust host launch preview</h2>
         <div class="small text-muted mb-2">
             The command below matches the storage session configured in this page.
@@ -141,33 +263,118 @@
 
 @code {
     private string endpoint = string.Empty;
-    private EngineStorageBackend storageBackend;
-    private string sqlitePath = string.Empty;
     private string? statusMessage;
     private IReadOnlyList<ToolAvailability> tools = Array.Empty<ToolAvailability>();
+    private List<RuntimeConfigEditorEntry> runtimeEntries = [];
+    private bool isRuntimeConfigBusy;
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
         endpoint = WorkbenchState.EngineEndpoint;
-        storageBackend = WorkbenchState.EngineStorageBackend;
-        sqlitePath = WorkbenchState.EngineSqlitePath;
         tools = ToolchainLocator.GetToolAvailability();
+        await RefreshRuntimeConfigAsync();
     }
 
     private Task SaveEndpointAsync()
     {
         WorkbenchState.UpdateEngineEndpoint(endpoint);
-        WorkbenchState.UpdateStorageOptions(storageBackend, sqlitePath);
-        statusMessage = $"Saved engine session for '{WorkbenchState.EngineEndpoint}' using {WorkbenchState.GetStorageBackendDisplayName()} storage.";
+        statusMessage = $"Saved engine session for '{WorkbenchState.EngineEndpoint}'.";
         return Task.CompletedTask;
     }
 
     private async Task ProbeAsync()
     {
         WorkbenchState.UpdateEngineEndpoint(endpoint);
-        WorkbenchState.UpdateStorageOptions(storageBackend, sqlitePath);
         statusMessage = "Probing engine transport...";
         await WorkbenchState.ProbeAsync();
         statusMessage = null;
+    }
+
+    private async Task RefreshRuntimeConfigAsync()
+    {
+        isRuntimeConfigBusy = true;
+        try
+        {
+            await RuntimeConfigWorkbenchService.RefreshAsync();
+            RebuildRuntimeEntries();
+        }
+        finally
+        {
+            isRuntimeConfigBusy = false;
+        }
+    }
+
+    private async Task ApplyRuntimeEntryAsync(RuntimeConfigEditorEntry entry)
+    {
+        statusMessage = $"Applying {entry.Definition.Label}...";
+        isRuntimeConfigBusy = true;
+        try
+        {
+            await RuntimeConfigWorkbenchService.ApplyAsync(
+            [
+                new RuntimeConfigMutation
+                {
+                    Key = entry.Definition.Key,
+                    Kind = RuntimeConfigMutationKind.Set,
+                    Value = entry.GetMutationValue()
+                }
+            ]);
+            RebuildRuntimeEntries();
+            statusMessage = $"Applied {entry.Definition.Label}.";
+        }
+        finally
+        {
+            isRuntimeConfigBusy = false;
+        }
+    }
+
+    private async Task ClearRuntimeEntryAsync(RuntimeConfigEditorEntry entry)
+    {
+        statusMessage = $"Clearing override for {entry.Definition.Label}...";
+        isRuntimeConfigBusy = true;
+        try
+        {
+            await RuntimeConfigWorkbenchService.ResetAsync([entry.Definition.Key]);
+            RebuildRuntimeEntries();
+            statusMessage = $"Cleared override for {entry.Definition.Label}.";
+        }
+        finally
+        {
+            isRuntimeConfigBusy = false;
+        }
+    }
+
+    private async Task ResetAllRuntimeOverridesAsync()
+    {
+        statusMessage = "Clearing all live runtime overrides...";
+        isRuntimeConfigBusy = true;
+        try
+        {
+            await RuntimeConfigWorkbenchService.ResetAsync();
+            RebuildRuntimeEntries();
+            statusMessage = "Cleared all live runtime overrides.";
+        }
+        finally
+        {
+            isRuntimeConfigBusy = false;
+        }
+    }
+
+    private void RebuildRuntimeEntries()
+    {
+        if (WorkbenchState.RuntimeConfigSnapshot is null)
+        {
+            runtimeEntries = [];
+            return;
+        }
+
+        runtimeEntries = WorkbenchState.RuntimeConfigSnapshot.Definitions
+            .Select(definition =>
+            {
+                var currentValue = WorkbenchState.RuntimeConfigSnapshot.Values
+                    .FirstOrDefault(value => string.Equals(value.Key, definition.Key, StringComparison.OrdinalIgnoreCase));
+                return new RuntimeConfigEditorEntry(definition, currentValue);
+            })
+            .ToList();
     }
 }

--- a/src/dotnet/LogRipper.DebugHost/Components/Pages/Engine.razor
+++ b/src/dotnet/LogRipper.DebugHost/Components/Pages/Engine.razor
@@ -12,13 +12,27 @@
 
 <EditForm Model="this" OnSubmit="SaveEndpointAsync">
     <div class="row g-3 align-items-end">
-        <div class="col-lg-8">
+        <div class="col-lg-5">
             <label class="form-label" for="engine-endpoint">Engine endpoint</label>
             <InputText id="engine-endpoint" class="form-control" @bind-Value="endpoint" />
+        </div>
+        <div class="col-lg-3">
+            <label class="form-label" for="engine-storage-backend">Storage backend</label>
+            <InputSelect id="engine-storage-backend" class="form-select" @bind-Value="storageBackend">
+                <option value="@EngineStorageBackend.Memory">Memory</option>
+                <option value="@EngineStorageBackend.Sqlite">SQLite</option>
+            </InputSelect>
         </div>
         <div class="col-lg-4 d-flex gap-2">
             <button type="submit" class="btn btn-primary">Save endpoint</button>
             <button type="button" class="btn btn-outline-primary" @onclick="ProbeAsync">Probe engine</button>
+        </div>
+    </div>
+    <div class="row g-3 mt-1">
+        <div class="col-lg-8">
+            <label class="form-label" for="engine-sqlite-path">SQLite path</label>
+            <InputText id="engine-sqlite-path" class="form-control" @bind-Value="sqlitePath" />
+            <div class="form-text">Only used when the engine is started with the SQLite backend.</div>
         </div>
     </div>
 </EditForm>
@@ -72,8 +86,8 @@
                 <ul class="mb-0">
                     <li>The workbench stores endpoint selection per Blazor server circuit.</li>
                     <li>Use <code>http://localhost:50051</code> by default for local Rust gRPC development.</li>
-                    <li>Start the current developer host with <code>cargo run --manifest-path src\rust\logripper-server\Cargo.toml</code>.</li>
-                    <li>The lookup page and future logbook pages use this endpoint automatically.</li>
+                    <li>Switch storage backend here, restart the Rust host, then rerun the storage workbench against the same endpoint.</li>
+                    <li>The lookup and storage workbench pages use this endpoint automatically.</li>
                 </ul>
             </div>
         </div>
@@ -110,27 +124,48 @@
     </div>
 </div>
 
+<div class="card shadow-sm mt-4">
+    <div class="card-body">
+        <h2 class="h5">Rust host launch preview</h2>
+        <div class="small text-muted mb-2">
+            The command below matches the storage session configured in this page.
+        </div>
+        <pre class="payload-view">@WorkbenchState.BuildRustServerCommand()</pre>
+        <div class="small text-muted mt-2 mb-1">Equivalent environment</div>
+        @foreach (var variable in WorkbenchState.GetEngineEnvironmentOverrides())
+        {
+            <div><code>@variable.Key=@variable.Value</code></div>
+        }
+    </div>
+</div>
+
 @code {
     private string endpoint = string.Empty;
+    private EngineStorageBackend storageBackend;
+    private string sqlitePath = string.Empty;
     private string? statusMessage;
     private IReadOnlyList<ToolAvailability> tools = Array.Empty<ToolAvailability>();
 
     protected override void OnInitialized()
     {
         endpoint = WorkbenchState.EngineEndpoint;
+        storageBackend = WorkbenchState.EngineStorageBackend;
+        sqlitePath = WorkbenchState.EngineSqlitePath;
         tools = ToolchainLocator.GetToolAvailability();
     }
 
     private Task SaveEndpointAsync()
     {
         WorkbenchState.UpdateEngineEndpoint(endpoint);
-        statusMessage = $"Saved endpoint '{WorkbenchState.EngineEndpoint}'.";
+        WorkbenchState.UpdateStorageOptions(storageBackend, sqlitePath);
+        statusMessage = $"Saved engine session for '{WorkbenchState.EngineEndpoint}' using {WorkbenchState.GetStorageBackendDisplayName()} storage.";
         return Task.CompletedTask;
     }
 
     private async Task ProbeAsync()
     {
         WorkbenchState.UpdateEngineEndpoint(endpoint);
+        WorkbenchState.UpdateStorageOptions(storageBackend, sqlitePath);
         statusMessage = "Probing engine transport...";
         await WorkbenchState.ProbeAsync();
         statusMessage = null;

--- a/src/dotnet/LogRipper.DebugHost/Components/Pages/Home.razor
+++ b/src/dotnet/LogRipper.DebugHost/Components/Pages/Home.razor
@@ -22,7 +22,7 @@
         <div class="card h-100 shadow-sm">
             <div class="card-body">
                 <h2 class="h5">Engine Session</h2>
-                <p class="text-muted">Configure the target Rust endpoint, probe transport reachability, and inspect developer tool availability.</p>
+                <p class="text-muted">Configure the target Rust endpoint, probe transport reachability, and hot-apply supported storage and QRZ runtime overrides.</p>
                 <a class="btn btn-primary" href="engine">Open engine tools</a>
             </div>
         </div>

--- a/src/dotnet/LogRipper.DebugHost/Components/Pages/Home.razor
+++ b/src/dotnet/LogRipper.DebugHost/Components/Pages/Home.razor
@@ -48,6 +48,15 @@
     <div class="col-md-6 col-xl-3">
         <div class="card h-100 shadow-sm">
             <div class="card-body">
+                <h2 class="h5">Storage Workbench</h2>
+                <p class="text-muted">Exercise logbook CRUD through gRPC, compare memory vs SQLite sessions, and verify persistence behavior after engine restarts.</p>
+                <a class="btn btn-primary" href="storage-workbench">Open storage workbench</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6 col-xl-3">
+        <div class="card h-100 shadow-sm">
+            <div class="card-body">
                 <h2 class="h5">Commands & Tests</h2>
                 <p class="text-muted">Run curated Rust/.NET validation commands from an allowlisted catalog and capture their output.</p>
                 <a class="btn btn-primary" href="commands">Open command runner</a>

--- a/src/dotnet/LogRipper.DebugHost/Components/Pages/LookupWorkbench.razor
+++ b/src/dotnet/LogRipper.DebugHost/Components/Pages/LookupWorkbench.razor
@@ -1,5 +1,6 @@
 @page "/lookup-workbench"
 @inject DebugWorkbenchState WorkbenchState
+@inject RuntimeConfigWorkbenchService RuntimeConfigWorkbenchService
 @inject LookupWorkbenchService LookupWorkbenchService
 @inject SampleProtoFactory SampleProtoFactory
 @inject ProtoJsonService ProtoJsonService
@@ -12,7 +13,11 @@
 </p>
 
 <div class="alert alert-secondary">
-    <strong>Current engine endpoint:</strong> @WorkbenchState.EngineEndpoint
+    <div><strong>Current engine endpoint:</strong> @WorkbenchState.EngineEndpoint</div>
+    @if (WorkbenchState.RuntimeConfigSnapshot is not null)
+    {
+        <div class="mt-1"><strong>Lookup provider:</strong> @WorkbenchState.RuntimeConfigSnapshot.LookupProviderSummary</div>
+    }
 </div>
 
 <div class="card shadow-sm mb-4">
@@ -105,8 +110,9 @@
     private LookupInvocationResult? liveResult;
     private List<ProtoPayloadView> livePayloads = [];
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
+        await RuntimeConfigWorkbenchService.RefreshAsync();
         Preview();
     }
 

--- a/src/dotnet/LogRipper.DebugHost/Components/Pages/StorageWorkbench.razor
+++ b/src/dotnet/LogRipper.DebugHost/Components/Pages/StorageWorkbench.razor
@@ -1,5 +1,6 @@
 @page "/storage-workbench"
 @inject DebugWorkbenchState WorkbenchState
+@inject RuntimeConfigWorkbenchService RuntimeConfigWorkbenchService
 @inject StorageWorkbenchService StorageWorkbenchService
 @inject SampleProtoFactory SampleProtoFactory
 @inject ProtoJsonService ProtoJsonService
@@ -8,18 +9,24 @@
 
 <h1 class="mb-3">Storage Workbench</h1>
 <p class="text-muted">
-    Exercise the logbook storage path against the active Rust engine endpoint. Switch the engine between memory and SQLite on the engine session page, restart the Rust host, then rerun the same smoke test here to compare behavior.
+    Exercise the logbook storage path against the active Rust engine endpoint. Use the engine session page to hot-apply memory or SQLite runtime overrides, then rerun the same smoke test here to compare behavior without restarting the process.
 </p>
 
 <div class="alert alert-secondary">
     <div><strong>Current engine endpoint:</strong> @WorkbenchState.EngineEndpoint</div>
     <div class="mt-1">
-        <strong>Planned backend:</strong> @WorkbenchState.GetStorageBackendDisplayName()
+        <strong>Active backend:</strong> @WorkbenchState.GetStorageBackendDisplayName()
         @if (WorkbenchState.EngineStorageBackend == EngineStorageBackend.Sqlite)
         {
             <span> using <code>@WorkbenchState.EngineSqlitePath</code></span>
         }
     </div>
+    @if (WorkbenchState.RuntimeConfigSnapshot is not null)
+    {
+        <div class="mt-1">
+            <strong>Lookup provider:</strong> @WorkbenchState.RuntimeConfigSnapshot.LookupProviderSummary
+        </div>
+    }
 </div>
 
 <div class="card shadow-sm mb-4">
@@ -151,8 +158,9 @@
     private ProtoPayloadView? deleteResponsePayload;
     private List<ProtoPayloadView> listedPayloads = [];
 
-    protected override void OnInitialized()
+    protected override async Task OnInitializedAsync()
     {
+        await RuntimeConfigWorkbenchService.RefreshAsync();
         Preview();
     }
 

--- a/src/dotnet/LogRipper.DebugHost/Components/Pages/StorageWorkbench.razor
+++ b/src/dotnet/LogRipper.DebugHost/Components/Pages/StorageWorkbench.razor
@@ -1,0 +1,174 @@
+@page "/storage-workbench"
+@inject DebugWorkbenchState WorkbenchState
+@inject StorageWorkbenchService StorageWorkbenchService
+@inject SampleProtoFactory SampleProtoFactory
+@inject ProtoJsonService ProtoJsonService
+
+<PageTitle>Storage Workbench</PageTitle>
+
+<h1 class="mb-3">Storage Workbench</h1>
+<p class="text-muted">
+    Exercise the logbook storage path against the active Rust engine endpoint. Switch the engine between memory and SQLite on the engine session page, restart the Rust host, then rerun the same smoke test here to compare behavior.
+</p>
+
+<div class="alert alert-secondary">
+    <div><strong>Current engine endpoint:</strong> @WorkbenchState.EngineEndpoint</div>
+    <div class="mt-1">
+        <strong>Planned backend:</strong> @WorkbenchState.GetStorageBackendDisplayName()
+        @if (WorkbenchState.EngineStorageBackend == EngineStorageBackend.Sqlite)
+        {
+            <span> using <code>@WorkbenchState.EngineSqlitePath</code></span>
+        }
+    </div>
+</div>
+
+<div class="card shadow-sm mb-4">
+    <div class="card-body">
+        <div class="row g-3 align-items-end">
+            <div class="col-md-6">
+                <label class="form-label" for="storage-callsign">Worked callsign</label>
+                <InputText id="storage-callsign" class="form-control" @bind-Value="workedCallsign" />
+            </div>
+            <div class="col-md-3">
+                <div class="form-check mb-2">
+                    <InputCheckbox id="retain-record" class="form-check-input" @bind-Value="retainRecord" />
+                    <label class="form-check-label" for="retain-record">Retain sample QSO after test</label>
+                </div>
+                <div class="small text-muted">
+                    Leave this enabled for SQLite if you want to restart the engine and confirm the record persists.
+                </div>
+            </div>
+            <div class="col-md-3 d-flex gap-2 flex-wrap">
+                <button class="btn btn-outline-primary" @onclick="Preview">Preview sample</button>
+                <button class="btn btn-primary" @onclick="RunSmokeTestAsync">Run smoke test</button>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row g-4">
+    <div class="col-xl-6">
+        <PayloadCard Title="Sample QSO payload"
+                     Payload="@samplePayload.Json" />
+    </div>
+    <div class="col-xl-6">
+        <PayloadCard Title="Rust host launch command"
+                     Payload="@WorkbenchState.BuildRustServerCommand()"
+                     BadgeText="@WorkbenchState.GetStorageBackendDisplayName()" />
+    </div>
+</div>
+
+<div class="card shadow-sm mt-4">
+    <div class="card-body">
+        <h2 class="h5">Equivalent environment</h2>
+        @foreach (var variable in WorkbenchState.GetEngineEnvironmentOverrides())
+        {
+            <div><code>@variable.Key=@variable.Value</code></div>
+        }
+    </div>
+</div>
+
+<div class="card shadow-sm mt-4">
+    <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h2 class="h5 mb-0">Smoke test result</h2>
+            @if (result is not null)
+            {
+                <span class="badge @(result.Succeeded ? "text-bg-success" : "text-bg-danger")">
+                    @(result.Succeeded ? "Completed" : "Failed")
+                </span>
+            }
+        </div>
+
+        @if (result is null)
+        {
+            <p class="text-muted mb-0">No smoke test run yet. Run the sample against the current engine session to exercise logbook storage through gRPC.</p>
+        }
+        else
+        {
+            <div class="mb-3">
+                <strong>Completed:</strong> @result.CompletedAtUtc.LocalDateTime.ToString("g")<br />
+                <strong>Local ID:</strong> @(result.LocalId ?? "(none)")<br />
+                <strong>Listed matches:</strong> @result.ListedQsos.Count<br />
+                <strong>Cleanup:</strong> @(result.RetainedRecord ? "Record retained for restart testing" : result.DeleteVerified ? "Deleted and verified" : "Delete verification failed")
+            </div>
+
+            @if (!string.IsNullOrWhiteSpace(result.ErrorMessage))
+            {
+                <div class="alert alert-danger">
+                    @result.ErrorMessage
+                </div>
+            }
+
+            <div class="row g-4">
+                @if (logResponsePayload is not null)
+                {
+                    <div class="col-xl-6">
+                        <PayloadCard Title="LogQso response" Payload="@logResponsePayload.Json" />
+                    </div>
+                }
+                @if (loadedPayload is not null)
+                {
+                    <div class="col-xl-6">
+                        <PayloadCard Title="Loaded QSO" Payload="@loadedPayload.Json" />
+                    </div>
+                }
+                @if (syncStatusPayload is not null)
+                {
+                    <div class="col-xl-6">
+                        <PayloadCard Title="Sync status" Payload="@syncStatusPayload.Json" />
+                    </div>
+                }
+                @if (deleteResponsePayload is not null)
+                {
+                    <div class="col-xl-6">
+                        <PayloadCard Title="DeleteQso response" Payload="@deleteResponsePayload.Json" />
+                    </div>
+                }
+                @if (listedPayloads.Count > 0)
+                {
+                    @for (var i = 0; i < listedPayloads.Count; i++)
+                    {
+                        <div class="col-xl-6">
+                            <PayloadCard Title="@($"Listed record {i + 1}")"
+                                         Payload="@listedPayloads[i].Json" />
+                        </div>
+                    }
+                }
+            </div>
+        }
+    </div>
+</div>
+
+@code {
+    private string workedCallsign = "W1AW";
+    private bool retainRecord;
+    private ProtoPayloadView samplePayload = new("{}", string.Empty, 0);
+    private StorageSmokeTestResult? result;
+    private ProtoPayloadView? logResponsePayload;
+    private ProtoPayloadView? loadedPayload;
+    private ProtoPayloadView? syncStatusPayload;
+    private ProtoPayloadView? deleteResponsePayload;
+    private List<ProtoPayloadView> listedPayloads = [];
+
+    protected override void OnInitialized()
+    {
+        Preview();
+    }
+
+    private void Preview()
+    {
+        samplePayload = ProtoJsonService.Describe(SampleProtoFactory.CreateQsoRecord(workedCallsign));
+    }
+
+    private async Task RunSmokeTestAsync()
+    {
+        Preview();
+        result = await StorageWorkbenchService.RunSmokeTestAsync(workedCallsign, retainRecord);
+        logResponsePayload = result.LogResponse is null ? null : ProtoJsonService.Describe(result.LogResponse);
+        loadedPayload = result.LoadedResponse?.Qso is null ? null : ProtoJsonService.Describe(result.LoadedResponse.Qso);
+        syncStatusPayload = result.SyncStatus is null ? null : ProtoJsonService.Describe(result.SyncStatus);
+        deleteResponsePayload = result.DeleteResponse is null ? null : ProtoJsonService.Describe(result.DeleteResponse);
+        listedPayloads = result.ListedQsos.Select(ProtoJsonService.Describe).ToList();
+    }
+}

--- a/src/dotnet/LogRipper.DebugHost/LogRipper.DebugHost.csproj
+++ b/src/dotnet/LogRipper.DebugHost/LogRipper.DebugHost.csproj
@@ -23,6 +23,9 @@
     <Protobuf Include="..\..\..\proto\services\logbook_service.proto"
               ProtoRoot="..\..\..\proto"
               GrpcServices="Client" />
+    <Protobuf Include="..\..\..\proto\services\debug_control_service.proto"
+              ProtoRoot="..\..\..\proto"
+              GrpcServices="Client" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/LogRipper.DebugHost/Models/DebugWorkbenchOptions.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/DebugWorkbenchOptions.cs
@@ -6,6 +6,10 @@ internal sealed class DebugWorkbenchOptions
 
     public string DefaultEngineEndpoint { get; set; } = "http://localhost:50051";
 
+    public string DefaultEngineStorageBackend { get; set; } = "memory";
+
+    public string DefaultEngineSqlitePath { get; set; } = @".\data\logripper.db";
+
     public int ProbeTimeoutSeconds { get; set; } = 3;
 
     public int CommandTimeoutSeconds { get; set; } = 300;

--- a/src/dotnet/LogRipper.DebugHost/Models/EngineStorageBackend.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/EngineStorageBackend.cs
@@ -1,0 +1,7 @@
+namespace LogRipper.DebugHost.Models;
+
+internal enum EngineStorageBackend
+{
+    Memory,
+    Sqlite
+}

--- a/src/dotnet/LogRipper.DebugHost/Models/RuntimeConfigEditorEntry.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/RuntimeConfigEditorEntry.cs
@@ -1,0 +1,61 @@
+using LogRipper.Services;
+
+namespace LogRipper.DebugHost.Models;
+
+internal sealed class RuntimeConfigEditorEntry
+{
+    public RuntimeConfigEditorEntry(RuntimeConfigDefinition definition, RuntimeConfigValue? currentValue)
+    {
+        ArgumentNullException.ThrowIfNull(definition);
+
+        Definition = definition;
+        UpdateCurrentValue(currentValue);
+    }
+
+    public RuntimeConfigDefinition Definition { get; }
+
+    public RuntimeConfigValue? CurrentValue { get; private set; }
+
+    public string DraftValue { get; set; } = string.Empty;
+
+    public string EffectiveDisplayValue => CurrentValue is { HasValue: true }
+        ? CurrentValue.DisplayValue
+        : "(unset)";
+
+    public bool IsOverridden => CurrentValue?.Overridden ?? false;
+
+    public bool IsSecret => Definition.Secret;
+
+    public bool HasAllowedValues => Definition.AllowedValues.Count > 0;
+
+    public bool CanSave => HasAllowedValues || !string.IsNullOrWhiteSpace(DraftValue);
+
+    public void UpdateCurrentValue(RuntimeConfigValue? currentValue)
+    {
+        CurrentValue = currentValue;
+
+        if (IsSecret)
+        {
+            DraftValue = string.Empty;
+            return;
+        }
+
+        if (currentValue is { HasValue: true })
+        {
+            DraftValue = currentValue.DisplayValue;
+        }
+        else if (HasAllowedValues)
+        {
+            DraftValue = Definition.AllowedValues[0];
+        }
+        else if (!HasAllowedValues)
+        {
+            DraftValue = string.Empty;
+        }
+    }
+
+    public string GetMutationValue()
+    {
+        return DraftValue.Trim();
+    }
+}

--- a/src/dotnet/LogRipper.DebugHost/Models/StorageSmokeTestResult.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/StorageSmokeTestResult.cs
@@ -1,0 +1,21 @@
+using LogRipper.Domain;
+using LogRipper.Services;
+
+namespace LogRipper.DebugHost.Models;
+
+internal sealed record StorageSmokeTestResult(
+    QsoRecord RequestedQso,
+    LogQsoResponse? LogResponse,
+    GetQsoResponse? LoadedResponse,
+    IReadOnlyList<QsoRecord> ListedQsos,
+    SyncStatusResponse? SyncStatus,
+    DeleteQsoResponse? DeleteResponse,
+    bool RetainedRecord,
+    bool DeleteVerified,
+    string? ErrorMessage,
+    DateTimeOffset CompletedAtUtc)
+{
+    public bool Succeeded => string.IsNullOrWhiteSpace(ErrorMessage);
+
+    public string? LocalId => LogResponse?.LocalId;
+}

--- a/src/dotnet/LogRipper.DebugHost/Program.cs
+++ b/src/dotnet/LogRipper.DebugHost/Program.cs
@@ -16,6 +16,7 @@ builder.Services.AddScoped<DebugWorkbenchState>();
 builder.Services.AddScoped<GrpcClientFactory>();
 builder.Services.AddScoped<LookupWorkbenchService>();
 builder.Services.AddScoped<StorageWorkbenchService>();
+builder.Services.AddScoped<RuntimeConfigWorkbenchService>();
 builder.Services.AddScoped<DebugCommandService>();
 
 var app = builder.Build();

--- a/src/dotnet/LogRipper.DebugHost/Program.cs
+++ b/src/dotnet/LogRipper.DebugHost/Program.cs
@@ -15,6 +15,7 @@ builder.Services.AddSingleton<SampleProtoFactory>();
 builder.Services.AddScoped<DebugWorkbenchState>();
 builder.Services.AddScoped<GrpcClientFactory>();
 builder.Services.AddScoped<LookupWorkbenchService>();
+builder.Services.AddScoped<StorageWorkbenchService>();
 builder.Services.AddScoped<DebugCommandService>();
 
 var app = builder.Build();

--- a/src/dotnet/LogRipper.DebugHost/Services/DebugCommandService.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/DebugCommandService.cs
@@ -45,6 +45,14 @@ internal sealed class DebugCommandService
                 _repositoryPaths.RepoRoot,
                 RequiresProtoc: true),
             new(
+                "cargo-storage-tests",
+                "Run storage adapter tests",
+                "Runs the memory and SQLite storage adapter tests plus backend-selection coverage in the Rust server host.",
+                "cargo",
+                "test --manifest-path src\\rust\\Cargo.toml -p logripper-storage-memory -p logripper-storage-sqlite -p logripper-server",
+                _repositoryPaths.RepoRoot,
+                RequiresProtoc: true),
+            new(
                 "dotnet-test",
                 "Run .NET workspace tests",
                 "Runs the full .NET workspace test suite through the root src\\dotnet\\LogRipper.slnx solution.",

--- a/src/dotnet/LogRipper.DebugHost/Services/DebugWorkbenchState.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/DebugWorkbenchState.cs
@@ -4,6 +4,7 @@ using Grpc.Net.Client;
 using LogRipper.DebugHost.Models;
 using LogRipper.Services;
 using Microsoft.Extensions.Options;
+using System.Linq;
 
 namespace LogRipper.DebugHost.Services;
 
@@ -29,6 +30,10 @@ internal sealed class DebugWorkbenchState
 
     public TransportProbeResult? LastProbe { get; private set; }
 
+    public RuntimeConfigSnapshot? RuntimeConfigSnapshot { get; private set; }
+
+    public string? RuntimeConfigErrorMessage { get; private set; }
+
     public void UpdateEngineEndpoint(string endpoint)
     {
         ArgumentNullException.ThrowIfNull(endpoint);
@@ -42,6 +47,29 @@ internal sealed class DebugWorkbenchState
 
         EngineStorageBackend = backend;
         EngineSqlitePath = NormalizeSqlitePath(sqlitePath);
+    }
+
+    public void UpdateRuntimeConfig(RuntimeConfigSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+
+        RuntimeConfigSnapshot = snapshot;
+        RuntimeConfigErrorMessage = null;
+        EngineStorageBackend = ParseStorageBackend(snapshot.ActiveStorageBackend);
+
+        var sqlitePath = snapshot.Values.FirstOrDefault(value =>
+            string.Equals(value.Key, "LOGRIPPER_SQLITE_PATH", StringComparison.OrdinalIgnoreCase));
+        if (sqlitePath is { HasValue: true })
+        {
+            EngineSqlitePath = NormalizeSqlitePath(sqlitePath.DisplayValue);
+        }
+    }
+
+    public void UpdateRuntimeConfigError(string? message)
+    {
+        RuntimeConfigErrorMessage = string.IsNullOrWhiteSpace(message)
+            ? null
+            : message.Trim();
     }
 
     public string GetStorageBackendDisplayName()
@@ -64,6 +92,16 @@ internal sealed class DebugWorkbenchState
 
     public IReadOnlyDictionary<string, string> GetEngineEnvironmentOverrides()
     {
+        if (RuntimeConfigSnapshot is not null)
+        {
+            return RuntimeConfigSnapshot.Values
+                .Where(value => value.HasValue)
+                .ToDictionary(
+                    value => value.Key,
+                    value => value.DisplayValue,
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
         var environment = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
         {
             ["LOGRIPPER_STORAGE_BACKEND"] = EngineStorageBackend == EngineStorageBackend.Sqlite ? "sqlite" : "memory"

--- a/src/dotnet/LogRipper.DebugHost/Services/DebugWorkbenchState.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/DebugWorkbenchState.cs
@@ -16,10 +16,16 @@ internal sealed class DebugWorkbenchState
         ArgumentNullException.ThrowIfNull(options);
 
         _options = options.Value;
-        EngineEndpoint = _options.DefaultEngineEndpoint;
+        EngineEndpoint = _options.DefaultEngineEndpoint.Trim();
+        EngineStorageBackend = ParseStorageBackend(_options.DefaultEngineStorageBackend);
+        EngineSqlitePath = NormalizeSqlitePath(_options.DefaultEngineSqlitePath);
     }
 
     public string EngineEndpoint { get; private set; }
+
+    public EngineStorageBackend EngineStorageBackend { get; private set; }
+
+    public string EngineSqlitePath { get; private set; }
 
     public TransportProbeResult? LastProbe { get; private set; }
 
@@ -28,6 +34,47 @@ internal sealed class DebugWorkbenchState
         ArgumentNullException.ThrowIfNull(endpoint);
 
         EngineEndpoint = endpoint.Trim();
+    }
+
+    public void UpdateStorageOptions(EngineStorageBackend backend, string sqlitePath)
+    {
+        ArgumentNullException.ThrowIfNull(sqlitePath);
+
+        EngineStorageBackend = backend;
+        EngineSqlitePath = NormalizeSqlitePath(sqlitePath);
+    }
+
+    public string GetStorageBackendDisplayName()
+    {
+        return EngineStorageBackend switch
+        {
+            EngineStorageBackend.Sqlite => "SQLite",
+            _ => "Memory"
+        };
+    }
+
+    public string BuildRustServerCommand()
+    {
+        return EngineStorageBackend switch
+        {
+            EngineStorageBackend.Sqlite => $"cargo run -p logripper-server -- --storage sqlite --sqlite-path {EngineSqlitePath}",
+            _ => "cargo run -p logripper-server -- --storage memory"
+        };
+    }
+
+    public IReadOnlyDictionary<string, string> GetEngineEnvironmentOverrides()
+    {
+        var environment = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["LOGRIPPER_STORAGE_BACKEND"] = EngineStorageBackend == EngineStorageBackend.Sqlite ? "sqlite" : "memory"
+        };
+
+        if (EngineStorageBackend == EngineStorageBackend.Sqlite)
+        {
+            environment["LOGRIPPER_SQLITE_PATH"] = EngineSqlitePath;
+        }
+
+        return environment;
     }
 
     public async Task<TransportProbeResult> ProbeAsync(CancellationToken cancellationToken = default)
@@ -160,5 +207,21 @@ internal sealed class DebugWorkbenchState
             await grpcChannel.ShutdownAsync();
             grpcChannel.Dispose();
         }
+    }
+
+    private static EngineStorageBackend ParseStorageBackend(string? configuredBackend)
+    {
+        return configuredBackend?.Trim().ToUpperInvariant() switch
+        {
+            "SQLITE" => EngineStorageBackend.Sqlite,
+            _ => EngineStorageBackend.Memory
+        };
+    }
+
+    private static string NormalizeSqlitePath(string sqlitePath)
+    {
+        return string.IsNullOrWhiteSpace(sqlitePath)
+            ? @".\data\logripper.db"
+            : sqlitePath.Trim();
     }
 }

--- a/src/dotnet/LogRipper.DebugHost/Services/DebugWorkbenchState.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/DebugWorkbenchState.cs
@@ -1,10 +1,10 @@
+using System.Linq;
 using System.Net.Sockets;
 using Grpc.Core;
 using Grpc.Net.Client;
 using LogRipper.DebugHost.Models;
 using LogRipper.Services;
 using Microsoft.Extensions.Options;
-using System.Linq;
 
 namespace LogRipper.DebugHost.Services;
 

--- a/src/dotnet/LogRipper.DebugHost/Services/GrpcClientFactory.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/GrpcClientFactory.cs
@@ -33,4 +33,9 @@ internal sealed class GrpcClientFactory
     {
         return new LogbookService.LogbookServiceClient(CreateChannel());
     }
+
+    public DeveloperControlService.DeveloperControlServiceClient CreateDeveloperControlClient()
+    {
+        return new DeveloperControlService.DeveloperControlServiceClient(CreateChannel());
+    }
 }

--- a/src/dotnet/LogRipper.DebugHost/Services/RuntimeConfigWorkbenchService.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/RuntimeConfigWorkbenchService.cs
@@ -1,0 +1,89 @@
+using Grpc.Core;
+using LogRipper.Services;
+
+namespace LogRipper.DebugHost.Services;
+
+internal sealed class RuntimeConfigWorkbenchService
+{
+    private readonly GrpcClientFactory _clientFactory;
+    private readonly DebugWorkbenchState _workbenchState;
+
+    public RuntimeConfigWorkbenchService(
+        GrpcClientFactory clientFactory,
+        DebugWorkbenchState workbenchState)
+    {
+        ArgumentNullException.ThrowIfNull(clientFactory);
+        ArgumentNullException.ThrowIfNull(workbenchState);
+
+        _clientFactory = clientFactory;
+        _workbenchState = workbenchState;
+    }
+
+    public Task<RuntimeConfigSnapshot?> RefreshAsync(CancellationToken cancellationToken = default)
+    {
+        return ExecuteAsync(
+            client => client.GetRuntimeConfigAsync(new GetRuntimeConfigRequest(), cancellationToken: cancellationToken).ResponseAsync,
+            cancellationToken);
+    }
+
+    public Task<RuntimeConfigSnapshot?> ApplyAsync(
+        IEnumerable<RuntimeConfigMutation> mutations,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(mutations);
+
+        return ExecuteAsync(
+            client => client.ApplyRuntimeConfigAsync(
+                    new ApplyRuntimeConfigRequest
+                    {
+                        Mutations = { mutations }
+                    },
+                    cancellationToken: cancellationToken)
+                .ResponseAsync,
+            cancellationToken);
+    }
+
+    public Task<RuntimeConfigSnapshot?> ResetAsync(
+        IEnumerable<string>? keys = null,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new ResetRuntimeConfigRequest();
+        if (keys is not null)
+        {
+            request.Keys.AddRange(keys);
+        }
+
+        return ExecuteAsync(
+            client => client.ResetRuntimeConfigAsync(request, cancellationToken: cancellationToken).ResponseAsync,
+            cancellationToken);
+    }
+
+    private async Task<RuntimeConfigSnapshot?> ExecuteAsync(
+        Func<DeveloperControlService.DeveloperControlServiceClient, Task<RuntimeConfigSnapshot>> action,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var channel = _clientFactory.CreateChannel();
+            var client = new DeveloperControlService.DeveloperControlServiceClient(channel);
+            var snapshot = await action(client);
+            _workbenchState.UpdateRuntimeConfig(snapshot);
+            return snapshot;
+        }
+        catch (RpcException ex)
+        {
+            _workbenchState.UpdateRuntimeConfigError(ex.Status.Detail);
+            return null;
+        }
+        catch (OperationCanceledException ex)
+        {
+            _workbenchState.UpdateRuntimeConfigError(ex.Message);
+            return null;
+        }
+        catch (InvalidOperationException ex)
+        {
+            _workbenchState.UpdateRuntimeConfigError(ex.Message);
+            return null;
+        }
+    }
+}

--- a/src/dotnet/LogRipper.DebugHost/Services/StorageWorkbenchService.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/StorageWorkbenchService.cs
@@ -1,0 +1,147 @@
+using Grpc.Core;
+using LogRipper.DebugHost.Models;
+using LogRipper.Domain;
+using LogRipper.Services;
+
+namespace LogRipper.DebugHost.Services;
+
+internal sealed class StorageWorkbenchService
+{
+    private readonly GrpcClientFactory _clientFactory;
+    private readonly SampleProtoFactory _sampleProtoFactory;
+
+    public StorageWorkbenchService(GrpcClientFactory clientFactory, SampleProtoFactory sampleProtoFactory)
+    {
+        ArgumentNullException.ThrowIfNull(clientFactory);
+        ArgumentNullException.ThrowIfNull(sampleProtoFactory);
+
+        _clientFactory = clientFactory;
+        _sampleProtoFactory = sampleProtoFactory;
+    }
+
+    public async Task<StorageSmokeTestResult> RunSmokeTestAsync(
+        string workedCallsign,
+        bool retainRecord,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(workedCallsign);
+
+        var sampleQso = _sampleProtoFactory.CreateQsoRecord(workedCallsign);
+        LogQsoResponse? logResponse = null;
+        GetQsoResponse? loadedResponse = null;
+        DeleteQsoResponse? deleteResponse = null;
+        SyncStatusResponse? syncStatus = null;
+        var listedQsos = new List<QsoRecord>();
+        var deleteVerified = false;
+
+        try
+        {
+            using var channel = _clientFactory.CreateChannel();
+            var client = new LogbookService.LogbookServiceClient(channel);
+
+            logResponse = await client.LogQsoAsync(
+                new LogQsoRequest
+                {
+                    Qso = sampleQso,
+                    SyncToQrz = false
+                },
+                cancellationToken: cancellationToken);
+
+            loadedResponse = await client.GetQsoAsync(
+                new GetQsoRequest { LocalId = logResponse.LocalId },
+                cancellationToken: cancellationToken);
+
+            using var listCall = client.ListQsos(
+                new ListQsosRequest
+                {
+                    CallsignFilter = sampleQso.WorkedCallsign,
+                    Limit = 25,
+                    Sort = SortOrder.NewestFirst
+                },
+                cancellationToken: cancellationToken);
+
+            await foreach (var qso in listCall.ResponseStream.ReadAllAsync(cancellationToken))
+            {
+                listedQsos.Add(qso);
+            }
+
+            syncStatus = await client.GetSyncStatusAsync(
+                new SyncStatusRequest(),
+                cancellationToken: cancellationToken);
+
+            if (!retainRecord)
+            {
+                deleteResponse = await client.DeleteQsoAsync(
+                    new DeleteQsoRequest
+                    {
+                        LocalId = logResponse.LocalId,
+                        DeleteFromQrz = false
+                    },
+                    cancellationToken: cancellationToken);
+                deleteVerified = await ConfirmDeleteAsync(client, logResponse.LocalId, cancellationToken);
+            }
+
+            var errorMessage = !retainRecord && !deleteVerified
+                ? "Delete verification failed. GetQso still returned the sample record after delete."
+                : null;
+
+            return new StorageSmokeTestResult(
+                sampleQso,
+                logResponse,
+                loadedResponse,
+                listedQsos,
+                syncStatus,
+                deleteResponse,
+                retainRecord,
+                deleteVerified,
+                errorMessage,
+                DateTimeOffset.UtcNow);
+        }
+        catch (RpcException ex)
+        {
+            return new StorageSmokeTestResult(
+                sampleQso,
+                logResponse,
+                loadedResponse,
+                listedQsos,
+                syncStatus,
+                deleteResponse,
+                retainRecord,
+                deleteVerified,
+                ex.Status.Detail,
+                DateTimeOffset.UtcNow);
+        }
+        catch (OperationCanceledException ex)
+        {
+            return new StorageSmokeTestResult(
+                sampleQso,
+                logResponse,
+                loadedResponse,
+                listedQsos,
+                syncStatus,
+                deleteResponse,
+                retainRecord,
+                deleteVerified,
+                ex.Message,
+                DateTimeOffset.UtcNow);
+        }
+    }
+
+    private static async Task<bool> ConfirmDeleteAsync(
+        LogbookService.LogbookServiceClient client,
+        string localId,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            _ = await client.GetQsoAsync(
+                new GetQsoRequest { LocalId = localId },
+                cancellationToken: cancellationToken);
+            return false;
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
+        {
+            return true;
+        }
+    }
+}

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -3,6 +3,8 @@ resolver = "2"
 members = [
     "logripper-core",
     "logripper-server",
+    "logripper-storage-memory",
+    "logripper-storage-sqlite",
 ]
 
 [workspace.package]
@@ -18,6 +20,7 @@ prost-types = "0.13"
 tonic = "0.12"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 uuid = { version = "1", features = ["v4"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -20,7 +20,7 @@ prost-types = "0.13"
 tonic = "0.12"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 uuid = { version = "1", features = ["v4"] }
-rusqlite = { version = "0.32", features = ["bundled"] }
+sqlite = { version = "0.37", features = ["bundled"] }
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/src/rust/logripper-core/build.rs
+++ b/src/rust/logripper-core/build.rs
@@ -10,6 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         proto_root.join("domain/callsign.proto"),
         proto_root.join("domain/qso.proto"),
         proto_root.join("domain/lookup.proto"),
+        proto_root.join("services/debug_control_service.proto"),
         proto_root.join("services/lookup_service.proto"),
         proto_root.join("services/logbook_service.proto"),
     ];

--- a/src/rust/logripper-core/src/application/logbook.rs
+++ b/src/rust/logripper-core/src/application/logbook.rs
@@ -1,0 +1,232 @@
+//! Logbook workflows built on top of the engine-owned storage ports.
+
+use crate::domain::qso::new_local_id;
+use crate::proto::logripper::domain::{QsoRecord, SyncStatus};
+use crate::storage::{EngineStorage, LogbookCounts, QsoListQuery, StorageError, SyncMetadata};
+use chrono::Utc;
+use prost_types::Timestamp;
+use std::sync::Arc;
+use thiserror::Error;
+
+/// Coordinates QSO CRUD and sync-status reads through a storage backend.
+#[derive(Clone)]
+pub struct LogbookEngine {
+    storage: Arc<dyn EngineStorage>,
+}
+
+impl LogbookEngine {
+    /// Create a logbook engine backed by the provided storage implementation.
+    #[must_use]
+    pub fn new(storage: Arc<dyn EngineStorage>) -> Self {
+        Self { storage }
+    }
+
+    /// Return the active storage backend name for diagnostics and startup logs.
+    #[must_use]
+    pub fn storage_backend_name(&self) -> &'static str {
+        self.storage.backend_name()
+    }
+
+    /// Persist a new QSO and return the normalized stored record.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LogbookError::Validation`] when required fields are missing and
+    /// [`LogbookError::Storage`] when the configured backend rejects the write.
+    pub async fn log_qso(&self, mut qso: QsoRecord) -> Result<QsoRecord, LogbookError> {
+        validate_required_callsigns(&qso)?;
+
+        if qso.local_id.trim().is_empty() {
+            qso.local_id = new_local_id();
+        }
+
+        let now = now_timestamp();
+        if qso.created_at.is_none() {
+            qso.created_at = Some(now);
+        }
+        qso.updated_at = Some(now);
+
+        self.storage.logbook().insert_qso(&qso).await?;
+        Ok(qso)
+    }
+
+    /// Update an existing QSO and return the normalized stored record.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LogbookError::Validation`] when the record is missing required
+    /// fields, [`LogbookError::NotFound`] when the local ID does not exist, and
+    /// [`LogbookError::Storage`] when the backend write fails.
+    pub async fn update_qso(&self, mut qso: QsoRecord) -> Result<QsoRecord, LogbookError> {
+        validate_required_callsigns(&qso)?;
+        if qso.local_id.trim().is_empty() {
+            return Err(LogbookError::Validation(
+                "local_id is required when updating a QSO.".into(),
+            ));
+        }
+
+        if qso.created_at.is_none() {
+            qso.created_at = Some(now_timestamp());
+        }
+        qso.updated_at = Some(now_timestamp());
+
+        let updated = self.storage.logbook().update_qso(&qso).await?;
+        if updated {
+            Ok(qso)
+        } else {
+            Err(LogbookError::NotFound(qso.local_id))
+        }
+    }
+
+    /// Delete a QSO by local identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LogbookError::Validation`] when the local ID is blank,
+    /// [`LogbookError::NotFound`] when the record does not exist, and
+    /// [`LogbookError::Storage`] when the backend delete fails.
+    pub async fn delete_qso(&self, local_id: &str) -> Result<(), LogbookError> {
+        if local_id.trim().is_empty() {
+            return Err(LogbookError::Validation(
+                "local_id is required when deleting a QSO.".into(),
+            ));
+        }
+
+        let deleted = self.storage.logbook().delete_qso(local_id).await?;
+        if deleted {
+            Ok(())
+        } else {
+            Err(LogbookError::NotFound(local_id.to_string()))
+        }
+    }
+
+    /// Retrieve a persisted QSO by local identifier.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LogbookError::Validation`] when the local ID is blank,
+    /// [`LogbookError::NotFound`] when the record does not exist, and
+    /// [`LogbookError::Storage`] when the backend read fails.
+    pub async fn get_qso(&self, local_id: &str) -> Result<QsoRecord, LogbookError> {
+        if local_id.trim().is_empty() {
+            return Err(LogbookError::Validation(
+                "local_id is required when loading a QSO.".into(),
+            ));
+        }
+
+        self.storage
+            .logbook()
+            .get_qso(local_id)
+            .await?
+            .ok_or_else(|| LogbookError::NotFound(local_id.to_string()))
+    }
+
+    /// List QSOs using the provided filter and pagination options.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LogbookError::Storage`] when the backend query fails.
+    pub async fn list_qsos(&self, query: &QsoListQuery) -> Result<Vec<QsoRecord>, LogbookError> {
+        self.storage
+            .logbook()
+            .list_qsos(query)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Return the current aggregate sync status derived from local and remote metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LogbookError::Storage`] when the backend count or metadata reads fail.
+    pub async fn get_sync_status(&self) -> Result<LogbookSyncStatus, LogbookError> {
+        let counts = self.storage.logbook().qso_counts().await?;
+        let metadata = self.storage.logbook().get_sync_metadata().await?;
+
+        Ok(LogbookSyncStatus::from_parts(counts, metadata))
+    }
+
+    /// Update the stored remote sync metadata.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LogbookError::Storage`] when the backend write fails.
+    pub async fn update_sync_metadata(&self, metadata: &SyncMetadata) -> Result<(), LogbookError> {
+        self.storage
+            .logbook()
+            .upsert_sync_metadata(metadata)
+            .await
+            .map_err(Into::into)
+    }
+}
+
+/// Aggregated sync status returned by the logbook engine.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogbookSyncStatus {
+    /// Total number of locally persisted QSOs.
+    pub local_qso_count: u32,
+    /// Number of local QSOs that are not yet fully synced.
+    pub pending_upload: u32,
+    /// Latest remote QSO count reported by QRZ metadata.
+    pub qrz_qso_count: u32,
+    /// Timestamp of the last completed QRZ sync, if known.
+    pub last_sync: Option<Timestamp>,
+    /// Remote logbook owner reported by QRZ, if known.
+    pub qrz_logbook_owner: Option<String>,
+}
+
+impl LogbookSyncStatus {
+    fn from_parts(counts: LogbookCounts, metadata: SyncMetadata) -> Self {
+        Self {
+            local_qso_count: counts.local_qso_count,
+            pending_upload: counts.pending_upload_count,
+            qrz_qso_count: metadata.qrz_qso_count,
+            last_sync: metadata.last_sync,
+            qrz_logbook_owner: metadata.qrz_logbook_owner,
+        }
+    }
+}
+
+/// Errors returned by logbook workflows before they are translated to transport status codes.
+#[derive(Debug, Error)]
+pub enum LogbookError {
+    /// The incoming request is missing required fields or contains invalid values.
+    #[error("Validation failed: {0}")]
+    Validation(String),
+    /// The requested QSO could not be found in persistent storage.
+    #[error("QSO '{0}' was not found.")]
+    NotFound(String),
+    /// The underlying storage layer failed to complete the requested operation.
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+}
+
+fn validate_required_callsigns(qso: &QsoRecord) -> Result<(), LogbookError> {
+    if qso.station_callsign.trim().is_empty() {
+        return Err(LogbookError::Validation(
+            "station_callsign is required.".into(),
+        ));
+    }
+
+    if qso.worked_callsign.trim().is_empty() {
+        return Err(LogbookError::Validation(
+            "worked_callsign is required.".into(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn now_timestamp() -> Timestamp {
+    let now = Utc::now();
+    Timestamp {
+        seconds: now.timestamp(),
+        nanos: i32::try_from(now.timestamp_subsec_nanos()).unwrap_or(0),
+    }
+}
+
+/// Return whether a QSO should count as pending upload work.
+#[must_use]
+pub fn is_pending_sync_status(sync_status: i32) -> bool {
+    sync_status != SyncStatus::Synced as i32
+}

--- a/src/rust/logripper-core/src/application/mod.rs
+++ b/src/rust/logripper-core/src/application/mod.rs
@@ -1,0 +1,3 @@
+//! Application services that coordinate engine workflows above storage ports.
+
+pub mod logbook;

--- a/src/rust/logripper-core/src/lib.rs
+++ b/src/rust/logripper-core/src/lib.rs
@@ -3,6 +3,8 @@
 
 /// ADIF import/export adapters.
 pub mod adif;
+/// Application services that coordinate engine workflows above storage ports.
+pub mod application;
 /// Domain helpers for QSO and lookup-related types.
 pub mod domain;
 /// FFI boundary for DSP helpers.
@@ -11,3 +13,5 @@ pub mod ffi;
 pub mod lookup;
 /// Generated protobuf and gRPC bindings.
 pub mod proto;
+/// Storage ports, errors, and query types for engine-owned persistence.
+pub mod storage;

--- a/src/rust/logripper-core/src/lookup/mod.rs
+++ b/src/rust/logripper-core/src/lookup/mod.rs
@@ -8,4 +8,9 @@ pub use coordinator::{LookupCoordinator, LookupCoordinatorConfig};
 pub use provider::{
     CallsignProvider, DisabledCallsignProvider, ProviderLookup, ProviderLookupError,
 };
-pub use qrz_xml::{QrzXmlConfig, QrzXmlConfigError, QrzXmlProvider};
+pub use qrz_xml::{
+    QrzXmlConfig, QrzXmlConfigError, QrzXmlProvider, DEFAULT_QRZ_HTTP_TIMEOUT_SECONDS,
+    DEFAULT_QRZ_MAX_RETRIES, DEFAULT_QRZ_XML_BASE_URL, QRZ_HTTP_TIMEOUT_SECONDS_ENV_VAR,
+    QRZ_MAX_RETRIES_ENV_VAR, QRZ_USER_AGENT_ENV_VAR, QRZ_XML_BASE_URL_ENV_VAR,
+    QRZ_XML_CAPTURE_ONLY_ENV_VAR, QRZ_XML_PASSWORD_ENV_VAR, QRZ_XML_USERNAME_ENV_VAR,
+};

--- a/src/rust/logripper-core/src/lookup/qrz_xml.rs
+++ b/src/rust/logripper-core/src/lookup/qrz_xml.rs
@@ -15,11 +15,28 @@ use crate::{
 
 use super::provider::{CallsignProvider, ProviderLookup, ProviderLookupError};
 
-const DEFAULT_QRZ_XML_BASE_URL: &str = "https://xmldata.qrz.com/xml/current/";
-const DEFAULT_HTTP_TIMEOUT_SECONDS: u64 = 8;
-const DEFAULT_MAX_RETRIES: u32 = 2;
+/// Environment variable that overrides the QRZ XML base URL.
+pub const QRZ_XML_BASE_URL_ENV_VAR: &str = "LOGRIPPER_QRZ_XML_BASE_URL";
+/// Environment variable that provides the QRZ XML username.
+pub const QRZ_XML_USERNAME_ENV_VAR: &str = "LOGRIPPER_QRZ_XML_USERNAME";
+/// Environment variable that provides the QRZ XML password.
+pub const QRZ_XML_PASSWORD_ENV_VAR: &str = "LOGRIPPER_QRZ_XML_PASSWORD";
+/// Environment variable that provides the QRZ request user agent.
+pub const QRZ_USER_AGENT_ENV_VAR: &str = "LOGRIPPER_QRZ_USER_AGENT";
+/// Environment variable that overrides the QRZ HTTP timeout in seconds.
+pub const QRZ_HTTP_TIMEOUT_SECONDS_ENV_VAR: &str = "LOGRIPPER_QRZ_HTTP_TIMEOUT_SECONDS";
+/// Environment variable that overrides the QRZ retry count.
+pub const QRZ_MAX_RETRIES_ENV_VAR: &str = "LOGRIPPER_QRZ_MAX_RETRIES";
+/// Environment variable that enables request-capture mode instead of live calls.
+pub const QRZ_XML_CAPTURE_ONLY_ENV_VAR: &str = "LOGRIPPER_QRZ_XML_CAPTURE_ONLY";
+
+/// Default QRZ XML endpoint.
+pub const DEFAULT_QRZ_XML_BASE_URL: &str = "https://xmldata.qrz.com/xml/current/";
+/// Default QRZ HTTP timeout in seconds.
+pub const DEFAULT_QRZ_HTTP_TIMEOUT_SECONDS: u64 = 8;
+/// Default retry count for retryable QRZ failures.
+pub const DEFAULT_QRZ_MAX_RETRIES: u32 = 2;
 const RETRY_BASE_DELAY_MILLIS: u64 = 200;
-const CAPTURE_ONLY_ENV_VAR: &str = "LOGRIPPER_QRZ_XML_CAPTURE_ONLY";
 
 /// QRZ XML provider configuration.
 #[derive(Clone)]
@@ -67,17 +84,39 @@ impl QrzXmlConfig {
     /// Returns `QrzXmlConfigError` when required values are missing/blank or
     /// integer-valued settings cannot be parsed.
     pub fn from_env() -> Result<Self, QrzXmlConfigError> {
-        let base_url = env::var("LOGRIPPER_QRZ_XML_BASE_URL")
-            .unwrap_or_else(|_| DEFAULT_QRZ_XML_BASE_URL.to_string());
-        let username = required_env("LOGRIPPER_QRZ_XML_USERNAME")?;
-        let password = required_env("LOGRIPPER_QRZ_XML_PASSWORD")?;
-        let user_agent = required_env("LOGRIPPER_QRZ_USER_AGENT")?;
-        let http_timeout_seconds = optional_env_u64(
-            "LOGRIPPER_QRZ_HTTP_TIMEOUT_SECONDS",
-            DEFAULT_HTTP_TIMEOUT_SECONDS,
+        Self::from_value_provider(|name| env::var(name).ok())
+    }
+
+    /// Load provider configuration from an arbitrary key/value source.
+    ///
+    /// This is used by the developer runtime-config surface so a running engine
+    /// can be reconfigured without mutating the process environment.
+    ///
+    /// # Errors
+    ///
+    /// Returns `QrzXmlConfigError` when required values are missing/blank or
+    /// integer-valued settings cannot be parsed.
+    pub fn from_value_provider<F>(mut get_value: F) -> Result<Self, QrzXmlConfigError>
+    where
+        F: FnMut(&'static str) -> Option<String>,
+    {
+        let base_url = optional_value(QRZ_XML_BASE_URL_ENV_VAR, &mut get_value)
+            .unwrap_or_else(|| DEFAULT_QRZ_XML_BASE_URL.to_string());
+        let username = required_value(QRZ_XML_USERNAME_ENV_VAR, &mut get_value)?;
+        let password = required_value(QRZ_XML_PASSWORD_ENV_VAR, &mut get_value)?;
+        let user_agent = required_value(QRZ_USER_AGENT_ENV_VAR, &mut get_value)?;
+        let http_timeout_seconds = optional_value_u64(
+            QRZ_HTTP_TIMEOUT_SECONDS_ENV_VAR,
+            DEFAULT_QRZ_HTTP_TIMEOUT_SECONDS,
+            &mut get_value,
         )?;
-        let max_retries = optional_env_u32("LOGRIPPER_QRZ_MAX_RETRIES", DEFAULT_MAX_RETRIES)?;
-        let capture_only = optional_env_bool(CAPTURE_ONLY_ENV_VAR, false)?;
+        let max_retries = optional_value_u32(
+            QRZ_MAX_RETRIES_ENV_VAR,
+            DEFAULT_QRZ_MAX_RETRIES,
+            &mut get_value,
+        )?;
+        let capture_only =
+            optional_value_bool(QRZ_XML_CAPTURE_ONLY_ENV_VAR, false, &mut get_value)?;
 
         Ok(Self {
             base_url: normalize_base_url(base_url),
@@ -88,6 +127,18 @@ impl QrzXmlConfig {
             max_retries,
             capture_only,
         })
+    }
+
+    /// Return the configured QRZ XML endpoint for diagnostics.
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Return whether request-capture mode is enabled.
+    #[must_use]
+    pub fn capture_only(&self) -> bool {
+        self.capture_only
     }
 }
 
@@ -241,7 +292,7 @@ impl QrzXmlProvider {
         };
 
         Ok(format!(
-            "QRZ XML request capture mode enabled ({CAPTURE_ONLY_ENV_VAR}=true): request not sent. QRZ XML uses HTTP GET query parameters (no JSON body). method={}, url={}, query_details=[{}]",
+            "QRZ XML request capture mode enabled ({QRZ_XML_CAPTURE_ONLY_ENV_VAR}=true): request not sent. QRZ XML uses HTTP GET query parameters (no JSON body). method={}, url={}, query_details=[{}]",
             request.method(),
             url,
             query_details
@@ -549,36 +600,74 @@ fn map_callsign_record(queried_callsign: &str, qrz: &QrzCallsign) -> CallsignRec
     }
 }
 
-fn required_env(name: &'static str) -> Result<String, QrzXmlConfigError> {
-    match env::var(name) {
-        Ok(value) if !value.trim().is_empty() => Ok(value),
+fn required_value<F>(name: &'static str, get_value: &mut F) -> Result<String, QrzXmlConfigError>
+where
+    F: FnMut(&'static str) -> Option<String>,
+{
+    match get_value(name) {
+        Some(value) if !value.trim().is_empty() => Ok(value),
         _ => Err(QrzXmlConfigError::Missing { name }),
     }
 }
 
-fn optional_env_u64(name: &'static str, default: u64) -> Result<u64, QrzXmlConfigError> {
-    match env::var(name) {
-        Ok(raw) => raw
+fn optional_value<F>(name: &'static str, get_value: &mut F) -> Option<String>
+where
+    F: FnMut(&'static str) -> Option<String>,
+{
+    get_value(name).and_then(|value| {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
+}
+
+fn optional_value_u64<F>(
+    name: &'static str,
+    default: u64,
+    get_value: &mut F,
+) -> Result<u64, QrzXmlConfigError>
+where
+    F: FnMut(&'static str) -> Option<String>,
+{
+    match get_value(name) {
+        Some(raw) => raw
             .trim()
             .parse::<u64>()
             .map_err(|_| QrzXmlConfigError::InvalidInteger { name, value: raw }),
-        Err(_) => Ok(default),
+        None => Ok(default),
     }
 }
 
-fn optional_env_u32(name: &'static str, default: u32) -> Result<u32, QrzXmlConfigError> {
-    match env::var(name) {
-        Ok(raw) => raw
+fn optional_value_u32<F>(
+    name: &'static str,
+    default: u32,
+    get_value: &mut F,
+) -> Result<u32, QrzXmlConfigError>
+where
+    F: FnMut(&'static str) -> Option<String>,
+{
+    match get_value(name) {
+        Some(raw) => raw
             .trim()
             .parse::<u32>()
             .map_err(|_| QrzXmlConfigError::InvalidInteger { name, value: raw }),
-        Err(_) => Ok(default),
+        None => Ok(default),
     }
 }
 
-fn optional_env_bool(name: &'static str, default: bool) -> Result<bool, QrzXmlConfigError> {
-    match env::var(name) {
-        Ok(raw) => {
+fn optional_value_bool<F>(
+    name: &'static str,
+    default: bool,
+    get_value: &mut F,
+) -> Result<bool, QrzXmlConfigError>
+where
+    F: FnMut(&'static str) -> Option<String>,
+{
+    match get_value(name) {
+        Some(raw) => {
             let normalized = raw.trim().to_ascii_lowercase();
             match normalized.as_str() {
                 "1" | "true" | "yes" | "y" | "on" => Ok(true),
@@ -586,7 +675,7 @@ fn optional_env_bool(name: &'static str, default: bool) -> Result<bool, QrzXmlCo
                 _ => Err(QrzXmlConfigError::InvalidBoolean { name, value: raw }),
             }
         }
-        Err(_) => Ok(default),
+        None => Ok(default),
     }
 }
 
@@ -1100,7 +1189,7 @@ mod tests {
         let saved_password = std::env::var("LOGRIPPER_QRZ_XML_PASSWORD").ok();
         let saved_agent = std::env::var("LOGRIPPER_QRZ_USER_AGENT").ok();
         let saved_base_url = std::env::var("LOGRIPPER_QRZ_XML_BASE_URL").ok();
-        let saved_capture_only = std::env::var(CAPTURE_ONLY_ENV_VAR).ok();
+        let saved_capture_only = std::env::var(QRZ_XML_CAPTURE_ONLY_ENV_VAR).ok();
 
         std::env::set_var("LOGRIPPER_QRZ_XML_USERNAME", "KC7AVA");
         std::env::set_var("LOGRIPPER_QRZ_XML_PASSWORD", "super-secret-password");
@@ -1109,7 +1198,7 @@ mod tests {
             "LOGRIPPER_QRZ_XML_BASE_URL",
             "https://xmldata.qrz.com/xml/current",
         );
-        std::env::set_var(CAPTURE_ONLY_ENV_VAR, "true");
+        std::env::set_var(QRZ_XML_CAPTURE_ONLY_ENV_VAR, "true");
 
         let config = QrzXmlConfig::from_env().expect("config");
 
@@ -1120,7 +1209,7 @@ mod tests {
         restore_env("LOGRIPPER_QRZ_XML_PASSWORD", saved_password);
         restore_env("LOGRIPPER_QRZ_USER_AGENT", saved_agent);
         restore_env("LOGRIPPER_QRZ_XML_BASE_URL", saved_base_url);
-        restore_env(CAPTURE_ONLY_ENV_VAR, saved_capture_only);
+        restore_env(QRZ_XML_CAPTURE_ONLY_ENV_VAR, saved_capture_only);
     }
 
     #[test]
@@ -1129,12 +1218,12 @@ mod tests {
         let saved_username = std::env::var("LOGRIPPER_QRZ_XML_USERNAME").ok();
         let saved_password = std::env::var("LOGRIPPER_QRZ_XML_PASSWORD").ok();
         let saved_agent = std::env::var("LOGRIPPER_QRZ_USER_AGENT").ok();
-        let saved_capture_only = std::env::var(CAPTURE_ONLY_ENV_VAR).ok();
+        let saved_capture_only = std::env::var(QRZ_XML_CAPTURE_ONLY_ENV_VAR).ok();
 
         std::env::set_var("LOGRIPPER_QRZ_XML_USERNAME", "KC7AVA");
         std::env::set_var("LOGRIPPER_QRZ_XML_PASSWORD", "super-secret-password");
         std::env::set_var("LOGRIPPER_QRZ_USER_AGENT", "LogRipper/0.1.0 (KC7AVA)");
-        std::env::set_var(CAPTURE_ONLY_ENV_VAR, "sometimes");
+        std::env::set_var(QRZ_XML_CAPTURE_ONLY_ENV_VAR, "sometimes");
 
         let error = QrzXmlConfig::from_env().expect_err("invalid bool");
 
@@ -1146,7 +1235,7 @@ mod tests {
         restore_env("LOGRIPPER_QRZ_XML_USERNAME", saved_username);
         restore_env("LOGRIPPER_QRZ_XML_PASSWORD", saved_password);
         restore_env("LOGRIPPER_QRZ_USER_AGENT", saved_agent);
-        restore_env(CAPTURE_ONLY_ENV_VAR, saved_capture_only);
+        restore_env(QRZ_XML_CAPTURE_ONLY_ENV_VAR, saved_capture_only);
     }
 
     #[test]

--- a/src/rust/logripper-core/src/storage/error.rs
+++ b/src/rust/logripper-core/src/storage/error.rs
@@ -1,0 +1,42 @@
+//! Storage-layer error types shared by all engine persistence adapters.
+
+use thiserror::Error;
+
+/// Errors returned by engine-owned storage ports.
+#[derive(Debug, Error)]
+pub enum StorageError {
+    /// A record already exists with the same unique key.
+    #[error("{entity} '{key}' already exists.")]
+    Duplicate {
+        /// Logical entity type for the duplicate record.
+        entity: &'static str,
+        /// Unique key value that already exists.
+        key: String,
+    },
+    /// Persisted data could not be decoded or did not match the expected shape.
+    #[error("Stored data is corrupt: {0}")]
+    CorruptData(String),
+    /// An adapter does not support the requested operation.
+    #[error("Storage operation is not supported: {0}")]
+    Unsupported(String),
+    /// The backend reported an operational failure.
+    #[error("Storage backend failure: {0}")]
+    Backend(String),
+}
+
+impl StorageError {
+    /// Create a duplicate-key storage error.
+    #[must_use]
+    pub fn duplicate(entity: &'static str, key: impl Into<String>) -> Self {
+        Self::Duplicate {
+            entity,
+            key: key.into(),
+        }
+    }
+
+    /// Create a backend failure storage error.
+    #[must_use]
+    pub fn backend(message: impl Into<String>) -> Self {
+        Self::Backend(message.into())
+    }
+}

--- a/src/rust/logripper-core/src/storage/mod.rs
+++ b/src/rust/logripper-core/src/storage/mod.rs
@@ -1,0 +1,9 @@
+//! Storage ports, errors, and query types for engine-owned persistence.
+
+mod error;
+mod ports;
+mod query;
+
+pub use error::StorageError;
+pub use ports::{EngineStorage, LogbookStore, LookupSnapshotStore};
+pub use query::{LogbookCounts, LookupSnapshot, QsoListQuery, QsoSortOrder, SyncMetadata};

--- a/src/rust/logripper-core/src/storage/ports.rs
+++ b/src/rust/logripper-core/src/storage/ports.rs
@@ -1,0 +1,60 @@
+//! Domain-facing storage contracts implemented by persistence adapters.
+
+use crate::proto::logripper::domain::QsoRecord;
+use crate::storage::{LogbookCounts, LookupSnapshot, QsoListQuery, StorageError, SyncMetadata};
+
+/// Root engine-owned storage abstraction used by application services.
+pub trait EngineStorage: Send + Sync {
+    /// Return the logbook-oriented storage surface.
+    fn logbook(&self) -> &dyn LogbookStore;
+
+    /// Return the persisted lookup snapshot surface.
+    fn lookup_snapshots(&self) -> &dyn LookupSnapshotStore;
+
+    /// Return a stable backend name for diagnostics and bootstrap logs.
+    fn backend_name(&self) -> &'static str;
+}
+
+/// Persistence operations for the QSO logbook and sync metadata.
+#[tonic::async_trait]
+pub trait LogbookStore: Send + Sync {
+    /// Insert a new QSO.
+    async fn insert_qso(&self, qso: &QsoRecord) -> Result<(), StorageError>;
+
+    /// Update an existing QSO. Returns `true` when a row was updated.
+    async fn update_qso(&self, qso: &QsoRecord) -> Result<bool, StorageError>;
+
+    /// Delete a QSO by local ID. Returns `true` when a row was removed.
+    async fn delete_qso(&self, local_id: &str) -> Result<bool, StorageError>;
+
+    /// Load a single QSO by local ID.
+    async fn get_qso(&self, local_id: &str) -> Result<Option<QsoRecord>, StorageError>;
+
+    /// List QSOs using the provided query object.
+    async fn list_qsos(&self, query: &QsoListQuery) -> Result<Vec<QsoRecord>, StorageError>;
+
+    /// Return aggregate counts derived from locally persisted QSOs.
+    async fn qso_counts(&self) -> Result<LogbookCounts, StorageError>;
+
+    /// Return the persisted remote sync metadata snapshot.
+    async fn get_sync_metadata(&self) -> Result<SyncMetadata, StorageError>;
+
+    /// Replace the persisted remote sync metadata snapshot.
+    async fn upsert_sync_metadata(&self, metadata: &SyncMetadata) -> Result<(), StorageError>;
+}
+
+/// Persistence operations for callsign lookup snapshots stored below the hot cache.
+#[tonic::async_trait]
+pub trait LookupSnapshotStore: Send + Sync {
+    /// Load a persisted lookup snapshot by callsign.
+    async fn get_lookup_snapshot(
+        &self,
+        callsign: &str,
+    ) -> Result<Option<LookupSnapshot>, StorageError>;
+
+    /// Insert or replace a persisted lookup snapshot.
+    async fn upsert_lookup_snapshot(&self, snapshot: &LookupSnapshot) -> Result<(), StorageError>;
+
+    /// Delete a persisted lookup snapshot by callsign. Returns `true` when removed.
+    async fn delete_lookup_snapshot(&self, callsign: &str) -> Result<bool, StorageError>;
+}

--- a/src/rust/logripper-core/src/storage/query.rs
+++ b/src/rust/logripper-core/src/storage/query.rs
@@ -1,0 +1,85 @@
+//! Query and snapshot types shared across storage adapters.
+
+use crate::proto::logripper::domain::{Band, LookupResult, Mode};
+use prost_types::Timestamp;
+
+/// Filter and pagination options for listing QSOs from persistent storage.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QsoListQuery {
+    /// Only return QSOs at or after this UTC timestamp.
+    pub after: Option<Timestamp>,
+    /// Only return QSOs at or before this UTC timestamp.
+    pub before: Option<Timestamp>,
+    /// Match callsigns containing this filter text.
+    pub callsign_filter: Option<String>,
+    /// Restrict results to a single band.
+    pub band_filter: Option<Band>,
+    /// Restrict results to a single mode.
+    pub mode_filter: Option<Mode>,
+    /// Restrict results to a single contest identifier.
+    pub contest_id: Option<String>,
+    /// Maximum number of rows to return. `None` means unbounded.
+    pub limit: Option<u32>,
+    /// Number of rows to skip before returning results.
+    pub offset: u32,
+    /// Requested sort order.
+    pub sort: QsoSortOrder,
+}
+
+impl Default for QsoListQuery {
+    fn default() -> Self {
+        Self {
+            after: None,
+            before: None,
+            callsign_filter: None,
+            band_filter: None,
+            mode_filter: None,
+            contest_id: None,
+            limit: None,
+            offset: 0,
+            sort: QsoSortOrder::NewestFirst,
+        }
+    }
+}
+
+/// Sort order for `QsoListQuery`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QsoSortOrder {
+    /// Newest records first.
+    NewestFirst,
+    /// Oldest records first.
+    OldestFirst,
+}
+
+/// Aggregate counts derived from locally persisted QSOs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct LogbookCounts {
+    /// Total number of locally stored QSOs.
+    pub local_qso_count: u32,
+    /// Number of locally stored QSOs that still need sync work.
+    pub pending_upload_count: u32,
+}
+
+/// Persisted remote logbook metadata reported by sync workflows.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SyncMetadata {
+    /// Remote QRZ QSO count from the last known status snapshot.
+    pub qrz_qso_count: u32,
+    /// Timestamp of the last successful remote sync.
+    pub last_sync: Option<Timestamp>,
+    /// Remote logbook owner reported by QRZ.
+    pub qrz_logbook_owner: Option<String>,
+}
+
+/// A persisted callsign lookup snapshot stored below the hot in-memory cache.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LookupSnapshot {
+    /// Normalized callsign key for the stored snapshot.
+    pub callsign: String,
+    /// Persisted lookup result payload.
+    pub result: LookupResult,
+    /// Timestamp when the snapshot was stored.
+    pub stored_at: Timestamp,
+    /// Optional expiry timestamp for stale-data decisions.
+    pub expires_at: Option<Timestamp>,
+}

--- a/src/rust/logripper-server/src/main.rs
+++ b/src/rust/logripper-server/src/main.rs
@@ -1,12 +1,10 @@
 //! Runnable tonic gRPC host for the `LogRipper` Rust engine.
 
+mod runtime_config;
+
 use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
-use logripper_core::application::logbook::{LogbookEngine, LogbookError};
-use logripper_core::lookup::{
-    CallsignProvider, DisabledCallsignProvider, LookupCoordinator, LookupCoordinatorConfig,
-    QrzXmlConfig, QrzXmlProvider,
-};
+use logripper_core::application::logbook::LogbookError;
 use logripper_core::storage::{EngineStorage, QsoListQuery, QsoSortOrder, StorageError};
 use logripper_storage_memory::MemoryStorage;
 use logripper_storage_sqlite::SqliteStorageBuilder;
@@ -19,29 +17,37 @@ use logripper_core::proto::logripper::domain::{
     LookupRequest, LookupResult, Mode, QsoRecord,
 };
 use logripper_core::proto::logripper::services::{
+    developer_control_service_server::{DeveloperControlService, DeveloperControlServiceServer},
     logbook_service_server::{LogbookService, LogbookServiceServer},
     lookup_service_server::{LookupService, LookupServiceServer},
-    AdifChunk, DeleteQsoRequest, DeleteQsoResponse, ExportRequest, GetQsoRequest, GetQsoResponse,
-    ImportResult, ListQsosRequest, LogQsoRequest, LogQsoResponse, SortOrder, SyncProgress,
-    SyncRequest, SyncStatusRequest, SyncStatusResponse, UpdateQsoRequest, UpdateQsoResponse,
+    AdifChunk, ApplyRuntimeConfigRequest, DeleteQsoRequest, DeleteQsoResponse, ExportRequest,
+    GetQsoRequest, GetQsoResponse, GetRuntimeConfigRequest, ImportResult, ListQsosRequest,
+    LogQsoRequest, LogQsoResponse, ResetRuntimeConfigRequest, RuntimeConfigSnapshot, SortOrder,
+    SyncProgress, SyncRequest, SyncStatusRequest, SyncStatusResponse, UpdateQsoRequest,
+    UpdateQsoResponse,
 };
+use runtime_config::RuntimeConfigManager;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let options = ServerOptions::from_env_and_args(std::env::args().skip(1))?;
     let address = options.listen_address;
-    let storage = build_storage(&options.storage)?;
-    let logbook_service = DeveloperLogbookService::new(LogbookEngine::new(storage));
-    let lookup_service = DeveloperLookupService::new(create_lookup_coordinator());
+    let runtime_config = Arc::new(RuntimeConfigManager::new_from_storage_options(
+        &options.storage,
+    )?);
+    let logbook_service = DeveloperLogbookService::new(runtime_config.clone());
+    let lookup_service = DeveloperLookupService::new(runtime_config.clone());
+    let developer_control_service = DeveloperControlSurface::new(runtime_config.clone());
+    let active_storage_backend = runtime_config.active_storage_backend().await;
 
-    println!(
-        "Starting LogRipper gRPC server on {address} using {} storage",
-        logbook_service.engine.storage_backend_name()
-    );
+    println!("Starting LogRipper gRPC server on {address} using {active_storage_backend} storage");
 
     Server::builder()
         .add_service(LogbookServiceServer::new(logbook_service))
         .add_service(LookupServiceServer::new(lookup_service))
+        .add_service(DeveloperControlServiceServer::new(
+            developer_control_service,
+        ))
         .serve(address)
         .await?;
 
@@ -50,12 +56,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[derive(Clone)]
 struct DeveloperLogbookService {
-    engine: LogbookEngine,
+    runtime_config: Arc<RuntimeConfigManager>,
 }
 
 impl DeveloperLogbookService {
-    fn new(engine: LogbookEngine) -> Self {
-        Self { engine }
+    fn new(runtime_config: Arc<RuntimeConfigManager>) -> Self {
+        Self { runtime_config }
     }
 }
 
@@ -69,11 +75,12 @@ impl LogbookService for DeveloperLogbookService {
         &self,
         request: Request<LogQsoRequest>,
     ) -> Result<Response<LogQsoResponse>, Status> {
+        let engine = self.runtime_config.logbook_engine().await;
         let request = request.into_inner();
         let qso = request
             .qso
             .ok_or_else(|| Status::invalid_argument("LogQso requires a qso payload."))?;
-        let stored = self.engine.log_qso(qso).await.map_err(map_logbook_error)?;
+        let stored = engine.log_qso(qso).await.map_err(map_logbook_error)?;
         let (sync_success, sync_error) = sync_result(request.sync_to_qrz, "QRZ sync");
 
         Ok(Response::new(LogQsoResponse {
@@ -88,15 +95,12 @@ impl LogbookService for DeveloperLogbookService {
         &self,
         request: Request<UpdateQsoRequest>,
     ) -> Result<Response<UpdateQsoResponse>, Status> {
+        let engine = self.runtime_config.logbook_engine().await;
         let request = request.into_inner();
         let qso = request
             .qso
             .ok_or_else(|| Status::invalid_argument("UpdateQso requires a qso payload."))?;
-        let _ = self
-            .engine
-            .update_qso(qso)
-            .await
-            .map_err(map_logbook_error)?;
+        let _ = engine.update_qso(qso).await.map_err(map_logbook_error)?;
         let (sync_success, sync_error) = sync_result(request.sync_to_qrz, "QRZ sync");
 
         Ok(Response::new(UpdateQsoResponse {
@@ -111,8 +115,9 @@ impl LogbookService for DeveloperLogbookService {
         &self,
         request: Request<DeleteQsoRequest>,
     ) -> Result<Response<DeleteQsoResponse>, Status> {
+        let engine = self.runtime_config.logbook_engine().await;
         let request = request.into_inner();
-        self.engine
+        engine
             .delete_qso(&request.local_id)
             .await
             .map_err(map_logbook_error)?;
@@ -131,9 +136,9 @@ impl LogbookService for DeveloperLogbookService {
         &self,
         request: Request<GetQsoRequest>,
     ) -> Result<Response<GetQsoResponse>, Status> {
+        let engine = self.runtime_config.logbook_engine().await;
         let request = request.into_inner();
-        let qso = self
-            .engine
+        let qso = engine
             .get_qso(&request.local_id)
             .await
             .map_err(map_logbook_error)?;
@@ -145,13 +150,10 @@ impl LogbookService for DeveloperLogbookService {
         &self,
         request: Request<ListQsosRequest>,
     ) -> Result<Response<Self::ListQsosStream>, Status> {
+        let engine = self.runtime_config.logbook_engine().await;
         let request = request.into_inner();
         let query = qso_list_query_from_request(&request).map_err(|status| *status)?;
-        let records = self
-            .engine
-            .list_qsos(&query)
-            .await
-            .map_err(map_logbook_error)?;
+        let records = engine.list_qsos(&query).await.map_err(map_logbook_error)?;
         let (sender, receiver) = tokio::sync::mpsc::channel(records.len().max(1));
 
         for record in records {
@@ -175,7 +177,9 @@ impl LogbookService for DeveloperLogbookService {
         _request: Request<SyncStatusRequest>,
     ) -> Result<Response<SyncStatusResponse>, Status> {
         let sync_status = self
-            .engine
+            .runtime_config
+            .logbook_engine()
+            .await
             .get_sync_status()
             .await
             .map_err(map_logbook_error)?;
@@ -206,12 +210,12 @@ impl LogbookService for DeveloperLogbookService {
 
 #[derive(Clone)]
 struct DeveloperLookupService {
-    coordinator: Arc<LookupCoordinator>,
+    runtime_config: Arc<RuntimeConfigManager>,
 }
 
 impl DeveloperLookupService {
-    fn new(coordinator: Arc<LookupCoordinator>) -> Self {
-        Self { coordinator }
+    fn new(runtime_config: Arc<RuntimeConfigManager>) -> Self {
+        Self { runtime_config }
     }
 }
 
@@ -223,9 +227,10 @@ impl LookupService for DeveloperLookupService {
         &self,
         request: Request<LookupRequest>,
     ) -> Result<Response<LookupResult>, Status> {
+        let coordinator = self.runtime_config.lookup_coordinator().await;
         let request = request.into_inner();
         Ok(Response::new(
-            self.coordinator
+            coordinator
                 .lookup(&request.callsign, request.skip_cache)
                 .await,
         ))
@@ -235,9 +240,9 @@ impl LookupService for DeveloperLookupService {
         &self,
         request: Request<LookupRequest>,
     ) -> Result<Response<Self::StreamLookupStream>, Status> {
+        let coordinator = self.runtime_config.lookup_coordinator().await;
         let request = request.into_inner();
-        let updates = self
-            .coordinator
+        let updates = coordinator
             .stream_lookup(&request.callsign, request.skip_cache)
             .await;
         let (sender, receiver) = tokio::sync::mpsc::channel(8);
@@ -255,11 +260,10 @@ impl LookupService for DeveloperLookupService {
         &self,
         request: Request<CachedCallsignRequest>,
     ) -> Result<Response<LookupResult>, Status> {
+        let coordinator = self.runtime_config.lookup_coordinator().await;
         let request = request.into_inner();
         Ok(Response::new(
-            self.coordinator
-                .get_cached_callsign(&request.callsign)
-                .await,
+            coordinator.get_cached_callsign(&request.callsign).await,
         ))
     }
 
@@ -282,26 +286,48 @@ impl LookupService for DeveloperLookupService {
     }
 }
 
-fn create_lookup_coordinator() -> Arc<LookupCoordinator> {
-    Arc::new(LookupCoordinator::new(
-        build_provider_from_env(),
-        LookupCoordinatorConfig::default(),
-    ))
+#[derive(Clone)]
+struct DeveloperControlSurface {
+    runtime_config: Arc<RuntimeConfigManager>,
 }
 
-fn build_provider_from_env() -> Arc<dyn CallsignProvider> {
-    match QrzXmlConfig::from_env() {
-        Ok(config) => match QrzXmlProvider::new(config) {
-            Ok(provider) => Arc::new(provider),
-            Err(error) => {
-                eprintln!("QRZ XML lookup disabled: {error}");
-                Arc::new(DisabledCallsignProvider::new(error.to_string()))
-            }
-        },
-        Err(error) => {
-            eprintln!("QRZ XML lookup disabled: {error}");
-            Arc::new(DisabledCallsignProvider::new(error.to_string()))
-        }
+impl DeveloperControlSurface {
+    fn new(runtime_config: Arc<RuntimeConfigManager>) -> Self {
+        Self { runtime_config }
+    }
+}
+
+#[tonic::async_trait]
+impl DeveloperControlService for DeveloperControlSurface {
+    async fn get_runtime_config(
+        &self,
+        _request: Request<GetRuntimeConfigRequest>,
+    ) -> Result<Response<RuntimeConfigSnapshot>, Status> {
+        Ok(Response::new(self.runtime_config.snapshot().await))
+    }
+
+    async fn apply_runtime_config(
+        &self,
+        request: Request<ApplyRuntimeConfigRequest>,
+    ) -> Result<Response<RuntimeConfigSnapshot>, Status> {
+        let snapshot = self
+            .runtime_config
+            .apply_request(request.into_inner())
+            .await
+            .map_err(Status::invalid_argument)?;
+        Ok(Response::new(snapshot))
+    }
+
+    async fn reset_runtime_config(
+        &self,
+        request: Request<ResetRuntimeConfigRequest>,
+    ) -> Result<Response<RuntimeConfigSnapshot>, Status> {
+        let snapshot = self
+            .runtime_config
+            .reset_request(request.into_inner())
+            .await
+            .map_err(Status::invalid_argument)?;
+        Ok(Response::new(snapshot))
     }
 }
 
@@ -469,6 +495,7 @@ fn sync_result(requested: bool, label: &str) -> (bool, Option<String>) {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::fs;
     use std::sync::Arc;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -477,10 +504,7 @@ mod tests {
         build_storage, parse_storage_backend, DeveloperLogbookService, DeveloperLookupService,
         ServerOptions, StorageBackendKind, StorageOptions,
     };
-    use logripper_core::application::logbook::LogbookEngine;
-    use logripper_core::lookup::{
-        DisabledCallsignProvider, LookupCoordinator, LookupCoordinatorConfig,
-    };
+    use crate::runtime_config::RuntimeConfigManager;
     use logripper_core::proto::logripper::domain::{
         dxcc_request, BatchLookupRequest, CachedCallsignRequest, DxccRequest, LookupRequest,
         LookupResult, LookupState,
@@ -493,11 +517,11 @@ mod tests {
     use tonic::{Code, Request};
 
     fn test_lookup_service() -> DeveloperLookupService {
-        let coordinator = Arc::new(LookupCoordinator::new(
-            Arc::new(DisabledCallsignProvider::new("lookup disabled")),
-            LookupCoordinatorConfig::default(),
-        ));
-        DeveloperLookupService::new(coordinator)
+        DeveloperLookupService::new(test_runtime_config())
+    }
+
+    fn test_runtime_config() -> Arc<RuntimeConfigManager> {
+        Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime config"))
     }
 
     #[test]
@@ -603,7 +627,9 @@ mod tests {
 
         assert_eq!(LookupState::Error as i32, response.state);
         assert_eq!(
-            Some("Provider configuration error: lookup disabled"),
+            Some(
+                "Provider configuration error: Required environment variable 'LOGRIPPER_QRZ_XML_USERNAME' is missing or blank."
+            ),
             response.error_message.as_deref()
         );
     }
@@ -681,12 +707,7 @@ mod tests {
 
     #[tokio::test]
     async fn logbook_sync_status_returns_zeroed_placeholder_values() {
-        let storage = build_storage(&StorageOptions {
-            backend: StorageBackendKind::Memory,
-            sqlite_path: std::path::PathBuf::from("ignored.db"),
-        })
-        .expect("storage");
-        let service = DeveloperLogbookService::new(LogbookEngine::new(storage));
+        let service = DeveloperLogbookService::new(test_runtime_config());
 
         let response =
             LogbookService::get_sync_status(&service, Request::new(SyncStatusRequest {}))

--- a/src/rust/logripper-server/src/main.rs
+++ b/src/rust/logripper-server/src/main.rs
@@ -1,37 +1,46 @@
 //! Runnable tonic gRPC host for the `LogRipper` Rust engine.
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
+use logripper_core::application::logbook::{LogbookEngine, LogbookError};
 use logripper_core::lookup::{
     CallsignProvider, DisabledCallsignProvider, LookupCoordinator, LookupCoordinatorConfig,
     QrzXmlConfig, QrzXmlProvider,
 };
+use logripper_core::storage::{EngineStorage, QsoListQuery, QsoSortOrder, StorageError};
+use logripper_storage_memory::MemoryStorage;
+use logripper_storage_sqlite::SqliteStorageBuilder;
 use tokio_stream::wrappers::ReceiverStream;
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 
 use logripper_core::proto::logripper::domain::{
-    BatchLookupRequest, BatchLookupResponse, CachedCallsignRequest, DxccEntity, DxccRequest,
-    LookupRequest, LookupResult, QsoRecord,
+    Band, BatchLookupRequest, BatchLookupResponse, CachedCallsignRequest, DxccEntity, DxccRequest,
+    LookupRequest, LookupResult, Mode, QsoRecord,
 };
 use logripper_core::proto::logripper::services::{
     logbook_service_server::{LogbookService, LogbookServiceServer},
     lookup_service_server::{LookupService, LookupServiceServer},
     AdifChunk, DeleteQsoRequest, DeleteQsoResponse, ExportRequest, GetQsoRequest, GetQsoResponse,
-    ImportResult, ListQsosRequest, LogQsoRequest, LogQsoResponse, SyncProgress, SyncRequest,
-    SyncStatusRequest, SyncStatusResponse, UpdateQsoRequest, UpdateQsoResponse,
+    ImportResult, ListQsosRequest, LogQsoRequest, LogQsoResponse, SortOrder, SyncProgress,
+    SyncRequest, SyncStatusRequest, SyncStatusResponse, UpdateQsoRequest, UpdateQsoResponse,
 };
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let options = ServerOptions::from_env_and_args(std::env::args().skip(1))?;
     let address = options.listen_address;
+    let storage = build_storage(&options.storage)?;
+    let logbook_service = DeveloperLogbookService::new(LogbookEngine::new(storage));
     let lookup_service = DeveloperLookupService::new(create_lookup_coordinator());
 
-    println!("Starting LogRipper gRPC server on {address}");
+    println!(
+        "Starting LogRipper gRPC server on {address} using {} storage",
+        logbook_service.engine.storage_backend_name()
+    );
 
     Server::builder()
-        .add_service(LogbookServiceServer::new(DeveloperLogbookService))
+        .add_service(LogbookServiceServer::new(logbook_service))
         .add_service(LookupServiceServer::new(lookup_service))
         .serve(address)
         .await?;
@@ -39,8 +48,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-#[derive(Debug, Clone, Copy)]
-struct DeveloperLogbookService;
+#[derive(Clone)]
+struct DeveloperLogbookService {
+    engine: LogbookEngine,
+}
+
+impl DeveloperLogbookService {
+    fn new(engine: LogbookEngine) -> Self {
+        Self { engine }
+    }
+}
 
 #[tonic::async_trait]
 impl LogbookService for DeveloperLogbookService {
@@ -50,37 +67,100 @@ impl LogbookService for DeveloperLogbookService {
 
     async fn log_qso(
         &self,
-        _request: Request<LogQsoRequest>,
+        request: Request<LogQsoRequest>,
     ) -> Result<Response<LogQsoResponse>, Status> {
-        Err(Status::unimplemented("LogQso is not implemented yet."))
+        let request = request.into_inner();
+        let qso = request
+            .qso
+            .ok_or_else(|| Status::invalid_argument("LogQso requires a qso payload."))?;
+        let stored = self.engine.log_qso(qso).await.map_err(map_logbook_error)?;
+        let (sync_success, sync_error) = sync_result(request.sync_to_qrz, "QRZ sync");
+
+        Ok(Response::new(LogQsoResponse {
+            local_id: stored.local_id,
+            qrz_logid: stored.qrz_logid,
+            sync_success,
+            sync_error,
+        }))
     }
 
     async fn update_qso(
         &self,
-        _request: Request<UpdateQsoRequest>,
+        request: Request<UpdateQsoRequest>,
     ) -> Result<Response<UpdateQsoResponse>, Status> {
-        Err(Status::unimplemented("UpdateQso is not implemented yet."))
+        let request = request.into_inner();
+        let qso = request
+            .qso
+            .ok_or_else(|| Status::invalid_argument("UpdateQso requires a qso payload."))?;
+        let _ = self
+            .engine
+            .update_qso(qso)
+            .await
+            .map_err(map_logbook_error)?;
+        let (sync_success, sync_error) = sync_result(request.sync_to_qrz, "QRZ sync");
+
+        Ok(Response::new(UpdateQsoResponse {
+            success: true,
+            error: None,
+            sync_success,
+            sync_error,
+        }))
     }
 
     async fn delete_qso(
         &self,
-        _request: Request<DeleteQsoRequest>,
+        request: Request<DeleteQsoRequest>,
     ) -> Result<Response<DeleteQsoResponse>, Status> {
-        Err(Status::unimplemented("DeleteQso is not implemented yet."))
+        let request = request.into_inner();
+        self.engine
+            .delete_qso(&request.local_id)
+            .await
+            .map_err(map_logbook_error)?;
+        let (qrz_delete_success, qrz_delete_error) =
+            sync_result(request.delete_from_qrz, "QRZ delete");
+
+        Ok(Response::new(DeleteQsoResponse {
+            success: true,
+            error: None,
+            qrz_delete_success,
+            qrz_delete_error,
+        }))
     }
 
     async fn get_qso(
         &self,
-        _request: Request<GetQsoRequest>,
+        request: Request<GetQsoRequest>,
     ) -> Result<Response<GetQsoResponse>, Status> {
-        Err(Status::unimplemented("GetQso is not implemented yet."))
+        let request = request.into_inner();
+        let qso = self
+            .engine
+            .get_qso(&request.local_id)
+            .await
+            .map_err(map_logbook_error)?;
+
+        Ok(Response::new(GetQsoResponse { qso: Some(qso) }))
     }
 
     async fn list_qsos(
         &self,
-        _request: Request<ListQsosRequest>,
+        request: Request<ListQsosRequest>,
     ) -> Result<Response<Self::ListQsosStream>, Status> {
-        Err(Status::unimplemented("ListQsos is not implemented yet."))
+        let request = request.into_inner();
+        let query = qso_list_query_from_request(&request).map_err(|status| *status)?;
+        let records = self
+            .engine
+            .list_qsos(&query)
+            .await
+            .map_err(map_logbook_error)?;
+        let (sender, receiver) = tokio::sync::mpsc::channel(records.len().max(1));
+
+        for record in records {
+            if sender.send(Ok(record)).await.is_err() {
+                break;
+            }
+        }
+
+        Ok(Response::new(ReceiverStream::new(receiver)))
     }
 
     async fn sync_with_qrz(
@@ -94,12 +174,18 @@ impl LogbookService for DeveloperLogbookService {
         &self,
         _request: Request<SyncStatusRequest>,
     ) -> Result<Response<SyncStatusResponse>, Status> {
+        let sync_status = self
+            .engine
+            .get_sync_status()
+            .await
+            .map_err(map_logbook_error)?;
+
         Ok(Response::new(SyncStatusResponse {
-            local_qso_count: 0,
-            qrz_qso_count: 0,
-            pending_upload: 0,
-            last_sync: None,
-            qrz_logbook_owner: None,
+            local_qso_count: sync_status.local_qso_count,
+            qrz_qso_count: sync_status.qrz_qso_count,
+            pending_upload: sync_status.pending_upload,
+            last_sync: sync_status.last_sync,
+            qrz_logbook_owner: sync_status.qrz_logbook_owner,
         }))
     }
 
@@ -219,9 +305,22 @@ fn build_provider_from_env() -> Arc<dyn CallsignProvider> {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct ServerOptions {
     listen_address: SocketAddr,
+    storage: StorageOptions,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct StorageOptions {
+    backend: StorageBackendKind,
+    sqlite_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StorageBackendKind {
+    Memory,
+    Sqlite,
 }
 
 impl ServerOptions {
@@ -231,6 +330,12 @@ impl ServerOptions {
     {
         let mut listen = std::env::var("LOGRIPPER_SERVER_ADDR")
             .unwrap_or_else(|_| "127.0.0.1:50051".to_string());
+        let mut storage_backend = parse_storage_backend(
+            &std::env::var("LOGRIPPER_STORAGE_BACKEND").unwrap_or_else(|_| "memory".to_string()),
+        )?;
+        let mut sqlite_path = PathBuf::from(
+            std::env::var("LOGRIPPER_SQLITE_PATH").unwrap_or_else(|_| "logripper.db".to_string()),
+        );
         let mut args = args.into_iter();
 
         while let Some(arg) = args.next() {
@@ -238,6 +343,14 @@ impl ServerOptions {
                 "--listen" => {
                     let value = args.next().ok_or("Missing value for --listen")?;
                     listen = value;
+                }
+                "--storage" => {
+                    let value = args.next().ok_or("Missing value for --storage")?;
+                    storage_backend = parse_storage_backend(&value)?;
+                }
+                "--sqlite-path" => {
+                    let value = args.next().ok_or("Missing value for --sqlite-path")?;
+                    sqlite_path = PathBuf::from(value);
                 }
                 "--help" | "-h" => {
                     print_help();
@@ -249,22 +362,122 @@ impl ServerOptions {
 
         Ok(Self {
             listen_address: listen.parse()?,
+            storage: StorageOptions {
+                backend: storage_backend,
+                sqlite_path,
+            },
         })
     }
 }
 
 fn print_help() {
     println!(
-        "LogRipper gRPC server\n\nUsage:\n  cargo run -p logripper-server -- [--listen 127.0.0.1:50051]\n\nEnvironment:\n  LOGRIPPER_SERVER_ADDR   Overrides the bind address"
+        "LogRipper gRPC server\n\nUsage:\n  cargo run -p logripper-server -- [--listen 127.0.0.1:50051] [--storage memory|sqlite] [--sqlite-path path\\to\\logripper.db]\n\nEnvironment:\n  LOGRIPPER_SERVER_ADDR       Overrides the bind address\n  LOGRIPPER_STORAGE_BACKEND   Selects memory or sqlite storage (default: memory)\n  LOGRIPPER_SQLITE_PATH       SQLite path when sqlite storage is selected (default: logripper.db)"
     );
+}
+
+fn build_storage(
+    options: &StorageOptions,
+) -> Result<Arc<dyn EngineStorage>, Box<dyn std::error::Error>> {
+    let storage: Arc<dyn EngineStorage> = match options.backend {
+        StorageBackendKind::Memory => Arc::new(MemoryStorage::new()),
+        StorageBackendKind::Sqlite => Arc::new(
+            SqliteStorageBuilder::new()
+                .path(options.sqlite_path.clone())
+                .build()?,
+        ),
+    };
+
+    Ok(storage)
+}
+
+fn parse_storage_backend(value: &str) -> Result<StorageBackendKind, Box<dyn std::error::Error>> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "memory" => Ok(StorageBackendKind::Memory),
+        "sqlite" => Ok(StorageBackendKind::Sqlite),
+        other => Err(format!("Unsupported storage backend: {other}").into()),
+    }
+}
+
+fn map_logbook_error(error: LogbookError) -> Status {
+    match error {
+        LogbookError::Validation(message) => Status::invalid_argument(message),
+        LogbookError::NotFound(local_id) => {
+            Status::not_found(format!("QSO '{local_id}' was not found."))
+        }
+        LogbookError::Storage(StorageError::Duplicate { entity, key }) => {
+            Status::already_exists(format!("{entity} '{key}' already exists."))
+        }
+        LogbookError::Storage(other) => Status::internal(other.to_string()),
+    }
+}
+
+fn qso_list_query_from_request(request: &ListQsosRequest) -> Result<QsoListQuery, Box<Status>> {
+    let band_filter = request
+        .band_filter
+        .map(|value| {
+            Band::try_from(value)
+                .map_err(|_| Box::new(Status::invalid_argument("Invalid band_filter value.")))
+        })
+        .transpose()?;
+    let mode_filter = request
+        .mode_filter
+        .map(|value| {
+            Mode::try_from(value)
+                .map_err(|_| Box::new(Status::invalid_argument("Invalid mode_filter value.")))
+        })
+        .transpose()?;
+    let sort = match SortOrder::try_from(request.sort) {
+        Ok(SortOrder::NewestFirst) => QsoSortOrder::NewestFirst,
+        Ok(SortOrder::OldestFirst) => QsoSortOrder::OldestFirst,
+        Err(_) => return Err(Box::new(Status::invalid_argument("Invalid sort order."))),
+    };
+
+    Ok(QsoListQuery {
+        after: request.after,
+        before: request.before,
+        callsign_filter: request
+            .callsign_filter
+            .as_deref()
+            .and_then(non_empty_string),
+        band_filter,
+        mode_filter,
+        contest_id: request.contest_id.as_deref().and_then(non_empty_string),
+        limit: (request.limit > 0).then_some(request.limit),
+        offset: request.offset,
+        sort,
+    })
+}
+
+fn non_empty_string(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn sync_result(requested: bool, label: &str) -> (bool, Option<String>) {
+    if requested {
+        (false, Some(format!("{label} is not implemented yet.")))
+    } else {
+        (true, None)
+    }
 }
 
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
+    use std::fs;
     use std::sync::Arc;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-    use super::{DeveloperLogbookService, DeveloperLookupService, ServerOptions};
+    use super::{
+        build_storage, parse_storage_backend, DeveloperLogbookService, DeveloperLookupService,
+        ServerOptions, StorageBackendKind, StorageOptions,
+    };
+    use logripper_core::application::logbook::LogbookEngine;
     use logripper_core::lookup::{
         DisabledCallsignProvider, LookupCoordinator, LookupCoordinatorConfig,
     };
@@ -290,10 +503,13 @@ mod tests {
     #[test]
     fn server_options_default_to_localhost_port_50051() {
         std::env::remove_var("LOGRIPPER_SERVER_ADDR");
+        std::env::remove_var("LOGRIPPER_STORAGE_BACKEND");
+        std::env::remove_var("LOGRIPPER_SQLITE_PATH");
 
         let options = ServerOptions::from_env_and_args(Vec::<String>::new()).unwrap();
 
         assert_eq!("127.0.0.1:50051", options.listen_address.to_string());
+        assert_eq!(options.storage.backend, StorageBackendKind::Memory);
     }
 
     #[test]
@@ -314,6 +530,60 @@ mod tests {
         let result = LookupResult::default();
 
         assert_eq!(LookupState::Unspecified as i32, result.state);
+    }
+
+    #[test]
+    fn server_options_allow_sqlite_storage_override() {
+        let options = ServerOptions::from_env_and_args([
+            "--storage".to_string(),
+            "sqlite".to_string(),
+            "--sqlite-path".to_string(),
+            "data\\logripper.db".to_string(),
+        ])
+        .unwrap();
+
+        assert_eq!(options.storage.backend, StorageBackendKind::Sqlite);
+        assert_eq!(
+            options.storage.sqlite_path,
+            std::path::PathBuf::from("data\\logripper.db")
+        );
+    }
+
+    #[test]
+    fn parse_storage_backend_rejects_unknown_values() {
+        let error = parse_storage_backend("rocksdb").unwrap_err();
+
+        assert!(error.to_string().contains("Unsupported storage backend"));
+    }
+
+    #[test]
+    fn build_storage_uses_requested_backend() {
+        let memory_storage = build_storage(&StorageOptions {
+            backend: StorageBackendKind::Memory,
+            sqlite_path: std::path::PathBuf::from("ignored.db"),
+        })
+        .expect("memory storage");
+        assert_eq!(memory_storage.backend_name(), "memory");
+
+        let unique_suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos();
+        let sqlite_path = std::env::temp_dir().join(format!(
+            "logripper-storage-{}-{unique_suffix}.db",
+            std::process::id()
+        ));
+        let sqlite_storage = build_storage(&StorageOptions {
+            backend: StorageBackendKind::Sqlite,
+            sqlite_path: sqlite_path.clone(),
+        })
+        .expect("sqlite storage");
+        assert_eq!(sqlite_storage.backend_name(), "sqlite");
+        drop(sqlite_storage);
+
+        if sqlite_path.exists() {
+            fs::remove_file(sqlite_path).expect("remove sqlite test database");
+        }
     }
 
     #[tokio::test]
@@ -411,13 +681,18 @@ mod tests {
 
     #[tokio::test]
     async fn logbook_sync_status_returns_zeroed_placeholder_values() {
-        let response = LogbookService::get_sync_status(
-            &DeveloperLogbookService,
-            Request::new(SyncStatusRequest {}),
-        )
-        .await
-        .expect("sync status")
-        .into_inner();
+        let storage = build_storage(&StorageOptions {
+            backend: StorageBackendKind::Memory,
+            sqlite_path: std::path::PathBuf::from("ignored.db"),
+        })
+        .expect("storage");
+        let service = DeveloperLogbookService::new(LogbookEngine::new(storage));
+
+        let response =
+            LogbookService::get_sync_status(&service, Request::new(SyncStatusRequest {}))
+                .await
+                .expect("sync status")
+                .into_inner();
 
         assert_eq!(0, response.local_qso_count);
         assert_eq!(0, response.qrz_qso_count);

--- a/src/rust/logripper-server/src/runtime_config.rs
+++ b/src/rust/logripper-server/src/runtime_config.rs
@@ -1,0 +1,632 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use logripper_core::application::logbook::LogbookEngine;
+use logripper_core::lookup::{
+    CallsignProvider, DisabledCallsignProvider, LookupCoordinator, LookupCoordinatorConfig,
+    QrzXmlConfig, QrzXmlProvider, DEFAULT_QRZ_XML_BASE_URL, QRZ_HTTP_TIMEOUT_SECONDS_ENV_VAR,
+    QRZ_MAX_RETRIES_ENV_VAR, QRZ_USER_AGENT_ENV_VAR, QRZ_XML_BASE_URL_ENV_VAR,
+    QRZ_XML_CAPTURE_ONLY_ENV_VAR, QRZ_XML_PASSWORD_ENV_VAR, QRZ_XML_USERNAME_ENV_VAR,
+};
+use logripper_core::proto::logripper::services::{
+    ApplyRuntimeConfigRequest, ResetRuntimeConfigRequest, RuntimeConfigDefinition,
+    RuntimeConfigMutation, RuntimeConfigMutationKind, RuntimeConfigSnapshot, RuntimeConfigValue,
+    RuntimeConfigValueKind,
+};
+use tokio::sync::RwLock;
+
+use crate::{build_storage, parse_storage_backend, StorageBackendKind, StorageOptions};
+
+pub(crate) const STORAGE_BACKEND_ENV_VAR: &str = "LOGRIPPER_STORAGE_BACKEND";
+pub(crate) const SQLITE_PATH_ENV_VAR: &str = "LOGRIPPER_SQLITE_PATH";
+const DEFAULT_STORAGE_BACKEND: &str = "memory";
+const DEFAULT_SQLITE_PATH: &str = "logripper.db";
+const REDACTED_VALUE: &str = "<redacted>";
+
+#[derive(Clone)]
+struct RuntimeBindings {
+    logbook_engine: LogbookEngine,
+    lookup_coordinator: Arc<LookupCoordinator>,
+    active_storage_backend: String,
+    lookup_provider_summary: String,
+}
+
+pub(crate) struct RuntimeConfigManager {
+    base_values: BTreeMap<String, String>,
+    overrides: RwLock<BTreeMap<String, String>>,
+    bindings: RwLock<RuntimeBindings>,
+}
+
+impl RuntimeConfigManager {
+    pub(crate) fn new_from_storage_options(storage: &StorageOptions) -> Result<Self, String> {
+        let base_values = capture_supported_env();
+        Self::new(seed_storage_values(base_values, storage))
+    }
+
+    pub(crate) fn new(base_values: BTreeMap<String, String>) -> Result<Self, String> {
+        let bindings = build_runtime_bindings(&base_values)?;
+        Ok(Self {
+            base_values,
+            overrides: RwLock::new(BTreeMap::new()),
+            bindings: RwLock::new(bindings),
+        })
+    }
+
+    pub(crate) async fn snapshot(&self) -> RuntimeConfigSnapshot {
+        let overrides = self.overrides.read().await.clone();
+        let bindings = self.bindings.read().await.clone();
+        build_snapshot(&self.base_values, &overrides, &bindings)
+    }
+
+    pub(crate) async fn apply_request(
+        &self,
+        request: ApplyRuntimeConfigRequest,
+    ) -> Result<RuntimeConfigSnapshot, String> {
+        let mut next_overrides = self.overrides.read().await.clone();
+
+        for mutation in request.mutations {
+            apply_mutation(&mut next_overrides, mutation)?;
+        }
+
+        self.swap_runtime(next_overrides).await
+    }
+
+    pub(crate) async fn reset_request(
+        &self,
+        request: ResetRuntimeConfigRequest,
+    ) -> Result<RuntimeConfigSnapshot, String> {
+        let mut next_overrides = self.overrides.read().await.clone();
+
+        if request.keys.is_empty() {
+            next_overrides.clear();
+        } else {
+            for raw_key in request.keys {
+                let key = canonical_key(&raw_key)?;
+                next_overrides.remove(key);
+            }
+        }
+
+        self.swap_runtime(next_overrides).await
+    }
+
+    pub(crate) async fn logbook_engine(&self) -> LogbookEngine {
+        self.bindings.read().await.logbook_engine.clone()
+    }
+
+    pub(crate) async fn lookup_coordinator(&self) -> Arc<LookupCoordinator> {
+        self.bindings.read().await.lookup_coordinator.clone()
+    }
+
+    pub(crate) async fn active_storage_backend(&self) -> String {
+        self.bindings.read().await.active_storage_backend.clone()
+    }
+
+    async fn swap_runtime(
+        &self,
+        next_overrides: BTreeMap<String, String>,
+    ) -> Result<RuntimeConfigSnapshot, String> {
+        let merged = merge_values(&self.base_values, &next_overrides);
+        let next_bindings = build_runtime_bindings(&merged)?;
+
+        {
+            let mut bindings = self.bindings.write().await;
+            *bindings = next_bindings;
+        }
+
+        {
+            let mut overrides = self.overrides.write().await;
+            *overrides = next_overrides;
+        }
+
+        Ok(self.snapshot().await)
+    }
+}
+
+struct ConfigFieldSpec {
+    key: &'static str,
+    label: &'static str,
+    description: &'static str,
+    kind: RuntimeConfigValueKind,
+    secret: bool,
+    allowed_values: &'static [&'static str],
+    default_value: Option<&'static str>,
+}
+
+const STORAGE_ALLOWED_VALUES: &[&str] = &["memory", "sqlite"];
+
+const SUPPORTED_FIELDS: &[ConfigFieldSpec] = &[
+    ConfigFieldSpec {
+        key: STORAGE_BACKEND_ENV_VAR,
+        label: "Storage backend",
+        description: "Hot-swap the active logbook storage implementation for new requests.",
+        kind: RuntimeConfigValueKind::String,
+        secret: false,
+        allowed_values: STORAGE_ALLOWED_VALUES,
+        default_value: Some(DEFAULT_STORAGE_BACKEND),
+    },
+    ConfigFieldSpec {
+        key: SQLITE_PATH_ENV_VAR,
+        label: "SQLite path",
+        description: "SQLite database path used when the active storage backend is sqlite.",
+        kind: RuntimeConfigValueKind::Path,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some(DEFAULT_SQLITE_PATH),
+    },
+    ConfigFieldSpec {
+        key: QRZ_XML_USERNAME_ENV_VAR,
+        label: "QRZ XML username",
+        description: "QRZ XML login username for live callsign lookups.",
+        kind: RuntimeConfigValueKind::String,
+        secret: false,
+        allowed_values: &[],
+        default_value: None,
+    },
+    ConfigFieldSpec {
+        key: QRZ_XML_PASSWORD_ENV_VAR,
+        label: "QRZ XML password",
+        description: "QRZ XML login password. The live snapshot always redacts this value.",
+        kind: RuntimeConfigValueKind::String,
+        secret: true,
+        allowed_values: &[],
+        default_value: None,
+    },
+    ConfigFieldSpec {
+        key: QRZ_USER_AGENT_ENV_VAR,
+        label: "QRZ user agent",
+        description: "User agent string supplied to QRZ XML requests.",
+        kind: RuntimeConfigValueKind::String,
+        secret: false,
+        allowed_values: &[],
+        default_value: None,
+    },
+    ConfigFieldSpec {
+        key: QRZ_XML_BASE_URL_ENV_VAR,
+        label: "QRZ XML base URL",
+        description: "QRZ XML endpoint used by the live lookup provider.",
+        kind: RuntimeConfigValueKind::String,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some(DEFAULT_QRZ_XML_BASE_URL),
+    },
+    ConfigFieldSpec {
+        key: QRZ_HTTP_TIMEOUT_SECONDS_ENV_VAR,
+        label: "QRZ HTTP timeout seconds",
+        description: "HTTP timeout used by live QRZ XML requests.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some("8"),
+    },
+    ConfigFieldSpec {
+        key: QRZ_MAX_RETRIES_ENV_VAR,
+        label: "QRZ max retries",
+        description: "Retry count for retryable QRZ XML transport failures.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some("2"),
+    },
+    ConfigFieldSpec {
+        key: QRZ_XML_CAPTURE_ONLY_ENV_VAR,
+        label: "QRZ capture-only mode",
+        description:
+            "When true, capture and redact the outbound QRZ request instead of sending it.",
+        kind: RuntimeConfigValueKind::Boolean,
+        secret: false,
+        allowed_values: &["true", "false"],
+        default_value: Some("false"),
+    },
+];
+
+fn capture_supported_env() -> BTreeMap<String, String> {
+    let mut values = BTreeMap::new();
+
+    for field in SUPPORTED_FIELDS {
+        if let Ok(value) = std::env::var(field.key) {
+            let trimmed = value.trim();
+            if !trimmed.is_empty() {
+                values.insert(field.key.to_string(), trimmed.to_string());
+            }
+        }
+    }
+
+    values
+}
+
+fn seed_storage_values(
+    mut base_values: BTreeMap<String, String>,
+    storage: &StorageOptions,
+) -> BTreeMap<String, String> {
+    base_values.insert(
+        STORAGE_BACKEND_ENV_VAR.to_string(),
+        match storage.backend {
+            StorageBackendKind::Memory => "memory".to_string(),
+            StorageBackendKind::Sqlite => "sqlite".to_string(),
+        },
+    );
+    base_values.insert(
+        SQLITE_PATH_ENV_VAR.to_string(),
+        storage.sqlite_path.display().to_string(),
+    );
+    base_values
+}
+
+fn apply_mutation(
+    overrides: &mut BTreeMap<String, String>,
+    mutation: RuntimeConfigMutation,
+) -> Result<(), String> {
+    let key = canonical_key(&mutation.key)?;
+    let action = RuntimeConfigMutationKind::try_from(mutation.kind)
+        .map_err(|_| format!("Unsupported mutation kind for '{key}'."))?;
+
+    match action {
+        RuntimeConfigMutationKind::Set => {
+            let value = mutation
+                .value
+                .ok_or_else(|| format!("A value is required when setting '{key}'."))?;
+            let normalized = normalize_value(key, &value)?;
+            overrides.insert(key.to_string(), normalized);
+        }
+        RuntimeConfigMutationKind::Clear => {
+            overrides.remove(key);
+        }
+        RuntimeConfigMutationKind::Unspecified => {
+            return Err(format!("A mutation kind is required for '{key}'."));
+        }
+    }
+
+    Ok(())
+}
+
+fn canonical_key(raw_key: &str) -> Result<&'static str, String> {
+    let trimmed = raw_key.trim();
+    SUPPORTED_FIELDS
+        .iter()
+        .find(|field| field.key.eq_ignore_ascii_case(trimmed))
+        .map(|field| field.key)
+        .ok_or_else(|| format!("Unsupported runtime config key '{trimmed}'."))
+}
+
+fn normalize_value(key: &'static str, raw_value: &str) -> Result<String, String> {
+    let trimmed = raw_value.trim();
+    if trimmed.is_empty() {
+        return Err(format!("A non-empty value is required for '{key}'."));
+    }
+
+    if key == STORAGE_BACKEND_ENV_VAR {
+        parse_storage_backend(trimmed)
+            .map_err(|error| error.to_string())
+            .map(|_| trimmed.to_ascii_lowercase())
+    } else if key == QRZ_XML_CAPTURE_ONLY_ENV_VAR {
+        parse_bool(trimmed).map(|value| {
+            if value {
+                "true".to_string()
+            } else {
+                "false".to_string()
+            }
+        })
+    } else if key == QRZ_HTTP_TIMEOUT_SECONDS_ENV_VAR {
+        trimmed
+            .parse::<u64>()
+            .map(|value| value.to_string())
+            .map_err(|_| format!("'{key}' expects an integer value."))
+    } else if key == QRZ_MAX_RETRIES_ENV_VAR {
+        trimmed
+            .parse::<u32>()
+            .map(|value| value.to_string())
+            .map_err(|_| format!("'{key}' expects an integer value."))
+    } else {
+        Ok(trimmed.to_string())
+    }
+}
+
+fn parse_bool(raw_value: &str) -> Result<bool, String> {
+    match raw_value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "y" | "on" => Ok(true),
+        "0" | "false" | "no" | "n" | "off" => Ok(false),
+        _ => Err(format!(
+            "'{raw_value}' is not a valid boolean. Use true/false, yes/no, 1/0, y/n, or on/off."
+        )),
+    }
+}
+
+fn merge_values(
+    base_values: &BTreeMap<String, String>,
+    overrides: &BTreeMap<String, String>,
+) -> BTreeMap<String, String> {
+    let mut merged = base_values.clone();
+    merged.extend(overrides.clone());
+    merged
+}
+
+fn build_runtime_bindings(values: &BTreeMap<String, String>) -> Result<RuntimeBindings, String> {
+    let storage = build_storage(
+        &parse_storage_options_from_values(values).map_err(|error| error.to_string())?,
+    )
+    .map_err(|error| error.to_string())?;
+    let logbook_engine = LogbookEngine::new(storage);
+    let active_storage_backend = logbook_engine.storage_backend_name().to_string();
+    let (provider, lookup_provider_summary) = build_lookup_provider(values);
+    let lookup_coordinator = Arc::new(LookupCoordinator::new(
+        provider,
+        LookupCoordinatorConfig::default(),
+    ));
+
+    Ok(RuntimeBindings {
+        logbook_engine,
+        lookup_coordinator,
+        active_storage_backend,
+        lookup_provider_summary,
+    })
+}
+
+fn parse_storage_options_from_values(
+    values: &BTreeMap<String, String>,
+) -> Result<StorageOptions, Box<dyn std::error::Error>> {
+    let backend = parse_storage_backend(
+        values
+            .get(STORAGE_BACKEND_ENV_VAR)
+            .map_or(DEFAULT_STORAGE_BACKEND, String::as_str),
+    )?;
+    let sqlite_path = values
+        .get(SQLITE_PATH_ENV_VAR)
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_SQLITE_PATH.to_string())
+        .into();
+
+    Ok(StorageOptions {
+        backend,
+        sqlite_path,
+    })
+}
+
+fn build_lookup_provider(values: &BTreeMap<String, String>) -> (Arc<dyn CallsignProvider>, String) {
+    match QrzXmlConfig::from_value_provider(|name| values.get(name).cloned()) {
+        Ok(config) => match QrzXmlProvider::new(config.clone()) {
+            Ok(provider) => {
+                let summary = if config.capture_only() {
+                    format!("QRZ XML capture-only via {}", config.base_url())
+                } else {
+                    format!("QRZ XML live via {}", config.base_url())
+                };
+                (Arc::new(provider), summary)
+            }
+            Err(error) => {
+                let reason = error.to_string();
+                (
+                    Arc::new(DisabledCallsignProvider::new(reason.clone())),
+                    format!("Disabled: {reason}"),
+                )
+            }
+        },
+        Err(error) => {
+            let reason = error.to_string();
+            (
+                Arc::new(DisabledCallsignProvider::new(reason.clone())),
+                format!("Disabled: {reason}"),
+            )
+        }
+    }
+}
+
+fn build_snapshot(
+    base_values: &BTreeMap<String, String>,
+    overrides: &BTreeMap<String, String>,
+    bindings: &RuntimeBindings,
+) -> RuntimeConfigSnapshot {
+    let merged = merge_values(base_values, overrides);
+    let definitions = SUPPORTED_FIELDS
+        .iter()
+        .map(|field| RuntimeConfigDefinition {
+            key: field.key.to_string(),
+            label: field.label.to_string(),
+            description: field.description.to_string(),
+            kind: field.kind as i32,
+            secret: field.secret,
+            allowed_values: field
+                .allowed_values
+                .iter()
+                .map(|value| (*value).to_string())
+                .collect(),
+        })
+        .collect();
+    let values = SUPPORTED_FIELDS
+        .iter()
+        .map(|field| build_value(field, &merged, overrides))
+        .collect();
+    let mut warnings = Vec::new();
+
+    if overrides.contains_key(STORAGE_BACKEND_ENV_VAR)
+        || overrides.contains_key(SQLITE_PATH_ENV_VAR)
+    {
+        warnings.push(
+            "Switching storage backends swaps the active engine state; records are not migrated automatically."
+                .to_string(),
+        );
+    }
+
+    RuntimeConfigSnapshot {
+        definitions,
+        values,
+        active_storage_backend: bindings.active_storage_backend.clone(),
+        lookup_provider_summary: bindings.lookup_provider_summary.clone(),
+        warnings,
+    }
+}
+
+fn build_value(
+    field: &ConfigFieldSpec,
+    merged: &BTreeMap<String, String>,
+    overrides: &BTreeMap<String, String>,
+) -> RuntimeConfigValue {
+    let effective_value = merged
+        .get(field.key)
+        .cloned()
+        .or_else(|| field.default_value.map(str::to_string));
+    let has_value = effective_value.is_some();
+    let display_value = if field.secret && has_value {
+        REDACTED_VALUE.to_string()
+    } else {
+        effective_value.unwrap_or_default()
+    };
+
+    RuntimeConfigValue {
+        key: field.key.to_string(),
+        has_value,
+        display_value,
+        overridden: overrides.contains_key(field.key),
+        secret: field.secret,
+        redacted: field.secret && has_value,
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use logripper_core::proto::logripper::domain::{Band, Mode, QsoRecord};
+
+    use super::{
+        ApplyRuntimeConfigRequest, ResetRuntimeConfigRequest, RuntimeConfigManager,
+        RuntimeConfigMutation, RuntimeConfigMutationKind, QRZ_USER_AGENT_ENV_VAR,
+        QRZ_XML_CAPTURE_ONLY_ENV_VAR, QRZ_XML_PASSWORD_ENV_VAR, QRZ_XML_USERNAME_ENV_VAR,
+        SQLITE_PATH_ENV_VAR, STORAGE_BACKEND_ENV_VAR,
+    };
+
+    fn sample_qso(local_id: &str) -> QsoRecord {
+        QsoRecord {
+            local_id: local_id.to_string(),
+            station_callsign: "K7DBG".to_string(),
+            worked_callsign: "W1AW".to_string(),
+            band: Band::Band20m as i32,
+            mode: Mode::Ssb as i32,
+            ..QsoRecord::default()
+        }
+    }
+
+    fn unique_sqlite_path() -> String {
+        let suffix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock")
+            .as_nanos();
+        std::env::temp_dir()
+            .join(format!(
+                "logripper-runtime-config-{}-{suffix}.db",
+                std::process::id()
+            ))
+            .display()
+            .to_string()
+    }
+
+    #[tokio::test]
+    async fn runtime_manager_hot_swaps_storage_backends() {
+        let manager = RuntimeConfigManager::new(BTreeMap::new()).expect("manager");
+        let initial_snapshot = manager.snapshot().await;
+        assert_eq!("memory", initial_snapshot.active_storage_backend);
+
+        let sqlite_path = unique_sqlite_path();
+        let sqlite_snapshot = manager
+            .apply_request(ApplyRuntimeConfigRequest {
+                mutations: vec![
+                    RuntimeConfigMutation {
+                        key: STORAGE_BACKEND_ENV_VAR.to_string(),
+                        kind: RuntimeConfigMutationKind::Set as i32,
+                        value: Some("sqlite".to_string()),
+                    },
+                    RuntimeConfigMutation {
+                        key: SQLITE_PATH_ENV_VAR.to_string(),
+                        kind: RuntimeConfigMutationKind::Set as i32,
+                        value: Some(sqlite_path.clone()),
+                    },
+                ],
+            })
+            .await
+            .expect("sqlite apply");
+        assert_eq!("sqlite", sqlite_snapshot.active_storage_backend);
+
+        let sqlite_engine = manager.logbook_engine().await;
+        sqlite_engine
+            .log_qso(sample_qso("sqlite-record"))
+            .await
+            .expect("sqlite write");
+        drop(sqlite_engine);
+
+        let memory_snapshot = manager
+            .apply_request(ApplyRuntimeConfigRequest {
+                mutations: vec![RuntimeConfigMutation {
+                    key: STORAGE_BACKEND_ENV_VAR.to_string(),
+                    kind: RuntimeConfigMutationKind::Set as i32,
+                    value: Some("memory".to_string()),
+                }],
+            })
+            .await
+            .expect("memory apply");
+        assert_eq!("memory", memory_snapshot.active_storage_backend);
+
+        let memory_status = manager
+            .logbook_engine()
+            .await
+            .get_sync_status()
+            .await
+            .expect("memory status");
+        assert_eq!(0, memory_status.local_qso_count);
+
+        let reset_snapshot = manager
+            .reset_request(ResetRuntimeConfigRequest {
+                keys: vec![
+                    STORAGE_BACKEND_ENV_VAR.to_string(),
+                    SQLITE_PATH_ENV_VAR.to_string(),
+                ],
+            })
+            .await
+            .expect("reset");
+        assert_eq!("memory", reset_snapshot.active_storage_backend);
+        drop(manager);
+
+        let sqlite_file = std::path::PathBuf::from(sqlite_path);
+        if sqlite_file.exists() {
+            std::fs::remove_file(sqlite_file).expect("remove sqlite file");
+        }
+    }
+
+    #[tokio::test]
+    async fn runtime_manager_updates_lookup_provider_summary_when_capture_only_changes() {
+        let mut base_values = BTreeMap::new();
+        base_values.insert(QRZ_XML_USERNAME_ENV_VAR.to_string(), "KC7AVA".to_string());
+        base_values.insert(
+            QRZ_XML_PASSWORD_ENV_VAR.to_string(),
+            "super-secret-password".to_string(),
+        );
+        base_values.insert(
+            QRZ_USER_AGENT_ENV_VAR.to_string(),
+            "LogRipper/0.1.0 (KC7AVA)".to_string(),
+        );
+
+        let manager = RuntimeConfigManager::new(base_values).expect("manager");
+        let initial_summary = manager.snapshot().await.lookup_provider_summary;
+        assert_contains(&initial_summary, "QRZ XML live");
+
+        let capture_only_summary = manager
+            .apply_request(ApplyRuntimeConfigRequest {
+                mutations: vec![RuntimeConfigMutation {
+                    key: QRZ_XML_CAPTURE_ONLY_ENV_VAR.to_string(),
+                    kind: RuntimeConfigMutationKind::Set as i32,
+                    value: Some("true".to_string()),
+                }],
+            })
+            .await
+            .expect("capture-only apply")
+            .lookup_provider_summary;
+        assert_contains(&capture_only_summary, "capture-only");
+    }
+
+    fn assert_contains(actual: &str, expected: &str) {
+        assert!(
+            actual.contains(expected),
+            "expected '{actual}' to contain '{expected}'"
+        );
+    }
+}

--- a/src/rust/logripper-storage-memory/Cargo.toml
+++ b/src/rust/logripper-storage-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "logripper-server"
-description = "Runnable gRPC server host for the LogRipper engine"
+name = "logripper-storage-memory"
+description = "In-memory storage adapter for LogRipper engine tests and local composition"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
@@ -9,11 +9,9 @@ repository.workspace = true
 
 [dependencies]
 logripper-core = { path = "../logripper-core", version = "0.1.0" }
-logripper-storage-memory = { path = "../logripper-storage-memory", version = "0.1.0" }
-logripper-storage-sqlite = { path = "../logripper-storage-sqlite", version = "0.1.0" }
 tokio = { workspace = true }
 tonic = { workspace = true }
-tokio-stream = "0.1"
+prost-types = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/rust/logripper-storage-memory/src/lib.rs
+++ b/src/rust/logripper-storage-memory/src/lib.rs
@@ -1,0 +1,363 @@
+//! In-memory storage adapter for `LogRipper` engine services.
+
+use logripper_core::application::logbook::is_pending_sync_status;
+use logripper_core::domain::lookup::normalize_callsign;
+use logripper_core::proto::logripper::domain::QsoRecord;
+use logripper_core::storage::{
+    EngineStorage, LogbookCounts, LogbookStore, LookupSnapshot, LookupSnapshotStore, QsoListQuery,
+    QsoSortOrder, StorageError, SyncMetadata,
+};
+use std::cmp::Reverse;
+use std::collections::BTreeMap;
+use tokio::sync::RwLock;
+
+/// In-memory storage implementation used for tests and backend-swapping validation.
+#[derive(Default)]
+pub struct MemoryStorage {
+    state: RwLock<MemoryState>,
+}
+
+#[derive(Debug, Default)]
+struct MemoryState {
+    qsos: BTreeMap<String, QsoRecord>,
+    sync_metadata: SyncMetadata,
+    lookup_snapshots: BTreeMap<String, LookupSnapshot>,
+}
+
+impl MemoryStorage {
+    /// Create a new empty in-memory storage backend.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl EngineStorage for MemoryStorage {
+    fn logbook(&self) -> &dyn LogbookStore {
+        self
+    }
+
+    fn lookup_snapshots(&self) -> &dyn LookupSnapshotStore {
+        self
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "memory"
+    }
+}
+
+#[tonic::async_trait]
+impl LogbookStore for MemoryStorage {
+    async fn insert_qso(&self, qso: &QsoRecord) -> Result<(), StorageError> {
+        let mut state = self.state.write().await;
+        if state.qsos.contains_key(&qso.local_id) {
+            return Err(StorageError::duplicate("qso", &qso.local_id));
+        }
+
+        state.qsos.insert(qso.local_id.clone(), qso.clone());
+        Ok(())
+    }
+
+    async fn update_qso(&self, qso: &QsoRecord) -> Result<bool, StorageError> {
+        let mut state = self.state.write().await;
+        if !state.qsos.contains_key(&qso.local_id) {
+            return Ok(false);
+        }
+
+        state.qsos.insert(qso.local_id.clone(), qso.clone());
+        Ok(true)
+    }
+
+    async fn delete_qso(&self, local_id: &str) -> Result<bool, StorageError> {
+        let mut state = self.state.write().await;
+        Ok(state.qsos.remove(local_id).is_some())
+    }
+
+    async fn get_qso(&self, local_id: &str) -> Result<Option<QsoRecord>, StorageError> {
+        let state = self.state.read().await;
+        Ok(state.qsos.get(local_id).cloned())
+    }
+
+    async fn list_qsos(&self, query: &QsoListQuery) -> Result<Vec<QsoRecord>, StorageError> {
+        let state = self.state.read().await;
+        let mut records = state
+            .qsos
+            .values()
+            .filter(|record| matches_query(record, query))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        match query.sort {
+            QsoSortOrder::NewestFirst => {
+                records.sort_by_key(|record| {
+                    (
+                        Reverse(timestamp_to_millis(record.utc_timestamp.as_ref())),
+                        Reverse(record.local_id.clone()),
+                    )
+                });
+            }
+            QsoSortOrder::OldestFirst => {
+                records.sort_by_key(|record| {
+                    (
+                        timestamp_to_millis(record.utc_timestamp.as_ref()),
+                        record.local_id.clone(),
+                    )
+                });
+            }
+        }
+
+        let offset = usize::try_from(query.offset)
+            .map_err(|_| StorageError::backend("offset does not fit in usize"))?;
+        let limit = query
+            .limit
+            .map(|value| {
+                usize::try_from(value)
+                    .map_err(|_| StorageError::backend("limit does not fit in usize"))
+            })
+            .transpose()?;
+
+        let sliced = records.into_iter().skip(offset);
+        let result = if let Some(limit) = limit {
+            sliced.take(limit).collect()
+        } else {
+            sliced.collect()
+        };
+
+        Ok(result)
+    }
+
+    async fn qso_counts(&self) -> Result<LogbookCounts, StorageError> {
+        let state = self.state.read().await;
+        let pending_upload_count = state
+            .qsos
+            .values()
+            .filter(|record| is_pending_sync_status(record.sync_status))
+            .count();
+
+        Ok(LogbookCounts {
+            local_qso_count: u32::try_from(state.qsos.len())
+                .map_err(|_| StorageError::backend("local_qso_count exceeds u32"))?,
+            pending_upload_count: u32::try_from(pending_upload_count)
+                .map_err(|_| StorageError::backend("pending_upload_count exceeds u32"))?,
+        })
+    }
+
+    async fn get_sync_metadata(&self) -> Result<SyncMetadata, StorageError> {
+        let state = self.state.read().await;
+        Ok(state.sync_metadata.clone())
+    }
+
+    async fn upsert_sync_metadata(&self, metadata: &SyncMetadata) -> Result<(), StorageError> {
+        let mut state = self.state.write().await;
+        state.sync_metadata = metadata.clone();
+        Ok(())
+    }
+}
+
+#[tonic::async_trait]
+impl LookupSnapshotStore for MemoryStorage {
+    async fn get_lookup_snapshot(
+        &self,
+        callsign: &str,
+    ) -> Result<Option<LookupSnapshot>, StorageError> {
+        let state = self.state.read().await;
+        Ok(state
+            .lookup_snapshots
+            .get(&normalize_callsign(callsign))
+            .cloned())
+    }
+
+    async fn upsert_lookup_snapshot(&self, snapshot: &LookupSnapshot) -> Result<(), StorageError> {
+        let mut state = self.state.write().await;
+        let key = normalize_callsign(&snapshot.callsign);
+        let mut stored_snapshot = snapshot.clone();
+        stored_snapshot.callsign.clone_from(&key);
+        state.lookup_snapshots.insert(key, stored_snapshot);
+        Ok(())
+    }
+
+    async fn delete_lookup_snapshot(&self, callsign: &str) -> Result<bool, StorageError> {
+        let mut state = self.state.write().await;
+        Ok(state
+            .lookup_snapshots
+            .remove(&normalize_callsign(callsign))
+            .is_some())
+    }
+}
+
+fn matches_query(record: &QsoRecord, query: &QsoListQuery) -> bool {
+    if let Some(after) = query.after.as_ref() {
+        if timestamp_to_millis(record.utc_timestamp.as_ref()) < timestamp_to_millis(Some(after)) {
+            return false;
+        }
+    }
+
+    if let Some(before) = query.before.as_ref() {
+        if timestamp_to_millis(record.utc_timestamp.as_ref()) > timestamp_to_millis(Some(before)) {
+            return false;
+        }
+    }
+
+    if let Some(filter) = query.callsign_filter.as_deref() {
+        let normalized_filter = filter.trim().to_ascii_uppercase();
+        if !normalized_filter.is_empty()
+            && !record
+                .station_callsign
+                .to_ascii_uppercase()
+                .contains(&normalized_filter)
+            && !record
+                .worked_callsign
+                .to_ascii_uppercase()
+                .contains(&normalized_filter)
+        {
+            return false;
+        }
+    }
+
+    if let Some(band) = query.band_filter {
+        if record.band != band as i32 {
+            return false;
+        }
+    }
+
+    if let Some(mode) = query.mode_filter {
+        if record.mode != mode as i32 {
+            return false;
+        }
+    }
+
+    if let Some(contest_id) = query.contest_id.as_deref() {
+        if record.contest_id.as_deref() != Some(contest_id) {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn timestamp_to_millis(timestamp: Option<&prost_types::Timestamp>) -> i64 {
+    timestamp.map_or(0, |value| {
+        value.seconds.saturating_mul(1_000) + i64::from(value.nanos) / 1_000_000
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::MemoryStorage;
+    use logripper_core::application::logbook::LogbookEngine;
+    use logripper_core::domain::qso::QsoRecordBuilder;
+    use logripper_core::proto::logripper::domain::{Band, LookupResult, LookupState, Mode};
+    use logripper_core::storage::{
+        EngineStorage, LookupSnapshot, LookupSnapshotStore, QsoListQuery, QsoSortOrder,
+    };
+    use prost_types::Timestamp;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn memory_storage_round_trips_qsos_through_logbook_engine() {
+        let storage: Arc<dyn EngineStorage> = Arc::new(MemoryStorage::new());
+        let engine = LogbookEngine::new(storage);
+        let qso = QsoRecordBuilder::new("W1AW", "K7ABC")
+            .band(Band::Band20m)
+            .mode(Mode::Ft8)
+            .build();
+
+        let stored = engine.log_qso(qso).await.unwrap();
+        let loaded = engine.get_qso(&stored.local_id).await.unwrap();
+
+        assert_eq!(loaded.local_id, stored.local_id);
+        assert_eq!(loaded.worked_callsign, "K7ABC");
+        assert!(loaded.created_at.is_some());
+        assert!(loaded.updated_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn memory_storage_lists_qsos_with_filters_and_sorting() {
+        let storage: Arc<dyn EngineStorage> = Arc::new(MemoryStorage::new());
+        let engine = LogbookEngine::new(storage.clone());
+
+        let older = QsoRecordBuilder::new("W1AW", "K7OLD")
+            .band(Band::Band20m)
+            .mode(Mode::Ft8)
+            .timestamp(Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            })
+            .contest("ARRL-DX")
+            .build();
+        let newer = QsoRecordBuilder::new("W1AW", "K7NEW")
+            .band(Band::Band40m)
+            .mode(Mode::Cw)
+            .timestamp(Timestamp {
+                seconds: 1_700_000_100,
+                nanos: 0,
+            })
+            .build();
+
+        let _ = engine.log_qso(older).await.unwrap();
+        let _ = engine.log_qso(newer).await.unwrap();
+
+        let records = engine
+            .list_qsos(&QsoListQuery {
+                callsign_filter: Some("K7".into()),
+                limit: Some(1),
+                sort: QsoSortOrder::NewestFirst,
+                ..QsoListQuery::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records
+                .first()
+                .map(|record| record.worked_callsign.as_str()),
+            Some("K7NEW")
+        );
+
+        let filtered = engine
+            .list_qsos(&QsoListQuery {
+                contest_id: Some("ARRL-DX".into()),
+                ..QsoListQuery::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(
+            filtered
+                .first()
+                .map(|record| record.worked_callsign.as_str()),
+            Some("K7OLD")
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_storage_persists_lookup_snapshots() {
+        let storage = MemoryStorage::new();
+        let snapshot = LookupSnapshot {
+            callsign: "w1aw".into(),
+            result: LookupResult {
+                state: LookupState::Found as i32,
+                queried_callsign: "W1AW".into(),
+                ..LookupResult::default()
+            },
+            stored_at: Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            },
+            expires_at: None,
+        };
+
+        storage.upsert_lookup_snapshot(&snapshot).await.unwrap();
+        let loaded = storage.get_lookup_snapshot("W1AW").await.unwrap();
+
+        let Some(loaded) = loaded else {
+            panic!("Expected persisted lookup snapshot to exist");
+        };
+
+        assert_eq!(loaded.callsign, "W1AW");
+        assert_eq!(loaded.result.state, LookupState::Found as i32);
+    }
+}

--- a/src/rust/logripper-storage-sqlite/Cargo.toml
+++ b/src/rust/logripper-storage-sqlite/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "logripper-storage-sqlite"
+description = "SQLite storage adapter for LogRipper engine services"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+logripper-core = { path = "../logripper-core", version = "0.1.0" }
+prost = { workspace = true }
+prost-types = { workspace = true }
+rusqlite = { workspace = true }
+tonic = { workspace = true }
+tokio = { workspace = true }
+
+[lints]
+workspace = true

--- a/src/rust/logripper-storage-sqlite/Cargo.toml
+++ b/src/rust/logripper-storage-sqlite/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 logripper-core = { path = "../logripper-core", version = "0.1.0" }
 prost = { workspace = true }
 prost-types = { workspace = true }
-rusqlite = { workspace = true }
+sqlite = { workspace = true }
 tonic = { workspace = true }
 tokio = { workspace = true }
 

--- a/src/rust/logripper-storage-sqlite/src/builder.rs
+++ b/src/rust/logripper-storage-sqlite/src/builder.rs
@@ -1,0 +1,101 @@
+//! Builder for configuring the `SQLite` storage adapter.
+
+use crate::migrations::INITIAL_SCHEMA;
+use crate::SqliteStorage;
+use logripper_core::storage::StorageError;
+use rusqlite::Connection;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::Duration;
+
+/// Configures SQLite-backed storage for the engine.
+#[derive(Debug, Clone)]
+pub struct SqliteStorageBuilder {
+    path: Option<PathBuf>,
+    busy_timeout: Duration,
+}
+
+impl Default for SqliteStorageBuilder {
+    fn default() -> Self {
+        Self {
+            path: Some(PathBuf::from("logripper.db")),
+            busy_timeout: Duration::from_secs(5),
+        }
+    }
+}
+
+impl SqliteStorageBuilder {
+    /// Create a builder that targets `logripper.db` in the current working directory.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Store the database at the provided filesystem path.
+    #[must_use]
+    pub fn path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.path = Some(path.into());
+        self
+    }
+
+    /// Use an in-memory `SQLite` database.
+    #[must_use]
+    pub fn in_memory(mut self) -> Self {
+        self.path = None;
+        self
+    }
+
+    /// Override the busy timeout used for `SQLite` write contention.
+    #[must_use]
+    pub fn busy_timeout(mut self, timeout: Duration) -> Self {
+        self.busy_timeout = timeout;
+        self
+    }
+
+    /// Open the database, apply PRAGMAs, run migrations, and return the storage backend.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StorageError`] when the database cannot be opened, configured,
+    /// or migrated.
+    pub fn build(self) -> Result<SqliteStorage, StorageError> {
+        let connection = match self.path.as_ref() {
+            Some(path) => {
+                ensure_parent_directory(path)?;
+                Connection::open(path).map_err(|err| StorageError::backend(err.to_string()))?
+            }
+            None => Connection::open_in_memory()
+                .map_err(|err| StorageError::backend(err.to_string()))?,
+        };
+
+        connection
+            .busy_timeout(self.busy_timeout)
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+        connection
+            .pragma_update(None, "foreign_keys", "ON")
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+        if self.path.is_some() {
+            connection
+                .pragma_update(None, "journal_mode", "WAL")
+                .map_err(|err| StorageError::backend(err.to_string()))?;
+        }
+        connection
+            .execute_batch(INITIAL_SCHEMA)
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+
+        Ok(SqliteStorage {
+            connection: Mutex::new(connection),
+        })
+    }
+}
+
+fn ensure_parent_directory(path: &Path) -> Result<(), StorageError> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent).map_err(|err| StorageError::backend(err.to_string()))?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/rust/logripper-storage-sqlite/src/builder.rs
+++ b/src/rust/logripper-storage-sqlite/src/builder.rs
@@ -3,7 +3,7 @@
 use crate::migrations::INITIAL_SCHEMA;
 use crate::SqliteStorage;
 use logripper_core::storage::StorageError;
-use rusqlite::Connection;
+use sqlite::Connection;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -60,29 +60,29 @@ impl SqliteStorageBuilder {
     /// Returns [`StorageError`] when the database cannot be opened, configured,
     /// or migrated.
     pub fn build(self) -> Result<SqliteStorage, StorageError> {
-        let connection = match self.path.as_ref() {
+        let mut connection = match self.path.as_ref() {
             Some(path) => {
                 ensure_parent_directory(path)?;
-                Connection::open(path).map_err(|err| StorageError::backend(err.to_string()))?
+                Connection::open_thread_safe(path).map_err(map_sqlite_error)?
             }
-            None => Connection::open_in_memory()
-                .map_err(|err| StorageError::backend(err.to_string()))?,
+            None => Connection::open_thread_safe(":memory:").map_err(map_sqlite_error)?,
         };
 
+        let timeout_ms = usize::try_from(self.busy_timeout.as_millis()).unwrap_or(usize::MAX);
         connection
-            .busy_timeout(self.busy_timeout)
-            .map_err(|err| StorageError::backend(err.to_string()))?;
+            .set_busy_timeout(timeout_ms)
+            .map_err(map_sqlite_error)?;
         connection
-            .pragma_update(None, "foreign_keys", "ON")
-            .map_err(|err| StorageError::backend(err.to_string()))?;
+            .execute("PRAGMA foreign_keys = ON;")
+            .map_err(map_sqlite_error)?;
         if self.path.is_some() {
             connection
-                .pragma_update(None, "journal_mode", "WAL")
-                .map_err(|err| StorageError::backend(err.to_string()))?;
+                .execute("PRAGMA journal_mode = WAL;")
+                .map_err(map_sqlite_error)?;
         }
         connection
-            .execute_batch(INITIAL_SCHEMA)
-            .map_err(|err| StorageError::backend(err.to_string()))?;
+            .execute(INITIAL_SCHEMA)
+            .map_err(map_sqlite_error)?;
 
         Ok(SqliteStorage {
             connection: Mutex::new(connection),
@@ -98,4 +98,15 @@ fn ensure_parent_directory(path: &Path) -> Result<(), StorageError> {
     }
 
     Ok(())
+}
+
+fn map_sqlite_error(error: sqlite::Error) -> StorageError {
+    let message = match (error.code, error.message) {
+        (Some(code), Some(message)) => format!("{message} (code {code})"),
+        (Some(code), None) => format!("an SQLite error (code {code})"),
+        (None, Some(message)) => message,
+        (None, None) => "an SQLite error".to_string(),
+    };
+
+    StorageError::backend(message)
 }

--- a/src/rust/logripper-storage-sqlite/src/lib.rs
+++ b/src/rust/logripper-storage-sqlite/src/lib.rs
@@ -1,0 +1,496 @@
+//! `SQLite` storage adapter for `LogRipper` engine services.
+
+mod builder;
+mod migrations;
+
+use logripper_core::domain::lookup::normalize_callsign;
+use logripper_core::proto::logripper::domain::{LookupResult, QsoRecord, SyncStatus};
+use logripper_core::storage::{
+    EngineStorage, LogbookCounts, LogbookStore, LookupSnapshot, LookupSnapshotStore, QsoListQuery,
+    QsoSortOrder, StorageError, SyncMetadata,
+};
+use prost::Message;
+use rusqlite::types::Value;
+use rusqlite::{params, params_from_iter, Connection, ErrorCode, OptionalExtension};
+use std::sync::{Mutex, MutexGuard};
+
+pub use builder::SqliteStorageBuilder;
+
+/// SQLite-backed storage implementation for engine-owned persistence.
+pub struct SqliteStorage {
+    pub(crate) connection: Mutex<Connection>,
+}
+
+impl SqliteStorage {
+    fn connection(&self) -> Result<MutexGuard<'_, Connection>, StorageError> {
+        self.connection
+            .lock()
+            .map_err(|_| StorageError::backend("SQLite connection mutex was poisoned"))
+    }
+}
+
+impl EngineStorage for SqliteStorage {
+    fn logbook(&self) -> &dyn LogbookStore {
+        self
+    }
+
+    fn lookup_snapshots(&self) -> &dyn LookupSnapshotStore {
+        self
+    }
+
+    fn backend_name(&self) -> &'static str {
+        "sqlite"
+    }
+}
+
+#[tonic::async_trait]
+impl LogbookStore for SqliteStorage {
+    async fn insert_qso(&self, qso: &QsoRecord) -> Result<(), StorageError> {
+        let connection = self.connection()?;
+        let encoded = encode_message(qso);
+
+        connection
+            .execute(
+                "INSERT INTO qsos (
+                    local_id,
+                    qrz_logid,
+                    qrz_bookid,
+                    station_callsign,
+                    worked_callsign,
+                    utc_timestamp_ms,
+                    band,
+                    mode,
+                    contest_id,
+                    created_at_ms,
+                    updated_at_ms,
+                    sync_status,
+                    record
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                params![
+                    qso.local_id,
+                    qso.qrz_logid,
+                    qso.qrz_bookid,
+                    qso.station_callsign,
+                    qso.worked_callsign,
+                    timestamp_to_millis(qso.utc_timestamp.as_ref()),
+                    qso.band,
+                    qso.mode,
+                    qso.contest_id,
+                    timestamp_to_millis(qso.created_at.as_ref()),
+                    timestamp_to_millis(qso.updated_at.as_ref()),
+                    qso.sync_status,
+                    encoded,
+                ],
+            )
+            .map_err(|err| map_insert_error(err, &qso.local_id))?;
+
+        Ok(())
+    }
+
+    async fn update_qso(&self, qso: &QsoRecord) -> Result<bool, StorageError> {
+        let connection = self.connection()?;
+        let encoded = encode_message(qso);
+        let rows = connection
+            .execute(
+                "UPDATE qsos
+                 SET qrz_logid = ?,
+                     qrz_bookid = ?,
+                     station_callsign = ?,
+                     worked_callsign = ?,
+                     utc_timestamp_ms = ?,
+                     band = ?,
+                     mode = ?,
+                     contest_id = ?,
+                     created_at_ms = ?,
+                     updated_at_ms = ?,
+                     sync_status = ?,
+                     record = ?
+                 WHERE local_id = ?",
+                params![
+                    qso.qrz_logid,
+                    qso.qrz_bookid,
+                    qso.station_callsign,
+                    qso.worked_callsign,
+                    timestamp_to_millis(qso.utc_timestamp.as_ref()),
+                    qso.band,
+                    qso.mode,
+                    qso.contest_id,
+                    timestamp_to_millis(qso.created_at.as_ref()),
+                    timestamp_to_millis(qso.updated_at.as_ref()),
+                    qso.sync_status,
+                    encoded,
+                    qso.local_id,
+                ],
+            )
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+
+        Ok(rows > 0)
+    }
+
+    async fn delete_qso(&self, local_id: &str) -> Result<bool, StorageError> {
+        let connection = self.connection()?;
+        let rows = connection
+            .execute("DELETE FROM qsos WHERE local_id = ?", params![local_id])
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+
+        Ok(rows > 0)
+    }
+
+    async fn get_qso(&self, local_id: &str) -> Result<Option<QsoRecord>, StorageError> {
+        let connection = self.connection()?;
+        let payload = connection
+            .query_row(
+                "SELECT record FROM qsos WHERE local_id = ?",
+                params![local_id],
+                |row| row.get::<_, Vec<u8>>(0),
+            )
+            .optional()
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+
+        payload.map(|bytes| decode_qso(&bytes)).transpose()
+    }
+
+    async fn list_qsos(&self, query: &QsoListQuery) -> Result<Vec<QsoRecord>, StorageError> {
+        let connection = self.connection()?;
+        let mut sql = String::from("SELECT record FROM qsos WHERE 1 = 1");
+        let mut values = Vec::<Value>::new();
+
+        if let Some(after) = query.after.as_ref() {
+            sql.push_str(" AND utc_timestamp_ms >= ?");
+            values.push(Value::Integer(
+                timestamp_to_millis(Some(after)).unwrap_or(0),
+            ));
+        }
+
+        if let Some(before) = query.before.as_ref() {
+            sql.push_str(" AND utc_timestamp_ms <= ?");
+            values.push(Value::Integer(
+                timestamp_to_millis(Some(before)).unwrap_or(0),
+            ));
+        }
+
+        if let Some(filter) = query.callsign_filter.as_deref() {
+            let pattern = format!("%{}%", filter.trim().to_ascii_uppercase());
+            sql.push_str(" AND (UPPER(station_callsign) LIKE ? OR UPPER(worked_callsign) LIKE ?)");
+            values.push(Value::Text(pattern.clone()));
+            values.push(Value::Text(pattern));
+        }
+
+        if let Some(band) = query.band_filter {
+            sql.push_str(" AND band = ?");
+            values.push(Value::Integer(i64::from(band as i32)));
+        }
+
+        if let Some(mode) = query.mode_filter {
+            sql.push_str(" AND mode = ?");
+            values.push(Value::Integer(i64::from(mode as i32)));
+        }
+
+        if let Some(contest_id) = query.contest_id.as_deref() {
+            sql.push_str(" AND contest_id = ?");
+            values.push(Value::Text(contest_id.to_string()));
+        }
+
+        match query.sort {
+            QsoSortOrder::NewestFirst => {
+                sql.push_str(" ORDER BY utc_timestamp_ms DESC, local_id DESC");
+            }
+            QsoSortOrder::OldestFirst => {
+                sql.push_str(" ORDER BY utc_timestamp_ms ASC, local_id ASC");
+            }
+        }
+
+        if let Some(limit) = query.limit {
+            sql.push_str(" LIMIT ? OFFSET ?");
+            values.push(Value::Integer(i64::from(limit)));
+            values.push(Value::Integer(i64::from(query.offset)));
+        } else if query.offset > 0 {
+            sql.push_str(" LIMIT -1 OFFSET ?");
+            values.push(Value::Integer(i64::from(query.offset)));
+        }
+
+        let mut statement = connection
+            .prepare(&sql)
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+        let rows = statement
+            .query_map(params_from_iter(values), |row| row.get::<_, Vec<u8>>(0))
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+
+        let payloads = rows
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+
+        payloads
+            .into_iter()
+            .map(|payload| decode_qso(&payload))
+            .collect()
+    }
+
+    async fn qso_counts(&self) -> Result<LogbookCounts, StorageError> {
+        let connection = self.connection()?;
+        let local_qso_count = connection
+            .query_row("SELECT COUNT(*) FROM qsos", [], |row| row.get::<_, i64>(0))
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+        let pending_upload_count = connection
+            .query_row(
+                "SELECT COUNT(*) FROM qsos WHERE sync_status != ?",
+                params![SyncStatus::Synced as i32],
+                |row| row.get::<_, i64>(0),
+            )
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+
+        Ok(LogbookCounts {
+            local_qso_count: u32::try_from(local_qso_count)
+                .map_err(|_| StorageError::backend("local_qso_count exceeds u32"))?,
+            pending_upload_count: u32::try_from(pending_upload_count)
+                .map_err(|_| StorageError::backend("pending_upload_count exceeds u32"))?,
+        })
+    }
+
+    async fn get_sync_metadata(&self) -> Result<SyncMetadata, StorageError> {
+        let connection = self.connection()?;
+        connection
+            .query_row(
+                "SELECT qrz_qso_count, last_sync_ms, qrz_logbook_owner
+                 FROM sync_metadata
+                 WHERE id = 1",
+                [],
+                |row| {
+                    Ok(SyncMetadata {
+                        qrz_qso_count: row.get::<_, u32>(0)?,
+                        last_sync: millis_to_timestamp(row.get::<_, Option<i64>>(1)?),
+                        qrz_logbook_owner: row.get::<_, Option<String>>(2)?,
+                    })
+                },
+            )
+            .map_err(|err| StorageError::backend(err.to_string()))
+    }
+
+    async fn upsert_sync_metadata(&self, metadata: &SyncMetadata) -> Result<(), StorageError> {
+        let connection = self.connection()?;
+        connection
+            .execute(
+                "INSERT INTO sync_metadata (id, qrz_qso_count, last_sync_ms, qrz_logbook_owner)
+                 VALUES (1, ?, ?, ?)
+                 ON CONFLICT(id) DO UPDATE SET
+                    qrz_qso_count = excluded.qrz_qso_count,
+                    last_sync_ms = excluded.last_sync_ms,
+                    qrz_logbook_owner = excluded.qrz_logbook_owner",
+                params![
+                    metadata.qrz_qso_count,
+                    timestamp_to_millis(metadata.last_sync.as_ref()),
+                    metadata.qrz_logbook_owner,
+                ],
+            )
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+
+        Ok(())
+    }
+}
+
+#[tonic::async_trait]
+impl LookupSnapshotStore for SqliteStorage {
+    async fn get_lookup_snapshot(
+        &self,
+        callsign: &str,
+    ) -> Result<Option<LookupSnapshot>, StorageError> {
+        let connection = self.connection()?;
+        connection
+            .query_row(
+                "SELECT callsign, result, stored_at_ms, expires_at_ms
+                 FROM lookup_snapshots
+                 WHERE callsign = ?",
+                params![normalize_callsign(callsign)],
+                |row| {
+                    let payload = row.get::<_, Vec<u8>>(1)?;
+                    let result = LookupResult::decode(payload.as_slice()).map_err(|err| {
+                        rusqlite::Error::FromSqlConversionFailure(
+                            1,
+                            rusqlite::types::Type::Blob,
+                            Box::new(err),
+                        )
+                    })?;
+
+                    Ok(LookupSnapshot {
+                        callsign: row.get::<_, String>(0)?,
+                        result,
+                        stored_at: millis_to_timestamp(row.get::<_, Option<i64>>(2)?)
+                            .unwrap_or_default(),
+                        expires_at: millis_to_timestamp(row.get::<_, Option<i64>>(3)?),
+                    })
+                },
+            )
+            .optional()
+            .map_err(|err| StorageError::backend(err.to_string()))
+    }
+
+    async fn upsert_lookup_snapshot(&self, snapshot: &LookupSnapshot) -> Result<(), StorageError> {
+        let connection = self.connection()?;
+        let normalized_callsign = normalize_callsign(&snapshot.callsign);
+        let encoded = encode_message(&snapshot.result);
+
+        connection
+            .execute(
+                "INSERT INTO lookup_snapshots (callsign, result, stored_at_ms, expires_at_ms)
+                 VALUES (?, ?, ?, ?)
+                 ON CONFLICT(callsign) DO UPDATE SET
+                    result = excluded.result,
+                    stored_at_ms = excluded.stored_at_ms,
+                    expires_at_ms = excluded.expires_at_ms",
+                params![
+                    normalized_callsign,
+                    encoded,
+                    timestamp_to_millis(Some(&snapshot.stored_at)),
+                    timestamp_to_millis(snapshot.expires_at.as_ref()),
+                ],
+            )
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn delete_lookup_snapshot(&self, callsign: &str) -> Result<bool, StorageError> {
+        let connection = self.connection()?;
+        let rows = connection
+            .execute(
+                "DELETE FROM lookup_snapshots WHERE callsign = ?",
+                params![normalize_callsign(callsign)],
+            )
+            .map_err(|err| StorageError::backend(err.to_string()))?;
+
+        Ok(rows > 0)
+    }
+}
+
+fn encode_message<T: Message>(message: &T) -> Vec<u8> {
+    message.encode_to_vec()
+}
+
+fn decode_qso(payload: &[u8]) -> Result<QsoRecord, StorageError> {
+    QsoRecord::decode(payload).map_err(|err| StorageError::CorruptData(err.to_string()))
+}
+
+fn map_insert_error(error: rusqlite::Error, local_id: &str) -> StorageError {
+    match error {
+        rusqlite::Error::SqliteFailure(result, _)
+            if result.code == ErrorCode::ConstraintViolation =>
+        {
+            StorageError::duplicate("qso", local_id)
+        }
+        other => StorageError::backend(other.to_string()),
+    }
+}
+
+fn timestamp_to_millis(timestamp: Option<&prost_types::Timestamp>) -> Option<i64> {
+    timestamp.map(|value| value.seconds.saturating_mul(1_000) + i64::from(value.nanos) / 1_000_000)
+}
+
+fn millis_to_timestamp(millis: Option<i64>) -> Option<prost_types::Timestamp> {
+    millis.map(|value| prost_types::Timestamp {
+        seconds: value.div_euclid(1_000),
+        nanos: i32::try_from(value.rem_euclid(1_000) * 1_000_000).unwrap_or(0),
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::panic)]
+mod tests {
+    use super::SqliteStorageBuilder;
+    use logripper_core::application::logbook::LogbookEngine;
+    use logripper_core::domain::qso::QsoRecordBuilder;
+    use logripper_core::proto::logripper::domain::{Band, LookupResult, LookupState, Mode};
+    use logripper_core::storage::{
+        EngineStorage, LookupSnapshot, LookupSnapshotStore, QsoListQuery,
+    };
+    use prost_types::Timestamp;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn sqlite_storage_round_trips_qsos_through_logbook_engine() {
+        let storage: Arc<dyn EngineStorage> =
+            Arc::new(SqliteStorageBuilder::new().in_memory().build().unwrap());
+        let engine = LogbookEngine::new(storage);
+        let qso = QsoRecordBuilder::new("W1AW", "K7ABC")
+            .band(Band::Band20m)
+            .mode(Mode::Ft8)
+            .build();
+
+        let stored = engine.log_qso(qso).await.unwrap();
+        let loaded = engine.get_qso(&stored.local_id).await.unwrap();
+
+        assert_eq!(loaded.local_id, stored.local_id);
+        assert_eq!(loaded.worked_callsign, "K7ABC");
+        assert!(loaded.created_at.is_some());
+        assert!(loaded.updated_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn sqlite_storage_lists_qsos_with_filters() {
+        let storage: Arc<dyn EngineStorage> =
+            Arc::new(SqliteStorageBuilder::new().in_memory().build().unwrap());
+        let engine = LogbookEngine::new(storage);
+
+        let first = QsoRecordBuilder::new("W1AW", "K7ONE")
+            .band(Band::Band20m)
+            .mode(Mode::Ft8)
+            .timestamp(Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            })
+            .contest("CQ-WW")
+            .build();
+        let second = QsoRecordBuilder::new("W1AW", "K7TWO")
+            .band(Band::Band40m)
+            .mode(Mode::Cw)
+            .timestamp(Timestamp {
+                seconds: 1_700_000_100,
+                nanos: 0,
+            })
+            .build();
+
+        let _ = engine.log_qso(first).await.unwrap();
+        let _ = engine.log_qso(second).await.unwrap();
+
+        let listed = engine
+            .list_qsos(&QsoListQuery {
+                contest_id: Some("CQ-WW".into()),
+                ..QsoListQuery::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed.first().map(|record| record.worked_callsign.as_str()),
+            Some("K7ONE")
+        );
+    }
+
+    #[tokio::test]
+    async fn sqlite_storage_persists_lookup_snapshots() {
+        let storage = SqliteStorageBuilder::new().in_memory().build().unwrap();
+        let snapshot = LookupSnapshot {
+            callsign: "w1aw".into(),
+            result: LookupResult {
+                state: LookupState::Found as i32,
+                queried_callsign: "W1AW".into(),
+                ..LookupResult::default()
+            },
+            stored_at: Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            },
+            expires_at: None,
+        };
+
+        storage.upsert_lookup_snapshot(&snapshot).await.unwrap();
+        let loaded = storage.get_lookup_snapshot("W1AW").await.unwrap();
+
+        let Some(loaded) = loaded else {
+            panic!("Expected persisted lookup snapshot to exist");
+        };
+
+        assert_eq!(loaded.callsign, "W1AW");
+        assert_eq!(loaded.result.state, LookupState::Found as i32);
+    }
+}

--- a/src/rust/logripper-storage-sqlite/src/lib.rs
+++ b/src/rust/logripper-storage-sqlite/src/lib.rs
@@ -10,19 +10,18 @@ use logripper_core::storage::{
     QsoSortOrder, StorageError, SyncMetadata,
 };
 use prost::Message;
-use rusqlite::types::Value;
-use rusqlite::{params, params_from_iter, Connection, ErrorCode, OptionalExtension};
+use sqlite::{ConnectionThreadSafe, ReadableWithIndex, State, Statement, Value};
 use std::sync::{Mutex, MutexGuard};
 
 pub use builder::SqliteStorageBuilder;
 
 /// SQLite-backed storage implementation for engine-owned persistence.
 pub struct SqliteStorage {
-    pub(crate) connection: Mutex<Connection>,
+    pub(crate) connection: Mutex<ConnectionThreadSafe>,
 }
 
 impl SqliteStorage {
-    fn connection(&self) -> Result<MutexGuard<'_, Connection>, StorageError> {
+    fn connection(&self) -> Result<MutexGuard<'_, ConnectionThreadSafe>, StorageError> {
         self.connection
             .lock()
             .map_err(|_| StorageError::backend("SQLite connection mutex was poisoned"))
@@ -48,41 +47,40 @@ impl LogbookStore for SqliteStorage {
     async fn insert_qso(&self, qso: &QsoRecord) -> Result<(), StorageError> {
         let connection = self.connection()?;
         let encoded = encode_message(qso);
-
-        connection
-            .execute(
-                "INSERT INTO qsos (
-                    local_id,
-                    qrz_logid,
-                    qrz_bookid,
-                    station_callsign,
-                    worked_callsign,
-                    utc_timestamp_ms,
-                    band,
-                    mode,
-                    contest_id,
-                    created_at_ms,
-                    updated_at_ms,
-                    sync_status,
-                    record
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                params![
-                    qso.local_id,
-                    qso.qrz_logid,
-                    qso.qrz_bookid,
-                    qso.station_callsign,
-                    qso.worked_callsign,
-                    timestamp_to_millis(qso.utc_timestamp.as_ref()),
-                    qso.band,
-                    qso.mode,
-                    qso.contest_id,
-                    timestamp_to_millis(qso.created_at.as_ref()),
-                    timestamp_to_millis(qso.updated_at.as_ref()),
-                    qso.sync_status,
-                    encoded,
-                ],
-            )
-            .map_err(|err| map_insert_error(err, &qso.local_id))?;
+        execute_statement(
+            &connection,
+            "INSERT INTO qsos (
+                local_id,
+                qrz_logid,
+                qrz_bookid,
+                station_callsign,
+                worked_callsign,
+                utc_timestamp_ms,
+                band,
+                mode,
+                contest_id,
+                created_at_ms,
+                updated_at_ms,
+                sync_status,
+                record
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            &[
+                Value::from(qso.local_id.as_str()),
+                Value::from(qso.qrz_logid.as_deref()),
+                Value::from(qso.qrz_bookid.as_deref()),
+                Value::from(qso.station_callsign.as_str()),
+                Value::from(qso.worked_callsign.as_str()),
+                Value::from(timestamp_to_millis(qso.utc_timestamp.as_ref())),
+                Value::Integer(i64::from(qso.band)),
+                Value::Integer(i64::from(qso.mode)),
+                Value::from(qso.contest_id.as_deref()),
+                Value::from(timestamp_to_millis(qso.created_at.as_ref())),
+                Value::from(timestamp_to_millis(qso.updated_at.as_ref())),
+                Value::Integer(i64::from(qso.sync_status)),
+                Value::Binary(encoded),
+            ],
+        )
+        .map_err(|err| map_insert_error(err, &qso.local_id))?;
 
         Ok(())
     }
@@ -90,62 +88,64 @@ impl LogbookStore for SqliteStorage {
     async fn update_qso(&self, qso: &QsoRecord) -> Result<bool, StorageError> {
         let connection = self.connection()?;
         let encoded = encode_message(qso);
-        let rows = connection
-            .execute(
-                "UPDATE qsos
-                 SET qrz_logid = ?,
-                     qrz_bookid = ?,
-                     station_callsign = ?,
-                     worked_callsign = ?,
-                     utc_timestamp_ms = ?,
-                     band = ?,
-                     mode = ?,
-                     contest_id = ?,
-                     created_at_ms = ?,
-                     updated_at_ms = ?,
-                     sync_status = ?,
-                     record = ?
-                 WHERE local_id = ?",
-                params![
-                    qso.qrz_logid,
-                    qso.qrz_bookid,
-                    qso.station_callsign,
-                    qso.worked_callsign,
-                    timestamp_to_millis(qso.utc_timestamp.as_ref()),
-                    qso.band,
-                    qso.mode,
-                    qso.contest_id,
-                    timestamp_to_millis(qso.created_at.as_ref()),
-                    timestamp_to_millis(qso.updated_at.as_ref()),
-                    qso.sync_status,
-                    encoded,
-                    qso.local_id,
-                ],
-            )
-            .map_err(|err| StorageError::backend(err.to_string()))?;
+        let rows = execute_statement(
+            &connection,
+            "UPDATE qsos
+             SET qrz_logid = ?,
+                 qrz_bookid = ?,
+                 station_callsign = ?,
+                 worked_callsign = ?,
+                 utc_timestamp_ms = ?,
+                 band = ?,
+                 mode = ?,
+                 contest_id = ?,
+                 created_at_ms = ?,
+                 updated_at_ms = ?,
+                 sync_status = ?,
+                 record = ?
+             WHERE local_id = ?",
+            &[
+                Value::from(qso.qrz_logid.as_deref()),
+                Value::from(qso.qrz_bookid.as_deref()),
+                Value::from(qso.station_callsign.as_str()),
+                Value::from(qso.worked_callsign.as_str()),
+                Value::from(timestamp_to_millis(qso.utc_timestamp.as_ref())),
+                Value::Integer(i64::from(qso.band)),
+                Value::Integer(i64::from(qso.mode)),
+                Value::from(qso.contest_id.as_deref()),
+                Value::from(timestamp_to_millis(qso.created_at.as_ref())),
+                Value::from(timestamp_to_millis(qso.updated_at.as_ref())),
+                Value::Integer(i64::from(qso.sync_status)),
+                Value::Binary(encoded),
+                Value::from(qso.local_id.as_str()),
+            ],
+        )
+        .map_err(map_sqlite_error)?;
 
         Ok(rows > 0)
     }
 
     async fn delete_qso(&self, local_id: &str) -> Result<bool, StorageError> {
         let connection = self.connection()?;
-        let rows = connection
-            .execute("DELETE FROM qsos WHERE local_id = ?", params![local_id])
-            .map_err(|err| StorageError::backend(err.to_string()))?;
+        let rows = execute_statement(
+            &connection,
+            "DELETE FROM qsos WHERE local_id = ?",
+            &[Value::from(local_id)],
+        )
+        .map_err(map_sqlite_error)?;
 
         Ok(rows > 0)
     }
 
     async fn get_qso(&self, local_id: &str) -> Result<Option<QsoRecord>, StorageError> {
         let connection = self.connection()?;
-        let payload = connection
-            .query_row(
-                "SELECT record FROM qsos WHERE local_id = ?",
-                params![local_id],
-                |row| row.get::<_, Vec<u8>>(0),
-            )
-            .optional()
-            .map_err(|err| StorageError::backend(err.to_string()))?;
+        let payload = query_optional::<Vec<u8>>(
+            &connection,
+            "SELECT record FROM qsos WHERE local_id = ?",
+            &[Value::from(local_id)],
+            0,
+        )
+        .map_err(map_sqlite_error)?;
 
         payload.map(|bytes| decode_qso(&bytes)).transpose()
     }
@@ -172,8 +172,8 @@ impl LogbookStore for SqliteStorage {
         if let Some(filter) = query.callsign_filter.as_deref() {
             let pattern = format!("%{}%", filter.trim().to_ascii_uppercase());
             sql.push_str(" AND (UPPER(station_callsign) LIKE ? OR UPPER(worked_callsign) LIKE ?)");
-            values.push(Value::Text(pattern.clone()));
-            values.push(Value::Text(pattern));
+            values.push(Value::String(pattern.clone()));
+            values.push(Value::String(pattern));
         }
 
         if let Some(band) = query.band_filter {
@@ -188,7 +188,7 @@ impl LogbookStore for SqliteStorage {
 
         if let Some(contest_id) = query.contest_id.as_deref() {
             sql.push_str(" AND contest_id = ?");
-            values.push(Value::Text(contest_id.to_string()));
+            values.push(Value::String(contest_id.to_string()));
         }
 
         match query.sort {
@@ -209,16 +209,12 @@ impl LogbookStore for SqliteStorage {
             values.push(Value::Integer(i64::from(query.offset)));
         }
 
-        let mut statement = connection
-            .prepare(&sql)
-            .map_err(|err| StorageError::backend(err.to_string()))?;
-        let rows = statement
-            .query_map(params_from_iter(values), |row| row.get::<_, Vec<u8>>(0))
-            .map_err(|err| StorageError::backend(err.to_string()))?;
-
-        let payloads = rows
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|err| StorageError::backend(err.to_string()))?;
+        let mut statement =
+            prepare_statement(&connection, &sql, &values).map_err(map_sqlite_error)?;
+        let mut payloads = Vec::new();
+        while let State::Row = statement.next().map_err(map_sqlite_error)? {
+            payloads.push(statement.read::<Vec<u8>, _>(0).map_err(map_sqlite_error)?);
+        }
 
         payloads
             .into_iter()
@@ -228,16 +224,18 @@ impl LogbookStore for SqliteStorage {
 
     async fn qso_counts(&self) -> Result<LogbookCounts, StorageError> {
         let connection = self.connection()?;
-        let local_qso_count = connection
-            .query_row("SELECT COUNT(*) FROM qsos", [], |row| row.get::<_, i64>(0))
-            .map_err(|err| StorageError::backend(err.to_string()))?;
-        let pending_upload_count = connection
-            .query_row(
-                "SELECT COUNT(*) FROM qsos WHERE sync_status != ?",
-                params![SyncStatus::Synced as i32],
-                |row| row.get::<_, i64>(0),
-            )
-            .map_err(|err| StorageError::backend(err.to_string()))?;
+        let local_qso_count =
+            query_optional::<i64>(&connection, "SELECT COUNT(*) FROM qsos", &[], 0)
+                .map_err(map_sqlite_error)?
+                .unwrap_or(0);
+        let pending_upload_count = query_optional::<i64>(
+            &connection,
+            "SELECT COUNT(*) FROM qsos WHERE sync_status != ?",
+            &[Value::Integer(i64::from(SyncStatus::Synced as i32))],
+            0,
+        )
+        .map_err(map_sqlite_error)?
+        .unwrap_or(0);
 
         Ok(LogbookCounts {
             local_qso_count: u32::try_from(local_qso_count)
@@ -249,40 +247,51 @@ impl LogbookStore for SqliteStorage {
 
     async fn get_sync_metadata(&self) -> Result<SyncMetadata, StorageError> {
         let connection = self.connection()?;
-        connection
-            .query_row(
-                "SELECT qrz_qso_count, last_sync_ms, qrz_logbook_owner
-                 FROM sync_metadata
-                 WHERE id = 1",
-                [],
-                |row| {
-                    Ok(SyncMetadata {
-                        qrz_qso_count: row.get::<_, u32>(0)?,
-                        last_sync: millis_to_timestamp(row.get::<_, Option<i64>>(1)?),
-                        qrz_logbook_owner: row.get::<_, Option<String>>(2)?,
-                    })
-                },
-            )
-            .map_err(|err| StorageError::backend(err.to_string()))
+        let mut statement = prepare_statement(
+            &connection,
+            "SELECT qrz_qso_count, last_sync_ms, qrz_logbook_owner
+             FROM sync_metadata
+             WHERE id = 1",
+            &[],
+        )
+        .map_err(map_sqlite_error)?;
+
+        match statement.next().map_err(map_sqlite_error)? {
+            State::Row => Ok(SyncMetadata {
+                qrz_qso_count: u32::try_from(
+                    statement.read::<i64, _>(0).map_err(map_sqlite_error)?,
+                )
+                .map_err(|_| StorageError::backend("qrz_qso_count exceeds u32"))?,
+                last_sync: millis_to_timestamp(
+                    statement
+                        .read::<Option<i64>, _>(1)
+                        .map_err(map_sqlite_error)?,
+                ),
+                qrz_logbook_owner: statement
+                    .read::<Option<String>, _>(2)
+                    .map_err(map_sqlite_error)?,
+            }),
+            State::Done => Ok(SyncMetadata::default()),
+        }
     }
 
     async fn upsert_sync_metadata(&self, metadata: &SyncMetadata) -> Result<(), StorageError> {
         let connection = self.connection()?;
-        connection
-            .execute(
-                "INSERT INTO sync_metadata (id, qrz_qso_count, last_sync_ms, qrz_logbook_owner)
-                 VALUES (1, ?, ?, ?)
-                 ON CONFLICT(id) DO UPDATE SET
-                    qrz_qso_count = excluded.qrz_qso_count,
-                    last_sync_ms = excluded.last_sync_ms,
-                    qrz_logbook_owner = excluded.qrz_logbook_owner",
-                params![
-                    metadata.qrz_qso_count,
-                    timestamp_to_millis(metadata.last_sync.as_ref()),
-                    metadata.qrz_logbook_owner,
-                ],
-            )
-            .map_err(|err| StorageError::backend(err.to_string()))?;
+        execute_statement(
+            &connection,
+            "INSERT INTO sync_metadata (id, qrz_qso_count, last_sync_ms, qrz_logbook_owner)
+             VALUES (1, ?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+                qrz_qso_count = excluded.qrz_qso_count,
+                last_sync_ms = excluded.last_sync_ms,
+                qrz_logbook_owner = excluded.qrz_logbook_owner",
+            &[
+                Value::Integer(i64::from(metadata.qrz_qso_count)),
+                Value::from(timestamp_to_millis(metadata.last_sync.as_ref())),
+                Value::from(metadata.qrz_logbook_owner.as_deref()),
+            ],
+        )
+        .map_err(map_sqlite_error)?;
 
         Ok(())
     }
@@ -295,33 +304,39 @@ impl LookupSnapshotStore for SqliteStorage {
         callsign: &str,
     ) -> Result<Option<LookupSnapshot>, StorageError> {
         let connection = self.connection()?;
-        connection
-            .query_row(
-                "SELECT callsign, result, stored_at_ms, expires_at_ms
-                 FROM lookup_snapshots
-                 WHERE callsign = ?",
-                params![normalize_callsign(callsign)],
-                |row| {
-                    let payload = row.get::<_, Vec<u8>>(1)?;
-                    let result = LookupResult::decode(payload.as_slice()).map_err(|err| {
-                        rusqlite::Error::FromSqlConversionFailure(
-                            1,
-                            rusqlite::types::Type::Blob,
-                            Box::new(err),
-                        )
-                    })?;
+        let mut statement = prepare_statement(
+            &connection,
+            "SELECT callsign, result, stored_at_ms, expires_at_ms
+             FROM lookup_snapshots
+             WHERE callsign = ?",
+            &[Value::from(normalize_callsign(callsign))],
+        )
+        .map_err(map_sqlite_error)?;
 
-                    Ok(LookupSnapshot {
-                        callsign: row.get::<_, String>(0)?,
-                        result,
-                        stored_at: millis_to_timestamp(row.get::<_, Option<i64>>(2)?)
-                            .unwrap_or_default(),
-                        expires_at: millis_to_timestamp(row.get::<_, Option<i64>>(3)?),
-                    })
-                },
-            )
-            .optional()
-            .map_err(|err| StorageError::backend(err.to_string()))
+        match statement.next().map_err(map_sqlite_error)? {
+            State::Row => {
+                let payload = statement.read::<Vec<u8>, _>(1).map_err(map_sqlite_error)?;
+                let result = LookupResult::decode(payload.as_slice())
+                    .map_err(|err| StorageError::CorruptData(err.to_string()))?;
+
+                Ok(Some(LookupSnapshot {
+                    callsign: statement.read::<String, _>(0).map_err(map_sqlite_error)?,
+                    result,
+                    stored_at: millis_to_timestamp(
+                        statement
+                            .read::<Option<i64>, _>(2)
+                            .map_err(map_sqlite_error)?,
+                    )
+                    .unwrap_or_default(),
+                    expires_at: millis_to_timestamp(
+                        statement
+                            .read::<Option<i64>, _>(3)
+                            .map_err(map_sqlite_error)?,
+                    ),
+                }))
+            }
+            State::Done => Ok(None),
+        }
     }
 
     async fn upsert_lookup_snapshot(&self, snapshot: &LookupSnapshot) -> Result<(), StorageError> {
@@ -329,34 +344,34 @@ impl LookupSnapshotStore for SqliteStorage {
         let normalized_callsign = normalize_callsign(&snapshot.callsign);
         let encoded = encode_message(&snapshot.result);
 
-        connection
-            .execute(
-                "INSERT INTO lookup_snapshots (callsign, result, stored_at_ms, expires_at_ms)
-                 VALUES (?, ?, ?, ?)
-                 ON CONFLICT(callsign) DO UPDATE SET
-                    result = excluded.result,
-                    stored_at_ms = excluded.stored_at_ms,
-                    expires_at_ms = excluded.expires_at_ms",
-                params![
-                    normalized_callsign,
-                    encoded,
-                    timestamp_to_millis(Some(&snapshot.stored_at)),
-                    timestamp_to_millis(snapshot.expires_at.as_ref()),
-                ],
-            )
-            .map_err(|err| StorageError::backend(err.to_string()))?;
+        execute_statement(
+            &connection,
+            "INSERT INTO lookup_snapshots (callsign, result, stored_at_ms, expires_at_ms)
+             VALUES (?, ?, ?, ?)
+             ON CONFLICT(callsign) DO UPDATE SET
+                result = excluded.result,
+                stored_at_ms = excluded.stored_at_ms,
+                expires_at_ms = excluded.expires_at_ms",
+            &[
+                Value::from(normalized_callsign.as_str()),
+                Value::Binary(encoded),
+                Value::from(timestamp_to_millis(Some(&snapshot.stored_at))),
+                Value::from(timestamp_to_millis(snapshot.expires_at.as_ref())),
+            ],
+        )
+        .map_err(map_sqlite_error)?;
 
         Ok(())
     }
 
     async fn delete_lookup_snapshot(&self, callsign: &str) -> Result<bool, StorageError> {
         let connection = self.connection()?;
-        let rows = connection
-            .execute(
-                "DELETE FROM lookup_snapshots WHERE callsign = ?",
-                params![normalize_callsign(callsign)],
-            )
-            .map_err(|err| StorageError::backend(err.to_string()))?;
+        let rows = execute_statement(
+            &connection,
+            "DELETE FROM lookup_snapshots WHERE callsign = ?",
+            &[Value::from(normalize_callsign(callsign))],
+        )
+        .map_err(map_sqlite_error)?;
 
         Ok(rows > 0)
     }
@@ -370,15 +385,65 @@ fn decode_qso(payload: &[u8]) -> Result<QsoRecord, StorageError> {
     QsoRecord::decode(payload).map_err(|err| StorageError::CorruptData(err.to_string()))
 }
 
-fn map_insert_error(error: rusqlite::Error, local_id: &str) -> StorageError {
-    match error {
-        rusqlite::Error::SqliteFailure(result, _)
-            if result.code == ErrorCode::ConstraintViolation =>
+fn prepare_statement<'a>(
+    connection: &'a ConnectionThreadSafe,
+    sql: &str,
+    values: &[Value],
+) -> Result<Statement<'a>, sqlite::Error> {
+    let mut statement = connection.prepare(sql)?;
+    if !values.is_empty() {
+        statement.bind(values)?;
+    }
+
+    Ok(statement)
+}
+
+fn execute_statement(
+    connection: &ConnectionThreadSafe,
+    sql: &str,
+    values: &[Value],
+) -> Result<usize, sqlite::Error> {
+    let mut statement = prepare_statement(connection, sql, values)?;
+    while let State::Row = statement.next()? {}
+    Ok(connection.change_count())
+}
+
+fn query_optional<T>(
+    connection: &ConnectionThreadSafe,
+    sql: &str,
+    values: &[Value],
+    column_index: usize,
+) -> Result<Option<T>, sqlite::Error>
+where
+    T: ReadableWithIndex,
+{
+    let mut statement = prepare_statement(connection, sql, values)?;
+    match statement.next()? {
+        State::Row => statement.read::<T, _>(column_index).map(Some),
+        State::Done => Ok(None),
+    }
+}
+
+fn map_insert_error(error: sqlite::Error, local_id: &str) -> StorageError {
+    match error.code {
+        Some(code)
+            if code == isize::try_from(sqlite::ffi::SQLITE_CONSTRAINT).unwrap_or_default() =>
         {
             StorageError::duplicate("qso", local_id)
         }
-        other => StorageError::backend(other.to_string()),
+        _ => map_sqlite_error(error),
     }
+}
+
+fn map_sqlite_error(error: sqlite::Error) -> StorageError {
+    let message = match (error.code, error.message) {
+        (Some(code), Some(message)) => format!("{message} (code {code})"),
+        (Some(code), None) => format!("an SQLite error (code {code})"),
+        (None, Some(message)) => message,
+        (None, None) => "an SQLite error".to_string(),
+    };
+
+    StorageError::backend(message)
 }
 
 fn timestamp_to_millis(timestamp: Option<&prost_types::Timestamp>) -> Option<i64> {

--- a/src/rust/logripper-storage-sqlite/src/migrations.rs
+++ b/src/rust/logripper-storage-sqlite/src/migrations.rs
@@ -1,0 +1,4 @@
+//! Embedded schema migrations for the `SQLite` storage adapter.
+
+/// Initial schema for QSO, sync metadata, and lookup snapshot persistence.
+pub(crate) const INITIAL_SCHEMA: &str = include_str!("migrations/0001_initial.sql");

--- a/src/rust/logripper-storage-sqlite/src/migrations/0001_initial.sql
+++ b/src/rust/logripper-storage-sqlite/src/migrations/0001_initial.sql
@@ -1,0 +1,39 @@
+CREATE TABLE IF NOT EXISTS qsos (
+    local_id TEXT PRIMARY KEY NOT NULL,
+    qrz_logid TEXT,
+    qrz_bookid TEXT,
+    station_callsign TEXT NOT NULL,
+    worked_callsign TEXT NOT NULL,
+    utc_timestamp_ms INTEGER,
+    band INTEGER NOT NULL,
+    mode INTEGER NOT NULL,
+    contest_id TEXT,
+    created_at_ms INTEGER,
+    updated_at_ms INTEGER,
+    sync_status INTEGER NOT NULL,
+    record BLOB NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_qsos_station_callsign ON qsos (station_callsign);
+CREATE INDEX IF NOT EXISTS idx_qsos_worked_callsign ON qsos (worked_callsign);
+CREATE INDEX IF NOT EXISTS idx_qsos_utc_timestamp_ms ON qsos (utc_timestamp_ms);
+CREATE INDEX IF NOT EXISTS idx_qsos_band ON qsos (band);
+CREATE INDEX IF NOT EXISTS idx_qsos_mode ON qsos (mode);
+CREATE INDEX IF NOT EXISTS idx_qsos_contest_id ON qsos (contest_id);
+CREATE INDEX IF NOT EXISTS idx_qsos_sync_status ON qsos (sync_status);
+
+CREATE TABLE IF NOT EXISTS sync_metadata (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    qrz_qso_count INTEGER NOT NULL DEFAULT 0,
+    last_sync_ms INTEGER,
+    qrz_logbook_owner TEXT
+);
+
+INSERT OR IGNORE INTO sync_metadata (id, qrz_qso_count) VALUES (1, 0);
+
+CREATE TABLE IF NOT EXISTS lookup_snapshots (
+    callsign TEXT PRIMARY KEY NOT NULL,
+    result BLOB NOT NULL,
+    stored_at_ms INTEGER NOT NULL,
+    expires_at_ms INTEGER
+);


### PR DESCRIPTION
## Summary
- add engine-owned storage ports plus memory and SQLite adapters
- wire logbook gRPC through LogbookEngine and add runtime backend selection
- extend the Debug Workbench with storage backend configuration and smoke tests

## Validation
- cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check
- cargo clippy --manifest-path src\rust\Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path src\rust\Cargo.toml
- dotnet test src\dotnet\LogRipper.slnx --artifacts-path C:\Users\randy\.copilot\session-state\b710089c-deea-41bc-8ea1-ee27a354fd19\files\dotnet-full-artifacts
- live Debug Workbench smoke test against memory and SQLite backends, including restart persistence checks