### PR TITLE
fix: make persisted setup storage agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ In capture mode, LogRipper builds the outgoing QRZ XML request and returns redac
 
 You can also set `LOGRIPPER_STATION_*` values in `.env` to define the active station profile that the Rust engine snapshots into newly logged QSOs.
 
-For the new first-run bootstrap surface, `SetupService` persists the engine's storage choice, initial station profile, and optional QRZ XML credentials to `config.toml`, then hot-applies those persisted values to the running engine. After setup, `StationProfileService` manages additional station profiles, persisted active-profile selection, and bounded in-memory session overrides for portable or event operation. The Debug Host `/engine` page now exposes setup and station-profile editor forms for these contract surfaces, so local bootstrap/profile lifecycle testing no longer requires `grpcurl`.
+For the new first-run bootstrap surface, `SetupService` persists the engine's log file path, initial station profile, and optional QRZ XML credentials to `config.toml`, then hot-applies those persisted values to the running engine. After setup, `StationProfileService` manages additional station profiles, persisted active-profile selection, and bounded in-memory session overrides for portable or event operation. The Debug Host `/engine` page now exposes setup and station-profile editor forms for these contract surfaces, so local bootstrap/profile lifecycle testing no longer requires `grpcurl`.
 
 ### Local lookup debug workflow
 

--- a/docs/api/setup-service.md
+++ b/docs/api/setup-service.md
@@ -12,15 +12,15 @@ Use it to:
 
 - detect whether a real config file already exists
 - discover the config path the engine will use
-- discover the suggested default SQLite path
-- inspect the currently persisted storage/station bootstrap
-- save the initial storage choice, station profile, and optional QRZ XML credentials
+- discover the suggested default log file path
+- inspect the currently persisted logbook/station bootstrap
+- save the initial log file path, station profile, and optional QRZ XML credentials
 
 ## Current behavior
 
 | RPC | Status | Notes |
 |---|---|---|
-| `GetSetupStatus` | ✅ Implemented | Returns persisted setup status, config path, suggested SQLite path, and validation warnings |
+| `GetSetupStatus` | ✅ Implemented | Returns persisted setup status, config path, suggested log file path, and validation warnings |
 | `SaveSetup` | ✅ Implemented | Validates and writes `config.toml`, then hot-applies the new persisted config to the running engine |
 
 ## RPCs
@@ -40,14 +40,13 @@ rpc GetSetupStatus(GetSetupStatusRequest) returns (SetupStatusResponse)
 | `config_file_exists` | `bool` | Whether the persisted setup file exists |
 | `setup_complete` | `bool` | Whether the saved setup is sufficient for the current first-run slice |
 | `config_path` | `string` | Path to the config file the engine is using |
-| `storage_backend` | `StorageBackend` | Persisted storage choice |
-| `sqlite_path` | `string` (optional) | Persisted SQLite path when SQLite is selected |
+| `log_file_path` | `string` (optional) | Persisted log file path for the durable logbook |
 | `station_profile` | `StationProfile` (optional) | Persisted bootstrap station profile |
 | `active_station_profile_id` | `string` (optional) | Persisted active station-profile id when profile lifecycle is configured |
 | `station_profile_count` | `uint32` | Count of persisted station profiles currently stored |
 | `qrz_xml_username` | `string` (optional) | Persisted QRZ XML username |
 | `has_qrz_xml_password` | `bool` | Whether a QRZ XML password is stored |
-| `suggested_sqlite_path` | `string` | Recommended SQLite path when the user has not picked one yet |
+| `suggested_log_file_path` | `string` | Recommended log file path when the user has not picked one yet |
 | `warnings` | `repeated string` | Human-readable setup gaps or validation warnings |
 
 ### SaveSetup
@@ -62,8 +61,7 @@ rpc SaveSetup(SaveSetupRequest) returns (SaveSetupResponse)
 
 | Field | Type | Meaning |
 |---|---|---|
-| `storage_backend` | `StorageBackend` | Required. `MEMORY` or `SQLITE` |
-| `sqlite_path` | `string` (optional) | Optional explicit SQLite path. When omitted for SQLite, the engine uses `suggested_sqlite_path` |
+| `log_file_path` | `string` (optional) | Preferred durable log file path for the operator-facing setup flow |
 | `station_profile` | `StationProfile` | Required bootstrap station profile |
 | `qrz_xml_username` | `string` (optional) | Optional QRZ XML username |
 | `qrz_xml_password` | `string` (optional) | Optional QRZ XML password |
@@ -71,9 +69,12 @@ rpc SaveSetup(SaveSetupRequest) returns (SaveSetupResponse)
 **Validation rules**
 
 - `station_profile.station_callsign` is required
+- `log_file_path` is required for the current operator-facing setup flow
 - QRZ XML username/password must either both be set or both be omitted
 - `dxcc`, `cq_zone`, and `itu_zone` must be greater than zero when present
 - `latitude` / `longitude` must be finite and within valid bounds
+
+Legacy compatibility note: the proto still carries `storage_backend`, `sqlite_path`, and `suggested_sqlite_path` for older clients, but new callers should use `log_file_path` and `suggested_log_file_path`.
 
 ## Persistence model
 

--- a/proto/services/setup_service.proto
+++ b/proto/services/setup_service.proto
@@ -10,7 +10,7 @@ import "domain/station.proto";
 //
 // This service owns persisted engine configuration, not ephemeral developer
 // runtime overrides. Clients can use it to detect missing setup, present the
-// recommended config/data paths, and save the initial station/storage settings.
+// recommended config/data paths, and save the initial station/logbook settings.
 service SetupService {
   // Read the current persisted setup status and suggested default paths.
   rpc GetSetupStatus(GetSetupStatusRequest) returns (SetupStatusResponse);
@@ -26,24 +26,32 @@ message SetupStatusResponse {
   bool config_file_exists = 1;
   bool setup_complete = 2;
   string config_path = 3;
+  // Legacy compatibility field. New clients should use log_file_path.
   StorageBackend storage_backend = 4;
+  // Legacy compatibility field. New clients should use log_file_path.
   optional string sqlite_path = 5;
   bool has_station_profile = 6;
   logripper.domain.StationProfile station_profile = 7;
   optional string qrz_xml_username = 8;
   bool has_qrz_xml_password = 9;
+  // Legacy compatibility field. New clients should use suggested_log_file_path.
   string suggested_sqlite_path = 10;
   repeated string warnings = 11;
   optional string active_station_profile_id = 12;
   uint32 station_profile_count = 13;
+  optional string log_file_path = 14;
+  string suggested_log_file_path = 15;
 }
 
 message SaveSetupRequest {
+  // Legacy compatibility field. New clients should use log_file_path.
   StorageBackend storage_backend = 1;
+  // Legacy compatibility field. New clients should use log_file_path.
   optional string sqlite_path = 2;
   logripper.domain.StationProfile station_profile = 3;
   optional string qrz_xml_username = 4;
   optional string qrz_xml_password = 5;
+  optional string log_file_path = 6;
 }
 
 message SaveSetupResponse {

--- a/src/dotnet/LogRipper.DebugHost.Tests/DebugWorkbenchStateTests.cs
+++ b/src/dotnet/LogRipper.DebugHost.Tests/DebugWorkbenchStateTests.cs
@@ -124,7 +124,7 @@ public class DebugWorkbenchStateTests
     }
 
     [Fact]
-    public void Update_setup_status_syncs_persisted_sqlite_defaults()
+    public void Update_setup_status_syncs_persisted_log_file_path()
     {
         var state = new DebugWorkbenchState(Options.Create(new DebugWorkbenchOptions()));
 
@@ -134,7 +134,7 @@ public class DebugWorkbenchStateTests
             SetupComplete = true,
             ConfigPath = @".\config\config.toml",
             StorageBackend = StorageBackend.Sqlite,
-            SqlitePath = @".\data\portable-logripper.db",
+            LogFilePath = @".\data\portable-logripper.db",
             StationProfile = new StationProfile
             {
                 StationCallsign = "K7RND",

--- a/src/dotnet/LogRipper.DebugHost.Tests/EditorModelTests.cs
+++ b/src/dotnet/LogRipper.DebugHost.Tests/EditorModelTests.cs
@@ -14,8 +14,7 @@ public class EditorModelTests
         var model = SetupEditorModel.Create(
             new SetupStatusResponse
             {
-                StorageBackend = StorageBackend.Sqlite,
-                SqlitePath = @".\data\portable.db",
+                LogFilePath = @".\data\portable.db",
                 QrzXmlUsername = "k7rnd",
                 StationProfile = new StationProfile
                 {
@@ -24,11 +23,9 @@ public class EditorModelTests
                     Grid = "CN87"
                 }
             },
-            EngineStorageBackend.Memory,
             @".\data\fallback.db");
 
-        Assert.Equal(StorageBackend.Sqlite, model.StorageBackend);
-        Assert.Equal(@".\data\portable.db", model.SqlitePath);
+        Assert.Equal(@".\data\portable.db", model.LogFilePath);
         Assert.Equal("k7rnd", model.QrzXmlUsername);
         Assert.Equal("Home", model.ProfileName);
         Assert.Equal("K7RND", model.StationCallsign);
@@ -40,8 +37,7 @@ public class EditorModelTests
     {
         var model = new SetupEditorModel
         {
-            StorageBackend = StorageBackend.Sqlite,
-            SqlitePath = @"  .\data\logripper.db  ",
+            LogFilePath = @"  .\data\logripper.db  ",
             QrzXmlUsername = "  k7rnd  ",
             QrzXmlPassword = "  secret  ",
             ProfileName = "  Home  ",
@@ -53,9 +49,8 @@ public class EditorModelTests
 
         var request = model.ToRequest();
 
-        Assert.Equal(StorageBackend.Sqlite, request.StorageBackend);
-        Assert.True(request.HasSqlitePath);
-        Assert.Equal(@".\data\logripper.db", request.SqlitePath);
+        Assert.True(request.HasLogFilePath);
+        Assert.Equal(@".\data\logripper.db", request.LogFilePath);
         Assert.True(request.HasQrzXmlUsername);
         Assert.True(request.HasQrzXmlPassword);
         Assert.Equal("k7rnd", request.QrzXmlUsername);
@@ -69,19 +64,18 @@ public class EditorModelTests
     }
 
     [Fact]
-    public void SetupEditorModel_validate_requires_sqlite_path_and_complete_qrz_pair()
+    public void SetupEditorModel_validate_requires_log_file_path_and_complete_qrz_pair()
     {
         var model = new SetupEditorModel
         {
-            StorageBackend = StorageBackend.Sqlite,
-            SqlitePath = "   ",
+            LogFilePath = "   ",
             QrzXmlUsername = "k7rnd",
             StationCallsign = "K7RND"
         };
 
         var results = Validate(model);
 
-        Assert.Contains(results, result => result.MemberNames.Contains(nameof(SetupEditorModel.SqlitePath), StringComparer.Ordinal));
+        Assert.Contains(results, result => result.MemberNames.Contains(nameof(SetupEditorModel.LogFilePath), StringComparer.Ordinal));
         Assert.Contains(results, result => result.MemberNames.Contains(nameof(SetupEditorModel.QrzXmlPassword), StringComparer.Ordinal));
     }
 

--- a/src/dotnet/LogRipper.DebugHost/Components/Pages/Engine.razor
+++ b/src/dotnet/LogRipper.DebugHost/Components/Pages/Engine.razor
@@ -511,7 +511,7 @@
             </div>
             <div class="row g-3 mb-3">
                 <div class="col-lg-6">
-                    <strong>Persisted storage:</strong> @GetSetupStorageSummary(setupStatus)
+                    <strong>Persisted log file:</strong> @GetSetupLogFileSummary(setupStatus)
                 </div>
                 <div class="col-lg-6">
                     <strong>QRZ XML:</strong>
@@ -530,7 +530,7 @@
         @if (WorkbenchState.SetupStatus?.SetupComplete == true && !isSetupExpanded)
         {
             <div class="small text-muted">
-                Bootstrap setup is complete. Expand this section if you want to inspect or edit storage, QRZ credentials, or the currently active persisted station profile.
+                Bootstrap setup is complete. Expand this section if you want to inspect or edit the log file path, QRZ credentials, or the currently active persisted station profile.
             </div>
         }
         else
@@ -570,7 +570,7 @@
                     <div>
                         <h3 class="h6 mb-1">Setup editor</h3>
                         <div class="small text-muted">
-                            This form calls <code>SetupService.SaveSetup</code> to edit bootstrap setup, storage, QRZ credentials, and the currently active persisted station profile. Use the station profile editor above to add additional profiles. If QRZ XML is enabled, the service requires both username and password on save.
+                            This form calls <code>SetupService.SaveSetup</code> to edit the persisted log file path, QRZ credentials, and the currently active bootstrap station profile. Use the station profile editor above to add additional profiles. If QRZ XML is enabled, the service requires both username and password on save.
                         </div>
                     </div>
                     @if (WorkbenchState.SetupStatus?.HasQrzXmlPassword == true)
@@ -584,23 +584,13 @@
                     <ValidationSummary />
 
                     <div class="row g-3">
-                        <div class="col-md-4">
-                            <label class="form-label" for="setup-storage-backend">Storage backend</label>
-                            <InputSelect id="setup-storage-backend"
-                                         class="form-select"
-                                         @bind-Value="setupEditor.StorageBackend"
-                                         disabled="@isSetupBusy">
-                                <option value="@StorageBackend.Memory">memory</option>
-                                <option value="@StorageBackend.Sqlite">sqlite</option>
-                            </InputSelect>
-                        </div>
-                        <div class="col-md-8">
-                            <label class="form-label" for="setup-sqlite-path">SQLite path</label>
-                            <InputText id="setup-sqlite-path"
+                        <div class="col-md-12">
+                            <label class="form-label" for="setup-log-file-path">Log file path</label>
+                            <InputText id="setup-log-file-path"
                                        class="form-control"
-                                       @bind-Value="setupEditor.SqlitePath"
+                                       @bind-Value="setupEditor.LogFilePath"
                                        disabled="@isSetupBusy" />
-                            <ValidationMessage For="@(() => setupEditor.SqlitePath)" />
+                            <ValidationMessage For="@(() => setupEditor.LogFilePath)" />
                         </div>
 
                         <div class="col-md-6">
@@ -901,7 +891,7 @@
     private ProtoPayloadView? activeStationProfilePayload;
     private ProtoPayloadView? persistedStationProfilePayload;
     private ProtoPayloadView? activeStationContextPayload;
-    private SetupEditorModel setupEditor = SetupEditorModel.Create(null, EngineStorageBackend.Memory, @".\data\logripper.db");
+    private SetupEditorModel setupEditor = SetupEditorModel.Create(null, @".\data\logripper.db");
     private StationProfileEditorModel stationProfileEditor = StationProfileEditorModel.CreateEmpty();
     private EditContext setupEditContext = default!;
     private EditContext stationProfileEditContext = default!;
@@ -914,7 +904,7 @@
     {
         endpoint = WorkbenchState.EngineEndpoint;
         tools = ToolchainLocator.GetToolAvailability();
-        ReplaceSetupEditor(SetupEditorModel.Create(null, WorkbenchState.EngineStorageBackend, WorkbenchState.EngineSqlitePath));
+        ReplaceSetupEditor(SetupEditorModel.Create(null, WorkbenchState.EngineSqlitePath));
         ReplaceStationProfileEditor(StationProfileEditorModel.CreateEmpty());
         await RefreshSetupStatusAsync();
         await RefreshStationProfilesAsync();
@@ -959,7 +949,6 @@
             RefreshSetupPayload();
             ReplaceSetupEditor(SetupEditorModel.Create(
                 WorkbenchState.SetupStatus,
-                WorkbenchState.EngineStorageBackend,
                 WorkbenchState.EngineSqlitePath));
             InitializeSetupExpansionDefault();
         }
@@ -985,7 +974,6 @@
             RefreshSetupPayload();
             ReplaceSetupEditor(SetupEditorModel.Create(
                 status,
-                WorkbenchState.EngineStorageBackend,
                 WorkbenchState.EngineSqlitePath));
             isSetupExpanded = status.SetupComplete != true;
             await RefreshStationProfilesAsync();
@@ -1320,16 +1308,19 @@
             : $"{summary} operator {profile.OperatorCallsign}";
     }
 
-    private static string GetSetupStorageSummary(SetupStatusResponse status)
+    private static string GetSetupLogFileSummary(SetupStatusResponse status)
     {
-        return status.StorageBackend switch
+        if (!string.IsNullOrWhiteSpace(status.LogFilePath))
         {
-            StorageBackend.Sqlite when !string.IsNullOrWhiteSpace(status.SqlitePath)
-                => $"SQLite ({status.SqlitePath})",
-            StorageBackend.Sqlite => $"SQLite (suggested: {status.SuggestedSqlitePath})",
-            StorageBackend.Memory => "Memory",
-            _ => $"Not configured (suggested SQLite path: {status.SuggestedSqlitePath})"
-        };
+            return status.LogFilePath;
+        }
+
+        if (status.StorageBackend == StorageBackend.Memory)
+        {
+            return "Not configured (legacy in-memory setup)";
+        }
+
+        return $"Not configured (suggested: {status.SuggestedLogFilePath})";
     }
 
     private static bool AreSameProfile(StationProfile left, StationProfile right)

--- a/src/dotnet/LogRipper.DebugHost/Models/SetupEditorModel.cs
+++ b/src/dotnet/LogRipper.DebugHost/Models/SetupEditorModel.cs
@@ -5,29 +5,19 @@ namespace LogRipper.DebugHost.Models;
 
 internal sealed class SetupEditorModel : StationProfileEditorModelBase
 {
-    public StorageBackend StorageBackend { get; set; } = StorageBackend.Memory;
-
-    public string SqlitePath { get; set; } = @".\data\logripper.db";
+    public string LogFilePath { get; set; } = @".\data\logripper.db";
 
     public string? QrzXmlUsername { get; set; }
 
     public string? QrzXmlPassword { get; set; }
 
-    public static SetupEditorModel Create(SetupStatusResponse? status, EngineStorageBackend fallbackStorageBackend, string fallbackSqlitePath)
+    public static SetupEditorModel Create(SetupStatusResponse? status, string fallbackLogFilePath)
     {
         var model = new SetupEditorModel
         {
-            StorageBackend = status?.StorageBackend switch
-            {
-                StorageBackend.Sqlite => StorageBackend.Sqlite,
-                StorageBackend.Memory => StorageBackend.Memory,
-                _ => fallbackStorageBackend == EngineStorageBackend.Sqlite
-                    ? StorageBackend.Sqlite
-                    : StorageBackend.Memory
-            },
-            SqlitePath = status?.SqlitePath
-                ?? status?.SuggestedSqlitePath
-                ?? fallbackSqlitePath,
+            LogFilePath = NormalizeOptional(status?.LogFilePath)
+                ?? NormalizeOptional(status?.SuggestedLogFilePath)
+                ?? fallbackLogFilePath,
             QrzXmlUsername = NormalizeOptional(status?.QrzXmlUsername)
         };
 
@@ -39,13 +29,12 @@ internal sealed class SetupEditorModel : StationProfileEditorModelBase
     {
         var request = new SaveSetupRequest
         {
-            StorageBackend = StorageBackend,
             StationProfile = ToStationProfile()
         };
 
-        if (!string.IsNullOrWhiteSpace(SqlitePath))
+        if (!string.IsNullOrWhiteSpace(LogFilePath))
         {
-            request.SqlitePath = SqlitePath.Trim();
+            request.LogFilePath = LogFilePath.Trim();
         }
 
         if (!string.IsNullOrWhiteSpace(QrzXmlUsername))
@@ -68,11 +57,11 @@ internal sealed class SetupEditorModel : StationProfileEditorModelBase
             yield return result;
         }
 
-        if (StorageBackend == StorageBackend.Sqlite && string.IsNullOrWhiteSpace(SqlitePath))
+        if (string.IsNullOrWhiteSpace(LogFilePath))
         {
             yield return new ValidationResult(
-                "SQLite path is required when SQLite storage is selected.",
-                [nameof(SqlitePath)]);
+                "Log file path is required.",
+                [nameof(LogFilePath)]);
         }
 
         if (string.IsNullOrWhiteSpace(QrzXmlUsername) != string.IsNullOrWhiteSpace(QrzXmlPassword))

--- a/src/dotnet/LogRipper.DebugHost/Services/DebugWorkbenchState.cs
+++ b/src/dotnet/LogRipper.DebugHost/Services/DebugWorkbenchState.cs
@@ -89,10 +89,13 @@ internal sealed class DebugWorkbenchState
         SetupStatus = status;
         SetupErrorMessage = null;
 
-        if (status.StorageBackend == StorageBackend.Sqlite && !string.IsNullOrWhiteSpace(status.SqlitePath))
+        var persistedLogFilePath = string.IsNullOrWhiteSpace(status.LogFilePath)
+            ? status.SqlitePath
+            : status.LogFilePath;
+        if (!string.IsNullOrWhiteSpace(persistedLogFilePath))
         {
             EngineStorageBackend = EngineStorageBackend.Sqlite;
-            EngineSqlitePath = NormalizeSqlitePath(status.SqlitePath);
+            EngineSqlitePath = NormalizeSqlitePath(persistedLogFilePath);
         }
     }
 

--- a/src/rust/logripper-server/src/setup.rs
+++ b/src/rust/logripper-server/src/setup.rs
@@ -30,7 +30,7 @@ use crate::station_profile_support::{
 
 pub(crate) const CONFIG_PATH_ENV_VAR: &str = "LOGRIPPER_CONFIG_PATH";
 const DEFAULT_CONFIG_FILE_NAME: &str = "config.toml";
-const DEFAULT_SQLITE_FILE_NAME: &str = "logripper.db";
+const DEFAULT_LOG_FILE_NAME: &str = "logripper.db";
 
 #[derive(Clone)]
 pub(crate) struct SetupControlSurface {
@@ -185,7 +185,7 @@ impl StationProfileService for StationProfileControlSurface {
 
 pub(crate) struct SetupState {
     config_path: PathBuf,
-    suggested_sqlite_path: PathBuf,
+    suggested_log_file_path: PathBuf,
     persisted_config: RwLock<Option<PersistedSetupConfig>>,
 }
 
@@ -193,7 +193,7 @@ impl SetupState {
     pub(crate) fn load(config_path: PathBuf) -> Result<Self, String> {
         let persisted_config = load_persisted_config(&config_path)?;
         Ok(Self {
-            suggested_sqlite_path: suggested_sqlite_path(&config_path),
+            suggested_log_file_path: suggested_log_file_path(&config_path),
             config_path,
             persisted_config: RwLock::new(persisted_config),
         })
@@ -211,7 +211,7 @@ impl SetupState {
         let persisted_config = self.persisted_config.read().await.clone();
         build_status(
             self.config_path.as_path(),
-            self.suggested_sqlite_path.as_path(),
+            self.suggested_log_file_path.as_path(),
             persisted_config.as_ref(),
         )
     }
@@ -225,7 +225,7 @@ impl SetupState {
         let config = PersistedSetupConfig::from_request(
             existing_config.as_ref(),
             &request,
-            self.suggested_sqlite_path.as_path(),
+            self.suggested_log_file_path.as_path(),
         )?;
         let runtime_values = config.to_runtime_values();
         runtime_config
@@ -432,7 +432,9 @@ impl SetupState {
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 struct PersistedSetupConfig {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "PersistedLogbookConfig::is_empty")]
+    logbook: PersistedLogbookConfig,
+    #[serde(default, skip_serializing_if = "PersistedStorageConfig::is_empty")]
     storage: PersistedStorageConfig,
     #[serde(default)]
     station_profile: PersistedStationProfile,
@@ -446,10 +448,8 @@ impl PersistedSetupConfig {
     fn from_request(
         existing: Option<&Self>,
         request: &SaveSetupRequest,
-        suggested_sqlite_path: &Path,
+        suggested_log_file_path: &Path,
     ) -> Result<Self, String> {
-        let storage_backend = StorageBackend::try_from(request.storage_backend)
-            .map_err(|_| "A supported storage_backend is required.".to_string())?;
         let station_profile = normalize_profile_payload(
             request
                 .station_profile
@@ -468,21 +468,39 @@ impl PersistedSetupConfig {
             );
         }
 
-        let sqlite_path = normalize_optional_string(request.sqlite_path.as_deref());
-        let storage = match storage_backend {
-            StorageBackend::Memory => PersistedStorageConfig {
-                backend: Some("memory".to_string()),
-                sqlite_path: None,
-            },
-            StorageBackend::Sqlite => PersistedStorageConfig {
-                backend: Some("sqlite".to_string()),
-                sqlite_path: Some(
-                    sqlite_path.unwrap_or_else(|| suggested_sqlite_path.display().to_string()),
-                ),
-            },
-            StorageBackend::Unspecified => {
-                return Err("A supported storage_backend is required.".to_string());
-            }
+        let requested_log_file_path = normalize_optional_string(request.log_file_path.as_deref());
+        let legacy_sqlite_path = normalize_optional_string(request.sqlite_path.as_deref());
+        let legacy_storage_backend = StorageBackend::try_from(request.storage_backend)
+            .unwrap_or(StorageBackend::Unspecified);
+        let (logbook, storage) = if let Some(log_file_path) = requested_log_file_path {
+            (
+                PersistedLogbookConfig {
+                    file_path: Some(log_file_path),
+                },
+                PersistedStorageConfig::default(),
+            )
+        } else if matches!(legacy_storage_backend, StorageBackend::Memory) {
+            (
+                PersistedLogbookConfig::default(),
+                PersistedStorageConfig {
+                    backend: Some("memory".to_string()),
+                    sqlite_path: None,
+                },
+            )
+        } else if matches!(legacy_storage_backend, StorageBackend::Sqlite)
+            || legacy_sqlite_path.is_some()
+        {
+            (
+                PersistedLogbookConfig {
+                    file_path: Some(
+                        legacy_sqlite_path
+                            .unwrap_or_else(|| suggested_log_file_path.display().to_string()),
+                    ),
+                },
+                PersistedStorageConfig::default(),
+            )
+        } else {
+            return Err("A log_file_path is required.".to_string());
         };
 
         let mut station_profiles = existing
@@ -500,6 +518,7 @@ impl PersistedSetupConfig {
         );
 
         let mut config = existing.cloned().unwrap_or_default();
+        config.logbook = logbook;
         config.storage = storage;
         config.station_profile = PersistedStationProfile::from_proto(&station_profile);
         config.station_profiles = station_profiles;
@@ -514,12 +533,19 @@ impl PersistedSetupConfig {
 
     fn to_runtime_values(&self) -> BTreeMap<String, String> {
         let mut values = BTreeMap::new();
+        let log_file_path = self.log_file_path();
 
-        if let Some(backend) = self.storage.backend.as_deref() {
-            values.insert(STORAGE_BACKEND_ENV_VAR.to_string(), backend.to_string());
-        }
-        if let Some(sqlite_path) = self.storage.sqlite_path.as_deref() {
-            values.insert(SQLITE_PATH_ENV_VAR.to_string(), sqlite_path.to_string());
+        match self.runtime_storage_backend() {
+            StorageBackend::Memory => {
+                values.insert(STORAGE_BACKEND_ENV_VAR.to_string(), "memory".to_string());
+            }
+            StorageBackend::Sqlite => {
+                values.insert(STORAGE_BACKEND_ENV_VAR.to_string(), "sqlite".to_string());
+                if let Some(log_file_path) = log_file_path {
+                    values.insert(SQLITE_PATH_ENV_VAR.to_string(), log_file_path);
+                }
+            }
+            StorageBackend::Unspecified => {}
         }
 
         if let Some(profile) = self.station_profile() {
@@ -536,7 +562,20 @@ impl PersistedSetupConfig {
         values
     }
 
-    fn storage_backend(&self) -> StorageBackend {
+    fn log_file_path(&self) -> Option<String> {
+        normalize_optional_string(self.logbook.file_path.as_deref())
+            .or_else(|| normalize_optional_string(self.storage.sqlite_path.as_deref()))
+    }
+
+    fn runtime_storage_backend(&self) -> StorageBackend {
+        if self.log_file_path().is_some() {
+            StorageBackend::Sqlite
+        } else {
+            self.legacy_storage_backend()
+        }
+    }
+
+    fn legacy_storage_backend(&self) -> StorageBackend {
         match self.storage.backend.as_deref() {
             Some("memory") => StorageBackend::Memory,
             Some("sqlite") => StorageBackend::Sqlite,
@@ -616,9 +655,27 @@ impl PersistedSetupConfig {
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct PersistedLogbookConfig {
+    file_path: Option<String>,
+}
+
+impl PersistedLogbookConfig {
+    fn is_empty(config: &Self) -> bool {
+        normalize_optional_string(config.file_path.as_deref()).is_none()
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 struct PersistedStorageConfig {
     backend: Option<String>,
     sqlite_path: Option<String>,
+}
+
+impl PersistedStorageConfig {
+    fn is_empty(config: &Self) -> bool {
+        config.backend.is_none()
+            && normalize_optional_string(config.sqlite_path.as_deref()).is_none()
+    }
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -879,11 +936,11 @@ pub(crate) fn default_config_path() -> Result<PathBuf, String> {
     }
 }
 
-fn suggested_sqlite_path(config_path: &Path) -> PathBuf {
+fn suggested_log_file_path(config_path: &Path) -> PathBuf {
     config_path
         .parent()
         .unwrap_or_else(|| Path::new("."))
-        .join(DEFAULT_SQLITE_FILE_NAME)
+        .join(DEFAULT_LOG_FILE_NAME)
 }
 
 fn load_persisted_config(config_path: &Path) -> Result<Option<PersistedSetupConfig>, String> {
@@ -933,14 +990,15 @@ fn write_persisted_config(config_path: &Path, config: &PersistedSetupConfig) -> 
 
 fn build_status(
     config_path: &Path,
-    suggested_sqlite_path: &Path,
+    suggested_log_file_path: &Path,
     persisted_config: Option<&PersistedSetupConfig>,
 ) -> SetupStatusResponse {
     let warnings = build_warnings(persisted_config);
     let station_profile = persisted_config.and_then(PersistedSetupConfig::station_profile);
+    let log_file_path = persisted_config.and_then(PersistedSetupConfig::log_file_path);
     let storage_backend = persisted_config.map_or(
         StorageBackend::Unspecified,
-        PersistedSetupConfig::storage_backend,
+        PersistedSetupConfig::runtime_storage_backend,
     );
 
     SetupStatusResponse {
@@ -948,20 +1006,22 @@ fn build_status(
         setup_complete: persisted_config.is_some() && warnings.is_empty(),
         config_path: config_path.display().to_string(),
         storage_backend: storage_backend as i32,
-        sqlite_path: persisted_config.and_then(|config| config.storage.sqlite_path.clone()),
+        sqlite_path: log_file_path.clone(),
         has_station_profile: station_profile.is_some(),
         station_profile,
         qrz_xml_username: persisted_config.and_then(|config| config.qrz_xml.username.clone()),
         has_qrz_xml_password: persisted_config
             .and_then(|config| config.qrz_xml.password.as_ref())
             .is_some(),
-        suggested_sqlite_path: suggested_sqlite_path.display().to_string(),
+        suggested_sqlite_path: suggested_log_file_path.display().to_string(),
         warnings,
         active_station_profile_id: persisted_config
             .and_then(PersistedSetupConfig::active_station_profile_id),
         station_profile_count: persisted_config.map_or(0, |config| {
             u32::try_from(config.station_profile_count()).unwrap_or(u32::MAX)
         }),
+        log_file_path,
+        suggested_log_file_path: suggested_log_file_path.display().to_string(),
     }
 }
 
@@ -971,18 +1031,17 @@ fn build_warnings(persisted_config: Option<&PersistedSetupConfig>) -> Vec<String
     };
 
     let mut warnings = Vec::new();
+    let log_file_path = config.log_file_path();
 
-    match config.storage_backend() {
-        StorageBackend::Memory | StorageBackend::Sqlite => {}
-        StorageBackend::Unspecified => {
-            warnings.push("Persisted setup is missing a supported storage backend.".to_string());
+    if log_file_path.is_none() {
+        if matches!(config.legacy_storage_backend(), StorageBackend::Memory) {
+            warnings.push(
+                "Persisted setup still uses legacy in-memory storage; save a log file path to migrate to the backend-agnostic setup model."
+                    .to_string(),
+            );
+        } else {
+            warnings.push("Persisted setup is missing a log_file_path.".to_string());
         }
-    }
-
-    if matches!(config.storage_backend(), StorageBackend::Sqlite)
-        && normalize_optional_string(config.storage.sqlite_path.as_deref()).is_none()
-    {
-        warnings.push("SQLite storage requires a sqlite_path.".to_string());
     }
 
     if config.station_profile().is_none() {
@@ -1082,8 +1141,8 @@ mod tests {
     use tonic::Request;
 
     use super::{
-        default_config_path, suggested_sqlite_path, SetupControlSurface, SetupState,
-        StationProfileControlSurface, DEFAULT_CONFIG_FILE_NAME,
+        default_config_path, suggested_log_file_path, PersistedSetupConfig, SetupControlSurface,
+        SetupState, StationProfileControlSurface, DEFAULT_CONFIG_FILE_NAME,
     };
     use crate::runtime_config::RuntimeConfigManager;
     use logripper_core::proto::logripper::domain::StationProfile;
@@ -1124,12 +1183,88 @@ mod tests {
         assert!(!status.setup_complete);
         assert_eq!(config_path.display().to_string(), status.config_path);
         assert_eq!(
-            suggested_sqlite_path(&config_path).display().to_string(),
-            status.suggested_sqlite_path
+            suggested_log_file_path(&config_path).display().to_string(),
+            status.suggested_log_file_path
         );
+        assert_eq!(status.suggested_log_file_path, status.suggested_sqlite_path);
         assert!(status
             .warnings
             .contains(&"No persisted LogRipper setup exists yet.".to_string()));
+    }
+
+    #[tokio::test]
+    async fn get_setup_status_reads_legacy_sqlite_storage_as_log_file_path() {
+        let config_path = unique_config_path();
+        let config_directory = config_path.parent().expect("config directory");
+        fs::create_dir_all(config_directory).expect("create config directory");
+        fs::write(
+            &config_path,
+            r#"[storage]
+backend = "sqlite"
+sqlite_path = 'legacy\portable.db'
+
+[station_profile]
+station_callsign = "K7RND"
+"#,
+        )
+        .expect("write legacy config");
+
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state, runtime_config);
+
+        let status =
+            SetupService::get_setup_status(&service, Request::new(GetSetupStatusRequest {}))
+                .await
+                .expect("status")
+                .into_inner();
+
+        assert!(status.config_file_exists);
+        assert!(status.setup_complete);
+        assert_eq!(StorageBackend::Sqlite as i32, status.storage_backend);
+        assert_eq!(Some("legacy\\portable.db"), status.log_file_path.as_deref());
+        assert_eq!(status.log_file_path, status.sqlite_path);
+        assert!(status.warnings.is_empty());
+
+        fs::remove_dir_all(config_directory).expect("remove temp config directory");
+    }
+
+    #[tokio::test]
+    async fn get_setup_status_flags_legacy_memory_setup_for_migration() {
+        let config_path = unique_config_path();
+        let config_directory = config_path.parent().expect("config directory");
+        fs::create_dir_all(config_directory).expect("create config directory");
+        fs::write(
+            &config_path,
+            r#"[storage]
+backend = "memory"
+
+[station_profile]
+station_callsign = "K7RND"
+"#,
+        )
+        .expect("write legacy config");
+
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state, runtime_config);
+
+        let status =
+            SetupService::get_setup_status(&service, Request::new(GetSetupStatusRequest {}))
+                .await
+                .expect("status")
+                .into_inner();
+
+        assert!(status.config_file_exists);
+        assert!(!status.setup_complete);
+        assert_eq!(StorageBackend::Memory as i32, status.storage_backend);
+        assert!(status.log_file_path.is_none());
+        assert!(status
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("legacy in-memory storage")));
+
+        fs::remove_dir_all(config_directory).expect("remove temp config directory");
     }
 
     #[tokio::test]
@@ -1142,8 +1277,9 @@ mod tests {
         let response = SetupService::save_setup(
             &service,
             Request::new(SaveSetupRequest {
-                storage_backend: StorageBackend::Sqlite as i32,
+                storage_backend: StorageBackend::Unspecified as i32,
                 sqlite_path: None,
+                log_file_path: Some("data\\portable.db".to_string()),
                 station_profile: Some(StationProfile {
                     station_callsign: "k7rnd".to_string(),
                     operator_name: Some("Randy".to_string()),
@@ -1162,9 +1298,20 @@ mod tests {
         assert!(status.config_file_exists);
         assert!(status.setup_complete);
         assert_eq!(StorageBackend::Sqlite as i32, status.storage_backend);
+        assert_eq!(Some("data\\portable.db"), status.log_file_path.as_deref());
+        assert_eq!(status.log_file_path, status.sqlite_path);
         assert_eq!(Some("Home"), station_profile.profile_name.as_deref());
         assert_eq!("K7RND", station_profile.station_callsign);
         assert!(config_path.exists());
+        let saved_config = fs::read_to_string(&config_path).expect("saved config");
+        let parsed_config =
+            toml::from_str::<PersistedSetupConfig>(&saved_config).expect("parse saved config");
+        assert_eq!(
+            Some("data\\portable.db"),
+            parsed_config.logbook.file_path.as_deref()
+        );
+        assert!(parsed_config.storage.backend.is_none());
+        assert!(parsed_config.storage.sqlite_path.is_none());
 
         let runtime_snapshot = runtime_config.snapshot().await;
         assert_eq!("sqlite", runtime_snapshot.active_storage_backend);
@@ -1184,6 +1331,7 @@ mod tests {
         fs::remove_dir_all(config_directory).expect("remove temp config directory");
     }
 
+    #[allow(clippy::too_many_lines)]
     #[tokio::test]
     async fn save_setup_preserves_existing_station_profiles() {
         let config_path = unique_config_path();
@@ -1196,8 +1344,9 @@ mod tests {
         SetupService::save_setup(
             &setup_service,
             Request::new(SaveSetupRequest {
-                storage_backend: StorageBackend::Memory as i32,
+                storage_backend: StorageBackend::Unspecified as i32,
                 sqlite_path: None,
+                log_file_path: Some("data\\home.db".to_string()),
                 station_profile: Some(StationProfile {
                     profile_name: Some("Home".to_string()),
                     station_callsign: "k7rnd".to_string(),
@@ -1230,8 +1379,9 @@ mod tests {
         let updated = SetupService::save_setup(
             &setup_service,
             Request::new(SaveSetupRequest {
-                storage_backend: StorageBackend::Sqlite as i32,
-                sqlite_path: Some("data\\updated.db".to_string()),
+                storage_backend: StorageBackend::Unspecified as i32,
+                sqlite_path: None,
+                log_file_path: Some("data\\updated.db".to_string()),
                 station_profile: Some(StationProfile {
                     profile_name: Some("Home Debug".to_string()),
                     station_callsign: "k7rnd".to_string(),
@@ -1249,6 +1399,7 @@ mod tests {
         .expect("status");
 
         assert_eq!(StorageBackend::Sqlite as i32, updated.storage_backend);
+        assert_eq!(Some("data\\updated.db"), updated.log_file_path.as_deref());
         assert_eq!(Some("home"), updated.active_station_profile_id.as_deref());
         assert_eq!(2, updated.station_profile_count);
         assert_eq!(
@@ -1304,8 +1455,9 @@ mod tests {
         let error = SetupService::save_setup(
             &service,
             Request::new(SaveSetupRequest {
-                storage_backend: StorageBackend::Memory as i32,
+                storage_backend: StorageBackend::Unspecified as i32,
                 sqlite_path: None,
+                log_file_path: Some("data\\partial.db".to_string()),
                 station_profile: Some(StationProfile {
                     station_callsign: "k7rnd".to_string(),
                     ..StationProfile::default()
@@ -1334,8 +1486,9 @@ mod tests {
         SetupService::save_setup(
             &setup_service,
             Request::new(SaveSetupRequest {
-                storage_backend: StorageBackend::Memory as i32,
+                storage_backend: StorageBackend::Unspecified as i32,
                 sqlite_path: None,
+                log_file_path: Some("data\\station-profiles.db".to_string()),
                 station_profile: Some(StationProfile {
                     profile_name: Some("Home".to_string()),
                     station_callsign: "k7rnd".to_string(),


### PR DESCRIPTION
## Summary
- switch persisted setup to neutral `log_file_path` / `suggested_log_file_path` fields while keeping legacy `storage_backend` / `sqlite_path` compatibility for existing clients and config files
- update the Debug Host setup editor and setup summaries to hide backend choice from the operator-facing first-run flow while leaving developer-only runtime/storage controls backend-aware
- add Rust and .NET coverage for the new setup behavior, including legacy SQLite compatibility and legacy in-memory migration warnings

## Validation
- `buf lint`
- `cargo fmt --manifest-path src\rust\Cargo.toml --all`
- `cargo clippy --manifest-path src\rust\Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path src\rust\Cargo.toml`
- `dotnet test src\dotnet\LogRipper.slnx`

Closes #65