### PR TITLE
fix: handle Ctrl+C gracefully in gRPC server

### DIFF
--- a/src/rust/logripper-server/Cargo.toml
+++ b/src/rust/logripper-server/Cargo.toml
@@ -14,7 +14,7 @@ logripper-storage-memory = { path = "../logripper-storage-memory", version = "0.
 logripper-storage-sqlite = { path = "../logripper-storage-sqlite", version = "0.1.0" }
 prost-types = { workspace = true }
 serde = { version = "1", features = ["derive"] }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["signal"] }
 tokio-stream = { version = "0.1", features = ["net"] }
 toml = "0.8"
 tonic = { workspace = true }

--- a/src/rust/logripper-server/src/main.rs
+++ b/src/rust/logripper-server/src/main.rs
@@ -4,7 +4,7 @@ mod runtime_config;
 mod setup;
 mod station_profile_support;
 
-use std::{net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{future::Future, net::SocketAddr, path::PathBuf, sync::Arc};
 
 use logripper_core::adif::{parse_adi_qsos, serialize_adi_qsos};
 use logripper_core::application::logbook::LogbookError;
@@ -41,6 +41,16 @@ use setup::{
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     load_dotenv_if_present();
     let options = ServerOptions::from_env_and_args(std::env::args().skip(1))?;
+    run_server(options, tokio::signal::ctrl_c()).await
+}
+
+async fn run_server<ShutdownSignal>(
+    options: ServerOptions,
+    shutdown_signal: ShutdownSignal,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    ShutdownSignal: Future<Output = std::io::Result<()>>,
+{
     let address = options.listen_address;
     let setup_state = Arc::new(SetupState::load(options.config_path.clone())?);
     let config_file_values = setup_state.runtime_config_values().await;
@@ -84,7 +94,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
     );
 
-    Server::builder()
+    let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel::<()>();
+    let server = Server::builder()
         .add_service(LogbookServiceServer::new(logbook_service))
         .add_service(LookupServiceServer::new(lookup_service))
         .add_service(SetupServiceServer::new(setup_service))
@@ -92,8 +103,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .add_service(DeveloperControlServiceServer::new(
             developer_control_service,
         ))
-        .serve_with_incoming(TcpListenerStream::new(listener))
-        .await?;
+        .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async move {
+            let _ = shutdown_receiver.await;
+        });
+    tokio::pin!(server);
+    tokio::pin!(shutdown_signal);
+
+    tokio::select! {
+        result = &mut server => {
+            result?;
+        }
+        signal_result = &mut shutdown_signal => {
+            signal_result?;
+            println!("Shutting down.");
+            let _ = shutdown_sender.send(());
+            server.await?;
+        }
+    }
 
     Ok(())
 }
@@ -681,8 +707,8 @@ mod tests {
 
     use super::{
         build_storage, load_dotenv_if_present, parse_storage_backend, server_ready_message,
-        server_starting_message, DeveloperLogbookService, DeveloperLookupService, Server,
-        ServerOptions, StorageBackendKind, StorageOptions,
+        server_starting_message, run_server, DeveloperLogbookService, DeveloperLookupService,
+        Server, ServerOptions, StorageBackendKind, StorageOptions,
     };
     use crate::runtime_config::{
         RuntimeConfigManager, SQLITE_PATH_ENV_VAR, STATION_CALLSIGN_ENV_VAR, STATION_GRID_ENV_VAR,
@@ -744,6 +770,17 @@ mod tests {
                 }
             }
         }
+    }
+
+    fn capture_clean_process_state() -> (std::sync::MutexGuard<'static, ()>, ProcessStateGuard) {
+        let process_state_lock = PROCESS_STATE_LOCK.lock().expect("lock process state");
+        let process_state = ProcessStateGuard::capture();
+
+        for key in SERVER_ENV_KEYS {
+            std::env::remove_var(key);
+        }
+
+        (process_state_lock, process_state)
     }
 
     fn test_lookup_service() -> DeveloperLookupService {
@@ -1000,12 +1037,7 @@ mod tests {
 
     #[test]
     fn load_dotenv_if_present_reads_env_from_current_directory() {
-        let _process_state_lock = PROCESS_STATE_LOCK.lock().expect("lock process state");
-        let process_state = ProcessStateGuard::capture();
-
-        for key in SERVER_ENV_KEYS {
-            std::env::remove_var(key);
-        }
+        let (_process_state_lock, process_state) = capture_clean_process_state();
 
         let temp_dir = std::env::temp_dir().join(format!(
             "logripper-dotenv-{}-{}",
@@ -1041,13 +1073,12 @@ mod tests {
 
         process_state.restore_current_dir();
         fs::remove_file(env_path).expect("remove temp .env");
-        fs::remove_dir(temp_dir).expect("remove temp dir");
+        fs::remove_dir_all(temp_dir).expect("remove temp dir");
     }
 
     #[test]
     fn load_dotenv_if_present_does_not_panic_on_malformed_env() {
-        let _process_state_lock = PROCESS_STATE_LOCK.lock().expect("lock process state");
-        let process_state = ProcessStateGuard::capture();
+        let (_process_state_lock, process_state) = capture_clean_process_state();
 
         let temp_dir = std::env::temp_dir().join(format!(
             "logripper-dotenv-bad-{}-{}",
@@ -1072,7 +1103,7 @@ mod tests {
 
         process_state.restore_current_dir();
         fs::remove_file(env_path).expect("remove temp .env");
-        fs::remove_dir(temp_dir).expect("remove temp dir");
+        fs::remove_dir_all(temp_dir).expect("remove temp dir");
     }
 
     #[test]
@@ -1107,9 +1138,7 @@ mod tests {
 
     #[test]
     fn server_options_default_to_localhost_port_50051() {
-        std::env::remove_var("LOGRIPPER_SERVER_ADDR");
-        std::env::remove_var("LOGRIPPER_STORAGE_BACKEND");
-        std::env::remove_var("LOGRIPPER_SQLITE_PATH");
+        let (_process_state_lock, _process_state) = capture_clean_process_state();
 
         let options = ServerOptions::from_env_and_args(Vec::<String>::new()).unwrap();
 
@@ -1120,7 +1149,7 @@ mod tests {
 
     #[test]
     fn server_options_allow_explicit_listen_override() {
-        std::env::remove_var("LOGRIPPER_SERVER_ADDR");
+        let (_process_state_lock, _process_state) = capture_clean_process_state();
 
         let options = ServerOptions::from_env_and_args([
             "--listen".to_string(),
@@ -1140,6 +1169,8 @@ mod tests {
 
     #[test]
     fn server_options_allow_sqlite_storage_override() {
+        let (_process_state_lock, _process_state) = capture_clean_process_state();
+
         let options = ServerOptions::from_env_and_args([
             "--storage".to_string(),
             "sqlite".to_string(),
@@ -1171,6 +1202,8 @@ mod tests {
 
     #[test]
     fn server_options_emit_default_sqlite_path_when_cli_selects_sqlite_without_path() {
+        let (_process_state_lock, _process_state) = capture_clean_process_state();
+
         let options =
             ServerOptions::from_env_and_args(["--storage".to_string(), "sqlite".to_string()])
                 .unwrap();
@@ -1226,6 +1259,35 @@ mod tests {
 
         if sqlite_path.exists() {
             fs::remove_file(sqlite_path).expect("remove sqlite test database");
+        }
+    }
+
+    #[tokio::test]
+    async fn server_exits_cleanly_when_shutdown_signal_resolves() {
+        let config_path = unique_sqlite_test_path("ctrl-c-config").with_extension("toml");
+        let options = ServerOptions {
+            listen_address: "127.0.0.1:0".parse().expect("listen address"),
+            config_path: config_path.clone(),
+            storage: StorageOptions {
+                backend: StorageBackendKind::Memory,
+                sqlite_path: PathBuf::from("ignored.db"),
+            },
+            storage_cli_overrides: BTreeMap::from([(
+                STORAGE_BACKEND_ENV_VAR.to_string(),
+                "memory".to_string(),
+            )]),
+        };
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            run_server(options, std::future::ready(Ok(()))),
+        )
+        .await
+        .expect("shutdown timeout")
+        .expect("clean server shutdown");
+
+        if config_path.exists() {
+            fs::remove_file(config_path).expect("remove config test file");
         }
     }
 

--- a/src/rust/logripper-server/src/main.rs
+++ b/src/rust/logripper-server/src/main.rs
@@ -706,9 +706,9 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use super::{
-        build_storage, load_dotenv_if_present, parse_storage_backend, server_ready_message,
-        server_starting_message, run_server, DeveloperLogbookService, DeveloperLookupService,
-        Server, ServerOptions, StorageBackendKind, StorageOptions,
+        build_storage, load_dotenv_if_present, parse_storage_backend, run_server,
+        server_ready_message, server_starting_message, DeveloperLogbookService,
+        DeveloperLookupService, Server, ServerOptions, StorageBackendKind, StorageOptions,
     };
     use crate::runtime_config::{
         RuntimeConfigManager, SQLITE_PATH_ENV_VAR, STATION_CALLSIGN_ENV_VAR, STATION_GRID_ENV_VAR,

--- a/src/rust/logripper-server/src/setup.rs
+++ b/src/rust/logripper-server/src/setup.rs
@@ -1166,6 +1166,15 @@ mod tests {
             .join(DEFAULT_CONFIG_FILE_NAME)
     }
 
+    fn absolute_log_file_path(config_path: &std::path::Path, file_name: &str) -> String {
+        config_path
+            .parent()
+            .expect("config directory")
+            .join(file_name)
+            .display()
+            .to_string()
+    }
+
     #[tokio::test]
     async fn get_setup_status_reports_missing_config() {
         let config_path = unique_config_path();
@@ -1270,6 +1279,7 @@ station_callsign = "K7RND"
     #[tokio::test]
     async fn save_setup_persists_config_and_hot_applies_runtime_values() {
         let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "portable.db");
         let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
         let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
         let service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
@@ -1279,7 +1289,7 @@ station_callsign = "K7RND"
             Request::new(SaveSetupRequest {
                 storage_backend: StorageBackend::Unspecified as i32,
                 sqlite_path: None,
-                log_file_path: Some("data\\portable.db".to_string()),
+                log_file_path: Some(log_file_path.clone()),
                 station_profile: Some(StationProfile {
                     station_callsign: "k7rnd".to_string(),
                     operator_name: Some("Randy".to_string()),
@@ -1298,7 +1308,10 @@ station_callsign = "K7RND"
         assert!(status.config_file_exists);
         assert!(status.setup_complete);
         assert_eq!(StorageBackend::Sqlite as i32, status.storage_backend);
-        assert_eq!(Some("data\\portable.db"), status.log_file_path.as_deref());
+        assert_eq!(
+            Some(log_file_path.as_str()),
+            status.log_file_path.as_deref()
+        );
         assert_eq!(status.log_file_path, status.sqlite_path);
         assert_eq!(Some("Home"), station_profile.profile_name.as_deref());
         assert_eq!("K7RND", station_profile.station_callsign);
@@ -1307,7 +1320,7 @@ station_callsign = "K7RND"
         let parsed_config =
             toml::from_str::<PersistedSetupConfig>(&saved_config).expect("parse saved config");
         assert_eq!(
-            Some("data\\portable.db"),
+            Some(log_file_path.as_str()),
             parsed_config.logbook.file_path.as_deref()
         );
         assert!(parsed_config.storage.backend.is_none());
@@ -1335,6 +1348,8 @@ station_callsign = "K7RND"
     #[tokio::test]
     async fn save_setup_preserves_existing_station_profiles() {
         let config_path = unique_config_path();
+        let initial_log_file_path = absolute_log_file_path(&config_path, "home.db");
+        let updated_log_file_path = absolute_log_file_path(&config_path, "updated.db");
         let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
         let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
         let setup_service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
@@ -1346,7 +1361,7 @@ station_callsign = "K7RND"
             Request::new(SaveSetupRequest {
                 storage_backend: StorageBackend::Unspecified as i32,
                 sqlite_path: None,
-                log_file_path: Some("data\\home.db".to_string()),
+                log_file_path: Some(initial_log_file_path),
                 station_profile: Some(StationProfile {
                     profile_name: Some("Home".to_string()),
                     station_callsign: "k7rnd".to_string(),
@@ -1381,7 +1396,7 @@ station_callsign = "K7RND"
             Request::new(SaveSetupRequest {
                 storage_backend: StorageBackend::Unspecified as i32,
                 sqlite_path: None,
-                log_file_path: Some("data\\updated.db".to_string()),
+                log_file_path: Some(updated_log_file_path.clone()),
                 station_profile: Some(StationProfile {
                     profile_name: Some("Home Debug".to_string()),
                     station_callsign: "k7rnd".to_string(),
@@ -1399,7 +1414,10 @@ station_callsign = "K7RND"
         .expect("status");
 
         assert_eq!(StorageBackend::Sqlite as i32, updated.storage_backend);
-        assert_eq!(Some("data\\updated.db"), updated.log_file_path.as_deref());
+        assert_eq!(
+            Some(updated_log_file_path.as_str()),
+            updated.log_file_path.as_deref()
+        );
         assert_eq!(Some("home"), updated.active_station_profile_id.as_deref());
         assert_eq!(2, updated.station_profile_count);
         assert_eq!(
@@ -1441,6 +1459,11 @@ station_callsign = "K7RND"
         let runtime_snapshot = runtime_config.snapshot().await;
         assert_eq!("sqlite", runtime_snapshot.active_storage_backend);
 
+        drop(station_profile_service);
+        drop(setup_service);
+        drop(runtime_config);
+        drop(setup_state);
+
         let config_directory = config_path.parent().expect("config directory");
         fs::remove_dir_all(config_directory).expect("remove temp config directory");
     }
@@ -1448,6 +1471,7 @@ station_callsign = "K7RND"
     #[tokio::test]
     async fn save_setup_rejects_partial_qrz_credentials() {
         let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "partial.db");
         let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
         let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
         let service = SetupControlSurface::new(setup_state, runtime_config);
@@ -1457,7 +1481,7 @@ station_callsign = "K7RND"
             Request::new(SaveSetupRequest {
                 storage_backend: StorageBackend::Unspecified as i32,
                 sqlite_path: None,
-                log_file_path: Some("data\\partial.db".to_string()),
+                log_file_path: Some(log_file_path),
                 station_profile: Some(StationProfile {
                     station_callsign: "k7rnd".to_string(),
                     ..StationProfile::default()
@@ -1477,6 +1501,7 @@ station_callsign = "K7RND"
     async fn station_profile_service_lists_legacy_profile_and_supports_activation_and_session_override(
     ) {
         let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "station-profiles.db");
         let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
         let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
         let setup_service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
@@ -1488,7 +1513,7 @@ station_callsign = "K7RND"
             Request::new(SaveSetupRequest {
                 storage_backend: StorageBackend::Unspecified as i32,
                 sqlite_path: None,
-                log_file_path: Some("data\\station-profiles.db".to_string()),
+                log_file_path: Some(log_file_path),
                 station_profile: Some(StationProfile {
                     profile_name: Some("Home".to_string()),
                     station_callsign: "k7rnd".to_string(),
@@ -1588,6 +1613,11 @@ station_callsign = "K7RND"
                 .as_ref()
                 .map(|profile| profile.station_callsign.as_str())
         );
+
+        drop(station_profile_service);
+        drop(setup_service);
+        drop(runtime_config);
+        drop(setup_state);
 
         let config_directory = config_path.parent().expect("config directory");
         fs::remove_dir_all(config_directory).expect("remove temp config directory");


### PR DESCRIPTION
## Summary
- handle Ctrl+C in `logripper-server` with a graceful shutdown path so `cargo run` exits cleanly
- add Rust server coverage for the shutdown path
- harden adjacent Rust server tests so env/current-dir and temp SQLite cleanup stay stable on Windows

Closes #58

## Validation

```powershell
cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check
cargo test --manifest-path src\rust\Cargo.toml
cargo clippy --manifest-path src\rust\Cargo.toml --all-targets -- -D warnings
```