### PR TITLE
Add CLI update command and surface lookup warnings

### DIFF
--- a/src/dotnet/LogRipper.Cli.Tests/CommandHelperTests.cs
+++ b/src/dotnet/LogRipper.Cli.Tests/CommandHelperTests.cs
@@ -186,6 +186,113 @@ public sealed class CommandHelperTests
     }
 
     [Fact]
+    public void TryApplyUpdates_sets_grid_and_freq()
+    {
+        var qso = new QsoRecord { WorkedCallsign = "W1AW", Band = Band._20M, Mode = Mode.Cw };
+        var enrich = false;
+
+        var success = UpdateQsoCommand.TryApplyUpdates(
+            ["--grid", "FN31", "--freq", "14035", "--comment", "Nice signal"],
+            qso,
+            ref enrich,
+            out var error);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.Equal("FN31", qso.WorkedGrid);
+        Assert.Equal((ulong)14035, qso.FrequencyKhz);
+        Assert.Equal("Nice signal", qso.Comment);
+        Assert.False(enrich);
+    }
+
+    [Fact]
+    public void TryApplyUpdates_sets_enrich_flag()
+    {
+        var qso = new QsoRecord { WorkedCallsign = "W1AW" };
+        var enrich = false;
+
+        var success = UpdateQsoCommand.TryApplyUpdates(["--enrich"], qso, ref enrich, out _);
+
+        Assert.True(success);
+        Assert.True(enrich);
+    }
+
+    [Fact]
+    public void TryApplyUpdates_sets_country_state_band_mode()
+    {
+        var qso = new QsoRecord { WorkedCallsign = "W1AW", Band = Band._20M, Mode = Mode.Cw };
+        var enrich = false;
+
+        var success = UpdateQsoCommand.TryApplyUpdates(
+            ["--country", "United States", "--state", "ct", "--band", "40m", "--mode", "SSB"],
+            qso,
+            ref enrich,
+            out var error);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.Equal("United States", qso.WorkedCountry);
+        Assert.Equal("CT", qso.WorkedState);
+        Assert.Equal(Band._40M, qso.Band);
+        Assert.Equal(Mode.Ssb, qso.Mode);
+    }
+
+    [Fact]
+    public void TryApplyUpdates_sets_rst_sent_and_received()
+    {
+        var qso = new QsoRecord { WorkedCallsign = "W1AW", Band = Band._20M, Mode = Mode.Cw };
+        var enrich = false;
+
+        var success = UpdateQsoCommand.TryApplyUpdates(
+            ["--rst-sent", "579", "--rst-rcvd", "589"],
+            qso,
+            ref enrich,
+            out var error);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.Equal(5u, qso.RstSent!.Readability);
+        Assert.Equal(7u, qso.RstSent.Strength);
+        Assert.Equal(9u, qso.RstSent.Tone);
+        Assert.Equal(5u, qso.RstReceived!.Readability);
+        Assert.Equal(8u, qso.RstReceived.Strength);
+        Assert.Equal(9u, qso.RstReceived.Tone);
+    }
+
+    [Theory]
+    [InlineData("--grid", "Missing value for --grid.")]
+    [InlineData("--country", "Missing value for --country.")]
+    [InlineData("--state", "Missing value for --state.")]
+    [InlineData("--freq", "Missing value for --freq.")]
+    [InlineData("--band", "Missing value for --band.")]
+    [InlineData("--mode", "Missing value for --mode.")]
+    [InlineData("--comment", "Missing value for --comment.")]
+    [InlineData("--rst-sent", "Missing value for --rst-sent.")]
+    [InlineData("--rst-rcvd", "Missing value for --rst-rcvd.")]
+    public void TryApplyUpdates_rejects_missing_values(string option, string expectedError)
+    {
+        var qso = new QsoRecord { WorkedCallsign = "W1AW" };
+        var enrich = false;
+
+        var success = UpdateQsoCommand.TryApplyUpdates([option], qso, ref enrich, out var error);
+
+        Assert.False(success);
+        Assert.Equal(expectedError, error);
+    }
+
+    [Fact]
+    public void TryApplyUpdates_rejects_unknown_option()
+    {
+        var qso = new QsoRecord { WorkedCallsign = "W1AW" };
+        var enrich = false;
+
+        var success = UpdateQsoCommand.TryApplyUpdates(["--bogus"], qso, ref enrich, out var error);
+
+        Assert.False(success);
+        Assert.Equal("Unknown option: --bogus", error);
+    }
+
+    [Fact]
     public async Task ReadRequestsAsync_splits_stream_into_chunks()
     {
         var bytes = Enumerable.Range(0, 131077).Select(static i => (byte)(i % 251)).ToArray();

--- a/src/dotnet/LogRipper.Cli/CliCommandMetadata.cs
+++ b/src/dotnet/LogRipper.Cli/CliCommandMetadata.cs
@@ -4,7 +4,7 @@ internal static class CliCommandMetadata
 {
     public static bool UsesPrimaryArgument(string? command)
     {
-        return command is "lookup" or "stream-lookup" or "cache-check" or "log" or "get" or "delete" or "import";
+        return command is "lookup" or "stream-lookup" or "cache-check" or "log" or "get" or "update" or "delete" or "import";
     }
 
     public static bool RequiresPrimaryArgument(string? command)

--- a/src/dotnet/LogRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/LogRipper.Cli/CliHelpText.cs
@@ -13,6 +13,7 @@ internal static class CliHelpText
               log <call> <band> <mode>         Log a QSO (e.g., log W1AW 20m FT8)
               get <local-id>                   Get a QSO by ID
               list [filters]                   List QSOs (--callsign, --band, --mode, --limit)
+              update <local-id> [fields]       Update a QSO (--grid, --freq, --enrich, etc.)
               delete <local-id>                Delete a QSO
 
             ADIF:
@@ -77,6 +78,26 @@ internal static class CliHelpText
                   --show-id            Include the QSO local ID column
                   --show-rst           Include RST sent/received columns
                   --show-comment       Include comment/notes column
+                """,
+            "update" => """
+                Usage: update <local-id> [options]
+
+                Update fields on an existing QSO.
+
+                  --grid <grid>        Set grid square (e.g., CN87)
+                  --country <name>     Set country
+                  --state <abbr>       Set state (e.g., WA)
+                  --freq <khz>         Set frequency in kHz
+                  --band <band>        Change band
+                  --mode <mode>        Change mode
+                  --rst-sent <rst>     Update RST sent
+                  --rst-rcvd <rst>     Update RST received
+                  --comment <text>     Set comment/notes
+                  --enrich             Re-run QRZ lookup enrichment
+
+                Examples:
+                  update abc123 --grid CN87 --freq 14074
+                  update abc123 --enrich
                 """,
             "delete" => """
                 Usage: delete <local-id>

--- a/src/dotnet/LogRipper.Cli/Commands/LogQsoCommand.cs
+++ b/src/dotnet/LogRipper.Cli/Commands/LogQsoCommand.cs
@@ -208,6 +208,13 @@ internal static class LogQsoCommand
             var result = response.Result;
             if (result is null || result.State != LookupState.Found || result.Record is null)
             {
+                var reason = result?.State switch
+                {
+                    LookupState.NotFound => "callsign not found",
+                    LookupState.Error => result.HasErrorMessage ? result.ErrorMessage : "lookup error",
+                    _ => "no result",
+                };
+                Console.Error.WriteLine($"  \u26a0 Lookup skipped for {qso.WorkedCallsign}: {reason}");
                 return;
             }
 
@@ -233,8 +240,11 @@ internal static class LogQsoCommand
                 qso.WorkedDxcc = record.DxccEntityId;
             }
         }
-        catch (Grpc.Core.RpcException)
+        catch (Grpc.Core.RpcException ex)
         {
+            var detail = ex.Status.Detail;
+            var message = string.IsNullOrEmpty(detail) ? ex.StatusCode.ToString() : detail;
+            Console.Error.WriteLine($"  \u26a0 Lookup unavailable for {qso.WorkedCallsign}: {message}");
         }
     }
 }

--- a/src/dotnet/LogRipper.Cli/Commands/UpdateQsoCommand.cs
+++ b/src/dotnet/LogRipper.Cli/Commands/UpdateQsoCommand.cs
@@ -1,0 +1,235 @@
+using Grpc.Net.Client;
+using LogRipper.Cli;
+using LogRipper.Domain;
+using LogRipper.Services;
+
+namespace LogRipper.Cli.Commands;
+
+internal static class UpdateQsoCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel, string localId, string[] args)
+    {
+        if (args.Length == 0 || args.Any(static a => a is "help" or "-?" or "--help"))
+        {
+            Console.WriteLine(CliHelpText.GetCommandHelp("update"));
+            return args.Length == 0 ? 1 : 0;
+        }
+
+        var client = new LogbookService.LogbookServiceClient(channel);
+
+        var getResponse = await client.GetQsoAsync(new GetQsoRequest { LocalId = localId });
+        if (getResponse.Qso is not { } qso)
+        {
+            Console.Error.WriteLine($"QSO not found: {localId}");
+            return 1;
+        }
+
+        var enrich = false;
+
+        if (!TryApplyUpdates(args, qso, ref enrich, out var error))
+        {
+            Console.Error.WriteLine(error);
+            return 1;
+        }
+
+        if (enrich)
+        {
+            await EnrichFromLookup(channel, qso);
+        }
+
+        var response = await client.UpdateQsoAsync(new UpdateQsoRequest { Qso = qso });
+
+        if (!response.Success)
+        {
+            Console.Error.WriteLine($"Update failed: {response.Error}");
+            return 1;
+        }
+
+        Console.WriteLine($"Updated QSO: {localId}");
+        Console.WriteLine($"  {qso.WorkedCallsign} on {EnumHelpers.FormatBand(qso.Band)} {EnumHelpers.FormatMode(qso.Mode)}");
+
+        if (qso.HasWorkedGrid)
+        {
+            Console.WriteLine($"  Grid: {qso.WorkedGrid}");
+        }
+
+        if (qso.HasWorkedCountry)
+        {
+            Console.WriteLine($"  Country: {qso.WorkedCountry}");
+        }
+
+        if (response.HasSyncError)
+        {
+            Console.WriteLine($"  QRZ sync: {response.SyncError}");
+        }
+
+        return 0;
+    }
+
+    internal static bool TryApplyUpdates(string[] args, QsoRecord qso, ref bool enrich, out string? error)
+    {
+        error = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--grid" when i < args.Length - 1:
+                    qso.WorkedGrid = args[++i].ToUpperInvariant();
+                    break;
+                case "--grid":
+                    error = "Missing value for --grid.";
+                    return false;
+                case "--country" when i < args.Length - 1:
+                    qso.WorkedCountry = args[++i];
+                    break;
+                case "--country":
+                    error = "Missing value for --country.";
+                    return false;
+                case "--state" when i < args.Length - 1:
+                    qso.WorkedState = args[++i].ToUpperInvariant();
+                    break;
+                case "--state":
+                    error = "Missing value for --state.";
+                    return false;
+                case "--freq" when i < args.Length - 1:
+                    var freqValue = args[++i];
+                    if (!ulong.TryParse(freqValue, out var freq))
+                    {
+                        error = $"Invalid value for --freq: {freqValue}";
+                        return false;
+                    }
+
+                    qso.FrequencyKhz = freq;
+                    break;
+                case "--freq":
+                    error = "Missing value for --freq.";
+                    return false;
+                case "--comment" when i < args.Length - 1:
+                    qso.Comment = args[++i];
+                    break;
+                case "--comment":
+                    error = "Missing value for --comment.";
+                    return false;
+                case "--band" when i < args.Length - 1:
+                    try
+                    {
+                        qso.Band = EnumHelpers.ParseBand(args[++i]);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        error = ex.Message;
+                        return false;
+                    }
+
+                    break;
+                case "--band":
+                    error = "Missing value for --band.";
+                    return false;
+                case "--mode" when i < args.Length - 1:
+                    try
+                    {
+                        qso.Mode = EnumHelpers.ParseMode(args[++i]);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        error = ex.Message;
+                        return false;
+                    }
+
+                    break;
+                case "--mode":
+                    error = "Missing value for --mode.";
+                    return false;
+                case "--rst-sent" when i < args.Length - 1:
+                    if (!LogQsoCommand.TryParseRst(args[++i], out var rstSent))
+                    {
+                        error = $"Invalid value for --rst-sent: {args[i]}. Expected 2 or 3 digits.";
+                        return false;
+                    }
+
+                    qso.RstSent = rstSent;
+                    break;
+                case "--rst-sent":
+                    error = "Missing value for --rst-sent.";
+                    return false;
+                case "--rst-rcvd" when i < args.Length - 1:
+                    if (!LogQsoCommand.TryParseRst(args[++i], out var rstReceived))
+                    {
+                        error = $"Invalid value for --rst-rcvd: {args[i]}. Expected 2 or 3 digits.";
+                        return false;
+                    }
+
+                    qso.RstReceived = rstReceived;
+                    break;
+                case "--rst-rcvd":
+                    error = "Missing value for --rst-rcvd.";
+                    return false;
+                case "--enrich":
+                    enrich = true;
+                    break;
+                default:
+                    error = $"Unknown option: {args[i]}";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static async Task EnrichFromLookup(GrpcChannel channel, QsoRecord qso)
+    {
+        try
+        {
+            var lookupClient = new LookupService.LookupServiceClient(channel);
+            var response = await lookupClient.LookupAsync(new LookupRequest
+            {
+                Callsign = qso.WorkedCallsign,
+                SkipCache = false,
+            });
+
+            var result = response.Result;
+            if (result is null || result.State != LookupState.Found || result.Record is null)
+            {
+                var reason = result?.State switch
+                {
+                    LookupState.NotFound => "callsign not found",
+                    LookupState.Error => result.HasErrorMessage ? result.ErrorMessage : "lookup error",
+                    _ => "no result",
+                };
+                Console.Error.WriteLine($"  \u26a0 Lookup skipped for {qso.WorkedCallsign}: {reason}");
+                return;
+            }
+
+            var record = result.Record;
+
+            if (record.HasGridSquare)
+            {
+                qso.WorkedGrid = record.GridSquare;
+            }
+
+            if (record.HasCountry)
+            {
+                qso.WorkedCountry = record.Country;
+            }
+
+            if (record.HasState)
+            {
+                qso.WorkedState = record.State;
+            }
+
+            if (record.DxccEntityId != 0)
+            {
+                qso.WorkedDxcc = record.DxccEntityId;
+            }
+
+            Console.WriteLine($"  Enriched from QRZ lookup");
+        }
+        catch (Grpc.Core.RpcException ex)
+        {
+            var detail = ex.Status.Detail;
+            var message = string.IsNullOrEmpty(detail) ? ex.StatusCode.ToString() : detail;
+            Console.Error.WriteLine($"  \u26a0 Lookup unavailable for {qso.WorkedCallsign}: {message}");
+        }
+    }
+}

--- a/src/dotnet/LogRipper.Cli/Program.cs
+++ b/src/dotnet/LogRipper.Cli/Program.cs
@@ -40,6 +40,7 @@ try
         "log" => await LogQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.RemainingArgs),
         "get" => await GetQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.JsonOutput),
         "list" => await ListQsosCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput),
+        "update" => await UpdateQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.RemainingArgs),
         "delete" => await DeleteQsoCommand.RunAsync(channel, arguments.Callsign!),
         "import" => await ImportAdifCommand.RunAsync(channel, arguments.Callsign ?? arguments.RemainingArgs.FirstOrDefault() ?? ""),
         "export" => await ExportAdifCommand.RunAsync(channel, arguments.RemainingArgs),


### PR DESCRIPTION
## Summary

Adds `LogRipper.Cli update <local-id>` command for patching existing QSOs and fixes silent lookup failure swallowing.

## Changes

### CLI `update` command
Wires to the existing `UpdateQso` gRPC RPC with field flags:

- `--grid`, `--country`, `--state` — set enrichment fields manually
- `--freq`, `--band`, `--mode` — update radio parameters
- `--rst-sent`, `--rst-rcvd` — update signal reports
- `--comment` — set notes
- `--enrich` — re-run QRZ lookup to populate grid/country/state/DXCC

Example:
```powershell
LogRipper.Cli update <local-id> --enrich
LogRipper.Cli update <local-id> --grid CN87 --freq 14074
```

### Lookup failure warnings
`EnrichFromLookup` in `LogQsoCommand` previously swallowed all failures silently. Now emits stderr warnings so operators know when QRZ enrichment is skipped (e.g., missing credentials, callsign not found).

### Tests
14 new tests for `UpdateQsoCommand.TryApplyUpdates` covering field updates, `--enrich` flag, missing value rejection, and unknown option rejection.