### PR TITLE
Add CLI comment and notes support

### DIFF
--- a/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
@@ -12,7 +12,7 @@ public sealed class CommandHelperTests
     {
         var success = LogQsoCommand.TryBuildQso(
             "W1AW",
-            ["20m", "FT8", "--station", "k7abv", "--rst-sent", "59", "--rst-rcvd", "57", "--freq", "14074"],
+            ["20m", "FT8", "--station", "k7abv", "--rst-sent", "59", "--rst-rcvd", "57", "--freq", "14074", "--comment", "Strong copy", "--notes", "Worked on dipole"],
             out var qso,
             out _,
             out var error);
@@ -30,6 +30,8 @@ public sealed class CommandHelperTests
         Assert.Equal((uint)5, qso.RstReceived!.Readability);
         Assert.Equal((uint)7, qso.RstReceived.Strength);
         Assert.NotNull(qso.UtcTimestamp);
+        Assert.Equal("Strong copy", qso.Comment);
+        Assert.Equal("Worked on dipole", qso.Notes);
     }
 
     [Theory]
@@ -52,6 +54,8 @@ public sealed class CommandHelperTests
     [Theory]
     [InlineData("--station", "Missing value for --station.")]
     [InlineData("--freq", "Missing value for --freq.")]
+    [InlineData("--comment", "Missing value for --comment.")]
+    [InlineData("--notes", "Missing value for --notes.")]
     public void TryBuildQso_rejects_missing_option_values(string option, string expectedError)
     {
         var success = LogQsoCommand.TryBuildQso("W1AW", ["20m", "FT8", option], out _, out _, out var error);
@@ -138,7 +142,7 @@ public sealed class CommandHelperTests
     {
         var success = ListQsosCommand.TryParseArgs(["--callsign", "w1aw", "--band", "20m", "--mode", "ft8", "--after", "2026-04-10T00:00:00Z", "--before", "2026-04-11T00:00:00Z", "--limit", "5"],
             out var request,
-            out _,
+            out var displayOptions,
             out var error);
 
         Assert.True(success);
@@ -149,6 +153,34 @@ public sealed class CommandHelperTests
         Assert.Equal((uint)5, request.Limit);
         Assert.NotNull(request.After);
         Assert.NotNull(request.Before);
+        Assert.True(displayOptions.ShowComment);
+    }
+
+    [Fact]
+    public void FormatCommentPreview_prefers_comment_then_trims()
+    {
+        var qso = new QsoRecord
+        {
+            Comment = "This is a very long comment that should be trimmed before it reaches the default list output column.",
+            Notes = "backup"
+        };
+
+        var preview = ListQsosCommand.FormatCommentPreview(qso);
+
+        Assert.Equal("This is a very long comment that shou...", preview);
+    }
+
+    [Fact]
+    public void FormatCommentPreview_falls_back_to_notes_and_flattens_newlines()
+    {
+        var qso = new QsoRecord
+        {
+            Notes = "first line" + Environment.NewLine + "second line"
+        };
+
+        var preview = ListQsosCommand.FormatCommentPreview(qso);
+
+        Assert.Equal("first line second line", preview);
     }
 
     public static TheoryData<string[], string> InvalidListArgs { get; } =

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -52,11 +52,13 @@ internal static class CliHelpText
                   --rst-sent <rst>     RST sent (e.g., 59, 599)
                   --rst-rcvd <rst>     RST received
                   --freq <khz>         Frequency in kHz (e.g., 14074)
+                  --comment <text>     Comment text
+                  --notes <text>       Notes text
                   --no-enrich          Skip automatic QRZ lookup enrichment
 
                 Examples:
                   log W1AW 20m FT8
-                  log W1AW 40m CW --station AE7XI --rst-sent 599 --freq 7030
+                  log W1AW 40m CW --station AE7XI --rst-sent 599 --freq 7030 --comment "Nice signal"
                   log K7ABV 20m SSB --at 30.minutes
                 """,
             "get" => """
@@ -77,7 +79,7 @@ internal static class CliHelpText
                   --limit <n>          Max results (default: 20)
                   --show-id            Include the QSO local ID column
                   --show-rst           Include RST sent/received columns
-                  --show-comment       Include comment/notes column
+                  --show-comment       Include comment/notes column (default)
                 """,
             "update" => """
                 Usage: update <local-id> [options]

--- a/src/dotnet/QsoRipper.Cli/Commands/ListQsosCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ListQsosCommand.cs
@@ -9,6 +9,8 @@ namespace QsoRipper.Cli.Commands;
 
 internal static class ListQsosCommand
 {
+    private const int CommentColumnWidth = 40;
+
     public static async Task<int> RunAsync(GrpcChannel channel, string[] args, bool jsonOutput = false)
     {
         if (!TryParseArgs(args, out var request, out var displayOptions, out var error))
@@ -77,7 +79,7 @@ internal static class ListQsosCommand
 
         if (options.ShowComment)
         {
-            header += $" {"Comment"}";
+            header += $" {"Comment",-40}";
         }
 
         Console.WriteLine(header);
@@ -107,8 +109,7 @@ internal static class ListQsosCommand
 
         if (options.ShowComment)
         {
-            var comment = qso.HasComment ? qso.Comment : (qso.HasNotes ? qso.Notes : "");
-            row += $" {comment}";
+            row += $" {FormatCommentPreview(qso),-40}";
         }
 
         Console.WriteLine(row);
@@ -228,13 +229,30 @@ internal static class ListQsosCommand
             ? $"{rst.Readability}{rst.Strength}{rst.Tone}"
             : $"{rst.Readability}{rst.Strength}";
     }
+
+    internal static string FormatCommentPreview(QsoRecord qso)
+    {
+        var comment = qso.HasComment ? qso.Comment : (qso.HasNotes ? qso.Notes : "");
+        return TrimComment(comment);
+    }
+
+    internal static string TrimComment(string value)
+    {
+        var sanitized = value.ReplaceLineEndings(" ").Trim();
+        if (sanitized.Length <= CommentColumnWidth)
+        {
+            return sanitized;
+        }
+
+        return $"{sanitized[..(CommentColumnWidth - 3)]}...";
+    }
 }
 
 internal sealed class ListDisplayOptions
 {
+    public bool ShowComment { get; set; } = true;
+
     public bool ShowId { get; set; }
 
     public bool ShowRst { get; set; }
-
-    public bool ShowComment { get; set; }
 }

--- a/src/dotnet/QsoRipper.Cli/Commands/LogQsoCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/LogQsoCommand.cs
@@ -40,6 +40,16 @@ internal static class LogQsoCommand
             Console.WriteLine($"  Country: {requestQso.WorkedCountry}");
         }
 
+        if (requestQso.HasComment)
+        {
+            Console.WriteLine($"  Comment: {requestQso.Comment}");
+        }
+
+        if (requestQso.HasNotes)
+        {
+            Console.WriteLine($"  Notes: {requestQso.Notes}");
+        }
+
         if (response.HasSyncError)
         {
             Console.WriteLine($"  QRZ sync: {response.SyncError}");
@@ -56,7 +66,7 @@ internal static class LogQsoCommand
 
         if (args.Length < 2 || args.Any(static a => a is "help" or "-?" or "--help"))
         {
-            error = "Usage: log <callsign> <band> <mode> [--station call] [--at time] [--rst-sent 59] [--rst-rcvd 59] [--freq khz] [--no-enrich]";
+            error = "Usage: log <callsign> <band> <mode> [--station call] [--at time] [--rst-sent 59] [--rst-rcvd 59] [--freq khz] [--comment text] [--notes text] [--no-enrich]";
             return false;
         }
 
@@ -161,6 +171,18 @@ internal static class LogQsoCommand
                     break;
                 case "--freq":
                     error = "Missing value for --freq.";
+                    return false;
+                case "--comment" when i < args.Length - 1:
+                    qso.Comment = args[++i];
+                    break;
+                case "--comment":
+                    error = "Missing value for --comment.";
+                    return false;
+                case "--notes" when i < args.Length - 1:
+                    qso.Notes = args[++i];
+                    break;
+                case "--notes":
+                    error = "Missing value for --notes.";
                     return false;
                 case "--no-enrich":
                     noEnrich = true;


### PR DESCRIPTION
Adds CLI support for logging comment and notes fields, and shows a trimmed comment column in the default list output.