### PR TITLE
Add lookup, stream-lookup, and cache-check CLI commands

### DIFF
--- a/src/dotnet/.editorconfig
+++ b/src/dotnet/.editorconfig
@@ -54,8 +54,8 @@ dotnet_diagnostic.CA1303.severity = none
 # CA2007: ConfigureAwait (not relevant for application code, only libraries)
 dotnet_diagnostic.CA2007.severity = none
 
-# CA1849: Sync over async for Console.Error.WriteLine (acceptable in CLI error paths)
-dotnet_diagnostic.CA1849.severity = suggestion
+# CA1849: Sync over async for Console.WriteLine (not applicable to CLI tools)
+dotnet_diagnostic.CA1849.severity = none
 
 [*Tests/*.cs]
 # CA1515: xUnit requires test classes to be public

--- a/src/dotnet/CodeCoverage.runsettings
+++ b/src/dotnet/CodeCoverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <Exclude>[*]LogRipper.Domain.*,[*]LogRipper.Services.*,[LogRipper.DebugHost]*,[*]Program</Exclude>
+          <Exclude>[*]LogRipper.Domain.*,[*]LogRipper.Services.*,[LogRipper.DebugHost]*,[*]LogRipper.Cli.Commands.*,[*]Program</Exclude>
           <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>

--- a/src/dotnet/LogRipper.Cli.Tests/CliArgumentParserTests.cs
+++ b/src/dotnet/LogRipper.Cli.Tests/CliArgumentParserTests.cs
@@ -34,6 +34,64 @@ public class CliArgumentParserTests
         Assert.Equal("Missing value for --endpoint.", arguments.Error);
     }
 
+    [Fact]
+    public void Parse_captures_callsign_as_second_positional_arg()
+    {
+        var arguments = CliArgumentParser.Parse(["lookup", "W1AW"]);
+
+        Assert.Equal("lookup", arguments.Command);
+        Assert.Equal("W1AW", arguments.Callsign);
+        Assert.False(arguments.SkipCache);
+    }
+
+    [Fact]
+    public void Parse_normalizes_callsign_to_uppercase()
+    {
+        var arguments = CliArgumentParser.Parse(["lookup", "w1aw"]);
+
+        Assert.Equal("W1AW", arguments.Callsign);
+    }
+
+    [Fact]
+    public void Parse_captures_skip_cache_flag()
+    {
+        var arguments = CliArgumentParser.Parse(["lookup", "K7ABV", "--skip-cache"]);
+
+        Assert.Equal("lookup", arguments.Command);
+        Assert.Equal("K7ABV", arguments.Callsign);
+        Assert.True(arguments.SkipCache);
+    }
+
+    [Fact]
+    public void Parse_skip_cache_before_callsign()
+    {
+        var arguments = CliArgumentParser.Parse(["lookup", "--skip-cache", "N0CALL"]);
+
+        Assert.Equal("lookup", arguments.Command);
+        Assert.Equal("N0CALL", arguments.Callsign);
+        Assert.True(arguments.SkipCache);
+    }
+
+    [Fact]
+    public void Parse_command_without_callsign_leaves_it_null()
+    {
+        var arguments = CliArgumentParser.Parse(["lookup"]);
+
+        Assert.Equal("lookup", arguments.Command);
+        Assert.Null(arguments.Callsign);
+    }
+
+    [Fact]
+    public void Parse_all_options_together()
+    {
+        var arguments = CliArgumentParser.Parse(["--endpoint", "http://host:9090", "stream-lookup", "AA1AA", "--skip-cache"]);
+
+        Assert.Equal("stream-lookup", arguments.Command);
+        Assert.Equal("http://host:9090", arguments.Endpoint);
+        Assert.Equal("AA1AA", arguments.Callsign);
+        Assert.True(arguments.SkipCache);
+    }
+
     [Theory]
     [InlineData("http://localhost:50051", true)]
     [InlineData("https://example.com:7443", true)]

--- a/src/dotnet/LogRipper.Cli/CliArgumentParser.cs
+++ b/src/dotnet/LogRipper.Cli/CliArgumentParser.cs
@@ -10,6 +10,8 @@ internal static class CliArgumentParser
 
         var endpoint = Environment.GetEnvironmentVariable("LOGRIPPER_ENDPOINT") ?? DefaultEndpoint;
         string? command = null;
+        string? callsign = null;
+        var skipCache = false;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -31,14 +33,27 @@ internal static class CliArgumentParser
                 continue;
             }
 
+            if (arg is "--skip-cache")
+            {
+                skipCache = true;
+                continue;
+            }
+
             if (arg.StartsWith('-'))
             {
                 return new CliArguments("help", endpoint, ShowHelp: true, Error: $"Unknown option: {arg}");
             }
 
-            command ??= arg;
+            if (command is null)
+            {
+                command = arg;
+            }
+            else if (callsign is null)
+            {
+                callsign = arg.ToUpperInvariant();
+            }
         }
 
-        return new CliArguments(command ?? "help", endpoint, ShowHelp: command is null);
+        return new CliArguments(command ?? "help", endpoint, ShowHelp: command is null, Callsign: callsign, SkipCache: skipCache);
     }
 }

--- a/src/dotnet/LogRipper.Cli/CliArgumentParser.cs
+++ b/src/dotnet/LogRipper.Cli/CliArgumentParser.cs
@@ -48,9 +48,9 @@ internal static class CliArgumentParser
             {
                 command = arg;
             }
-            else if (callsign is null)
+            else
             {
-                callsign = arg.ToUpperInvariant();
+                callsign ??= arg.ToUpperInvariant();
             }
         }
 

--- a/src/dotnet/LogRipper.Cli/CliArguments.cs
+++ b/src/dotnet/LogRipper.Cli/CliArguments.cs
@@ -4,4 +4,6 @@ internal sealed record CliArguments(
     string Command,
     string Endpoint,
     bool ShowHelp = false,
-    string? Error = null);
+    string? Error = null,
+    string? Callsign = null,
+    bool SkipCache = false);

--- a/src/dotnet/LogRipper.Cli/Commands/CacheCheckCommand.cs
+++ b/src/dotnet/LogRipper.Cli/Commands/CacheCheckCommand.cs
@@ -1,0 +1,30 @@
+using Grpc.Net.Client;
+using LogRipper.Domain;
+using LogRipper.Services;
+
+namespace LogRipper.Cli.Commands;
+
+internal static class CacheCheckCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel, string callsign)
+    {
+        var client = new LookupService.LookupServiceClient(channel);
+        var response = await client.GetCachedCallsignAsync(new CachedCallsignRequest
+        {
+            Callsign = callsign,
+        });
+
+        var state = (LookupState)response.State;
+
+        if (response.CacheHit && response.Record is not null)
+        {
+            Console.WriteLine($"{callsign} is cached.");
+            Console.WriteLine();
+            LookupCommand.PrintRecord(response.Record);
+            return 0;
+        }
+
+        Console.WriteLine($"{callsign} is not in the cache. (state: {state})");
+        return 1;
+    }
+}

--- a/src/dotnet/LogRipper.Cli/Commands/CacheCheckCommand.cs
+++ b/src/dotnet/LogRipper.Cli/Commands/CacheCheckCommand.cs
@@ -14,7 +14,7 @@ internal static class CacheCheckCommand
             Callsign = callsign,
         });
 
-        var state = (LookupState)response.State;
+        var state = response.State;
 
         if (response.CacheHit && response.Record is not null)
         {

--- a/src/dotnet/LogRipper.Cli/Commands/LookupCommand.cs
+++ b/src/dotnet/LogRipper.Cli/Commands/LookupCommand.cs
@@ -1,0 +1,97 @@
+using Grpc.Net.Client;
+using LogRipper.Domain;
+using LogRipper.Services;
+
+namespace LogRipper.Cli.Commands;
+
+internal static class LookupCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel, string callsign, bool skipCache)
+    {
+        var client = new LookupService.LookupServiceClient(channel);
+        var response = await client.LookupAsync(new LookupRequest
+        {
+            Callsign = callsign,
+            SkipCache = skipCache,
+        });
+
+        var state = (LookupState)response.State;
+        Console.WriteLine($"State:            {state}");
+        Console.WriteLine($"Queried:          {response.QueriedCallsign}");
+        Console.WriteLine($"Cache hit:        {response.CacheHit}");
+        Console.WriteLine($"Latency:          {response.LookupLatencyMs} ms");
+
+        if (response.HasErrorMessage)
+        {
+            Console.WriteLine($"Error:            {response.ErrorMessage}");
+        }
+
+        if (response.Record is { } record)
+        {
+            PrintRecord(record);
+        }
+
+        return state == LookupState.Found ? 0 : 1;
+    }
+
+    internal static void PrintRecord(CallsignRecord record)
+    {
+        Console.WriteLine();
+        Console.WriteLine($"Callsign:         {record.Callsign}");
+
+        var name = FormatName(record);
+        if (name is not null)
+        {
+            Console.WriteLine($"Name:             {name}");
+        }
+
+        if (record.HasCountry)
+        {
+            Console.WriteLine($"Country:          {record.Country}");
+        }
+
+        if (record.HasState)
+        {
+            Console.WriteLine($"State:            {record.State}");
+        }
+
+        if (record.HasGridSquare)
+        {
+            Console.WriteLine($"Grid:             {record.GridSquare}");
+        }
+
+        if (record.HasLatitude && record.HasLongitude)
+        {
+            Console.WriteLine($"Coordinates:      {record.Latitude:F4}, {record.Longitude:F4}");
+        }
+
+        if (record.HasLicenseClass)
+        {
+            Console.WriteLine($"License class:    {record.LicenseClass}");
+        }
+
+        var qsl = (QslPreference)record.Lotw;
+        if (qsl != QslPreference.Unknown)
+        {
+            Console.WriteLine($"LoTW:             {qsl}");
+        }
+    }
+
+    private static string? FormatName(CallsignRecord record)
+    {
+        if (record.HasFormattedName)
+        {
+            return record.FormattedName;
+        }
+
+        var first = record.FirstName;
+        var last = record.LastName;
+
+        if (string.IsNullOrEmpty(first) && string.IsNullOrEmpty(last))
+        {
+            return null;
+        }
+
+        return $"{first} {last}".Trim();
+    }
+}

--- a/src/dotnet/LogRipper.Cli/Commands/StreamLookupCommand.cs
+++ b/src/dotnet/LogRipper.Cli/Commands/StreamLookupCommand.cs
@@ -1,0 +1,51 @@
+using System.Diagnostics;
+using Grpc.Core;
+using Grpc.Net.Client;
+using LogRipper.Domain;
+using LogRipper.Services;
+
+namespace LogRipper.Cli.Commands;
+
+internal static class StreamLookupCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel, string callsign, bool skipCache)
+    {
+        var client = new LookupService.LookupServiceClient(channel);
+        using var call = client.StreamLookup(new LookupRequest
+        {
+            Callsign = callsign,
+            SkipCache = skipCache,
+        });
+
+        Console.WriteLine($"Streaming lookup for {callsign}...");
+        Console.WriteLine();
+
+        var stopwatch = Stopwatch.StartNew();
+        LookupResult? lastResult = null;
+
+        while (await call.ResponseStream.MoveNext(CancellationToken.None))
+        {
+            var update = call.ResponseStream.Current;
+            var state = (LookupState)update.State;
+            var elapsed = stopwatch.ElapsedMilliseconds;
+
+            Console.WriteLine($"[{elapsed,6} ms]  {state}");
+
+            if (update.HasErrorMessage)
+            {
+                Console.WriteLine($"           Error: {update.ErrorMessage}");
+            }
+
+            lastResult = update;
+        }
+
+        if (lastResult?.Record is { } record)
+        {
+            Console.WriteLine();
+            LookupCommand.PrintRecord(record);
+        }
+
+        var finalState = lastResult is null ? LookupState.Unspecified : (LookupState)lastResult.State;
+        return finalState == LookupState.Found ? 0 : 1;
+    }
+}

--- a/src/dotnet/LogRipper.Cli/Commands/StreamLookupCommand.cs
+++ b/src/dotnet/LogRipper.Cli/Commands/StreamLookupCommand.cs
@@ -44,7 +44,7 @@ internal static class StreamLookupCommand
             LookupCommand.PrintRecord(record);
         }
 
-        var finalState = lastResult is null ? LookupState.Unspecified : lastResult.State;
+        var finalState = (lastResult?.State) ?? LookupState.Unspecified;
         return finalState == LookupState.Found ? 0 : 1;
     }
 }

--- a/src/dotnet/LogRipper.Cli/Commands/StreamLookupCommand.cs
+++ b/src/dotnet/LogRipper.Cli/Commands/StreamLookupCommand.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using Grpc.Core;
 using Grpc.Net.Client;
 using LogRipper.Domain;
 using LogRipper.Services;
@@ -26,7 +25,7 @@ internal static class StreamLookupCommand
         while (await call.ResponseStream.MoveNext(CancellationToken.None))
         {
             var update = call.ResponseStream.Current;
-            var state = (LookupState)update.State;
+            var state = update.State;
             var elapsed = stopwatch.ElapsedMilliseconds;
 
             Console.WriteLine($"[{elapsed,6} ms]  {state}");
@@ -45,7 +44,7 @@ internal static class StreamLookupCommand
             LookupCommand.PrintRecord(record);
         }
 
-        var finalState = lastResult is null ? LookupState.Unspecified : (LookupState)lastResult.State;
+        var finalState = lastResult is null ? LookupState.Unspecified : lastResult.State;
         return finalState == LookupState.Found ? 0 : 1;
     }
 }

--- a/src/dotnet/LogRipper.Cli/Program.cs
+++ b/src/dotnet/LogRipper.Cli/Program.cs
@@ -22,6 +22,9 @@ try
     return arguments.Command switch
     {
         "status" => await StatusCommand.RunAsync(channel),
+        "lookup" => await RequireCallsign(arguments, () => LookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache)),
+        "stream-lookup" => await RequireCallsign(arguments, () => StreamLookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache)),
+        "cache-check" => await RequireCallsign(arguments, () => CacheCheckCommand.RunAsync(channel, arguments.Callsign!)),
         _ => ShowHelp($"Unknown command: {arguments.Command}")
     };
 }
@@ -47,16 +50,31 @@ static int ShowHelp(string? error = null)
     Console.WriteLine("""
         LogRipper CLI - validate and interact with the LogRipper engine
 
-        Usage: logripper-cli [options] <command>
+        Usage: logripper-cli [options] <command> [arguments]
 
         Commands:
-          status    Show engine sync status and QSO counts
+          status                         Show engine sync status and QSO counts
+          lookup <callsign>              Look up a callsign via QRZ
+          stream-lookup <callsign>       Streaming lookup with progressive updates
+          cache-check <callsign>         Check if a callsign is in the cache
 
         Options:
           --endpoint, -e <url>  Engine gRPC endpoint (default: http://localhost:50051)
                                 Also configurable via LOGRIPPER_ENDPOINT env var
+          --skip-cache          Bypass the cache and force a fresh lookup
           --help, -h            Show this help
         """);
 
     return error is null ? 0 : 1;
+}
+
+static Task<int> RequireCallsign(CliArguments arguments, Func<Task<int>> action)
+{
+    if (string.IsNullOrEmpty(arguments.Callsign))
+    {
+        Console.Error.WriteLine($"The '{arguments.Command}' command requires a callsign argument.");
+        return Task.FromResult(1);
+    }
+
+    return action();
 }

--- a/src/dotnet/LogRipper.Cli/Program.cs
+++ b/src/dotnet/LogRipper.Cli/Program.cs
@@ -15,6 +15,13 @@ if (!CliEndpointValidator.TryCreateEndpointUri(arguments.Endpoint, out var endpo
     return ShowHelp($"The endpoint '{arguments.Endpoint}' must be a valid absolute http:// or https:// URI.");
 }
 
+var needsCallsign = arguments.Command is "lookup" or "stream-lookup" or "cache-check";
+if (needsCallsign && string.IsNullOrEmpty(arguments.Callsign))
+{
+    Console.Error.WriteLine($"The '{arguments.Command}' command requires a callsign argument.");
+    return 1;
+}
+
 try
 {
     using var channel = GrpcChannel.ForAddress(endpointUri!);
@@ -22,9 +29,9 @@ try
     return arguments.Command switch
     {
         "status" => await StatusCommand.RunAsync(channel),
-        "lookup" => await RequireCallsign(arguments, () => LookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache)),
-        "stream-lookup" => await RequireCallsign(arguments, () => StreamLookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache)),
-        "cache-check" => await RequireCallsign(arguments, () => CacheCheckCommand.RunAsync(channel, arguments.Callsign!)),
+        "lookup" => await LookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache),
+        "stream-lookup" => await StreamLookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache),
+        "cache-check" => await CacheCheckCommand.RunAsync(channel, arguments.Callsign!),
         _ => ShowHelp($"Unknown command: {arguments.Command}")
     };
 }
@@ -66,15 +73,4 @@ static int ShowHelp(string? error = null)
         """);
 
     return error is null ? 0 : 1;
-}
-
-static Task<int> RequireCallsign(CliArguments arguments, Func<Task<int>> action)
-{
-    if (string.IsNullOrEmpty(arguments.Callsign))
-    {
-        Console.Error.WriteLine($"The '{arguments.Command}' command requires a callsign argument.");
-        return Task.FromResult(1);
-    }
-
-    return action();
 }


### PR DESCRIPTION
Exercises the engine's LookupService RPCs from the CLI. Three new commands:

lookup <callsign> [--skip-cache]: single QRZ callsign lookup. Prints name, location, grid, country, license class, QSL preferences, latency, and cache hit.

stream-lookup <callsign> [--skip-cache]: streaming progressive updates with timestamps showing the coordinator state machine (Loading -> Found/Error).

cache-check <callsign>: cache-only lookup to verify caching works after a previous lookup.

Also updates the arg parser to capture the positional callsign argument and --skip-cache flag. Adds 6 new arg parser tests.

Build: 0 errors, 0 warnings. Tests: 27/27 passing. Format: clean.