### PR TITLE
Use active station profile in storage workbench smoke test

### DIFF
--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/StorageWorkbench.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/StorageWorkbench.razor
@@ -187,16 +187,25 @@
 
     private void Preview()
     {
-        samplePayload = ProtoJsonService.Describe(SampleProtoFactory.CreateQsoRecord(workedCallsign));
-        activeStationProfilePayload = WorkbenchState.RuntimeConfigSnapshot?.ActiveStationProfile is null
+        var activeProfile = WorkbenchState.RuntimeConfigSnapshot?.ActiveStationProfile;
+        var previewQso = SampleProtoFactory.CreateQsoRecord(workedCallsign);
+
+        if (activeProfile is not null)
+        {
+            previewQso.StationCallsign = activeProfile.StationCallsign;
+        }
+
+        samplePayload = ProtoJsonService.Describe(previewQso);
+        activeStationProfilePayload = activeProfile is null
             ? null
-            : ProtoJsonService.Describe(WorkbenchState.RuntimeConfigSnapshot.ActiveStationProfile);
+            : ProtoJsonService.Describe(activeProfile);
     }
 
     private async Task RunSmokeTestAsync()
     {
         Preview();
-        result = await StorageWorkbenchService.RunSmokeTestAsync(workedCallsign, retainRecord);
+        var activeProfile = WorkbenchState.RuntimeConfigSnapshot?.ActiveStationProfile;
+        result = await StorageWorkbenchService.RunSmokeTestAsync(workedCallsign, retainRecord, activeProfile);
         logResponsePayload = result.LogResponse is null ? null : ProtoJsonService.Describe(result.LogResponse);
         loadedPayload = result.LoadedResponse?.Qso is null ? null : ProtoJsonService.Describe(result.LoadedResponse.Qso);
         loadedStationSnapshotPayload = result.LoadedResponse?.Qso?.StationSnapshot is null

--- a/src/dotnet/QsoRipper.DebugHost/Services/StorageWorkbenchService.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Services/StorageWorkbenchService.cs
@@ -22,11 +22,13 @@ internal sealed class StorageWorkbenchService
     public async Task<StorageSmokeTestResult> RunSmokeTestAsync(
         string workedCallsign,
         bool retainRecord,
+        StationProfile? activeStationProfile = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(workedCallsign);
 
         var sampleQso = _sampleProtoFactory.CreateQsoRecord(workedCallsign);
+        ApplyStationProfile(sampleQso, activeStationProfile);
         LogQsoResponse? logResponse = null;
         GetQsoResponse? loadedResponse = null;
         DeleteQsoResponse? deleteResponse = null;
@@ -125,6 +127,33 @@ internal sealed class StorageWorkbenchService
                 ex.Message,
                 DateTimeOffset.UtcNow);
         }
+    }
+
+    private static void ApplyStationProfile(QsoRecord qso, StationProfile? profile)
+    {
+        if (profile is null)
+        {
+            return;
+        }
+
+        qso.StationCallsign = profile.StationCallsign;
+        qso.StationSnapshot = new StationSnapshot
+        {
+            ProfileName = profile.ProfileName,
+            StationCallsign = profile.StationCallsign,
+            OperatorCallsign = profile.OperatorCallsign,
+            OperatorName = profile.OperatorName,
+            Grid = profile.Grid,
+            County = profile.County,
+            State = profile.State,
+            Country = profile.Country,
+            Dxcc = profile.Dxcc,
+            CqZone = profile.CqZone,
+            ItuZone = profile.ItuZone,
+            Latitude = profile.Latitude,
+            Longitude = profile.Longitude,
+            ArrlSection = profile.ArrlSection
+        };
     }
 
     private static async Task<bool> ConfirmDeleteAsync(


### PR DESCRIPTION
## Summary

The storage workbench smoke test was always building sample QSOs with hardcoded `SampleProtoFactory` constants (`K7DBG`, `CN87up`, etc.) instead of using the engine's active station profile.

## Changes

- **`StorageWorkbenchService`** — added an optional `StationProfile?` parameter to `RunSmokeTestAsync`. When present, `ApplyStationProfile` overwrites `StationCallsign` and builds a real `StationSnapshot` from the profile. Falls back to sample data when null.
- **`StorageWorkbench.razor`** — passes `WorkbenchState.RuntimeConfigSnapshot?.ActiveStationProfile` into the smoke test and preview paths.

## What's not changed

`SampleProtoFactory` remains a pure sample generator with no runtime/engine coupling. The Protobuf Lab and catalog behavior is unaffected.

## Design

The Razor page is the coordinator between workbench state and the service — no new DI coupling was added to `StorageWorkbenchService`. This follows the consumer-driven interface pattern from the architecture doc.

Fixes #95