### PR TITLE
Expand DebugHost logbook interop tools

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -38,6 +38,7 @@ Primary goals:
 - Use `buf lint` to validate proto files. Use `buf breaking` to guard against incompatible schema changes.
 - ADIF is for external interchange (QRZ API, file I/O) only — internal IPC uses protobuf.
 - Keep shared proto messages discoverable in the Debug Host Protobuf Lab; prefer auto-discovered message catalogs over hand-maintained UI enums or lists.
+- In .NET UI and DebugHost surfaces, do not hand-format generated proto enum names with `ToString()`/string replacement. Use shared display helpers such as `src/dotnet/QsoRipper.DebugHost/Utilities/ProtoEnumDisplay.cs` so labels stay aligned with protobuf original names.
 - See `docs/architecture/data-model.md` for full conventions.
 
 ## Domain Guidance

--- a/.github/instructions/proto-contract.instructions.md
+++ b/.github/instructions/proto-contract.instructions.md
@@ -33,6 +33,7 @@ These instructions govern schema and gRPC contract work in `proto/` and any Rust
 - .NET clients consume the same contracts through generated gRPC client code under `src/dotnet/`.
 - If a proto change affects logbook or lookup semantics, update both Rust server-side handling and the .NET debugging/client surfaces in the same change when practical.
 - Shared contract visibility in `src/dotnet/QsoRipper.DebugHost` is part of the .NET client surface. Keep `/protobuf-lab` able to inspect generated message shapes for shared proto messages, and prefer automatic discovery over hand-maintained message lists.
+- Treat generated enum/member names as transport artifacts, not UI labels. In .NET UI and DebugHost code, do not derive band/mode/enum display text from raw generated `ToString()` output; route it through shared helpers such as `src/dotnet/QsoRipper.DebugHost/Utilities/ProtoEnumDisplay.cs`.
 - When a new shared message needs richer example data than the default constructor provides, extend the custom builder path in `src/dotnet/QsoRipper.DebugHost/Services/SampleProtoFactory.cs` instead of adding another manual UI registry.
 
 ## Validation

--- a/.github/instructions/ui-ux.instructions.md
+++ b/.github/instructions/ui-ux.instructions.md
@@ -9,6 +9,7 @@ Design for keyboard-first operation with fast operator feedback.
 - Make form navigation efficient for rapid QSO entry.
 - Use consistent keymaps across TUI and GUI where practical.
 - Surface validation errors clearly and immediately.
+- For labels sourced from shared proto enums (for example band/mode in DebugHost), use shared display helpers rather than page-local string munging of generated enum names.
 
 ## Workflow Focus
 

--- a/src/dotnet/QsoRipper.DebugHost.Tests/EditorModelTests.cs
+++ b/src/dotnet/QsoRipper.DebugHost.Tests/EditorModelTests.cs
@@ -129,6 +129,48 @@ public class EditorModelTests
         Assert.Contains(results, result => result.MemberNames.Contains(nameof(StationProfileEditorModel.ItuZone), StringComparer.Ordinal));
     }
 
+    [Fact]
+    public void AdifExportEditorModel_to_request_trims_values_and_parses_utc_filters()
+    {
+        var model = new AdifExportEditorModel
+        {
+            AfterUtc = " 2026-04-10T00:00:00Z ",
+            BeforeUtc = "2026-04-11T12:30:00Z",
+            ContestId = "  ARRL-DX-SSB  ",
+            IncludeHeader = true
+        };
+
+        var request = model.ToRequest();
+
+        Assert.True(request.IncludeHeader);
+        Assert.NotNull(request.After);
+        Assert.NotNull(request.Before);
+        Assert.Equal("ARRL-DX-SSB", request.ContestId);
+    }
+
+    [Fact]
+    public void AdifExportEditorModel_validate_rejects_invalid_and_reversed_ranges()
+    {
+        var invalid = new AdifExportEditorModel
+        {
+            AfterUtc = "not-a-time"
+        };
+
+        var invalidResults = Validate(invalid);
+
+        Assert.Contains(invalidResults, result => result.MemberNames.Contains(nameof(AdifExportEditorModel.AfterUtc), StringComparer.Ordinal));
+
+        var reversed = new AdifExportEditorModel
+        {
+            AfterUtc = "2026-04-12T00:00:00Z",
+            BeforeUtc = "2026-04-11T00:00:00Z"
+        };
+
+        var reversedResults = Validate(reversed);
+
+        Assert.Contains(reversedResults, result => result.MemberNames.Contains(nameof(AdifExportEditorModel.BeforeUtc), StringComparer.Ordinal));
+    }
+
     private static List<ValidationResult> Validate(object model)
     {
         var results = new List<ValidationResult>();

--- a/src/dotnet/QsoRipper.DebugHost.Tests/LogbookInteropWorkbenchServiceTests.cs
+++ b/src/dotnet/QsoRipper.DebugHost.Tests/LogbookInteropWorkbenchServiceTests.cs
@@ -1,0 +1,67 @@
+using QsoRipper.DebugHost.Models;
+using QsoRipper.DebugHost.Services;
+using QsoRipper.Domain;
+using QsoRipper.Services;
+
+namespace QsoRipper.DebugHost.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+public class LogbookInteropWorkbenchServiceTests
+{
+    [Fact]
+    public async Task CreateImportRequestsAsync_splits_stream_and_sets_refresh_only_on_first_chunk()
+    {
+        var bytes = Enumerable.Range(0, 131077).Select(static i => (byte)(i % 251)).ToArray();
+        await using var stream = new MemoryStream(bytes);
+
+        var requests = new List<ImportAdifRequest>();
+        await foreach (var request in LogbookInteropWorkbenchService.CreateImportRequestsAsync(stream, refresh: true))
+        {
+            requests.Add(request);
+        }
+
+        Assert.Equal(3, requests.Count);
+        Assert.True(requests[0].Refresh);
+        Assert.False(requests[1].Refresh);
+        Assert.False(requests[2].Refresh);
+        Assert.Equal(65536, requests[0].Chunk!.Data.Length);
+        Assert.Equal(65536, requests[1].Chunk!.Data.Length);
+        Assert.Equal(5, requests[2].Chunk!.Data.Length);
+
+        var reconstructed = requests
+            .SelectMany(static request => request.Chunk!.Data.ToByteArray())
+            .ToArray();
+        Assert.Equal(bytes, reconstructed);
+    }
+
+    [Theory]
+    [InlineData("", 0)]
+    [InlineData("<EOH>\n", 0)]
+    [InlineData("<CALL:4>W1AW<EOR>", 1)]
+    [InlineData("<CALL:4>W1AW<eor>\n<CALL:4>K7RND<EOr>", 2)]
+    public void CountAdifRecords_counts_case_insensitive_end_of_record_markers(string payload, int expected)
+    {
+        Assert.Equal(expected, LogbookInteropWorkbenchService.CountAdifRecords(payload));
+    }
+
+    [Fact]
+    public void BuildUpdatedQso_preserves_identity_and_sets_verification_comment()
+    {
+        var original = new QsoRecord
+        {
+            LocalId = "local-123",
+            WorkedCallsign = "W1AW",
+            Band = Band._20M,
+            Mode = Mode.Ssb,
+            Comment = "Original"
+        };
+
+        var updated = StorageWorkbenchService.BuildUpdatedQso(original);
+
+        Assert.NotSame(original, updated);
+        Assert.Equal("local-123", updated.LocalId);
+        Assert.Equal("Original", original.Comment);
+        Assert.StartsWith("DebugHost storage smoke update ", updated.Comment, StringComparison.Ordinal);
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.DebugHost.Tests/ProtoEnumDisplayTests.cs
+++ b/src/dotnet/QsoRipper.DebugHost.Tests/ProtoEnumDisplayTests.cs
@@ -1,0 +1,21 @@
+using QsoRipper.DebugHost.Utilities;
+using QsoRipper.Domain;
+
+namespace QsoRipper.DebugHost.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+public class ProtoEnumDisplayTests
+{
+    [Fact]
+    public void ForBand_uses_original_proto_name_without_leading_period()
+    {
+        Assert.Equal("40M", ProtoEnumDisplay.ForBand(Band._40M));
+    }
+
+    [Fact]
+    public void ForMode_uses_original_proto_name()
+    {
+        Assert.Equal("FT8", ProtoEnumDisplay.ForMode(Mode.Ft8));
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.DebugHost/Components/Layout/NavMenu.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Layout/NavMenu.razor
@@ -40,6 +40,12 @@
         </div>
 
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="logbook-interop">
+                ADIF &amp; Sync
+            </NavLink>
+        </div>
+
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="qso-viewer">
                 QSO Viewer
             </NavLink>

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/Home.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/Home.razor
@@ -57,6 +57,24 @@
     <div class="col-md-6 col-xl-3">
         <div class="card h-100 shadow-sm">
             <div class="card-body">
+                <h2 class="h5">ADIF &amp; Sync</h2>
+                <p class="text-muted">Import/export ADIF, run QRZ logbook sync, and inspect streamed interop/status payloads through the live logbook service.</p>
+                <a class="btn btn-primary" href="logbook-interop">Open ADIF &amp; sync tools</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6 col-xl-3">
+        <div class="card h-100 shadow-sm">
+            <div class="card-body">
+                <h2 class="h5">QSO Viewer</h2>
+                <p class="text-muted">Inspect stored QSOs through the shared gRPC surface with filters and side-by-side record detail output.</p>
+                <a class="btn btn-primary" href="qso-viewer">Open QSO viewer</a>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-6 col-xl-3">
+        <div class="card h-100 shadow-sm">
+            <div class="card-body">
                 <h2 class="h5">Commands & Tests</h2>
                 <p class="text-muted">Run curated Rust/.NET validation commands from an allowlisted catalog and capture their output.</p>
                 <a class="btn btn-primary" href="commands">Open command runner</a>
@@ -72,7 +90,7 @@
             <li>A permanent Blazor Server host under <code>src/dotnet/</code>.</li>
             <li>Real C# protobuf and gRPC client generation from the shared <code>proto/</code> contracts.</li>
             <li>Developer tooling that stays on the engine boundary instead of recreating business logic in .NET.</li>
-            <li>A foundation that can absorb future QRZ, logbook, ADIF, and diagnostics workbenches.</li>
+            <li>Dedicated workbenches for runtime config, lookup, storage, ADIF interchange, and logbook sync workflows.</li>
         </ul>
     </div>
 </div>

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/LogbookInterop.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/LogbookInterop.razor
@@ -1,0 +1,581 @@
+@page "/logbook-interop"
+@using System.ComponentModel.DataAnnotations
+@using System.Text
+@using QsoRipper.Services
+@inject DebugWorkbenchState WorkbenchState
+@inject RuntimeConfigWorkbenchService RuntimeConfigWorkbenchService
+@inject LogbookInteropWorkbenchService LogbookInteropWorkbenchService
+@inject ProtoJsonService ProtoJsonService
+
+<PageTitle>ADIF & Sync Workbench</PageTitle>
+
+<h1 class="mb-3">ADIF & Sync Workbench</h1>
+<p class="text-muted">
+    Import and export ADIF, then exercise QRZ logbook sync through the live <code>LogbookService</code>
+    gRPC surface. This page fills the interop gap between the storage CRUD smoke test and the QSO viewer.
+</p>
+
+<div class="alert alert-secondary">
+    <div><strong>Current engine endpoint:</strong> @WorkbenchState.EngineEndpoint</div>
+    <div class="mt-1">
+        <strong>Active backend:</strong> @WorkbenchState.GetStorageBackendDisplayName()
+        @if (WorkbenchState.EngineStorageBackend == EngineStorageBackend.Sqlite)
+        {
+            <span> using <code>@WorkbenchState.EngineSqlitePath</code></span>
+        }
+    </div>
+    @if (WorkbenchState.RuntimeConfigSnapshot is not null)
+    {
+        <div class="mt-1">
+            <strong>Lookup provider:</strong> @WorkbenchState.RuntimeConfigSnapshot.LookupProviderSummary
+        </div>
+    }
+</div>
+
+<div class="row g-4">
+    <div class="col-xxl-6">
+        <div class="card shadow-sm h-100">
+            <div class="card-body">
+                <h2 class="h5">Import ADIF</h2>
+                <p class="text-muted small">
+                    Paste ADIF text or load a local <code>.adi</code>/<code>.adif</code> file, then stream it into
+                    <code>ImportAdif</code>. Enable refresh to merge duplicates instead of skipping them.
+                </p>
+
+                <div class="row g-3">
+                    <div class="col-lg-8">
+                        <label class="form-label" for="adif-import-file">Load local ADIF file</label>
+                        <InputFile id="adif-import-file"
+                                   OnChange="LoadImportFileAsync"
+                                   accept=".adi,.adif,text/plain" />
+                        @if (!string.IsNullOrWhiteSpace(importSourceDescription))
+                        {
+                            <div class="small text-muted mt-2">@importSourceDescription</div>
+                        }
+                    </div>
+                    <div class="col-lg-4 d-flex align-items-end">
+                        <div class="form-check mb-2">
+                            <InputCheckbox id="adif-refresh"
+                                           class="form-check-input"
+                                           @bind-Value="importRefresh" />
+                            <label class="form-check-label" for="adif-refresh">
+                                Refresh duplicates
+                            </label>
+                        </div>
+                    </div>
+                    <div class="col-12">
+                        <label class="form-label" for="adif-import-text">ADIF payload</label>
+                        <InputTextArea id="adif-import-text"
+                                       class="form-control font-monospace"
+                                       @bind-Value="importText"
+                                       rows="14" />
+                    </div>
+                    <div class="col-12 d-flex gap-2 flex-wrap">
+                        <button class="btn btn-outline-secondary"
+                                type="button"
+                                @onclick="UseLatestExportAsImport"
+                                disabled="@string.IsNullOrWhiteSpace(exportResult?.AdifText)">
+                            Use latest export
+                        </button>
+                        <button class="btn btn-outline-secondary"
+                                type="button"
+                                @onclick="ClearImport">
+                            Clear
+                        </button>
+                        <button class="btn btn-primary"
+                                type="button"
+                                @onclick="RunImportAsync"
+                                disabled="@isImporting">
+                            @(isImporting ? "Importing..." : "Import ADIF")
+                        </button>
+                    </div>
+                </div>
+
+                @if (!string.IsNullOrWhiteSpace(importErrorMessage))
+                {
+                    <div class="alert alert-danger mt-3 mb-0">@importErrorMessage</div>
+                }
+            </div>
+        </div>
+    </div>
+
+    <div class="col-xxl-6">
+        <div class="card shadow-sm h-100">
+            <div class="card-body">
+                <h2 class="h5">Export ADIF</h2>
+                <p class="text-muted small">
+                    Build an <code>ExportAdifRequest</code>, stream the raw ADIF payload back from the engine, and
+                    inspect the reconstructed text side-by-side with the request envelope.
+                </p>
+
+                <div class="row g-3 align-items-end">
+                    <div class="col-md-6">
+                        <label class="form-label" for="adif-after">After (UTC / ISO-8601)</label>
+                        <InputText id="adif-after"
+                                   class="form-control"
+                                   @bind-Value="exportModel.AfterUtc"
+                                   placeholder="2026-04-13T00:00:00Z" />
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label" for="adif-before">Before (UTC / ISO-8601)</label>
+                        <InputText id="adif-before"
+                                   class="form-control"
+                                   @bind-Value="exportModel.BeforeUtc"
+                                   placeholder="2026-04-13T23:59:59Z" />
+                    </div>
+                    <div class="col-md-8">
+                        <label class="form-label" for="adif-contest">Contest ID</label>
+                        <InputText id="adif-contest"
+                                   class="form-control"
+                                   @bind-Value="exportModel.ContestId"
+                                   placeholder="ARRL-DX-SSB" />
+                    </div>
+                    <div class="col-md-4 d-flex align-items-end">
+                        <div class="form-check mb-2">
+                            <InputCheckbox id="adif-header"
+                                           class="form-check-input"
+                                           @bind-Value="exportModel.IncludeHeader" />
+                            <label class="form-check-label" for="adif-header">
+                                Include ADIF header
+                            </label>
+                        </div>
+                    </div>
+                    <div class="col-12 d-flex gap-2 flex-wrap">
+                        <button class="btn btn-outline-primary"
+                                type="button"
+                                @onclick="PreviewExportRequest">
+                            Preview request
+                        </button>
+                        <button class="btn btn-primary"
+                                type="button"
+                                @onclick="RunExportAsync"
+                                disabled="@isExporting">
+                            @(isExporting ? "Exporting..." : "Export ADIF")
+                        </button>
+                    </div>
+                </div>
+
+                @if (!string.IsNullOrWhiteSpace(exportErrorMessage))
+                {
+                    <div class="alert alert-danger mt-3 mb-0">@exportErrorMessage</div>
+                }
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="row g-4 mt-1">
+    <div class="col-xl-6">
+        <PayloadCard Title="Export request payload"
+                     Payload="@exportRequestPayload.Json" />
+    </div>
+    @if (importResult is not null)
+    {
+        <div class="col-xl-6">
+            <PayloadCard Title="Import summary"
+                         BadgeText="@(importResult.Succeeded ? "Completed" : "Failed")"
+                         Payload="@BuildImportSummary(importResult)" />
+        </div>
+        @if (importResponsePayload is not null)
+        {
+            <div class="col-xl-6">
+                <PayloadCard Title="ImportAdif response"
+                             Payload="@importResponsePayload.Json" />
+            </div>
+        }
+        @if (importResult.WarningCount > 0)
+        {
+            <div class="col-xl-6">
+                <div class="card shadow-sm h-100">
+                    <div class="card-body">
+                        <h2 class="h5">Import warnings</h2>
+                        <ul class="mb-0">
+                            @foreach (var warning in importResult.Response!.Warnings)
+                            {
+                                <li>@warning</li>
+                            }
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        }
+    }
+    @if (exportResult is not null)
+    {
+        <div class="col-xl-6">
+            <PayloadCard Title="Export summary"
+                         BadgeText="@($"{exportResult.RecordCountEstimate} record(s)")"
+                         Payload="@BuildExportSummary(exportResult)" />
+        </div>
+        <div class="col-12">
+            <PayloadCard Title="Exported ADIF"
+                         BadgeText="@($"{exportResult.ByteCount:N0} bytes")"
+                         Payload="@GetExportPayload(exportResult)" />
+        </div>
+    }
+</div>
+
+<div class="card shadow-sm mt-4">
+    <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3 gap-3 flex-wrap">
+            <div>
+                <h2 class="h5 mb-1">QRZ sync</h2>
+                <div class="small text-muted">
+                    Stream live <code>SyncWithQrz</code> progress frames and then refresh <code>GetSyncStatus</code>
+                    against the same endpoint.
+                </div>
+            </div>
+            <div class="d-flex gap-2 flex-wrap align-items-center">
+                <div class="form-check">
+                    <InputCheckbox id="full-sync"
+                                   class="form-check-input"
+                                   @bind-Value="fullSync" />
+                    <label class="form-check-label" for="full-sync">
+                        Full sync
+                    </label>
+                </div>
+                <button class="btn btn-outline-secondary"
+                        type="button"
+                        @onclick="RefreshSyncStatusAsync"
+                        disabled="@isSyncing">
+                    Refresh status
+                </button>
+                <button class="btn btn-primary"
+                        type="button"
+                        @onclick="RunSyncAsync"
+                        disabled="@isSyncing">
+                    @(isSyncing ? "Syncing..." : "Run QRZ sync")
+                </button>
+            </div>
+        </div>
+
+        @if (!string.IsNullOrWhiteSpace(syncErrorMessage))
+        {
+            <div class="alert alert-danger">@syncErrorMessage</div>
+        }
+
+        <div class="row g-4">
+            @if (syncStatusPayload is not null)
+            {
+                <div class="col-xl-6">
+                    <PayloadCard Title="Current sync status"
+                                 Payload="@syncStatusPayload.Json" />
+                </div>
+            }
+            @if (latestSyncPayload is not null)
+            {
+                <div class="col-xl-6">
+                    <PayloadCard Title="Latest SyncWithQrz frame"
+                                 Payload="@latestSyncPayload.Json" />
+                </div>
+            }
+        </div>
+
+        @if (syncResult is null)
+        {
+            <p class="text-muted mt-3 mb-0">
+                No QRZ sync run yet. Use this page to inspect both the streamed sync frames and the refreshed sync status envelope.
+            </p>
+        }
+        else
+        {
+            <div class="d-flex justify-content-between align-items-center mt-4 mb-2">
+                <h3 class="h6 mb-0">Sync progress</h3>
+                <span class="badge @(syncResult.Succeeded ? "text-bg-success" : "text-bg-danger")">
+                    @(syncResult.Succeeded ? "Completed" : "Failed")
+                </span>
+            </div>
+            <div class="small text-muted mb-3">
+                Completed @syncResult.CompletedAtUtc.LocalDateTime.ToString("g")
+                using @(syncResult.FullSync ? "full" : "incremental") sync mode.
+            </div>
+
+            @if (syncResult.ProgressUpdates.Count == 0)
+            {
+                <p class="text-muted mb-0">No streamed progress frames were returned.</p>
+            }
+            else
+            {
+                <div class="table-responsive">
+                    <table class="table table-sm align-middle mb-0">
+                        <thead class="table-light">
+                            <tr>
+                                <th>#</th>
+                                <th>Action</th>
+                                <th>Processed</th>
+                                <th>Uploaded</th>
+                                <th>Downloaded</th>
+                                <th>Conflicts</th>
+                                <th>Complete</th>
+                                <th>Error</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @foreach (var (update, index) in syncResult.ProgressUpdates.Select((value, i) => (value, i)))
+                            {
+                                <tr>
+                                    <td>@(index + 1)</td>
+                                    <td>@(string.IsNullOrWhiteSpace(update.CurrentAction) ? "—" : update.CurrentAction)</td>
+                                    <td>@FormatProcessed(update)</td>
+                                    <td>@update.UploadedRecords</td>
+                                    <td>@update.DownloadedRecords</td>
+                                    <td>@update.ConflictRecords</td>
+                                    <td>@(update.Complete ? "Yes" : "No")</td>
+                                    <td>@(string.IsNullOrWhiteSpace(update.Error) ? "—" : update.Error)</td>
+                                </tr>
+                            }
+                        </tbody>
+                    </table>
+                </div>
+            }
+        }
+    </div>
+</div>
+
+@code {
+    private const long MaxImportFileSizeBytes = 16 * 1024 * 1024;
+
+    private readonly AdifExportEditorModel exportModel = new();
+
+    private string importText = string.Empty;
+    private string importSourceDescription = "Pasted ADIF text";
+    private bool importRefresh;
+    private bool fullSync;
+    private bool isImporting;
+    private bool isExporting;
+    private bool isSyncing;
+    private string? importErrorMessage;
+    private string? exportErrorMessage;
+    private string? syncErrorMessage;
+    private AdifImportInvocationResult? importResult;
+    private AdifExportInvocationResult? exportResult;
+    private QrzSyncInvocationResult? syncResult;
+    private ProtoPayloadView exportRequestPayload = new("{}", string.Empty, 0);
+    private ProtoPayloadView? importResponsePayload;
+    private ProtoPayloadView? latestSyncPayload;
+    private ProtoPayloadView? syncStatusPayload;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RuntimeConfigWorkbenchService.RefreshAsync();
+        PreviewExportRequest();
+        await RefreshSyncStatusAsync();
+    }
+
+    private async Task LoadImportFileAsync(InputFileChangeEventArgs args)
+    {
+        var file = args.File;
+        if (file is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await using var input = file.OpenReadStream(MaxImportFileSizeBytes);
+            await using var buffer = new MemoryStream();
+            await input.CopyToAsync(buffer);
+            importText = Encoding.UTF8.GetString(buffer.ToArray());
+            importSourceDescription = $"{file.Name} ({buffer.Length:N0} bytes)";
+            importErrorMessage = null;
+            importResult = null;
+            importResponsePayload = null;
+        }
+        catch (IOException ex)
+        {
+            importErrorMessage = $"Could not load file: {ex.Message}";
+        }
+        catch (OperationCanceledException ex)
+        {
+            importErrorMessage = ex.Message;
+        }
+    }
+
+    private void UseLatestExportAsImport()
+    {
+        if (string.IsNullOrWhiteSpace(exportResult?.AdifText))
+        {
+            return;
+        }
+
+        importText = exportResult.AdifText;
+        importSourceDescription = $"Latest export output ({exportResult.ByteCount:N0} bytes)";
+        importErrorMessage = null;
+        importResult = null;
+        importResponsePayload = null;
+    }
+
+    private void ClearImport()
+    {
+        importText = string.Empty;
+        importSourceDescription = "Pasted ADIF text";
+        importErrorMessage = null;
+        importResult = null;
+        importResponsePayload = null;
+    }
+
+    private async Task RunImportAsync()
+    {
+        if (string.IsNullOrWhiteSpace(importText))
+        {
+            importErrorMessage = "ADIF payload is required.";
+            return;
+        }
+
+        isImporting = true;
+        try
+        {
+            importErrorMessage = null;
+            importResult = await LogbookInteropWorkbenchService.ImportAdifAsync(
+                importText,
+                importRefresh,
+                importSourceDescription);
+            importErrorMessage = importResult.ErrorMessage;
+            importResponsePayload = importResult.Response is null
+                ? null
+                : ProtoJsonService.Describe(importResult.Response);
+        }
+        finally
+        {
+            isImporting = false;
+        }
+    }
+
+    private void PreviewExportRequest()
+    {
+        if (!TryBuildExportRequest(out var request))
+        {
+            return;
+        }
+
+        exportRequestPayload = ProtoJsonService.Describe(request);
+    }
+
+    private async Task RunExportAsync()
+    {
+        if (!TryBuildExportRequest(out var request))
+        {
+            return;
+        }
+
+        isExporting = true;
+        try
+        {
+            exportErrorMessage = null;
+            exportResult = await LogbookInteropWorkbenchService.ExportAdifAsync(request);
+            exportErrorMessage = exportResult.ErrorMessage;
+        }
+        finally
+        {
+            isExporting = false;
+        }
+    }
+
+    private async Task RefreshSyncStatusAsync()
+    {
+        var (response, errorMessage) = await LogbookInteropWorkbenchService.GetSyncStatusAsync();
+        syncStatusPayload = response is null ? null : ProtoJsonService.Describe(response);
+        syncErrorMessage = errorMessage;
+    }
+
+    private async Task RunSyncAsync()
+    {
+        isSyncing = true;
+        try
+        {
+            syncErrorMessage = null;
+            syncResult = await LogbookInteropWorkbenchService.SyncWithQrzAsync(fullSync);
+            syncErrorMessage = syncResult.ErrorMessage;
+            latestSyncPayload = syncResult.LatestUpdate is null
+                ? null
+                : ProtoJsonService.Describe(syncResult.LatestUpdate);
+            syncStatusPayload = syncResult.SyncStatus is null
+                ? syncStatusPayload
+                : ProtoJsonService.Describe(syncResult.SyncStatus);
+        }
+        finally
+        {
+            isSyncing = false;
+        }
+    }
+
+    private bool TryBuildExportRequest(out ExportAdifRequest request)
+    {
+        var validationResults = new List<ValidationResult>();
+        var isValid = Validator.TryValidateObject(
+            exportModel,
+            new ValidationContext(exportModel),
+            validationResults,
+            validateAllProperties: true);
+
+        if (!isValid)
+        {
+            exportErrorMessage = string.Join(Environment.NewLine, validationResults.Select(result => result.ErrorMessage));
+            request = new ExportAdifRequest { IncludeHeader = exportModel.IncludeHeader };
+            return false;
+        }
+
+        exportErrorMessage = null;
+        request = exportModel.ToRequest();
+        return true;
+    }
+
+    private static string BuildImportSummary(AdifImportInvocationResult result)
+    {
+        var response = result.Response;
+
+        return
+            $"""
+            Source: {result.SourceDescription}
+            Refresh duplicates: {(result.Refresh ? "Yes" : "No")}
+            Bytes sent: {result.ByteCount:N0}
+            Chunks sent: {result.ChunkCount:N0}
+            Imported: {(response?.RecordsImported ?? 0)}
+            Updated: {(response?.RecordsUpdated ?? 0)}
+            Skipped: {(response?.RecordsSkipped ?? 0)}
+            Warnings: {result.WarningCount}
+            Completed: {result.CompletedAtUtc.LocalDateTime:g}
+            """;
+    }
+
+    private static string BuildExportSummary(AdifExportInvocationResult result)
+    {
+        var request = result.Request;
+
+        return
+            $"""
+            Bytes received: {result.ByteCount:N0}
+            Chunks received: {result.ChunkCount:N0}
+            Estimated records: {result.RecordCountEstimate}
+            Include header: {(request.IncludeHeader ? "Yes" : "No")}
+            Contest ID: {(string.IsNullOrWhiteSpace(request.ContestId) ? "(none)" : request.ContestId)}
+            After: {FormatTimestamp(request.After)}
+            Before: {FormatTimestamp(request.Before)}
+            Completed: {result.CompletedAtUtc.LocalDateTime:g}
+            """;
+    }
+
+    private static string GetExportPayload(AdifExportInvocationResult result)
+    {
+        return string.IsNullOrWhiteSpace(result.AdifText)
+            ? "(empty)"
+            : result.AdifText;
+    }
+
+    private static string FormatTimestamp(Timestamp? timestamp)
+    {
+        return timestamp is null
+            ? "(none)"
+            : timestamp.ToDateTime().ToLocalTime().ToString("g");
+    }
+
+    private static string FormatProcessed(SyncWithQrzResponse update)
+    {
+        if (update.TotalRecords == 0)
+        {
+            return update.ProcessedRecords.ToString();
+        }
+
+        return $"{update.ProcessedRecords}/{update.TotalRecords}";
+    }
+}

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/QsoViewer.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/QsoViewer.razor
@@ -285,19 +285,11 @@
 
     private static string FormatBand(QsoRipper.Domain.Band band)
     {
-        return band.ToString().Replace("Band", "").Replace("_", ".").ToUpperInvariant() switch
-        {
-            var s when s.StartsWith("BAND", StringComparison.Ordinal) => s[4..],
-            var s => s
-        };
+        return ProtoEnumDisplay.ForBand(band);
     }
 
     private static string FormatMode(QsoRipper.Domain.Mode mode)
     {
-        return mode.ToString().Replace("Mode", "").ToUpperInvariant() switch
-        {
-            var s when s.StartsWith("MODE", StringComparison.Ordinal) => s[4..],
-            var s => s
-        };
+        return ProtoEnumDisplay.ForMode(mode);
     }
 }

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/StorageWorkbench.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/StorageWorkbench.razor
@@ -9,7 +9,9 @@
 
 <h1 class="mb-3">Storage Workbench</h1>
 <p class="text-muted">
-    Exercise the logbook storage path against the active Rust engine endpoint. Use the engine session page to hot-apply memory or SQLite runtime overrides, then rerun the same smoke test here to compare behavior without restarting the process.
+    Exercise the logbook CRUD path against the active Rust engine endpoint. Use the engine session page to
+    hot-apply memory or SQLite runtime overrides, then rerun the same smoke test here to compare create,
+    update, read, list, sync-status, and cleanup behavior without restarting the process.
 </p>
 
 <div class="alert alert-secondary">
@@ -109,6 +111,7 @@
             <div class="mb-3">
                 <strong>Completed:</strong> @result.CompletedAtUtc.LocalDateTime.ToString("g")<br />
                 <strong>Local ID:</strong> @(result.LocalId ?? "(none)")<br />
+                <strong>Update:</strong> @(result.UpdateSucceeded ? "Updated and verified" : "Update verification failed")<br />
                 <strong>Listed matches:</strong> @result.ListedQsos.Count<br />
                 <strong>Cleanup:</strong> @(result.RetainedRecord ? "Record retained for restart testing" : result.DeleteVerified ? "Deleted and verified" : "Delete verification failed")
             </div>
@@ -130,7 +133,19 @@
                 @if (loadedPayload is not null)
                 {
                     <div class="col-xl-6">
-                        <PayloadCard Title="Loaded QSO" Payload="@loadedPayload.Json" />
+                        <PayloadCard Title="Loaded QSO before update" Payload="@loadedPayload.Json" />
+                    </div>
+                }
+                @if (updateResponsePayload is not null)
+                {
+                    <div class="col-xl-6">
+                        <PayloadCard Title="UpdateQso response" Payload="@updateResponsePayload.Json" />
+                    </div>
+                }
+                @if (updatedPayload is not null)
+                {
+                    <div class="col-xl-6">
+                        <PayloadCard Title="Updated QSO after update" Payload="@updatedPayload.Json" />
                     </div>
                 }
                 @if (loadedStationSnapshotPayload is not null)
@@ -174,6 +189,8 @@
     private ProtoPayloadView? activeStationProfilePayload;
     private ProtoPayloadView? logResponsePayload;
     private ProtoPayloadView? loadedPayload;
+    private ProtoPayloadView? updateResponsePayload;
+    private ProtoPayloadView? updatedPayload;
     private ProtoPayloadView? loadedStationSnapshotPayload;
     private ProtoPayloadView? syncStatusPayload;
     private ProtoPayloadView? deleteResponsePayload;
@@ -208,9 +225,11 @@
         result = await StorageWorkbenchService.RunSmokeTestAsync(workedCallsign, retainRecord, activeProfile);
         logResponsePayload = result.LogResponse is null ? null : ProtoJsonService.Describe(result.LogResponse);
         loadedPayload = result.LoadedResponse?.Qso is null ? null : ProtoJsonService.Describe(result.LoadedResponse.Qso);
-        loadedStationSnapshotPayload = result.LoadedResponse?.Qso?.StationSnapshot is null
+        updateResponsePayload = result.UpdateResponse is null ? null : ProtoJsonService.Describe(result.UpdateResponse);
+        updatedPayload = result.UpdatedResponse?.Qso is null ? null : ProtoJsonService.Describe(result.UpdatedResponse.Qso);
+        loadedStationSnapshotPayload = result.UpdatedResponse?.Qso?.StationSnapshot is null
             ? null
-            : ProtoJsonService.Describe(result.LoadedResponse.Qso.StationSnapshot);
+            : ProtoJsonService.Describe(result.UpdatedResponse.Qso.StationSnapshot);
         syncStatusPayload = result.SyncStatus is null ? null : ProtoJsonService.Describe(result.SyncStatus);
         deleteResponsePayload = result.DeleteResponse is null ? null : ProtoJsonService.Describe(result.DeleteResponse);
         listedPayloads = result.ListedQsos.Select(ProtoJsonService.Describe).ToList();

--- a/src/dotnet/QsoRipper.DebugHost/Models/AdifExportEditorModel.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Models/AdifExportEditorModel.cs
@@ -1,0 +1,110 @@
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Services;
+
+namespace QsoRipper.DebugHost.Models;
+
+internal sealed class AdifExportEditorModel : IValidatableObject
+{
+    public string? AfterUtc { get; set; }
+
+    public string? BeforeUtc { get; set; }
+
+    public string? ContestId { get; set; }
+
+    public bool IncludeHeader { get; set; } = true;
+
+    public ExportAdifRequest ToRequest()
+    {
+        var request = new ExportAdifRequest
+        {
+            IncludeHeader = IncludeHeader
+        };
+
+        if (TryParseTimestamp(AfterUtc, out var after))
+        {
+            request.After = after;
+        }
+
+        if (TryParseTimestamp(BeforeUtc, out var before))
+        {
+            request.Before = before;
+        }
+
+        var contestId = NormalizeOptional(ContestId);
+        if (contestId is not null)
+        {
+            request.ContestId = contestId;
+        }
+
+        return request;
+    }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        var afterRaw = NormalizeOptional(AfterUtc);
+        var beforeRaw = NormalizeOptional(BeforeUtc);
+
+        var afterParsed = afterRaw is null
+            ? null
+            : TryParseTimestamp(afterRaw, out var after)
+                ? after
+                : null;
+        if (afterRaw is not null && afterParsed is null)
+        {
+            yield return new ValidationResult(
+                "After must be a valid UTC timestamp such as 2026-04-13T00:00:00Z.",
+                [nameof(AfterUtc)]);
+        }
+
+        var beforeParsed = beforeRaw is null
+            ? null
+            : TryParseTimestamp(beforeRaw, out var before)
+                ? before
+                : null;
+        if (beforeRaw is not null && beforeParsed is null)
+        {
+            yield return new ValidationResult(
+                "Before must be a valid UTC timestamp such as 2026-04-13T23:59:59Z.",
+                [nameof(BeforeUtc)]);
+        }
+
+        if (afterParsed is not null && beforeParsed is not null && beforeParsed.ToDateTime() <= afterParsed.ToDateTime())
+        {
+            yield return new ValidationResult(
+                "Before must be later than After.",
+                [nameof(BeforeUtc)]);
+        }
+    }
+
+    private static bool TryParseTimestamp(string? raw, out Timestamp? timestamp)
+    {
+        timestamp = null;
+
+        var normalized = NormalizeOptional(raw);
+        if (normalized is null)
+        {
+            return false;
+        }
+
+        if (!DateTimeOffset.TryParse(
+                normalized,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var parsed))
+        {
+            return false;
+        }
+
+        timestamp = Timestamp.FromDateTime(parsed.UtcDateTime);
+        return true;
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value)
+            ? null
+            : value.Trim();
+    }
+}

--- a/src/dotnet/QsoRipper.DebugHost/Models/AdifExportInvocationResult.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Models/AdifExportInvocationResult.cs
@@ -1,0 +1,15 @@
+using QsoRipper.Services;
+
+namespace QsoRipper.DebugHost.Models;
+
+internal sealed record AdifExportInvocationResult(
+    ExportAdifRequest Request,
+    string AdifText,
+    int ByteCount,
+    int ChunkCount,
+    int RecordCountEstimate,
+    string? ErrorMessage,
+    DateTimeOffset CompletedAtUtc)
+{
+    public bool Succeeded => string.IsNullOrWhiteSpace(ErrorMessage);
+}

--- a/src/dotnet/QsoRipper.DebugHost/Models/AdifImportInvocationResult.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Models/AdifImportInvocationResult.cs
@@ -1,0 +1,17 @@
+using QsoRipper.Services;
+
+namespace QsoRipper.DebugHost.Models;
+
+internal sealed record AdifImportInvocationResult(
+    ImportAdifResponse? Response,
+    string SourceDescription,
+    int ByteCount,
+    int ChunkCount,
+    bool Refresh,
+    string? ErrorMessage,
+    DateTimeOffset CompletedAtUtc)
+{
+    public bool Succeeded => string.IsNullOrWhiteSpace(ErrorMessage);
+
+    public int WarningCount => Response?.Warnings.Count ?? 0;
+}

--- a/src/dotnet/QsoRipper.DebugHost/Models/QrzSyncInvocationResult.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Models/QrzSyncInvocationResult.cs
@@ -1,0 +1,15 @@
+using QsoRipper.Services;
+
+namespace QsoRipper.DebugHost.Models;
+
+internal sealed record QrzSyncInvocationResult(
+    bool FullSync,
+    IReadOnlyList<SyncWithQrzResponse> ProgressUpdates,
+    GetSyncStatusResponse? SyncStatus,
+    string? ErrorMessage,
+    DateTimeOffset CompletedAtUtc)
+{
+    public bool Succeeded => string.IsNullOrWhiteSpace(ErrorMessage);
+
+    public SyncWithQrzResponse? LatestUpdate => ProgressUpdates.Count == 0 ? null : ProgressUpdates[^1];
+}

--- a/src/dotnet/QsoRipper.DebugHost/Models/StorageSmokeTestResult.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Models/StorageSmokeTestResult.cs
@@ -7,10 +7,13 @@ internal sealed record StorageSmokeTestResult(
     QsoRecord RequestedQso,
     LogQsoResponse? LogResponse,
     GetQsoResponse? LoadedResponse,
+    UpdateQsoResponse? UpdateResponse,
+    GetQsoResponse? UpdatedResponse,
     IReadOnlyList<QsoRecord> ListedQsos,
     GetSyncStatusResponse? SyncStatus,
     DeleteQsoResponse? DeleteResponse,
     bool RetainedRecord,
+    bool UpdateVerified,
     bool DeleteVerified,
     string? ErrorMessage,
     DateTimeOffset CompletedAtUtc)
@@ -18,4 +21,6 @@ internal sealed record StorageSmokeTestResult(
     public bool Succeeded => string.IsNullOrWhiteSpace(ErrorMessage);
 
     public string? LocalId => LogResponse?.LocalId;
+
+    public bool UpdateSucceeded => UpdateResponse?.Success == true && UpdateVerified;
 }

--- a/src/dotnet/QsoRipper.DebugHost/Program.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Program.cs
@@ -18,6 +18,7 @@ builder.Services.AddScoped<GrpcClientFactory>();
 builder.Services.AddScoped<LookupWorkbenchService>();
 builder.Services.AddScoped<StorageWorkbenchService>();
 builder.Services.AddScoped<QsoViewerService>();
+builder.Services.AddScoped<LogbookInteropWorkbenchService>();
 builder.Services.AddScoped<RuntimeConfigWorkbenchService>();
 builder.Services.AddScoped<SetupWorkbenchService>();
 builder.Services.AddScoped<StationProfileWorkbenchService>();

--- a/src/dotnet/QsoRipper.DebugHost/Services/LogbookInteropWorkbenchService.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Services/LogbookInteropWorkbenchService.cs
@@ -1,0 +1,290 @@
+using System.Runtime.CompilerServices;
+using System.Text;
+using Google.Protobuf;
+using Grpc.Core;
+using QsoRipper.DebugHost.Models;
+using QsoRipper.Services;
+
+namespace QsoRipper.DebugHost.Services;
+
+internal sealed class LogbookInteropWorkbenchService
+{
+    private const int ChunkSize = 65536;
+    private static readonly Encoding AdifEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    private readonly GrpcClientFactory _clientFactory;
+
+    public LogbookInteropWorkbenchService(GrpcClientFactory clientFactory)
+    {
+        ArgumentNullException.ThrowIfNull(clientFactory);
+
+        _clientFactory = clientFactory;
+    }
+
+    public async Task<AdifImportInvocationResult> ImportAdifAsync(
+        string adifText,
+        bool refresh,
+        string sourceDescription,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(adifText);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceDescription);
+
+        var adifBytes = AdifEncoding.GetBytes(adifText);
+        var chunkCount = Math.Max(1, (adifBytes.Length + ChunkSize - 1) / ChunkSize);
+
+        try
+        {
+            var client = _clientFactory.CreateLogbookClient();
+            using var call = client.ImportAdif(cancellationToken: cancellationToken);
+            await using var input = new MemoryStream(adifBytes, writable: false);
+
+            await foreach (var request in CreateImportRequestsAsync(input, refresh, cancellationToken))
+            {
+                await WriteImportRequestAsync(call.RequestStream, request).WaitAsync(cancellationToken);
+            }
+
+            await call.RequestStream.CompleteAsync();
+            var response = await call.ResponseAsync;
+
+            return new AdifImportInvocationResult(
+                response,
+                sourceDescription,
+                adifBytes.Length,
+                chunkCount,
+                refresh,
+                ErrorMessage: null,
+                DateTimeOffset.UtcNow);
+        }
+        catch (RpcException ex)
+        {
+            return new AdifImportInvocationResult(
+                Response: null,
+                sourceDescription,
+                adifBytes.Length,
+                chunkCount,
+                refresh,
+                ex.Status.Detail,
+                DateTimeOffset.UtcNow);
+        }
+        catch (OperationCanceledException ex)
+        {
+            return new AdifImportInvocationResult(
+                Response: null,
+                sourceDescription,
+                adifBytes.Length,
+                chunkCount,
+                refresh,
+                ex.Message,
+                DateTimeOffset.UtcNow);
+        }
+    }
+
+    public async Task<AdifExportInvocationResult> ExportAdifAsync(
+        ExportAdifRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var chunkCount = 0;
+        var bytes = Array.Empty<byte>();
+        var adifText = string.Empty;
+
+        try
+        {
+            var client = _clientFactory.CreateLogbookClient();
+            using var call = client.ExportAdif(request, cancellationToken: cancellationToken);
+            await using var output = new MemoryStream();
+
+            await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken))
+            {
+                var chunk = response.Chunk;
+                if (chunk is null)
+                {
+                    continue;
+                }
+
+                chunkCount++;
+                await output.WriteAsync(chunk.Data.Memory, cancellationToken);
+            }
+
+            bytes = output.ToArray();
+            adifText = AdifEncoding.GetString(bytes);
+
+            return new AdifExportInvocationResult(
+                request,
+                adifText,
+                bytes.Length,
+                chunkCount,
+                CountAdifRecords(adifText),
+                ErrorMessage: null,
+                DateTimeOffset.UtcNow);
+        }
+        catch (RpcException ex)
+        {
+            return new AdifExportInvocationResult(
+                request,
+                adifText,
+                bytes.Length,
+                chunkCount,
+                CountAdifRecords(adifText),
+                ex.Status.Detail,
+                DateTimeOffset.UtcNow);
+        }
+        catch (OperationCanceledException ex)
+        {
+            return new AdifExportInvocationResult(
+                request,
+                adifText,
+                bytes.Length,
+                chunkCount,
+                CountAdifRecords(adifText),
+                ex.Message,
+                DateTimeOffset.UtcNow);
+        }
+    }
+
+    public async Task<QrzSyncInvocationResult> SyncWithQrzAsync(
+        bool fullSync,
+        CancellationToken cancellationToken = default)
+    {
+        var progressUpdates = new List<SyncWithQrzResponse>();
+        GetSyncStatusResponse? syncStatus = null;
+
+        try
+        {
+            var client = _clientFactory.CreateLogbookClient();
+            using var call = client.SyncWithQrz(
+                new SyncWithQrzRequest { FullSync = fullSync },
+                cancellationToken: cancellationToken);
+
+            await foreach (var response in call.ResponseStream.ReadAllAsync(cancellationToken))
+            {
+                progressUpdates.Add(response);
+            }
+
+            syncStatus = await client.GetSyncStatusAsync(
+                new GetSyncStatusRequest(),
+                cancellationToken: cancellationToken);
+
+            var errorMessage = progressUpdates
+                .LastOrDefault(update => !string.IsNullOrWhiteSpace(update.Error))
+                ?.Error;
+
+            return new QrzSyncInvocationResult(
+                fullSync,
+                progressUpdates,
+                syncStatus,
+                errorMessage,
+                DateTimeOffset.UtcNow);
+        }
+        catch (RpcException ex)
+        {
+            return new QrzSyncInvocationResult(
+                fullSync,
+                progressUpdates,
+                syncStatus,
+                ex.Status.Detail,
+                DateTimeOffset.UtcNow);
+        }
+        catch (OperationCanceledException ex)
+        {
+            return new QrzSyncInvocationResult(
+                fullSync,
+                progressUpdates,
+                syncStatus,
+                ex.Message,
+                DateTimeOffset.UtcNow);
+        }
+    }
+
+    public async Task<(GetSyncStatusResponse? Response, string? ErrorMessage)> GetSyncStatusAsync(
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var client = _clientFactory.CreateLogbookClient();
+            var response = await client.GetSyncStatusAsync(
+                new GetSyncStatusRequest(),
+                cancellationToken: cancellationToken);
+            return (response, null);
+        }
+        catch (RpcException ex)
+        {
+            return (null, ex.Status.Detail);
+        }
+        catch (OperationCanceledException ex)
+        {
+            return (null, ex.Message);
+        }
+    }
+
+    internal static async IAsyncEnumerable<ImportAdifRequest> CreateImportRequestsAsync(
+        Stream input,
+        bool refresh = false,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        var buffer = new byte[ChunkSize];
+        var isFirst = true;
+
+        while (true)
+        {
+            var bytesRead = await input.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken);
+            if (bytesRead == 0)
+            {
+                yield break;
+            }
+
+            var request = new ImportAdifRequest
+            {
+                Chunk = new AdifChunk
+                {
+                    Data = ByteString.CopyFrom(buffer, 0, bytesRead)
+                }
+            };
+
+            if (isFirst && refresh)
+            {
+                request.Refresh = true;
+            }
+
+            isFirst = false;
+            yield return request;
+        }
+    }
+
+    internal static int CountAdifRecords(string adifText)
+    {
+        if (string.IsNullOrWhiteSpace(adifText))
+        {
+            return 0;
+        }
+
+        var count = 0;
+        var start = 0;
+
+        while (true)
+        {
+            var markerIndex = adifText.IndexOf("<EOR>", start, StringComparison.OrdinalIgnoreCase);
+            if (markerIndex < 0)
+            {
+                return count;
+            }
+
+            count++;
+            start = markerIndex + "<EOR>".Length;
+        }
+    }
+
+    private static Task WriteImportRequestAsync(
+        IClientStreamWriter<ImportAdifRequest> requestStream,
+        ImportAdifRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(requestStream);
+        ArgumentNullException.ThrowIfNull(request);
+
+        return requestStream.WriteAsync(request);
+    }
+}

--- a/src/dotnet/QsoRipper.DebugHost/Services/StorageWorkbenchService.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Services/StorageWorkbenchService.cs
@@ -31,9 +31,12 @@ internal sealed class StorageWorkbenchService
         ApplyStationProfile(sampleQso, activeStationProfile);
         LogQsoResponse? logResponse = null;
         GetQsoResponse? loadedResponse = null;
+        UpdateQsoResponse? updateResponse = null;
+        GetQsoResponse? updatedResponse = null;
         DeleteQsoResponse? deleteResponse = null;
         GetSyncStatusResponse? syncStatus = null;
         var listedQsos = new List<QsoRecord>();
+        var updateVerified = false;
         var deleteVerified = false;
 
         try
@@ -51,6 +54,21 @@ internal sealed class StorageWorkbenchService
             loadedResponse = await client.GetQsoAsync(
                 new GetQsoRequest { LocalId = logResponse.LocalId },
                 cancellationToken: cancellationToken);
+
+            var updatedQso = BuildUpdatedQso(
+                loadedResponse.Qso ?? throw new InvalidOperationException("GetQso returned a response without a qso payload."));
+            updateResponse = await client.UpdateQsoAsync(
+                new UpdateQsoRequest
+                {
+                    Qso = updatedQso,
+                    SyncToQrz = false
+                },
+                cancellationToken: cancellationToken);
+
+            updatedResponse = await client.GetQsoAsync(
+                new GetQsoRequest { LocalId = logResponse.LocalId },
+                cancellationToken: cancellationToken);
+            updateVerified = updateResponse.Success && VerifyUpdatedQso(updatedResponse.Qso, updatedQso);
 
             using var listCall = client.ListQsos(
                 new ListQsosRequest
@@ -83,18 +101,45 @@ internal sealed class StorageWorkbenchService
                 deleteVerified = await ConfirmDeleteAsync(client, logResponse.LocalId, cancellationToken);
             }
 
-            var errorMessage = !retainRecord && !deleteVerified
-                ? "Delete verification failed. GetQso still returned the sample record after delete."
-                : null;
+            var errorMessages = new List<string>();
+            if (updateResponse is { Success: false })
+            {
+                errorMessages.Add(
+                    $"UpdateQso returned failure: {updateResponse.Error ?? "(no detail was returned by the engine)"}");
+            }
+            else if (!updateVerified)
+            {
+                errorMessages.Add("Update verification failed. GetQso did not return the updated sample record.");
+            }
+
+            if (!retainRecord)
+            {
+                if (deleteResponse is { Success: false })
+                {
+                    errorMessages.Add(
+                        $"DeleteQso returned failure: {deleteResponse.Error ?? "(no detail was returned by the engine)"}");
+                }
+                else if (!deleteVerified)
+                {
+                    errorMessages.Add("Delete verification failed. GetQso still returned the sample record after delete.");
+                }
+            }
+
+            var errorMessage = errorMessages.Count == 0
+                ? null
+                : string.Join(" ", errorMessages);
 
             return new StorageSmokeTestResult(
                 sampleQso,
                 logResponse,
                 loadedResponse,
+                updateResponse,
+                updatedResponse,
                 listedQsos,
                 syncStatus,
                 deleteResponse,
                 retainRecord,
+                updateVerified,
                 deleteVerified,
                 errorMessage,
                 DateTimeOffset.UtcNow);
@@ -105,10 +150,13 @@ internal sealed class StorageWorkbenchService
                 sampleQso,
                 logResponse,
                 loadedResponse,
+                updateResponse,
+                updatedResponse,
                 listedQsos,
                 syncStatus,
                 deleteResponse,
                 retainRecord,
+                updateVerified,
                 deleteVerified,
                 ex.Status.Detail,
                 DateTimeOffset.UtcNow);
@@ -119,14 +167,26 @@ internal sealed class StorageWorkbenchService
                 sampleQso,
                 logResponse,
                 loadedResponse,
+                updateResponse,
+                updatedResponse,
                 listedQsos,
                 syncStatus,
                 deleteResponse,
                 retainRecord,
+                updateVerified,
                 deleteVerified,
                 ex.Message,
                 DateTimeOffset.UtcNow);
         }
+    }
+
+    internal static QsoRecord BuildUpdatedQso(QsoRecord source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+
+        var updated = source.Clone();
+        updated.Comment = $"DebugHost storage smoke update {DateTime.UtcNow:O}";
+        return updated;
     }
 
     private static void ApplyStationProfile(QsoRecord qso, StationProfile? profile)
@@ -154,6 +214,15 @@ internal sealed class StorageWorkbenchService
             Longitude = profile.Longitude,
             ArrlSection = profile.ArrlSection
         };
+    }
+
+    private static bool VerifyUpdatedQso(QsoRecord? persisted, QsoRecord expected)
+    {
+        ArgumentNullException.ThrowIfNull(expected);
+
+        return persisted is not null
+            && string.Equals(persisted.LocalId, expected.LocalId, StringComparison.Ordinal)
+            && string.Equals(persisted.Comment, expected.Comment, StringComparison.Ordinal);
     }
 
     private static async Task<bool> ConfirmDeleteAsync(


### PR DESCRIPTION
## Summary
- add an ADIF & Sync page to the DebugHost for ADIF import/export, QRZ sync invocation, and sync-status inspection
- expand the Storage Workbench smoke test to cover UpdateQso and surface richer logbook payloads
- fix QSO Viewer band and mode labels by routing proto enums through ProtoEnumDisplay and document that rule in the repo instructions

## Testing
- dotnet format src\dotnet\QsoRipper.slnx --verify-no-changes
- dotnet build src\dotnet\QsoRipper.DebugHost\QsoRipper.DebugHost.csproj -p:OutputPath=C:\Users\randy\Git\qsoripper\artifacts\debughost-build-bin\ -v minimal
- dotnet test src\dotnet\QsoRipper.DebugHost.Tests\QsoRipper.DebugHost.Tests.csproj -p:OutputPath=C:\Users\randy\Git\qsoripper\artifacts\debughost-test-bin\ -v minimal

## Notes
- this page reflects the current engine surface; SyncWithQrz still returns UNIMPLEMENTED server-side until the Rust implementation lands
- issue #104 tracks the richer paged QSO query surface needed for product-grade logbook browsing