### PR TITLE
docs: clarify post-#74 compatibility baseline

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -67,7 +67,7 @@ In general:
 - `SetupService` can report persisted setup status and save the initial storage/station bootstrap config.
 - `LogbookService` local QSO CRUD, ADIF import/export, and local sync-status reporting are implemented against the active storage backend. QRZ sync remains planned, and `GetSyncStatus` still reports QRZ fields as zero/absent until remote sync lands.
 
-The proto contract is considered stable for additive changes. Client code generated from the proto files will continue to compile as new fields and RPCs are added. See [client-integration.md](client-integration.md#schema-evolution-and-compatibility) for field tolerance guidance.
+The current proto contract should now be treated as the stable **post-1-1-1 baseline**. PR [#74](https://github.com/rtreit/logripper/pull/74) was a deliberate breaking-contract cutover while the project is still early. From this baseline forward, additive changes are preferred and client code generated from the current proto files should continue to compile as new fields and RPCs are added. See [client-integration.md](client-integration.md#schema-evolution-and-compatibility) for field tolerance guidance.
 
 ## Quick Links
 

--- a/docs/api/client-integration.md
+++ b/docs/api/client-integration.md
@@ -263,12 +263,14 @@ Do not attempt to connect a browser-side JavaScript client directly to `http://l
 
 ## Schema Evolution and Compatibility
 
-The LogRipper proto contract follows standard proto3 additive evolution rules:
+The current LogRipper proto contract follows standard proto3 additive evolution rules **from the current 1-1-1 envelope baseline forward**.
+
+> PR [#74](https://github.com/rtreit/logripper/pull/74) was a deliberate breaking-contract cleanup performed while the project is still early. Clients pinned to older pre-1-1-1 revisions must regenerate against the current `proto/` surface rather than assuming wire compatibility across that cutover.
 
 - **New optional fields** may be added to any message in future releases without breaking existing clients.
 - **New RPCs** may be added to existing services. Old clients will not call them.
 - **Enum values** may be added. Clients should handle unknown enum integer values gracefully (proto3 preserves unknown enum values as their integer form).
-- **Field numbers and types** are never changed. `buf breaking` enforces this in CI.
+- **Field numbers and types** should not be changed within the current published baseline. `buf breaking` is the guardrail for future changes against that baseline.
 
 **Client tolerance recommendations:**
 - Ignore unknown fields in responses — proto3 decoders do this by default.


### PR DESCRIPTION
## Summary

Clarify the compatibility docs after PR #74.

- explain that the protobuf 1-1-1 envelope refactor was a deliberate early breaking cutover
- scope additive-compatibility guidance to the current post-#74 baseline
- keep client expectations aligned with the contract that now exists on `main`
