### PR TITLE
fix: prevent timestamp_to_millis overflow in Rust storage backends

### DIFF
--- a/src/rust/logripper-storage-memory/src/lib.rs
+++ b/src/rust/logripper-storage-memory/src/lib.rs
@@ -237,7 +237,10 @@ fn matches_query(record: &QsoRecord, query: &QsoListQuery) -> bool {
 
 fn timestamp_to_millis(timestamp: Option<&prost_types::Timestamp>) -> i64 {
     timestamp.map_or(0, |value| {
-        value.seconds.saturating_mul(1_000) + i64::from(value.nanos) / 1_000_000
+        value
+            .seconds
+            .saturating_mul(1_000)
+            .saturating_add(i64::from(value.nanos) / 1_000_000)
     })
 }
 
@@ -363,5 +366,25 @@ mod tests {
 
         assert_eq!(loaded.callsign, "W1AW");
         assert_eq!(loaded.result.state, LookupState::Found as i32);
+    }
+
+    #[test]
+    fn timestamp_to_millis_saturates_positive_overflow() {
+        let value = super::timestamp_to_millis(Some(&Timestamp {
+            seconds: i64::MAX,
+            nanos: 999_999_999,
+        }));
+
+        assert_eq!(value, i64::MAX);
+    }
+
+    #[test]
+    fn timestamp_to_millis_saturates_negative_overflow() {
+        let value = super::timestamp_to_millis(Some(&Timestamp {
+            seconds: i64::MIN,
+            nanos: -999_999_999,
+        }));
+
+        assert_eq!(value, i64::MIN);
     }
 }

--- a/src/rust/logripper-storage-sqlite/src/lib.rs
+++ b/src/rust/logripper-storage-sqlite/src/lib.rs
@@ -447,7 +447,12 @@ fn map_sqlite_error(error: sqlite::Error) -> StorageError {
 }
 
 fn timestamp_to_millis(timestamp: Option<&prost_types::Timestamp>) -> Option<i64> {
-    timestamp.map(|value| value.seconds.saturating_mul(1_000) + i64::from(value.nanos) / 1_000_000)
+    timestamp.map(|value| {
+        value
+            .seconds
+            .saturating_mul(1_000)
+            .saturating_add(i64::from(value.nanos) / 1_000_000)
+    })
 }
 
 fn millis_to_timestamp(millis: Option<i64>) -> Option<prost_types::Timestamp> {
@@ -561,5 +566,25 @@ mod tests {
 
         assert_eq!(loaded.callsign, "W1AW");
         assert_eq!(loaded.result.state, LookupState::Found as i32);
+    }
+
+    #[test]
+    fn timestamp_to_millis_saturates_positive_overflow() {
+        let value = super::timestamp_to_millis(Some(&Timestamp {
+            seconds: i64::MAX,
+            nanos: 999_999_999,
+        }));
+
+        assert_eq!(value, Some(i64::MAX));
+    }
+
+    #[test]
+    fn timestamp_to_millis_saturates_negative_overflow() {
+        let value = super::timestamp_to_millis(Some(&Timestamp {
+            seconds: i64::MIN,
+            nanos: -999_999_999,
+        }));
+
+        assert_eq!(value, Some(i64::MIN));
     }
 }


### PR DESCRIPTION
## Summary

Closes #79.

Fix integer overflow in Rust `timestamp_to_millis` conversion by replacing the final `+` with `saturating_add` after the existing `saturating_mul`.

## What changed

- Fixed `src\rust\logripper-storage-memory\src\lib.rs`
- Fixed the same overflow pattern in `src\rust\logripper-storage-sqlite\src\lib.rs`
- Added regression tests for both backends covering:
  - positive overflow (`i64::MAX` seconds with positive nanos)
  - negative overflow (`i64::MIN` seconds with negative nanos)

## Why

The previous implementation saturated the multiply but still used ordinary addition:

```
value.seconds.saturating_mul(1_000) + i64::from(value.nanos) / 1_000_000
```

That could still overflow when the multiplied value was already pinned to `i64::MAX` or `i64::MIN`.

## Validation

- `cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check`
- `cargo test --manifest-path src\rust\Cargo.toml`
- `cargo clippy --manifest-path src\rust\Cargo.toml --all-targets -- -D warnings`