### PR TITLE
feat: setup wizard — engine foundation + CLI interactive wizard

### DIFF
--- a/proto/services/get_setup_wizard_state_request.proto
+++ b/proto/services/get_setup_wizard_state_request.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+message GetSetupWizardStateRequest {}

--- a/proto/services/get_setup_wizard_state_response.proto
+++ b/proto/services/get_setup_wizard_state_response.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "services/setup_wizard_step_status.proto";
+import "services/setup_status.proto";
+import "services/station_profile_record.proto";
+
+// Full wizard state: per-step status, suggested defaults, and current setup.
+message GetSetupWizardStateResponse {
+  // Current setup status (superset of GetSetupStatusResponse).
+  SetupStatus status = 1;
+  // Per-step completion status in wizard order.
+  repeated SetupWizardStepStatus steps = 2;
+  // All currently persisted station profiles.
+  repeated StationProfileRecord station_profiles = 3;
+}

--- a/proto/services/save_setup_request.proto
+++ b/proto/services/save_setup_request.proto
@@ -8,10 +8,10 @@ import "domain/station_profile.proto";
 import "services/storage_backend.proto";
 
 message SaveSetupRequest {
-  // Legacy compatibility field. New clients should use log_file_path.
-  StorageBackend storage_backend = 1;
-  // Legacy compatibility field. New clients should use log_file_path.
-  optional string sqlite_path = 2;
+  // Deprecated: legacy storage backend selector. Use log_file_path instead.
+  StorageBackend storage_backend = 1 [deprecated = true];
+  // Deprecated: legacy SQLite path. Use log_file_path instead.
+  optional string sqlite_path = 2 [deprecated = true];
   qsoripper.domain.StationProfile station_profile = 3;
   optional string qrz_xml_username = 4;
   optional string qrz_xml_password = 5;

--- a/proto/services/setup_field_validation.proto
+++ b/proto/services/setup_field_validation.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+// Per-field validation result returned by ValidateSetupStep.
+message SetupFieldValidation {
+  // Field name (e.g. "log_file_path", "station_callsign").
+  string field = 1;
+  // True when the field value is acceptable.
+  bool valid = 2;
+  // Human-readable reason when invalid, empty when valid.
+  string message = 3;
+}

--- a/proto/services/setup_service.proto
+++ b/proto/services/setup_service.proto
@@ -6,14 +6,23 @@ option csharp_namespace = "QsoRipper.Services";
 
 import "services/get_setup_status_request.proto";
 import "services/get_setup_status_response.proto";
+import "services/get_setup_wizard_state_request.proto";
+import "services/get_setup_wizard_state_response.proto";
 import "services/save_setup_request.proto";
 import "services/save_setup_response.proto";
+import "services/test_qrz_credentials_request.proto";
+import "services/test_qrz_credentials_response.proto";
+import "services/validate_setup_step_request.proto";
+import "services/validate_setup_step_response.proto";
 
 // Production setup/bootstrap surface for first-run configuration.
 //
 // This service owns persisted engine configuration, not ephemeral developer
 // runtime overrides. Clients can use it to detect missing setup, present the
 // recommended config/data paths, and save the initial station/logbook settings.
+//
+// The wizard RPCs (GetSetupWizardState, ValidateSetupStep, TestQrzCredentials)
+// support step-by-step guided setup for new users in any UI surface.
 service SetupService {
   // Read the current persisted setup status and suggested default paths.
   rpc GetSetupStatus(GetSetupStatusRequest) returns (GetSetupStatusResponse);
@@ -21,4 +30,14 @@ service SetupService {
   // Validate and persist the initial setup payload, then hot-apply it to the
   // running engine for new requests.
   rpc SaveSetup(SaveSetupRequest) returns (SaveSetupResponse);
+
+  // Return full wizard state: per-step completion, suggested defaults, and
+  // current station profiles. Used by setup wizards and settings screens.
+  rpc GetSetupWizardState(GetSetupWizardStateRequest) returns (GetSetupWizardStateResponse);
+
+  // Validate one wizard step without persisting. Returns per-field results.
+  rpc ValidateSetupStep(ValidateSetupStepRequest) returns (ValidateSetupStepResponse);
+
+  // Test QRZ XML credentials by performing a live login attempt.
+  rpc TestQrzCredentials(TestQrzCredentialsRequest) returns (TestQrzCredentialsResponse);
 }

--- a/proto/services/setup_status.proto
+++ b/proto/services/setup_status.proto
@@ -11,19 +11,21 @@ message SetupStatus {
   bool config_file_exists = 1;
   bool setup_complete = 2;
   string config_path = 3;
-  // Legacy compatibility field. New clients should use log_file_path.
-  StorageBackend storage_backend = 4;
-  // Legacy compatibility field. New clients should use log_file_path.
-  optional string sqlite_path = 5;
+  // Deprecated: legacy storage backend selector. Use log_file_path instead.
+  StorageBackend storage_backend = 4 [deprecated = true];
+  // Deprecated: legacy SQLite path. Use log_file_path instead.
+  optional string sqlite_path = 5 [deprecated = true];
   bool has_station_profile = 6;
   qsoripper.domain.StationProfile station_profile = 7;
   optional string qrz_xml_username = 8;
   bool has_qrz_xml_password = 9;
-  // Legacy compatibility field. New clients should use suggested_log_file_path.
-  string suggested_sqlite_path = 10;
+  // Deprecated: legacy suggested SQLite path. Use suggested_log_file_path instead.
+  string suggested_sqlite_path = 10 [deprecated = true];
   repeated string warnings = 11;
   optional string active_station_profile_id = 12;
   uint32 station_profile_count = 13;
   optional string log_file_path = 14;
   string suggested_log_file_path = 15;
+  // True when no config file exists and setup has never been completed.
+  bool is_first_run = 16;
 }

--- a/proto/services/setup_wizard_step.proto
+++ b/proto/services/setup_wizard_step.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+// Identifies a single step in the setup wizard flow.
+enum SetupWizardStep {
+  SETUP_WIZARD_STEP_UNSPECIFIED = 0;
+  SETUP_WIZARD_STEP_LOG_FILE = 1;
+  SETUP_WIZARD_STEP_STATION_PROFILES = 2;
+  SETUP_WIZARD_STEP_QRZ_INTEGRATION = 3;
+  SETUP_WIZARD_STEP_REVIEW = 4;
+}

--- a/proto/services/setup_wizard_step_status.proto
+++ b/proto/services/setup_wizard_step_status.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+// Per-step completion and readiness summary used by the setup wizard.
+message SetupWizardStepStatus {
+  // Which wizard step this status describes.
+  SetupWizardStep step = 1;
+  // True when the step has valid persisted data.
+  bool complete = 2;
+  // Human-readable summary of what is missing or invalid, if any.
+  repeated string issues = 3;
+}
+
+import "services/setup_wizard_step.proto";

--- a/proto/services/test_qrz_credentials_request.proto
+++ b/proto/services/test_qrz_credentials_request.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+// Test QRZ XML credentials by performing a live login attempt.
+message TestQrzCredentialsRequest {
+  string qrz_xml_username = 1;
+  string qrz_xml_password = 2;
+}

--- a/proto/services/test_qrz_credentials_response.proto
+++ b/proto/services/test_qrz_credentials_response.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+message TestQrzCredentialsResponse {
+  // True when the login succeeded and a session key was obtained.
+  bool success = 1;
+  // Human-readable error message when login failed.
+  string error_message = 2;
+}

--- a/proto/services/validate_setup_step_request.proto
+++ b/proto/services/validate_setup_step_request.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "services/setup_wizard_step.proto";
+import "domain/station_profile.proto";
+
+// Validate one wizard step without persisting. The client populates only the
+// fields relevant to the indicated step; the server ignores unrelated fields.
+message ValidateSetupStepRequest {
+  SetupWizardStep step = 1;
+  // Step 1: log file path.
+  optional string log_file_path = 2;
+  // Step 2: station profile being validated (one at a time).
+  qsoripper.domain.StationProfile station_profile = 3;
+  // Step 3: QRZ credentials.
+  optional string qrz_xml_username = 4;
+  optional string qrz_xml_password = 5;
+}

--- a/proto/services/validate_setup_step_response.proto
+++ b/proto/services/validate_setup_step_response.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "services/setup_field_validation.proto";
+
+message ValidateSetupStepResponse {
+  // True when all fields for the step are valid.
+  bool valid = 1;
+  // Per-field validation results.
+  repeated SetupFieldValidation fields = 2;
+}

--- a/src/dotnet/QsoRipper.Cli.Tests/CliArgumentParserTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliArgumentParserTests.cs
@@ -92,6 +92,56 @@ public class CliArgumentParserTests
         Assert.True(arguments.SkipCache);
     }
 
+    [Fact]
+    public void Parse_setup_status_flag()
+    {
+        var arguments = CliArgumentParser.Parse(["setup", "--status"]);
+
+        Assert.Equal("setup", arguments.Command);
+        Assert.True(arguments.SetupStatus);
+        Assert.False(arguments.SetupFromEnv);
+    }
+
+    [Fact]
+    public void Parse_setup_from_env_flag()
+    {
+        var arguments = CliArgumentParser.Parse(["setup", "--from-env"]);
+
+        Assert.Equal("setup", arguments.Command);
+        Assert.False(arguments.SetupStatus);
+        Assert.True(arguments.SetupFromEnv);
+    }
+
+    [Fact]
+    public void Parse_setup_without_flags_defaults_both_false()
+    {
+        var arguments = CliArgumentParser.Parse(["setup"]);
+
+        Assert.Equal("setup", arguments.Command);
+        Assert.False(arguments.SetupStatus);
+        Assert.False(arguments.SetupFromEnv);
+    }
+
+    [Fact]
+    public void Parse_setup_status_with_json()
+    {
+        var arguments = CliArgumentParser.Parse(["setup", "--status", "--json"]);
+
+        Assert.Equal("setup", arguments.Command);
+        Assert.True(arguments.SetupStatus);
+        Assert.True(arguments.JsonOutput);
+    }
+
+    [Fact]
+    public void Parse_setup_from_env_with_endpoint()
+    {
+        var arguments = CliArgumentParser.Parse(["--endpoint", "http://host:9090", "setup", "--from-env"]);
+
+        Assert.Equal("setup", arguments.Command);
+        Assert.Equal("http://host:9090", arguments.Endpoint);
+        Assert.True(arguments.SetupFromEnv);
+    }
+
     [Theory]
     [InlineData("http://localhost:50051", true)]
     [InlineData("https://example.com:7443", true)]

--- a/src/dotnet/QsoRipper.Cli.Tests/SetupWizardTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/SetupWizardTests.cs
@@ -1,0 +1,111 @@
+using QsoRipper.Cli.Commands;
+
+namespace QsoRipper.Cli.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+public class SetupWizardTests
+{
+    [Fact]
+    public void PromptField_returns_default_on_empty_input()
+    {
+        var original = Console.In;
+        try
+        {
+            Console.SetIn(new StringReader(Environment.NewLine));
+            var result = SetupCommand.PromptField("Test", "default_value");
+            Assert.Equal("default_value", result);
+        }
+        finally
+        {
+            Console.SetIn(original);
+        }
+    }
+
+    [Fact]
+    public void PromptField_returns_user_input_when_provided()
+    {
+        var original = Console.In;
+        try
+        {
+            Console.SetIn(new StringReader("user_input" + Environment.NewLine));
+            var result = SetupCommand.PromptField("Test", "default_value");
+            Assert.Equal("user_input", result);
+        }
+        finally
+        {
+            Console.SetIn(original);
+        }
+    }
+
+    [Fact]
+    public void PromptField_trims_whitespace()
+    {
+        var original = Console.In;
+        try
+        {
+            Console.SetIn(new StringReader("  trimmed  " + Environment.NewLine));
+            var result = SetupCommand.PromptField("Test", "default");
+            Assert.Equal("trimmed", result);
+        }
+        finally
+        {
+            Console.SetIn(original);
+        }
+    }
+
+    [Theory]
+    [InlineData("y", true, true)]
+    [InlineData("Y", true, true)]
+    [InlineData("yes", true, true)]
+    [InlineData("YES", true, true)]
+    [InlineData("n", true, false)]
+    [InlineData("N", true, false)]
+    [InlineData("no", true, false)]
+    [InlineData("anything", true, false)]
+    [InlineData("", true, true)]    // default yes
+    [InlineData("", false, false)]  // default no
+    [InlineData("y", false, true)]
+    [InlineData("n", false, false)]
+    public void PromptYesNo_handles_inputs(string input, bool defaultYes, bool expected)
+    {
+        var original = Console.In;
+        try
+        {
+            Console.SetIn(new StringReader(input + Environment.NewLine));
+            var result = SetupCommand.PromptYesNo("Question?", defaultYes);
+            Assert.Equal(expected, result);
+        }
+        finally
+        {
+            Console.SetIn(original);
+        }
+    }
+
+    [Fact]
+    public void CliArguments_defaults_setup_flags_to_false()
+    {
+        var args = new CliArguments("setup", "http://localhost:50051");
+
+        Assert.False(args.SetupStatus);
+        Assert.False(args.SetupFromEnv);
+    }
+
+    [Fact]
+    public void CliArguments_can_set_setup_status()
+    {
+        var args = new CliArguments("setup", "http://localhost:50051", SetupStatus: true);
+
+        Assert.True(args.SetupStatus);
+        Assert.False(args.SetupFromEnv);
+    }
+
+    [Fact]
+    public void CliArguments_can_set_setup_from_env()
+    {
+        var args = new CliArguments("setup", "http://localhost:50051", SetupFromEnv: true);
+
+        Assert.False(args.SetupStatus);
+        Assert.True(args.SetupFromEnv);
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli/CliArgumentParser.cs
+++ b/src/dotnet/QsoRipper.Cli/CliArgumentParser.cs
@@ -13,6 +13,8 @@ internal static class CliArgumentParser
         string? callsign = null;
         var skipCache = false;
         var jsonOutput = false;
+        var setupStatus = false;
+        var setupFromEnv = false;
 
         var remaining = new List<string>();
 
@@ -54,6 +56,18 @@ internal static class CliArgumentParser
                 continue;
             }
 
+            if (arg is "--status")
+            {
+                setupStatus = true;
+                continue;
+            }
+
+            if (arg is "--from-env")
+            {
+                setupFromEnv = true;
+                continue;
+            }
+
             if (command is null && !arg.StartsWith('-'))
             {
                 command = arg;
@@ -78,6 +92,8 @@ internal static class CliArgumentParser
             Callsign: callsign,
             SkipCache: skipCache,
             JsonOutput: jsonOutput,
+            SetupStatus: setupStatus,
+            SetupFromEnv: setupFromEnv,
             RemainingArgs: remaining.ToArray());
     }
 }

--- a/src/dotnet/QsoRipper.Cli/CliArguments.cs
+++ b/src/dotnet/QsoRipper.Cli/CliArguments.cs
@@ -8,6 +8,8 @@ internal sealed record CliArguments(
     string? Callsign = null,
     bool SkipCache = false,
     bool JsonOutput = false,
+    bool SetupStatus = false,
+    bool SetupFromEnv = false,
     string[] RemainingArgs = default!)
 {
     public string[] RemainingArgs { get; init; } = RemainingArgs ?? [];

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -28,7 +28,7 @@ internal static class CliHelpText
             Engine:
               status                           Show sync status and QSO counts
               config [--set KEY=VALUE]         View or modify runtime config
-              setup                            Check first-run setup status
+              setup [--status | --from-env]    Interactive setup wizard or headless config
 
             Options:
               --endpoint, -e <url>             Engine endpoint (default: http://127.0.0.1:50051)
@@ -141,9 +141,29 @@ internal static class CliHelpText
                   --reset              Reset all overrides to defaults
                 """,
             "setup" => """
-                Usage: setup
+                Usage: setup [--status] [--from-env]
 
-                Check first-run setup status.
+                Interactive setup wizard for first-run configuration. Walks through
+                log file path, station profile, and optional QRZ integration step by step.
+
+                Modes:
+                  (default)          Interactive wizard — prompts for each setting
+                  --status           Show current setup status (read-only)
+                  --from-env         Headless setup from environment variables (no prompts)
+
+                Environment variables for --from-env:
+                  QSORIPPER_LOG_FILE              Log file path
+                  QSORIPPER_STATION_CALLSIGN      Station callsign (required)
+                  QSORIPPER_OPERATOR_CALLSIGN     Operator callsign (defaults to station)
+                  QSORIPPER_PROFILE_NAME          Profile name (defaults to "Default")
+                  QSORIPPER_GRID                  Grid square
+                  QSORIPPER_QRZ_USERNAME          QRZ XML username (optional)
+                  QSORIPPER_QRZ_PASSWORD          QRZ XML password (optional)
+
+                Examples:
+                  setup                           Start the interactive wizard
+                  setup --status                  Check if setup is complete
+                  setup --from-env                Configure from environment variables
                 """,
             "status" => """
                 Usage: status

--- a/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
@@ -28,7 +28,9 @@ internal static class SetupCommand
         Console.WriteLine($"Config path:       {status.ConfigPath}");
         Console.WriteLine($"QRZ username:      {status.QrzXmlUsername ?? "(not set)"}");
         Console.WriteLine($"Station profile:   {status.HasStationProfile}");
+#pragma warning disable CS0612 // Type or member is obsolete
         Console.WriteLine($"Storage backend:   {status.StorageBackend}");
+#pragma warning restore CS0612
 
         return status.SetupComplete ? 0 : 1;
     }

--- a/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
@@ -1,12 +1,36 @@
 using Grpc.Net.Client;
 using QsoRipper.Cli;
+using QsoRipper.Domain;
 using QsoRipper.Services;
 
 namespace QsoRipper.Cli.Commands;
 
 internal static class SetupCommand
 {
-    public static async Task<int> RunAsync(GrpcChannel channel, bool jsonOutput = false)
+    public static async Task<int> RunAsync(GrpcChannel channel, CliArguments arguments)
+    {
+        if (arguments.SetupStatus)
+        {
+            return await RunStatusAsync(channel, arguments.JsonOutput);
+        }
+
+        if (arguments.SetupFromEnv)
+        {
+            return await RunFromEnvAsync(channel);
+        }
+
+        // Default: interactive wizard
+        if (Console.IsInputRedirected)
+        {
+            Console.Error.WriteLine("Error: stdin is redirected. Interactive wizard requires a terminal.");
+            Console.Error.WriteLine("Use 'setup --from-env' for headless setup from environment variables.");
+            return 1;
+        }
+
+        return await RunWizardAsync(channel);
+    }
+
+    internal static async Task<int> RunStatusAsync(GrpcChannel channel, bool jsonOutput)
     {
         var client = new SetupService.SetupServiceClient(channel);
         var response = await client.GetSetupStatusAsync(new GetSetupStatusRequest());
@@ -33,5 +57,432 @@ internal static class SetupCommand
 #pragma warning restore CS0612
 
         return status.SetupComplete ? 0 : 1;
+    }
+
+    internal static async Task<int> RunFromEnvAsync(GrpcChannel channel)
+    {
+        var client = new SetupService.SetupServiceClient(channel);
+
+        var stationCallsign = Environment.GetEnvironmentVariable("QSORIPPER_STATION_CALLSIGN");
+        if (string.IsNullOrWhiteSpace(stationCallsign))
+        {
+            Console.Error.WriteLine("Error: QSORIPPER_STATION_CALLSIGN is required for --from-env setup.");
+            return 1;
+        }
+
+        var logFilePath = Environment.GetEnvironmentVariable("QSORIPPER_LOG_FILE");
+        var operatorCallsign = Environment.GetEnvironmentVariable("QSORIPPER_OPERATOR_CALLSIGN") ?? stationCallsign;
+        var profileName = Environment.GetEnvironmentVariable("QSORIPPER_PROFILE_NAME") ?? "Default";
+        var grid = Environment.GetEnvironmentVariable("QSORIPPER_GRID");
+        var qrzUsername = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_USERNAME");
+        var qrzPassword = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_PASSWORD");
+
+        // If no log file path, fetch the suggested one from the engine.
+        if (string.IsNullOrWhiteSpace(logFilePath))
+        {
+            var statusResponse = await client.GetSetupStatusAsync(new GetSetupStatusRequest());
+            logFilePath = statusResponse.Status?.SuggestedLogFilePath;
+        }
+
+        var profile = new StationProfile
+        {
+            ProfileName = profileName,
+            StationCallsign = stationCallsign,
+            OperatorCallsign = operatorCallsign,
+        };
+
+        if (!string.IsNullOrWhiteSpace(grid))
+        {
+            profile.Grid = grid;
+        }
+
+        // Validate log file step.
+        var logValidation = await client.ValidateSetupStepAsync(new ValidateSetupStepRequest
+        {
+            Step = SetupWizardStep.LogFile,
+            LogFilePath = logFilePath ?? "",
+        });
+
+        if (!logValidation.Valid)
+        {
+            Console.Error.WriteLine("Log file path validation failed:");
+            PrintFieldErrors(logValidation.Fields);
+            return 1;
+        }
+
+        // Validate station profile step.
+        var profileValidation = await client.ValidateSetupStepAsync(new ValidateSetupStepRequest
+        {
+            Step = SetupWizardStep.StationProfiles,
+            StationProfile = profile,
+        });
+
+        if (!profileValidation.Valid)
+        {
+            Console.Error.WriteLine("Station profile validation failed:");
+            PrintFieldErrors(profileValidation.Fields);
+            return 1;
+        }
+
+        // Validate QRZ step if credentials were provided.
+        if (!string.IsNullOrWhiteSpace(qrzUsername) && !string.IsNullOrWhiteSpace(qrzPassword))
+        {
+            var qrzValidation = await client.ValidateSetupStepAsync(new ValidateSetupStepRequest
+            {
+                Step = SetupWizardStep.QrzIntegration,
+                QrzXmlUsername = qrzUsername,
+                QrzXmlPassword = qrzPassword,
+            });
+
+            if (!qrzValidation.Valid)
+            {
+                Console.Error.WriteLine("QRZ credentials validation failed:");
+                PrintFieldErrors(qrzValidation.Fields);
+                return 1;
+            }
+        }
+
+        // Save.
+        var saveRequest = new SaveSetupRequest
+        {
+            LogFilePath = logFilePath ?? "",
+            StationProfile = profile,
+        };
+
+        if (!string.IsNullOrWhiteSpace(qrzUsername))
+        {
+            saveRequest.QrzXmlUsername = qrzUsername;
+        }
+
+        if (!string.IsNullOrWhiteSpace(qrzPassword))
+        {
+            saveRequest.QrzXmlPassword = qrzPassword;
+        }
+
+        var saveResponse = await client.SaveSetupAsync(saveRequest);
+        var savedStatus = saveResponse.Status;
+
+        if (savedStatus is null || !savedStatus.SetupComplete)
+        {
+            Console.Error.WriteLine("Setup save failed. Engine did not confirm completion.");
+            return 1;
+        }
+
+        Console.WriteLine("Setup complete.");
+        return 0;
+    }
+
+    internal static async Task<int> RunWizardAsync(GrpcChannel channel)
+    {
+        var client = new SetupService.SetupServiceClient(channel);
+
+        // Fetch initial wizard state for defaults.
+        var wizardState = await client.GetSetupWizardStateAsync(new GetSetupWizardStateRequest());
+        var status = wizardState.Status;
+
+        if (status is null)
+        {
+            Console.Error.WriteLine("Could not retrieve setup wizard state from the engine.");
+            return 1;
+        }
+
+        var isFirstRun = status.IsFirstRun;
+        Console.WriteLine();
+        Console.WriteLine(isFirstRun
+            ? "Welcome to QsoRipper! Let's set up your station."
+            : "QsoRipper Setup Wizard");
+        Console.WriteLine(new string('=', 48));
+
+        // ── Step 1: Log File Path ──────────────────────────────────
+        Console.WriteLine();
+        Console.WriteLine("Step 1 of 4: Log File Path");
+        Console.WriteLine(new string('-', 30));
+
+        var suggestedPath = status.SuggestedLogFilePath;
+        var currentLogPath = status.LogFilePath;
+        var defaultLogPath = !string.IsNullOrWhiteSpace(currentLogPath)
+            ? currentLogPath
+            : suggestedPath;
+
+        if (!string.IsNullOrWhiteSpace(currentLogPath))
+        {
+            Console.WriteLine($"  Current: {currentLogPath}");
+        }
+
+        string logFilePath;
+        while (true)
+        {
+            Console.Write($"Log file path [{defaultLogPath}]: ");
+            var input = Console.ReadLine()?.Trim();
+            logFilePath = string.IsNullOrEmpty(input) ? defaultLogPath : input;
+
+            var validation = await client.ValidateSetupStepAsync(new ValidateSetupStepRequest
+            {
+                Step = SetupWizardStep.LogFile,
+                LogFilePath = logFilePath,
+            });
+
+            if (validation.Valid)
+            {
+                break;
+            }
+
+            PrintFieldErrors(validation.Fields);
+        }
+
+        // ── Step 2: Station Profile ────────────────────────────────
+        Console.WriteLine();
+        Console.WriteLine("Step 2 of 4: Station Profile");
+        Console.WriteLine(new string('-', 30));
+
+        var existingProfile = status.StationProfile;
+        var defaultProfileName = existingProfile?.ProfileName ?? "Default";
+        var defaultStationCall = existingProfile?.StationCallsign ?? "";
+        var defaultOperatorCall = existingProfile?.OperatorCallsign ?? "";
+        var defaultGrid = existingProfile?.Grid ?? "";
+
+        if (!string.IsNullOrWhiteSpace(defaultStationCall))
+        {
+            Console.WriteLine($"  Current station callsign: {defaultStationCall}");
+        }
+
+        string profileName;
+        string stationCallsign;
+        string operatorCallsign;
+        string grid;
+
+        // We collect all fields first, then validate. If invalid, re-prompt only bad fields.
+        while (true)
+        {
+            profileName = PromptField("Profile name", defaultProfileName);
+            stationCallsign = PromptField("Station callsign", defaultStationCall);
+            operatorCallsign = PromptField("Operator callsign", string.IsNullOrWhiteSpace(defaultOperatorCall) ? stationCallsign : defaultOperatorCall);
+            grid = PromptField("Grid square", defaultGrid);
+
+            var profile = new StationProfile
+            {
+                ProfileName = profileName,
+                StationCallsign = stationCallsign,
+                OperatorCallsign = operatorCallsign,
+            };
+
+            if (!string.IsNullOrWhiteSpace(grid))
+            {
+                profile.Grid = grid;
+            }
+
+            var validation = await client.ValidateSetupStepAsync(new ValidateSetupStepRequest
+            {
+                Step = SetupWizardStep.StationProfiles,
+                StationProfile = profile,
+            });
+
+            if (validation.Valid)
+            {
+                break;
+            }
+
+            PrintFieldErrors(validation.Fields);
+            Console.WriteLine();
+
+            // Update defaults with what the user just entered so they don't have to re-type valid fields.
+            defaultProfileName = profileName;
+            defaultStationCall = stationCallsign;
+            defaultOperatorCall = operatorCallsign;
+            defaultGrid = grid;
+        }
+
+        // ── Step 3: QRZ Integration (Optional) ────────────────────
+        Console.WriteLine();
+        Console.WriteLine("Step 3 of 4: QRZ Integration (Optional)");
+        Console.WriteLine(new string('-', 30));
+
+        string? qrzUsername = null;
+        string? qrzPassword = null;
+
+        var existingQrzUser = status.QrzXmlUsername;
+        var hasExistingQrz = !string.IsNullOrWhiteSpace(existingQrzUser);
+
+        if (hasExistingQrz)
+        {
+            Console.WriteLine($"  Current QRZ username: {existingQrzUser}");
+        }
+
+        var setupQrz = PromptYesNo("Set up QRZ integration?", defaultYes: false);
+
+        if (setupQrz)
+        {
+            while (true)
+            {
+                qrzUsername = PromptField("QRZ XML username", hasExistingQrz ? existingQrzUser! : "");
+                qrzPassword = PromptField("QRZ XML password", "");
+
+                if (string.IsNullOrWhiteSpace(qrzUsername) || string.IsNullOrWhiteSpace(qrzPassword))
+                {
+                    Console.WriteLine("  Both username and password are required.");
+                    continue;
+                }
+
+                var validation = await client.ValidateSetupStepAsync(new ValidateSetupStepRequest
+                {
+                    Step = SetupWizardStep.QrzIntegration,
+                    QrzXmlUsername = qrzUsername,
+                    QrzXmlPassword = qrzPassword,
+                });
+
+                if (!validation.Valid)
+                {
+                    PrintFieldErrors(validation.Fields);
+                    continue;
+                }
+
+                // Offer to test credentials.
+                var testConnection = PromptYesNo("Test connection?", defaultYes: true);
+                if (testConnection)
+                {
+                    Console.Write("  Testing QRZ credentials... ");
+                    var testResult = await client.TestQrzCredentialsAsync(new TestQrzCredentialsRequest
+                    {
+                        QrzXmlUsername = qrzUsername,
+                        QrzXmlPassword = qrzPassword,
+                    });
+
+                    if (testResult.Success)
+                    {
+                        Console.WriteLine("OK");
+                        break;
+                    }
+
+                    Console.WriteLine("FAILED");
+                    Console.WriteLine($"  Error: {testResult.ErrorMessage}");
+
+                    var retry = PromptYesNo("Retry with different credentials?", defaultYes: true);
+                    if (!retry)
+                    {
+                        var keepAnyway = PromptYesNo("Keep these credentials anyway?", defaultYes: false);
+                        if (keepAnyway)
+                        {
+                            break;
+                        }
+
+                        // User chose to skip QRZ entirely.
+                        qrzUsername = null;
+                        qrzPassword = null;
+                        break;
+                    }
+                }
+                else
+                {
+                    // Validation passed, user declined test — keep credentials.
+                    break;
+                }
+            }
+        }
+
+        // ── Step 4: Review & Save ──────────────────────────────────
+        Console.WriteLine();
+        Console.WriteLine("Step 4 of 4: Review & Save");
+        Console.WriteLine(new string('-', 30));
+        Console.WriteLine();
+        Console.WriteLine($"  Log file path:       {logFilePath}");
+        Console.WriteLine($"  Profile name:        {profileName}");
+        Console.WriteLine($"  Station callsign:    {stationCallsign}");
+        Console.WriteLine($"  Operator callsign:   {operatorCallsign}");
+        Console.WriteLine($"  Grid square:         {(string.IsNullOrWhiteSpace(grid) ? "(not set)" : grid)}");
+        Console.WriteLine($"  QRZ username:        {(string.IsNullOrWhiteSpace(qrzUsername) ? "(not set)" : qrzUsername)}");
+        Console.WriteLine($"  QRZ password:        {(string.IsNullOrWhiteSpace(qrzPassword) ? "(not set)" : "********")}");
+        Console.WriteLine();
+
+        var save = PromptYesNo("Save and apply?", defaultYes: true);
+        if (!save)
+        {
+            Console.WriteLine("Setup cancelled.");
+            return 1;
+        }
+
+        // Build save request.
+        var stationProfile = new StationProfile
+        {
+            ProfileName = profileName,
+            StationCallsign = stationCallsign,
+            OperatorCallsign = operatorCallsign,
+        };
+
+        if (!string.IsNullOrWhiteSpace(grid))
+        {
+            stationProfile.Grid = grid;
+        }
+
+        var saveRequest = new SaveSetupRequest
+        {
+            LogFilePath = logFilePath,
+            StationProfile = stationProfile,
+        };
+
+        if (!string.IsNullOrWhiteSpace(qrzUsername))
+        {
+            saveRequest.QrzXmlUsername = qrzUsername;
+        }
+
+        if (!string.IsNullOrWhiteSpace(qrzPassword))
+        {
+            saveRequest.QrzXmlPassword = qrzPassword;
+        }
+
+        var saveResponse = await client.SaveSetupAsync(saveRequest);
+        var savedStatus = saveResponse.Status;
+
+        if (savedStatus is null || !savedStatus.SetupComplete)
+        {
+            Console.Error.WriteLine("Setup save failed. The engine did not confirm completion.");
+            return 1;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Setup complete! You're ready to start logging QSOs.");
+        Console.WriteLine($"Config saved to: {savedStatus.ConfigPath}");
+        return 0;
+    }
+
+    internal static string PromptField(string label, string defaultValue)
+    {
+        if (!string.IsNullOrEmpty(defaultValue))
+        {
+            Console.Write($"{label} [{defaultValue}]: ");
+        }
+        else
+        {
+            Console.Write($"{label}: ");
+        }
+
+        var input = Console.ReadLine()?.Trim();
+        return string.IsNullOrEmpty(input) ? defaultValue : input;
+    }
+
+    internal static bool PromptYesNo(string question, bool defaultYes)
+    {
+        var hint = defaultYes ? "Y/n" : "y/N";
+        Console.Write($"{question} ({hint}): ");
+        var input = Console.ReadLine()?.Trim();
+
+        if (string.IsNullOrEmpty(input))
+        {
+            return defaultYes;
+        }
+
+        return input.Equals("y", StringComparison.OrdinalIgnoreCase)
+            || input.Equals("yes", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void PrintFieldErrors(
+        Google.Protobuf.Collections.RepeatedField<SetupFieldValidation> fields)
+    {
+        foreach (var field in fields)
+        {
+            if (!field.Valid)
+            {
+                Console.WriteLine($"  {field.Field}: {field.Message}");
+            }
+        }
     }
 }

--- a/src/dotnet/QsoRipper.Cli/Program.cs
+++ b/src/dotnet/QsoRipper.Cli/Program.cs
@@ -45,7 +45,7 @@ try
         "import" => await ImportAdifCommand.RunAsync(channel, arguments.Callsign ?? arguments.RemainingArgs.FirstOrDefault() ?? ""),
         "export" => await ExportAdifCommand.RunAsync(channel, arguments.RemainingArgs),
         "config" => await ConfigCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput),
-        "setup" => await SetupCommand.RunAsync(channel, arguments.JsonOutput),
+        "setup" => await SetupCommand.RunAsync(channel, arguments),
         _ => ShowHelp($"Unknown command: {arguments.Command}")
     };
 }

--- a/src/dotnet/QsoRipper.DebugHost.Tests/DebugWorkbenchStateTests.cs
+++ b/src/dotnet/QsoRipper.DebugHost.Tests/DebugWorkbenchStateTests.cs
@@ -133,7 +133,9 @@ public class DebugWorkbenchStateTests
             ConfigFileExists = true,
             SetupComplete = true,
             ConfigPath = @".\config\config.toml",
+#pragma warning disable CS0612 // Type or member is obsolete
             StorageBackend = StorageBackend.Sqlite,
+#pragma warning restore CS0612
             LogFilePath = @".\data\portable-qsoripper.db",
             StationProfile = new StationProfile
             {

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/Engine.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/Engine.razor
@@ -1316,7 +1316,9 @@
             return status.LogFilePath;
         }
 
+#pragma warning disable CS0612 // Type or member is obsolete
         if (status.StorageBackend == StorageBackend.Memory)
+#pragma warning restore CS0612
         {
             return "Not configured (legacy in-memory setup)";
         }

--- a/src/dotnet/QsoRipper.DebugHost/Services/DebugWorkbenchState.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Services/DebugWorkbenchState.cs
@@ -89,9 +89,11 @@ internal sealed class DebugWorkbenchState
         SetupStatus = status;
         SetupErrorMessage = null;
 
+#pragma warning disable CS0612 // Type or member is obsolete
         var persistedLogFilePath = string.IsNullOrWhiteSpace(status.LogFilePath)
             ? status.SqlitePath
             : status.LogFilePath;
+#pragma warning restore CS0612
         if (!string.IsNullOrWhiteSpace(persistedLogFilePath))
         {
             EngineStorageBackend = EngineStorageBackend.Sqlite;

--- a/src/rust/qsoripper-core/src/lookup/qrz_xml.rs
+++ b/src/rust/qsoripper-core/src/lookup/qrz_xml.rs
@@ -207,6 +207,19 @@ impl QrzXmlProvider {
         })
     }
 
+    /// Test credentials by performing a login attempt.
+    ///
+    /// Returns `Ok(())` when the login succeeds and a session key is obtained.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ProviderLookupError` when authentication fails or the network
+    /// request cannot be completed.
+    pub async fn test_login(&self) -> Result<(), ProviderLookupError> {
+        let (_key, _exchanges) = self.login().await?;
+        Ok(())
+    }
+
     async fn ensure_session_key(
         &self,
     ) -> Result<(String, Vec<DebugHttpExchange>), ProviderLookupError> {

--- a/src/rust/qsoripper-server/src/runtime_config.rs
+++ b/src/rust/qsoripper-server/src/runtime_config.rs
@@ -158,6 +158,13 @@ impl RuntimeConfigManager {
         self.bindings.read().await.active_storage_backend.clone()
     }
 
+    pub(crate) async fn effective_values(&self) -> BTreeMap<String, String> {
+        let config_file_values = self.config_file_values.read().await.clone();
+        let overrides = self.overrides.read().await.clone();
+        let base = merged_base_values(&config_file_values, &self.startup_values);
+        merge_values(&base, &overrides)
+    }
+
     pub(crate) async fn preview_config_file_values(
         &self,
         next_config_file_values: BTreeMap<String, String>,

--- a/src/rust/qsoripper-server/src/setup.rs
+++ b/src/rust/qsoripper-server/src/setup.rs
@@ -5,19 +5,24 @@ use std::sync::Arc;
 
 use qsoripper_core::domain::lookup::normalize_callsign;
 use qsoripper_core::domain::station::station_profile_has_values;
-use qsoripper_core::lookup::{QRZ_XML_PASSWORD_ENV_VAR, QRZ_XML_USERNAME_ENV_VAR};
+use qsoripper_core::lookup::{
+    QrzXmlConfig, QrzXmlProvider, QRZ_USER_AGENT_ENV_VAR, QRZ_XML_PASSWORD_ENV_VAR,
+    QRZ_XML_USERNAME_ENV_VAR,
+};
 use qsoripper_core::proto::qsoripper::domain::StationProfile;
 use qsoripper_core::proto::qsoripper::services::{
     setup_service_server::SetupService, station_profile_service_server::StationProfileService,
     ActiveStationContext, ClearSessionStationProfileOverrideRequest,
     ClearSessionStationProfileOverrideResponse, DeleteStationProfileRequest,
     DeleteStationProfileResponse, GetActiveStationContextRequest, GetActiveStationContextResponse,
-    GetSetupStatusRequest, GetSetupStatusResponse, GetStationProfileRequest,
-    GetStationProfileResponse, ListStationProfilesRequest, ListStationProfilesResponse,
-    SaveSetupRequest, SaveSetupResponse, SaveStationProfileRequest, SaveStationProfileResponse,
-    SetActiveStationProfileRequest, SetActiveStationProfileResponse,
-    SetSessionStationProfileOverrideRequest, SetSessionStationProfileOverrideResponse, SetupStatus,
-    StationProfileRecord, StorageBackend,
+    GetSetupStatusRequest, GetSetupStatusResponse, GetSetupWizardStateRequest,
+    GetSetupWizardStateResponse, GetStationProfileRequest, GetStationProfileResponse,
+    ListStationProfilesRequest, ListStationProfilesResponse, SaveSetupRequest, SaveSetupResponse,
+    SaveStationProfileRequest, SaveStationProfileResponse, SetActiveStationProfileRequest,
+    SetActiveStationProfileResponse, SetSessionStationProfileOverrideRequest,
+    SetSessionStationProfileOverrideResponse, SetupFieldValidation, SetupStatus, SetupWizardStep,
+    SetupWizardStepStatus, StationProfileRecord, StorageBackend, TestQrzCredentialsRequest,
+    TestQrzCredentialsResponse, ValidateSetupStepRequest, ValidateSetupStepResponse,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -86,6 +91,36 @@ impl SetupService for SetupControlSurface {
         Ok(Response::new(SaveSetupResponse {
             status: Some(status),
         }))
+    }
+
+    async fn get_setup_wizard_state(
+        &self,
+        _request: Request<GetSetupWizardStateRequest>,
+    ) -> Result<Response<GetSetupWizardStateResponse>, Status> {
+        Ok(Response::new(self.state.wizard_state().await))
+    }
+
+    async fn validate_setup_step(
+        &self,
+        request: Request<ValidateSetupStepRequest>,
+    ) -> Result<Response<ValidateSetupStepResponse>, Status> {
+        let inner = request.into_inner();
+        let step = SetupWizardStep::try_from(inner.step).unwrap_or(SetupWizardStep::Unspecified);
+        Ok(Response::new(validate_step(step, &inner)))
+    }
+
+    async fn test_qrz_credentials(
+        &self,
+        request: Request<TestQrzCredentialsRequest>,
+    ) -> Result<Response<TestQrzCredentialsResponse>, Status> {
+        let inner = request.into_inner();
+        let result = test_qrz_login(
+            &inner.qrz_xml_username,
+            &inner.qrz_xml_password,
+            &self.runtime_config,
+        )
+        .await;
+        Ok(Response::new(result))
     }
 }
 
@@ -219,6 +254,24 @@ impl SetupState {
             self.suggested_log_file_path.as_path(),
             persisted_config.as_ref(),
         )
+    }
+
+    async fn wizard_state(&self) -> GetSetupWizardStateResponse {
+        let persisted_config = self.persisted_config.read().await.clone();
+        let status = build_status(
+            self.config_path.as_path(),
+            self.suggested_log_file_path.as_path(),
+            persisted_config.as_ref(),
+        );
+        let steps = build_wizard_steps(persisted_config.as_ref());
+        let station_profiles = persisted_config
+            .as_ref()
+            .map_or_else(Vec::new, PersistedSetupConfig::list_station_profile_records);
+        GetSetupWizardStateResponse {
+            status: Some(status),
+            steps,
+            station_profiles,
+        }
     }
 
     async fn save_setup(
@@ -474,7 +527,9 @@ impl PersistedSetupConfig {
         }
 
         let requested_log_file_path = normalize_optional_string(request.log_file_path.as_deref());
+        #[allow(deprecated)]
         let legacy_sqlite_path = normalize_optional_string(request.sqlite_path.as_deref());
+        #[allow(deprecated)]
         let legacy_storage_backend = StorageBackend::try_from(request.storage_backend)
             .unwrap_or(StorageBackend::Unspecified);
         let (logbook, storage) = if let Some(log_file_path) = requested_log_file_path {
@@ -1009,6 +1064,7 @@ fn build_status(
         PersistedSetupConfig::runtime_storage_backend,
     );
 
+    #[allow(deprecated)]
     SetupStatus {
         config_file_exists: persisted_config.is_some(),
         setup_complete: persisted_config.is_some() && warnings.is_empty(),
@@ -1030,6 +1086,7 @@ fn build_status(
         }),
         log_file_path,
         suggested_log_file_path: suggested_log_file_path.display().to_string(),
+        is_first_run: persisted_config.is_none(),
     }
 }
 
@@ -1068,6 +1125,291 @@ fn build_warnings(persisted_config: Option<&PersistedSetupConfig>) -> Vec<String
     }
 
     warnings
+}
+
+fn build_wizard_steps(
+    persisted_config: Option<&PersistedSetupConfig>,
+) -> Vec<SetupWizardStepStatus> {
+    vec![
+        build_log_file_step(persisted_config),
+        build_station_profiles_step(persisted_config),
+        build_qrz_integration_step(persisted_config),
+        build_review_step(persisted_config),
+    ]
+}
+
+fn build_log_file_step(config: Option<&PersistedSetupConfig>) -> SetupWizardStepStatus {
+    let log_file = config.and_then(PersistedSetupConfig::log_file_path);
+    let complete = log_file.is_some();
+    let issues = if complete {
+        Vec::new()
+    } else {
+        vec!["A log file path is required.".to_string()]
+    };
+    SetupWizardStepStatus {
+        step: SetupWizardStep::LogFile.into(),
+        complete,
+        issues,
+    }
+}
+
+fn build_station_profiles_step(config: Option<&PersistedSetupConfig>) -> SetupWizardStepStatus {
+    let has_profiles = config.is_some_and(|c| c.station_profile_count() > 0);
+    let has_active = config
+        .and_then(PersistedSetupConfig::active_station_profile_id)
+        .is_some();
+    let complete = has_profiles && has_active;
+    let mut issues = Vec::new();
+    if !has_profiles {
+        issues.push("At least one station profile is required.".to_string());
+    }
+    if has_profiles && !has_active {
+        issues.push("An active station profile must be selected.".to_string());
+    }
+    SetupWizardStepStatus {
+        step: SetupWizardStep::StationProfiles.into(),
+        complete,
+        issues,
+    }
+}
+
+fn build_qrz_integration_step(config: Option<&PersistedSetupConfig>) -> SetupWizardStepStatus {
+    let username = config.and_then(|c| c.qrz_xml.username.as_ref());
+    let password = config.and_then(|c| c.qrz_xml.password.as_ref());
+    // QRZ is optional — step is complete if either both are set or both are absent.
+    let paired = username.is_some() == password.is_some();
+    let issues = if paired {
+        Vec::new()
+    } else {
+        vec![
+            "QRZ XML username and password must either both be set or both be omitted.".to_string(),
+        ]
+    };
+    SetupWizardStepStatus {
+        step: SetupWizardStep::QrzIntegration.into(),
+        complete: paired,
+        issues,
+    }
+}
+
+fn build_review_step(config: Option<&PersistedSetupConfig>) -> SetupWizardStepStatus {
+    let all_prior_complete = config.is_some()
+        && config
+            .and_then(PersistedSetupConfig::log_file_path)
+            .is_some()
+        && config.is_some_and(|c| c.station_profile_count() > 0)
+        && config
+            .and_then(PersistedSetupConfig::active_station_profile_id)
+            .is_some();
+    let issues = if all_prior_complete {
+        Vec::new()
+    } else {
+        vec!["Complete the previous steps before reviewing.".to_string()]
+    };
+    SetupWizardStepStatus {
+        step: SetupWizardStep::Review.into(),
+        complete: all_prior_complete,
+        issues,
+    }
+}
+
+fn validate_step(
+    step: SetupWizardStep,
+    request: &ValidateSetupStepRequest,
+) -> ValidateSetupStepResponse {
+    match step {
+        SetupWizardStep::LogFile => validate_log_file_step(request),
+        SetupWizardStep::StationProfiles => validate_station_profiles_step(request),
+        SetupWizardStep::QrzIntegration => validate_qrz_step(request),
+        SetupWizardStep::Review | SetupWizardStep::Unspecified => ValidateSetupStepResponse {
+            valid: true,
+            fields: Vec::new(),
+        },
+    }
+}
+
+fn validate_log_file_step(request: &ValidateSetupStepRequest) -> ValidateSetupStepResponse {
+    let path = normalize_optional_string(request.log_file_path.as_deref());
+    let (valid, message) = match &path {
+        Some(p) => {
+            let parent = Path::new(p.as_str()).parent();
+            match parent {
+                Some(d) if !d.as_os_str().is_empty() && !d.exists() => (
+                    false,
+                    format!("Parent directory '{}' does not exist.", d.display()),
+                ),
+                _ => (true, String::new()),
+            }
+        }
+        None => (false, "A log file path is required.".to_string()),
+    };
+    ValidateSetupStepResponse {
+        valid,
+        fields: vec![SetupFieldValidation {
+            field: "log_file_path".to_string(),
+            valid,
+            message,
+        }],
+    }
+}
+
+fn validate_station_profiles_step(request: &ValidateSetupStepRequest) -> ValidateSetupStepResponse {
+    let profile = request.station_profile.as_ref();
+    let mut fields = Vec::new();
+
+    let callsign_valid = profile
+        .and_then(|p| normalize_optional_string(Some(p.station_callsign.as_str())))
+        .is_some();
+    fields.push(SetupFieldValidation {
+        field: "station_callsign".to_string(),
+        valid: callsign_valid,
+        message: if callsign_valid {
+            String::new()
+        } else {
+            "Station callsign is required.".to_string()
+        },
+    });
+
+    let name_valid = profile
+        .and_then(|p| normalize_optional_string(p.profile_name.as_deref()))
+        .is_some();
+    fields.push(SetupFieldValidation {
+        field: "profile_name".to_string(),
+        valid: name_valid,
+        message: if name_valid {
+            String::new()
+        } else {
+            "Profile name is required.".to_string()
+        },
+    });
+
+    let operator_valid = profile
+        .and_then(|p| normalize_optional_string(p.operator_callsign.as_deref()))
+        .is_some();
+    fields.push(SetupFieldValidation {
+        field: "operator_callsign".to_string(),
+        valid: operator_valid,
+        message: if operator_valid {
+            String::new()
+        } else {
+            "Operator callsign is required.".to_string()
+        },
+    });
+
+    let grid_valid = profile
+        .and_then(|p| normalize_optional_string(p.grid.as_deref()))
+        .is_some();
+    fields.push(SetupFieldValidation {
+        field: "grid".to_string(),
+        valid: grid_valid,
+        message: if grid_valid {
+            String::new()
+        } else {
+            "Grid square is required.".to_string()
+        },
+    });
+
+    let all_valid = callsign_valid && name_valid && operator_valid && grid_valid;
+    ValidateSetupStepResponse {
+        valid: all_valid,
+        fields,
+    }
+}
+
+fn validate_qrz_step(request: &ValidateSetupStepRequest) -> ValidateSetupStepResponse {
+    let username = normalize_optional_string(request.qrz_xml_username.as_deref());
+    let password = normalize_optional_string(request.qrz_xml_password.as_deref());
+    let mut fields = Vec::new();
+
+    // Both or neither must be set — absent is valid (skip QRZ).
+    let paired = username.is_some() == password.is_some();
+
+    fields.push(SetupFieldValidation {
+        field: "qrz_xml_username".to_string(),
+        valid: paired || username.is_some(),
+        message: if !paired && username.is_none() {
+            "Username is required when password is set.".to_string()
+        } else {
+            String::new()
+        },
+    });
+
+    fields.push(SetupFieldValidation {
+        field: "qrz_xml_password".to_string(),
+        valid: paired || password.is_some(),
+        message: if !paired && password.is_none() {
+            "Password is required when username is set.".to_string()
+        } else {
+            String::new()
+        },
+    });
+
+    ValidateSetupStepResponse {
+        valid: paired,
+        fields,
+    }
+}
+
+async fn test_qrz_login(
+    username: &str,
+    password: &str,
+    runtime_config: &RuntimeConfigManager,
+) -> TestQrzCredentialsResponse {
+    let username = username.trim();
+    let password = password.trim();
+
+    if username.is_empty() || password.is_empty() {
+        return TestQrzCredentialsResponse {
+            success: false,
+            error_message: "Username and password are both required.".to_string(),
+        };
+    }
+
+    // Build a temporary QRZ config using the test credentials plus the current
+    // runtime user-agent setting (required by QRZ to identify clients).
+    let effective = runtime_config.effective_values().await;
+    let user_agent = effective
+        .get(QRZ_USER_AGENT_ENV_VAR)
+        .cloned()
+        .unwrap_or_else(|| format!("QsoRipper/0.1.0 ({username})"));
+
+    let config = QrzXmlConfig::from_value_provider(|name| match name {
+        n if n == QRZ_XML_USERNAME_ENV_VAR => Some(username.to_string()),
+        n if n == QRZ_XML_PASSWORD_ENV_VAR => Some(password.to_string()),
+        n if n == QRZ_USER_AGENT_ENV_VAR => Some(user_agent.clone()),
+        _ => effective.get(name).cloned(),
+    });
+
+    let config = match config {
+        Ok(c) => c,
+        Err(error) => {
+            return TestQrzCredentialsResponse {
+                success: false,
+                error_message: format!("Invalid QRZ configuration: {error}"),
+            };
+        }
+    };
+
+    let provider = match QrzXmlProvider::new(config) {
+        Ok(p) => p,
+        Err(error) => {
+            return TestQrzCredentialsResponse {
+                success: false,
+                error_message: format!("Failed to create QRZ provider: {error}"),
+            };
+        }
+    };
+
+    match provider.test_login().await {
+        Ok(()) => TestQrzCredentialsResponse {
+            success: true,
+            error_message: String::new(),
+        },
+        Err(error) => TestQrzCredentialsResponse {
+            success: false,
+            error_message: format!("{error}"),
+        },
+    }
 }
 
 fn normalize_optional_string(value: Option<&str>) -> Option<String> {
@@ -1139,7 +1481,12 @@ fn generate_profile_id(
 }
 
 #[cfg(test)]
-#[allow(clippy::expect_used, clippy::unwrap_used)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    deprecated
+)]
 mod tests {
     use std::collections::BTreeMap;
     use std::fs;
@@ -1149,16 +1496,20 @@ mod tests {
     use tonic::Request;
 
     use super::{
-        default_config_path, suggested_log_file_path, PersistedSetupConfig, SetupControlSurface,
-        SetupState, StationProfileControlSurface, DEFAULT_CONFIG_FILE_NAME,
+        build_log_file_step, build_qrz_integration_step, build_review_step,
+        build_station_profiles_step, build_wizard_steps, default_config_path,
+        suggested_log_file_path, validate_log_file_step, validate_qrz_step,
+        validate_station_profiles_step, PersistedSetupConfig, SetupControlSurface, SetupState,
+        StationProfileControlSurface, DEFAULT_CONFIG_FILE_NAME,
     };
     use crate::runtime_config::RuntimeConfigManager;
     use qsoripper_core::proto::qsoripper::domain::StationProfile;
     use qsoripper_core::proto::qsoripper::services::{
         setup_service_server::SetupService, station_profile_service_server::StationProfileService,
-        GetActiveStationContextRequest, GetSetupStatusRequest, ListStationProfilesRequest,
-        SaveSetupRequest, SaveStationProfileRequest, SetActiveStationProfileRequest,
-        SetSessionStationProfileOverrideRequest, StorageBackend,
+        GetActiveStationContextRequest, GetSetupStatusRequest, GetSetupWizardStateRequest,
+        ListStationProfilesRequest, SaveSetupRequest, SaveStationProfileRequest,
+        SetActiveStationProfileRequest, SetSessionStationProfileOverrideRequest, SetupWizardStep,
+        StorageBackend, ValidateSetupStepRequest,
     };
 
     fn unique_config_path() -> std::path::PathBuf {
@@ -1653,5 +2004,355 @@ station_callsign = "K7RND"
             Some(DEFAULT_CONFIG_FILE_NAME),
             path.file_name().and_then(|name| name.to_str())
         );
+    }
+
+    // ── Wizard step builder tests ───────────────────────────────────────────
+
+    #[test]
+    fn build_wizard_steps_none_config_yields_four_steps() {
+        let steps = build_wizard_steps(None);
+        assert_eq!(4, steps.len());
+        assert_eq!(i32::from(SetupWizardStep::LogFile), steps[0].step);
+        assert_eq!(i32::from(SetupWizardStep::StationProfiles), steps[1].step);
+        assert_eq!(i32::from(SetupWizardStep::QrzIntegration), steps[2].step);
+        assert_eq!(i32::from(SetupWizardStep::Review), steps[3].step);
+    }
+
+    #[test]
+    fn log_file_step_incomplete_when_no_config() {
+        let step = build_log_file_step(None);
+        assert!(!step.complete);
+        assert!(!step.issues.is_empty());
+    }
+
+    #[test]
+    fn log_file_step_complete_when_log_file_set() {
+        let mut config = PersistedSetupConfig::default();
+        config.logbook.file_path = Some("/tmp/test.db".to_string());
+        let step = build_log_file_step(Some(&config));
+        assert!(step.complete);
+        assert!(step.issues.is_empty());
+    }
+
+    #[test]
+    fn station_profiles_step_incomplete_when_no_profiles() {
+        let step = build_station_profiles_step(None);
+        assert!(!step.complete);
+        assert!(step.issues.iter().any(|i| i.contains("At least one")));
+    }
+
+    #[test]
+    fn station_profiles_step_incomplete_without_active_profile() {
+        // The catalog falls back to the first entry when no explicit active ID is set,
+        // so we must also verify that having no entries at all is incomplete.
+        let config = PersistedSetupConfig::default();
+        let step = build_station_profiles_step(Some(&config));
+        assert!(!step.complete);
+        assert!(step.issues.iter().any(|i| i.contains("At least one")));
+    }
+
+    #[test]
+    fn station_profiles_step_complete_with_active_profile() {
+        let mut config = PersistedSetupConfig::default();
+        config
+            .station_profiles
+            .entries
+            .push(super::PersistedStationProfileEntry {
+                profile_id: "home".to_string(),
+                profile: super::PersistedStationProfile {
+                    profile_name: Some("Home".to_string()),
+                    station_callsign: Some("K7RND".to_string()),
+                    ..Default::default()
+                },
+            });
+        config.station_profiles.active_profile_id = Some("home".to_string());
+        let step = build_station_profiles_step(Some(&config));
+        assert!(step.complete);
+        assert!(step.issues.is_empty());
+    }
+
+    #[test]
+    fn qrz_step_complete_when_both_absent() {
+        let step = build_qrz_integration_step(None);
+        assert!(step.complete);
+        assert!(step.issues.is_empty());
+    }
+
+    #[test]
+    fn qrz_step_complete_when_both_present() {
+        let mut config = PersistedSetupConfig::default();
+        config.qrz_xml.username = Some("user".to_string());
+        config.qrz_xml.password = Some("pass".to_string());
+        let step = build_qrz_integration_step(Some(&config));
+        assert!(step.complete);
+        assert!(step.issues.is_empty());
+    }
+
+    #[test]
+    fn qrz_step_incomplete_when_only_username() {
+        let mut config = PersistedSetupConfig::default();
+        config.qrz_xml.username = Some("user".to_string());
+        let step = build_qrz_integration_step(Some(&config));
+        assert!(!step.complete);
+        assert!(!step.issues.is_empty());
+    }
+
+    #[test]
+    fn review_step_incomplete_when_prior_steps_incomplete() {
+        let step = build_review_step(None);
+        assert!(!step.complete);
+    }
+
+    #[test]
+    fn review_step_complete_when_all_prior_complete() {
+        let mut config = PersistedSetupConfig::default();
+        config.logbook.file_path = Some("/tmp/test.db".to_string());
+        config
+            .station_profiles
+            .entries
+            .push(super::PersistedStationProfileEntry {
+                profile_id: "home".to_string(),
+                profile: super::PersistedStationProfile {
+                    profile_name: Some("Home".to_string()),
+                    station_callsign: Some("K7RND".to_string()),
+                    ..Default::default()
+                },
+            });
+        config.station_profiles.active_profile_id = Some("home".to_string());
+        let step = build_review_step(Some(&config));
+        assert!(step.complete);
+        assert!(step.issues.is_empty());
+    }
+
+    // ── Validation tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn validate_log_file_step_rejects_empty_path() {
+        let request = ValidateSetupStepRequest {
+            step: SetupWizardStep::LogFile.into(),
+            log_file_path: None,
+            ..Default::default()
+        };
+        let result = validate_log_file_step(&request);
+        assert!(!result.valid);
+        assert_eq!(1, result.fields.len());
+        assert!(!result.fields[0].valid);
+    }
+
+    #[test]
+    fn validate_log_file_step_accepts_valid_path() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("test-validate.db");
+        let request = ValidateSetupStepRequest {
+            step: SetupWizardStep::LogFile.into(),
+            log_file_path: Some(path.display().to_string()),
+            ..Default::default()
+        };
+        let result = validate_log_file_step(&request);
+        assert!(result.valid);
+        assert!(result.fields[0].valid);
+    }
+
+    #[test]
+    fn validate_station_profiles_rejects_empty_profile() {
+        let request = ValidateSetupStepRequest {
+            step: SetupWizardStep::StationProfiles.into(),
+            station_profile: Some(StationProfile::default()),
+            ..Default::default()
+        };
+        let result = validate_station_profiles_step(&request);
+        assert!(!result.valid);
+        assert_eq!(4, result.fields.len());
+    }
+
+    #[test]
+    fn validate_station_profiles_accepts_complete_profile() {
+        let request = ValidateSetupStepRequest {
+            step: SetupWizardStep::StationProfiles.into(),
+            station_profile: Some(StationProfile {
+                profile_name: Some("Home".to_string()),
+                station_callsign: "K7RND".to_string(),
+                operator_callsign: Some("K7RND".to_string()),
+                grid: Some("CN87".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let result = validate_station_profiles_step(&request);
+        assert!(result.valid);
+        assert!(result.fields.iter().all(|f| f.valid));
+    }
+
+    #[test]
+    fn validate_qrz_step_accepts_both_absent() {
+        let request = ValidateSetupStepRequest {
+            step: SetupWizardStep::QrzIntegration.into(),
+            ..Default::default()
+        };
+        let result = validate_qrz_step(&request);
+        assert!(result.valid);
+    }
+
+    #[test]
+    fn validate_qrz_step_accepts_both_present() {
+        let request = ValidateSetupStepRequest {
+            step: SetupWizardStep::QrzIntegration.into(),
+            qrz_xml_username: Some("user".to_string()),
+            qrz_xml_password: Some("pass".to_string()),
+            ..Default::default()
+        };
+        let result = validate_qrz_step(&request);
+        assert!(result.valid);
+    }
+
+    #[test]
+    fn validate_qrz_step_rejects_partial_credentials() {
+        let request = ValidateSetupStepRequest {
+            step: SetupWizardStep::QrzIntegration.into(),
+            qrz_xml_username: Some("user".to_string()),
+            qrz_xml_password: None,
+            ..Default::default()
+        };
+        let result = validate_qrz_step(&request);
+        assert!(!result.valid);
+    }
+
+    // ── is_first_run tests ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn is_first_run_true_when_no_config() {
+        let config_path = unique_config_path();
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state, runtime_config);
+
+        let status =
+            SetupService::get_setup_status(&service, Request::new(GetSetupStatusRequest {}))
+                .await
+                .expect("status")
+                .into_inner()
+                .status
+                .expect("status payload");
+
+        assert!(status.is_first_run);
+    }
+
+    #[tokio::test]
+    async fn is_first_run_false_after_save() {
+        let config_path = unique_config_path();
+        let config_directory = config_path.parent().expect("config directory");
+        fs::create_dir_all(config_directory).expect("create config directory");
+
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state, runtime_config);
+
+        let log_file = absolute_log_file_path(&config_path, "test.db");
+        SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file),
+                station_profile: Some(StationProfile {
+                    profile_name: Some("Home".to_string()),
+                    station_callsign: "K7RND".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("save setup");
+
+        let status =
+            SetupService::get_setup_status(&service, Request::new(GetSetupStatusRequest {}))
+                .await
+                .expect("status")
+                .into_inner()
+                .status
+                .expect("status payload");
+
+        assert!(!status.is_first_run);
+
+        drop(service);
+        let _ = fs::remove_dir_all(config_directory);
+    }
+
+    // ── GetSetupWizardState RPC test ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_wizard_state_returns_steps_and_status() {
+        let config_path = unique_config_path();
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state, runtime_config);
+
+        let response = SetupService::get_setup_wizard_state(
+            &service,
+            Request::new(GetSetupWizardStateRequest {}),
+        )
+        .await
+        .expect("wizard state")
+        .into_inner();
+
+        assert!(response.status.is_some());
+        assert_eq!(4, response.steps.len());
+        assert!(response.station_profiles.is_empty());
+
+        // For a fresh config, LogFile should be incomplete
+        let log_step = &response.steps[0];
+        assert_eq!(i32::from(SetupWizardStep::LogFile), log_step.step);
+        assert!(!log_step.complete);
+    }
+
+    // ── ValidateSetupStep RPC test ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn validate_step_rpc_validates_log_file() {
+        let config_path = unique_config_path();
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state, runtime_config);
+
+        let dir = std::env::temp_dir();
+        let path = dir.join("validate-rpc-test.db");
+        let response = SetupService::validate_setup_step(
+            &service,
+            Request::new(ValidateSetupStepRequest {
+                step: SetupWizardStep::LogFile.into(),
+                log_file_path: Some(path.display().to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("validate")
+        .into_inner();
+
+        assert!(response.valid);
+    }
+
+    // ── TestQrzCredentials RPC test (empty creds) ───────────────────────────
+
+    #[tokio::test]
+    async fn test_qrz_credentials_rejects_empty() {
+        let config_path = unique_config_path();
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state, runtime_config);
+
+        let response = SetupService::test_qrz_credentials(
+            &service,
+            Request::new(
+                qsoripper_core::proto::qsoripper::services::TestQrzCredentialsRequest {
+                    qrz_xml_username: String::new(),
+                    qrz_xml_password: String::new(),
+                },
+            ),
+        )
+        .await
+        .expect("test qrz")
+        .into_inner();
+
+        assert!(!response.success);
+        assert!(!response.error_message.is_empty());
     }
 }


### PR DESCRIPTION
## Summary

Adds a first-run setup wizard to QsoRipper in two layers:

1. **Engine foundation (Phase 1)** — new gRPC RPCs and Rust handlers for wizard state, per-step validation, and QRZ credential testing
2. **CLI interactive wizard (Phase 2)** — guided step-by-step setup via `qsoripper setup`

Closes #7 (Phases 1–2)

## What's new

### Proto contracts (9 new files, 3 modified)

- `SetupWizardStep` enum (LogFile, StationProfiles, QrzIntegration, Review)
- `GetSetupWizardState` RPC — assembles current wizard state from persisted config
- `ValidateSetupStep` RPC — per-step field validation with structured error messages
- `TestQrzCredentials` RPC — live QRZ login test without persisting credentials
- Deprecated legacy fields in `SetupStatus` and `SaveSetupRequest`
- Added `is_first_run` to `SetupStatus`

### Rust engine

- Wizard state builder reads persisted config and computes per-step completion
- Step validators for log file (writable directory check), station profiles (required fields), and QRZ credentials (format + live test)
- `test_login()` on `QrzXmlProvider` for credential testing without side effects
- `effective_values()` on `RuntimeConfigManager` for merged config access
- 23 new unit tests (178 total Rust tests passing)

### CLI wizard (3 modes)

```powershell
qsoripper setup              # Interactive 4-step wizard
qsoripper setup --status     # Read-only status check
qsoripper setup --from-env   # Headless setup from environment variables
```

Interactive wizard walks through:
1. Log file path (validates writable directory)
2. Station profile (callsign required, grid/name/qth optional)
3. QRZ integration (optional, with inline credential testing)
4. Review & save

### Tests

- 20 new .NET tests (PromptField, PromptYesNo, CLI flag parsing)
- 23 new Rust tests (wizard state, step validation, QRZ test)
- All quality gates green: `buf lint`, `cargo fmt/clippy/test`, `dotnet format/build/test`

## How to test locally

Start the engine, then run the CLI wizard:

```powershell
# Terminal 1 — start engine
cargo run --manifest-path src\rust\Cargo.toml -p qsoripper-server

# Terminal 2 — run wizard
dotnet run --project src\dotnet\QsoRipper.Cli -- setup

# Or check status only
dotnet run --project src\dotnet\QsoRipper.Cli -- setup --status

# Or headless from env
$env:QSORIPPER_STATION_CALLSIGN = "W1AW"
dotnet run --project src\dotnet\QsoRipper.Cli -- setup --from-env
```
