### PR TITLE
Add NOAA space weather service and CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Proto files under `proto/` are the **single source of truth** for all shared typ
 | **StationProfileService** | Persisted station profile CRUD, active profile selection, bounded session overrides |
 | **LookupService** | Callsign lookups -- single, streaming, batch, cached, DXCC |
 | **LogbookService** | QSO CRUD, QRZ logbook sync, ADIF import/export |
+| **SpaceWeatherService** | Current NOAA SWPC snapshot reads and explicit refresh for engine clients |
 
 **Building a client?** See the [Engine API Documentation](docs/api/README.md) for a client-facing reference covering service contracts, implementation status, stub generation, transport options, and workflow examples.
 
@@ -199,6 +200,17 @@ The QRZ credentials are easy to mix up, so keep this split in mind:
 | `QSORIPPER_QRZ_LOGBOOK_API_KEY` | Your separate **QRZ Logbook API access key** from the QRZ website |
 
 **Important:** `QSORIPPER_QRZ_XML_PASSWORD` and `QSORIPPER_QRZ_LOGBOOK_API_KEY` are **not** the same value and are **not** interchangeable. Using the logbook API key as the XML password will cause QRZ XML login failures and may trigger a temporary lockout.
+
+Current space weather can also be enabled for engine clients through the NOAA SWPC-backed service:
+
+```powershell
+QSORIPPER_NOAA_SPACE_WEATHER_ENABLED=true
+QSORIPPER_NOAA_HTTP_TIMEOUT_SECONDS=8
+QSORIPPER_NOAA_REFRESH_INTERVAL_SECONDS=900
+QSORIPPER_NOAA_STALE_AFTER_SECONDS=3600
+```
+
+Optional endpoint overrides are available with `QSORIPPER_NOAA_KP_INDEX_URL` and `QSORIPPER_NOAA_SOLAR_INDICES_URL` if you need to point the engine at alternate NOAA-compatible feeds during local testing.
 
 For lockout-safe debugging, you can temporarily set:
 

--- a/proto/domain/space_weather_snapshot.proto
+++ b/proto/domain/space_weather_snapshot.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package qsoripper.domain;
+
+option csharp_namespace = "QsoRipper.Domain";
+
+import "domain/space_weather_status.proto";
+import "google/protobuf/timestamp.proto";
+
+message SpaceWeatherSnapshot {
+  optional google.protobuf.Timestamp observed_at = 1;
+  optional google.protobuf.Timestamp fetched_at = 2;
+  SpaceWeatherStatus status = 3;
+  optional string error_message = 4;
+  optional double planetary_k_index = 5;
+  optional uint32 planetary_a_index = 6;
+  optional double solar_flux_index = 7;
+  optional uint32 sunspot_number = 8;
+  optional uint32 geomagnetic_storm_scale = 9;
+  optional string source_name = 10;
+}

--- a/proto/domain/space_weather_status.proto
+++ b/proto/domain/space_weather_status.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package qsoripper.domain;
+
+option csharp_namespace = "QsoRipper.Domain";
+
+enum SpaceWeatherStatus {
+  SPACE_WEATHER_STATUS_UNSPECIFIED = 0;
+  SPACE_WEATHER_STATUS_CURRENT = 1;
+  SPACE_WEATHER_STATUS_STALE = 2;
+  SPACE_WEATHER_STATUS_ERROR = 3;
+}

--- a/proto/services/get_current_space_weather_request.proto
+++ b/proto/services/get_current_space_weather_request.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+message GetCurrentSpaceWeatherRequest {}

--- a/proto/services/get_current_space_weather_response.proto
+++ b/proto/services/get_current_space_weather_response.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "domain/space_weather_snapshot.proto";
+
+message GetCurrentSpaceWeatherResponse {
+  qsoripper.domain.SpaceWeatherSnapshot snapshot = 1;
+}

--- a/proto/services/refresh_space_weather_request.proto
+++ b/proto/services/refresh_space_weather_request.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+message RefreshSpaceWeatherRequest {}

--- a/proto/services/refresh_space_weather_response.proto
+++ b/proto/services/refresh_space_weather_response.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "domain/space_weather_snapshot.proto";
+
+message RefreshSpaceWeatherResponse {
+  qsoripper.domain.SpaceWeatherSnapshot snapshot = 1;
+}

--- a/proto/services/space_weather_service.proto
+++ b/proto/services/space_weather_service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "services/get_current_space_weather_request.proto";
+import "services/get_current_space_weather_response.proto";
+import "services/refresh_space_weather_request.proto";
+import "services/refresh_space_weather_response.proto";
+
+service SpaceWeatherService {
+  rpc GetCurrentSpaceWeather(GetCurrentSpaceWeatherRequest) returns (GetCurrentSpaceWeatherResponse);
+  rpc RefreshSpaceWeather(RefreshSpaceWeatherRequest) returns (RefreshSpaceWeatherResponse);
+}

--- a/src/dotnet/QsoRipper.Cli.Tests/CliArgumentParserTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliArgumentParserTests.cs
@@ -142,6 +142,17 @@ public class CliArgumentParserTests
         Assert.True(arguments.SetupFromEnv);
     }
 
+    [Fact]
+    public void Parse_space_weather_refresh_with_json()
+    {
+        var arguments = CliArgumentParser.Parse(["space-weather", "--refresh", "--json"]);
+
+        Assert.Equal("space-weather", arguments.Command);
+        Assert.True(arguments.Refresh);
+        Assert.True(arguments.JsonOutput);
+        Assert.Null(arguments.Callsign);
+    }
+
     [Theory]
     [InlineData("http://localhost:50051", true)]
     [InlineData("https://example.com:7443", true)]

--- a/src/dotnet/QsoRipper.Cli.Tests/CliRegressionTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliRegressionTests.cs
@@ -63,5 +63,15 @@ public class CliRegressionTests
         Assert.False(arguments.ShowHelp);
         Assert.Equal(["--help"], arguments.RemainingArgs);
     }
+
+    [Fact]
+    public async Task Entry_point_shows_command_help_for_space_weather_help()
+    {
+        var result = await CliProcessRunner.RunAsync("space-weather", "--help");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("Usage: space-weather [--refresh]", result.StandardOutput, StringComparison.Ordinal);
+        Assert.DoesNotContain("Could not connect to QsoRipper engine", result.StandardError, StringComparison.Ordinal);
+    }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
@@ -2,7 +2,6 @@ using System.Text;
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
 using QsoRipper.Services;
-
 namespace QsoRipper.Cli.Tests;
 
 #pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
@@ -150,7 +149,7 @@ public sealed class CliUtilityTests
     [Fact]
     public void JsonOutput_Print_writes_indented_json()
     {
-        var output = CaptureConsoleOut(() => JsonOutput.Print(new GetSyncStatusResponse { LocalQsoCount = 3 }));
+        var output = ConsoleCapture.Out(() => JsonOutput.Print(new GetSyncStatusResponse { LocalQsoCount = 3 }));
 
         Assert.Contains("\"localQsoCount\": 3", output, StringComparison.Ordinal);
     }
@@ -164,7 +163,7 @@ public sealed class CliUtilityTests
             new GetSyncStatusResponse { LocalQsoCount = 2 }
         };
 
-        var output = CaptureConsoleOut(() => JsonOutput.PrintArray(messages));
+        var output = ConsoleCapture.Out(() => JsonOutput.PrintArray(messages));
 
         Assert.StartsWith("[", output, StringComparison.Ordinal);
         Assert.Contains("\"localQsoCount\": 1", output, StringComparison.Ordinal);
@@ -178,25 +177,6 @@ public sealed class CliUtilityTests
         var help = CliHelpText.GetGeneralHelp();
 
         Assert.Contains("space-weather [--refresh]", help, StringComparison.Ordinal);
-    }
-
-    private static string CaptureConsoleOut(Action action)
-    {
-        var builder = new StringBuilder();
-        using var writer = new StringWriter(builder);
-        var original = Console.Out;
-
-        try
-        {
-            Console.SetOut(writer);
-            action();
-        }
-        finally
-        {
-            Console.SetOut(original);
-        }
-
-        return builder.ToString();
     }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
@@ -54,6 +54,7 @@ public sealed class CliUtilityTests
         new()
         {
             { "status", "Usage: status" },
+            { "space-weather", "Usage: space-weather [--refresh]" },
             { "config", "Usage: config [options]" },
             { "lookup", "Usage: lookup <callsign> [--skip-cache]" }
         };
@@ -169,6 +170,14 @@ public sealed class CliUtilityTests
         Assert.Contains("\"localQsoCount\": 1", output, StringComparison.Ordinal);
         Assert.Contains("\"localQsoCount\": 2", output, StringComparison.Ordinal);
         Assert.EndsWith(Environment.NewLine + "]" + Environment.NewLine, output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetGeneralHelp_includes_space_weather_command()
+    {
+        var help = CliHelpText.GetGeneralHelp();
+
+        Assert.Contains("space-weather [--refresh]", help, StringComparison.Ordinal);
     }
 
     private static string CaptureConsoleOut(Action action)

--- a/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
@@ -5,6 +5,7 @@ using QsoRipper.Services;
 namespace QsoRipper.Cli.Tests;
 
 #pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+[Collection("ConsoleCapture")]
 public sealed class CliUtilityTests
 {
     [Theory]

--- a/src/dotnet/QsoRipper.Cli.Tests/ConsoleCapture.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/ConsoleCapture.cs
@@ -1,0 +1,44 @@
+using System.Text;
+
+namespace QsoRipper.Cli.Tests;
+
+internal static class ConsoleCapture
+{
+    internal static string Out(Action action)
+    {
+        var builder = new StringBuilder();
+        using var writer = new StringWriter(builder);
+        var original = Console.Out;
+
+        try
+        {
+            Console.SetOut(writer);
+            action();
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        return builder.ToString();
+    }
+
+    internal static string Error(Action action)
+    {
+        var builder = new StringBuilder();
+        using var writer = new StringWriter(builder);
+        var original = Console.Error;
+
+        try
+        {
+            Console.SetError(writer);
+            action();
+        }
+        finally
+        {
+            Console.SetError(original);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/dotnet/QsoRipper.Cli.Tests/SpaceWeatherCommandTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/SpaceWeatherCommandTests.cs
@@ -1,0 +1,114 @@
+using System.Text;
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Cli.Commands;
+using QsoRipper.Domain;
+
+namespace QsoRipper.Cli.Tests;
+
+#pragma warning disable CA1707
+public sealed class SpaceWeatherCommandTests
+{
+    [Fact]
+    public void HandleSnapshot_returns_error_when_snapshot_is_missing()
+    {
+        var error = CaptureConsoleError(() => Assert.Equal(1, SpaceWeatherCommand.HandleSnapshot(null, false)));
+
+        Assert.Contains("Space weather snapshot unavailable.", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HandleSnapshot_writes_text_output_for_current_snapshot()
+    {
+        var snapshot = new SpaceWeatherSnapshot
+        {
+            Status = SpaceWeatherStatus.Current,
+            ObservedAt = Timestamp.FromDateTime(DateTime.SpecifyKind(new DateTime(2026, 4, 14, 1, 2, 3), DateTimeKind.Utc)),
+            FetchedAt = Timestamp.FromDateTime(DateTime.SpecifyKind(new DateTime(2026, 4, 14, 1, 5, 0), DateTimeKind.Utc)),
+            PlanetaryKIndex = 3.67,
+            PlanetaryAIndex = 12,
+            SolarFluxIndex = 145.2,
+            SunspotNumber = 88,
+            GeomagneticStormScale = 1,
+            SourceName = "NOAA SWPC"
+        };
+
+        var output = CaptureConsoleOut(() => Assert.Equal(0, SpaceWeatherCommand.HandleSnapshot(snapshot, false)));
+
+        Assert.Contains("Status:           current", output, StringComparison.Ordinal);
+        Assert.Contains("Planetary K:      3.67", output, StringComparison.Ordinal);
+        Assert.Contains("Planetary A:      12", output, StringComparison.Ordinal);
+        Assert.Contains("Solar flux:       145.2", output, StringComparison.Ordinal);
+        Assert.Contains("Sunspot number:   88", output, StringComparison.Ordinal);
+        Assert.Contains("Storm scale:      G1", output, StringComparison.Ordinal);
+        Assert.Contains("Source:           NOAA SWPC", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HandleSnapshot_returns_error_for_error_snapshot()
+    {
+        var snapshot = new SpaceWeatherSnapshot
+        {
+            Status = SpaceWeatherStatus.Error,
+            ErrorMessage = "NOAA unavailable"
+        };
+
+        var output = CaptureConsoleOut(() => Assert.Equal(1, SpaceWeatherCommand.HandleSnapshot(snapshot, false)));
+
+        Assert.Contains("Status:           error", output, StringComparison.Ordinal);
+        Assert.Contains("Error:            NOAA unavailable", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HandleSnapshot_writes_json_when_requested()
+    {
+        var snapshot = new SpaceWeatherSnapshot
+        {
+            Status = SpaceWeatherStatus.Stale,
+            SourceName = "NOAA SWPC"
+        };
+
+        var output = CaptureConsoleOut(() => Assert.Equal(0, SpaceWeatherCommand.HandleSnapshot(snapshot, true)));
+
+        Assert.Contains("\"status\": \"SPACE_WEATHER_STATUS_STALE\"", output, StringComparison.Ordinal);
+        Assert.Contains("\"sourceName\": \"NOAA SWPC\"", output, StringComparison.Ordinal);
+    }
+
+    private static string CaptureConsoleOut(Action action)
+    {
+        var builder = new StringBuilder();
+        using var writer = new StringWriter(builder);
+        var original = Console.Out;
+
+        try
+        {
+            Console.SetOut(writer);
+            action();
+        }
+        finally
+        {
+            Console.SetOut(original);
+        }
+
+        return builder.ToString();
+    }
+
+    private static string CaptureConsoleError(Action action)
+    {
+        var builder = new StringBuilder();
+        using var writer = new StringWriter(builder);
+        var original = Console.Error;
+
+        try
+        {
+            Console.SetError(writer);
+            action();
+        }
+        finally
+        {
+            Console.SetError(original);
+        }
+
+        return builder.ToString();
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli.Tests/SpaceWeatherCommandTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/SpaceWeatherCommandTests.cs
@@ -11,7 +11,7 @@ public sealed class SpaceWeatherCommandTests
     [Fact]
     public void HandleSnapshot_returns_error_when_snapshot_is_missing()
     {
-        var error = CaptureConsoleError(() => Assert.Equal(1, SpaceWeatherCommand.HandleSnapshot(null, false)));
+        var error = ConsoleCapture.Error(() => Assert.Equal(1, SpaceWeatherCommand.HandleSnapshot(null, false)));
 
         Assert.Contains("Space weather snapshot unavailable.", error, StringComparison.Ordinal);
     }
@@ -32,7 +32,7 @@ public sealed class SpaceWeatherCommandTests
             SourceName = "NOAA SWPC"
         };
 
-        var output = CaptureConsoleOut(() => Assert.Equal(0, SpaceWeatherCommand.HandleSnapshot(snapshot, false)));
+        var output = ConsoleCapture.Out(() => Assert.Equal(0, SpaceWeatherCommand.HandleSnapshot(snapshot, false)));
 
         Assert.Contains("Status:           current", output, StringComparison.Ordinal);
         Assert.Contains("Planetary K:      3.67", output, StringComparison.Ordinal);
@@ -52,7 +52,7 @@ public sealed class SpaceWeatherCommandTests
             ErrorMessage = "NOAA unavailable"
         };
 
-        var output = CaptureConsoleOut(() => Assert.Equal(1, SpaceWeatherCommand.HandleSnapshot(snapshot, false)));
+        var output = ConsoleCapture.Out(() => Assert.Equal(1, SpaceWeatherCommand.HandleSnapshot(snapshot, false)));
 
         Assert.Contains("Status:           error", output, StringComparison.Ordinal);
         Assert.Contains("Error:            NOAA unavailable", output, StringComparison.Ordinal);
@@ -67,48 +67,11 @@ public sealed class SpaceWeatherCommandTests
             SourceName = "NOAA SWPC"
         };
 
-        var output = CaptureConsoleOut(() => Assert.Equal(0, SpaceWeatherCommand.HandleSnapshot(snapshot, true)));
+        var output = ConsoleCapture.Out(() => Assert.Equal(0, SpaceWeatherCommand.HandleSnapshot(snapshot, true)));
 
         Assert.Contains("\"status\": \"SPACE_WEATHER_STATUS_STALE\"", output, StringComparison.Ordinal);
         Assert.Contains("\"sourceName\": \"NOAA SWPC\"", output, StringComparison.Ordinal);
     }
-
-    private static string CaptureConsoleOut(Action action)
-    {
-        var builder = new StringBuilder();
-        using var writer = new StringWriter(builder);
-        var original = Console.Out;
-
-        try
-        {
-            Console.SetOut(writer);
-            action();
-        }
-        finally
-        {
-            Console.SetOut(original);
-        }
-
-        return builder.ToString();
-    }
-
-    private static string CaptureConsoleError(Action action)
-    {
-        var builder = new StringBuilder();
-        using var writer = new StringWriter(builder);
-        var original = Console.Error;
-
-        try
-        {
-            Console.SetError(writer);
-            action();
-        }
-        finally
-        {
-            Console.SetError(original);
-        }
-
-        return builder.ToString();
-    }
 }
 #pragma warning restore CA1707
+

--- a/src/dotnet/QsoRipper.Cli.Tests/SpaceWeatherCommandTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/SpaceWeatherCommandTests.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Cli.Commands;
 using QsoRipper.Domain;
@@ -6,6 +5,7 @@ using QsoRipper.Domain;
 namespace QsoRipper.Cli.Tests;
 
 #pragma warning disable CA1707
+[Collection("ConsoleCapture")]
 public sealed class SpaceWeatherCommandTests
 {
     [Fact]

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -27,6 +27,7 @@ internal static class CliHelpText
 
             Engine:
               status                           Show sync status and QSO counts
+              space-weather [--refresh]        Show current NOAA space weather snapshot
               config [--set KEY=VALUE]         View or modify runtime config
               setup [--status | --from-env]    Interactive setup wizard or headless config
 
@@ -175,6 +176,14 @@ internal static class CliHelpText
                 Usage: status
 
                 Show engine sync status and QSO counts.
+                """,
+            "space-weather" => """
+                Usage: space-weather [--refresh]
+
+                Show the current engine-backed NOAA space weather snapshot.
+
+                  --refresh          Force an immediate refresh before printing
+                  --json             Output the snapshot as JSON
                 """,
             _ => $"No help available for '{command}'."
         };

--- a/src/dotnet/QsoRipper.Cli/Commands/SpaceWeatherCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SpaceWeatherCommand.cs
@@ -1,0 +1,93 @@
+using Grpc.Net.Client;
+using QsoRipper.Domain;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli.Commands;
+
+internal static class SpaceWeatherCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel, bool refresh = false, bool jsonOutput = false)
+    {
+        var client = new SpaceWeatherService.SpaceWeatherServiceClient(channel);
+
+        var snapshot = refresh
+            ? (await client.RefreshSpaceWeatherAsync(new RefreshSpaceWeatherRequest())).Snapshot
+            : (await client.GetCurrentSpaceWeatherAsync(new GetCurrentSpaceWeatherRequest())).Snapshot;
+
+        return HandleSnapshot(snapshot, jsonOutput);
+    }
+
+    internal static int HandleSnapshot(SpaceWeatherSnapshot? snapshot, bool jsonOutput)
+    {
+        if (snapshot is null)
+        {
+            Console.Error.WriteLine("Space weather snapshot unavailable.");
+            return 1;
+        }
+
+        if (jsonOutput)
+        {
+            JsonOutput.Print(snapshot);
+        }
+        else
+        {
+            PrintSnapshot(snapshot);
+        }
+
+        return snapshot.Status == SpaceWeatherStatus.Error ? 1 : 0;
+    }
+
+    internal static void PrintSnapshot(SpaceWeatherSnapshot snapshot)
+    {
+        Console.WriteLine($"Status:           {FormatStatus(snapshot.Status)}");
+        Console.WriteLine($"Observed at:      {FormatTimestamp(snapshot.ObservedAt)}");
+        Console.WriteLine($"Fetched at:       {FormatTimestamp(snapshot.FetchedAt)}");
+        Console.WriteLine($"Planetary K:      {FormatDouble(snapshot.HasPlanetaryKIndex, snapshot.PlanetaryKIndex)}");
+        Console.WriteLine($"Planetary A:      {FormatUInt32(snapshot.HasPlanetaryAIndex, snapshot.PlanetaryAIndex)}");
+        Console.WriteLine($"Solar flux:       {FormatDouble(snapshot.HasSolarFluxIndex, snapshot.SolarFluxIndex)}");
+        Console.WriteLine($"Sunspot number:   {FormatUInt32(snapshot.HasSunspotNumber, snapshot.SunspotNumber)}");
+        Console.WriteLine($"Storm scale:      {FormatUInt32(snapshot.HasGeomagneticStormScale, snapshot.GeomagneticStormScale, "G")}");
+        Console.WriteLine($"Source:           {FormatString(snapshot.SourceName)}");
+
+        if (snapshot.ErrorMessage is not null)
+        {
+            Console.WriteLine($"Error:            {snapshot.ErrorMessage}");
+        }
+    }
+
+    private static string FormatStatus(SpaceWeatherStatus status)
+    {
+        return status switch
+        {
+            SpaceWeatherStatus.Current => "current",
+            SpaceWeatherStatus.Stale => "stale",
+            SpaceWeatherStatus.Error => "error",
+            _ => "unspecified"
+        };
+    }
+
+    private static string FormatTimestamp(Google.Protobuf.WellKnownTypes.Timestamp? timestamp)
+    {
+        return timestamp is null ? "(unavailable)" : timestamp.ToDateTime().ToUniversalTime().ToString("u");
+    }
+
+    private static string FormatDouble(bool hasValue, double value)
+    {
+        return hasValue ? value.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture) : "(unavailable)";
+    }
+
+    private static string FormatUInt32(bool hasValue, uint value, string? prefix = null)
+    {
+        if (!hasValue)
+        {
+            return "(unavailable)";
+        }
+
+        return prefix is null ? value.ToString(System.Globalization.CultureInfo.InvariantCulture) : $"{prefix}{value}";
+    }
+
+    private static string FormatString(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "(unavailable)" : value;
+    }
+}

--- a/src/dotnet/QsoRipper.Cli/Commands/SpaceWeatherCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SpaceWeatherCommand.cs
@@ -1,8 +1,8 @@
+using System.Globalization;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Net.Client;
 using QsoRipper.Domain;
 using QsoRipper.Services;
-using System.Globalization;
 
 namespace QsoRipper.Cli.Commands;
 

--- a/src/dotnet/QsoRipper.Cli/Commands/SpaceWeatherCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SpaceWeatherCommand.cs
@@ -70,7 +70,7 @@ internal static class SpaceWeatherCommand
 
     private static string FormatTimestamp(Timestamp? timestamp)
     {
-        return timestamp is null ? "(unavailable)" : timestamp.ToDateTime().ToUniversalTime().ToString("u");
+        return timestamp is null ? "(unavailable)" : timestamp.ToDateTime().ToString("u");
     }
 
     private static string FormatDouble(bool hasValue, double value)

--- a/src/dotnet/QsoRipper.Cli/Commands/SpaceWeatherCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SpaceWeatherCommand.cs
@@ -1,6 +1,8 @@
+using Google.Protobuf.WellKnownTypes;
 using Grpc.Net.Client;
 using QsoRipper.Domain;
 using QsoRipper.Services;
+using System.Globalization;
 
 namespace QsoRipper.Cli.Commands;
 
@@ -66,14 +68,14 @@ internal static class SpaceWeatherCommand
         };
     }
 
-    private static string FormatTimestamp(Google.Protobuf.WellKnownTypes.Timestamp? timestamp)
+    private static string FormatTimestamp(Timestamp? timestamp)
     {
         return timestamp is null ? "(unavailable)" : timestamp.ToDateTime().ToUniversalTime().ToString("u");
     }
 
     private static string FormatDouble(bool hasValue, double value)
     {
-        return hasValue ? value.ToString("0.##", System.Globalization.CultureInfo.InvariantCulture) : "(unavailable)";
+        return hasValue ? value.ToString("0.##", CultureInfo.InvariantCulture) : "(unavailable)";
     }
 
     private static string FormatUInt32(bool hasValue, uint value, string? prefix = null)
@@ -83,7 +85,7 @@ internal static class SpaceWeatherCommand
             return "(unavailable)";
         }
 
-        return prefix is null ? value.ToString(System.Globalization.CultureInfo.InvariantCulture) : $"{prefix}{value}";
+        return prefix is null ? value.ToString(CultureInfo.InvariantCulture) : $"{prefix}{value}";
     }
 
     private static string FormatString(string? value)

--- a/src/dotnet/QsoRipper.Cli/Program.cs
+++ b/src/dotnet/QsoRipper.Cli/Program.cs
@@ -34,6 +34,7 @@ try
     return arguments.Command switch
     {
         "status" => await StatusCommand.RunAsync(channel, arguments.JsonOutput),
+        "space-weather" => await SpaceWeatherCommand.RunAsync(channel, arguments.Refresh, arguments.JsonOutput),
         "lookup" => await LookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache, arguments.JsonOutput),
         "stream-lookup" => await StreamLookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache),
         "cache-check" => await CacheCheckCommand.RunAsync(channel, arguments.Callsign!, arguments.JsonOutput),

--- a/src/rust/qsoripper-core/Cargo.toml
+++ b/src/rust/qsoripper-core/Cargo.toml
@@ -20,6 +20,7 @@ futures = "0.3"
 quick-xml = { version = "0.37", features = ["serialize"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 
 [lints]
 workspace = true

--- a/src/rust/qsoripper-core/src/lib.rs
+++ b/src/rust/qsoripper-core/src/lib.rs
@@ -13,5 +13,7 @@ pub mod ffi;
 pub mod lookup;
 /// Generated protobuf and gRPC bindings.
 pub mod proto;
+/// Space weather providers, caching, and normalization.
+pub mod space_weather;
 /// Storage ports, errors, and query types for engine-owned persistence.
 pub mod storage;

--- a/src/rust/qsoripper-core/src/space_weather/mod.rs
+++ b/src/rust/qsoripper-core/src/space_weather/mod.rs
@@ -1,0 +1,19 @@
+//! Space weather providers, normalization, and cached current snapshots.
+
+mod monitor;
+mod noaa;
+mod provider;
+
+pub use monitor::SpaceWeatherMonitor;
+pub use noaa::{
+    NoaaSpaceWeatherConfig, NoaaSpaceWeatherConfigError, NoaaSpaceWeatherProvider,
+    DEFAULT_NOAA_HTTP_TIMEOUT_SECONDS, DEFAULT_NOAA_KP_INDEX_URL,
+    DEFAULT_NOAA_REFRESH_INTERVAL_SECONDS, DEFAULT_NOAA_SOLAR_INDICES_URL,
+    DEFAULT_NOAA_STALE_AFTER_SECONDS, NOAA_HTTP_TIMEOUT_SECONDS_ENV_VAR, NOAA_KP_INDEX_URL_ENV_VAR,
+    NOAA_REFRESH_INTERVAL_SECONDS_ENV_VAR, NOAA_SOLAR_INDICES_URL_ENV_VAR,
+    NOAA_SPACE_WEATHER_ENABLED_ENV_VAR, NOAA_STALE_AFTER_SECONDS_ENV_VAR,
+};
+pub use provider::{
+    DisabledSpaceWeatherProvider, SpaceWeatherProvider, SpaceWeatherProviderError,
+    SpaceWeatherProviderErrorKind,
+};

--- a/src/rust/qsoripper-core/src/space_weather/monitor.rs
+++ b/src/rust/qsoripper-core/src/space_weather/monitor.rs
@@ -1,0 +1,195 @@
+//! Cached current space weather snapshots.
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use prost_types::Timestamp;
+use tokio::sync::RwLock;
+
+use crate::proto::qsoripper::domain::{SpaceWeatherSnapshot, SpaceWeatherStatus};
+
+use super::provider::SpaceWeatherProvider;
+
+#[derive(Clone)]
+struct CachedSnapshot {
+    snapshot: SpaceWeatherSnapshot,
+    fetched_monotonic: Instant,
+}
+
+/// Small cache around the current space weather provider.
+pub struct SpaceWeatherMonitor {
+    provider: Arc<dyn SpaceWeatherProvider>,
+    refresh_interval: Duration,
+    stale_after: Duration,
+    state: RwLock<Option<CachedSnapshot>>,
+}
+
+impl SpaceWeatherMonitor {
+    /// Create a monitor around a provider with refresh and stale thresholds.
+    #[must_use]
+    pub fn new(
+        provider: Arc<dyn SpaceWeatherProvider>,
+        refresh_interval: Duration,
+        stale_after: Duration,
+    ) -> Self {
+        Self {
+            provider,
+            refresh_interval,
+            stale_after,
+            state: RwLock::new(None),
+        }
+    }
+
+    /// Return the current snapshot, refreshing when needed.
+    pub async fn current_snapshot(&self) -> SpaceWeatherSnapshot {
+        if let Some(cached) = self.state.read().await.clone() {
+            if cached.fetched_monotonic.elapsed() < self.refresh_interval {
+                return snapshot_with_age_status(&cached.snapshot, self.stale_after, &cached);
+            }
+        }
+
+        self.refresh_snapshot().await
+    }
+
+    /// Force a refresh and return the latest available snapshot.
+    pub async fn refresh_snapshot(&self) -> SpaceWeatherSnapshot {
+        let cached = self.state.read().await.clone();
+
+        match self.provider.fetch_current().await {
+            Ok(mut snapshot) => {
+                snapshot.fetched_at = Some(now_timestamp());
+                snapshot.status = SpaceWeatherStatus::Current as i32;
+                snapshot.error_message = None;
+                let cached_snapshot = CachedSnapshot {
+                    snapshot: snapshot.clone(),
+                    fetched_monotonic: Instant::now(),
+                };
+                *self.state.write().await = Some(cached_snapshot);
+                snapshot
+            }
+            Err(error) => {
+                if let Some(cached) = cached {
+                    let mut snapshot =
+                        snapshot_with_age_status(&cached.snapshot, self.stale_after, &cached);
+                    snapshot.status = SpaceWeatherStatus::Stale as i32;
+                    snapshot.error_message = Some(error.to_string());
+                    snapshot
+                } else {
+                    SpaceWeatherSnapshot {
+                        fetched_at: Some(now_timestamp()),
+                        status: SpaceWeatherStatus::Error as i32,
+                        error_message: Some(error.to_string()),
+                        source_name: Some("NOAA SWPC".to_string()),
+                        ..SpaceWeatherSnapshot::default()
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn snapshot_with_age_status(
+    snapshot: &SpaceWeatherSnapshot,
+    stale_after: Duration,
+    cached: &CachedSnapshot,
+) -> SpaceWeatherSnapshot {
+    let mut snapshot = snapshot.clone();
+    snapshot.status = if cached.fetched_monotonic.elapsed() >= stale_after {
+        SpaceWeatherStatus::Stale as i32
+    } else {
+        SpaceWeatherStatus::Current as i32
+    };
+    snapshot
+}
+
+fn now_timestamp() -> Timestamp {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    Timestamp {
+        seconds: i64::try_from(now.as_secs()).unwrap_or(i64::MAX),
+        nanos: i32::try_from(now.subsec_nanos()).unwrap_or(i32::MAX),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::proto::qsoripper::domain::SpaceWeatherStatus;
+    use crate::space_weather::provider::{SpaceWeatherProvider, SpaceWeatherProviderError};
+
+    #[derive(Clone)]
+    struct FakeProvider {
+        result: Result<SpaceWeatherSnapshot, SpaceWeatherProviderError>,
+    }
+
+    #[tonic::async_trait]
+    impl SpaceWeatherProvider for FakeProvider {
+        async fn fetch_current(&self) -> Result<SpaceWeatherSnapshot, SpaceWeatherProviderError> {
+            self.result.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn current_snapshot_returns_cached_value_without_refreshing() {
+        let provider = Arc::new(FakeProvider {
+            result: Ok(SpaceWeatherSnapshot {
+                source_name: Some("NOAA SWPC".to_string()),
+                planetary_k_index: Some(2.33),
+                ..SpaceWeatherSnapshot::default()
+            }),
+        });
+        let monitor =
+            SpaceWeatherMonitor::new(provider, Duration::from_secs(60), Duration::from_secs(300));
+
+        let initial = monitor.refresh_snapshot().await;
+        let cached = monitor.current_snapshot().await;
+
+        assert_eq!(initial.planetary_k_index, cached.planetary_k_index);
+        assert_eq!(SpaceWeatherStatus::Current as i32, cached.status);
+    }
+
+    #[tokio::test]
+    async fn refresh_snapshot_returns_stale_cached_snapshot_when_refresh_fails() {
+        let good_provider = Arc::new(FakeProvider {
+            result: Ok(SpaceWeatherSnapshot {
+                source_name: Some("NOAA SWPC".to_string()),
+                planetary_k_index: Some(3.0),
+                ..SpaceWeatherSnapshot::default()
+            }),
+        });
+        let monitor = SpaceWeatherMonitor::new(
+            good_provider,
+            Duration::from_secs(0),
+            Duration::from_secs(0),
+        );
+        let _ = monitor.refresh_snapshot().await;
+
+        {
+            let bad_provider = Arc::new(FakeProvider {
+                result: Err(SpaceWeatherProviderError::transport("offline")),
+            });
+            let state = monitor.state.write().await;
+            let existing = state.clone().expect("cached snapshot");
+            drop(state);
+            let monitor = SpaceWeatherMonitor {
+                provider: bad_provider,
+                refresh_interval: Duration::from_secs(0),
+                stale_after: Duration::from_secs(0),
+                state: RwLock::new(Some(existing)),
+            };
+
+            let snapshot = monitor.refresh_snapshot().await;
+
+            assert_eq!(SpaceWeatherStatus::Stale as i32, snapshot.status);
+            assert_eq!(
+                Some("Space weather provider transport error: offline".to_string()),
+                snapshot.error_message
+            );
+            assert_eq!(Some(3.0), snapshot.planetary_k_index);
+        }
+    }
+}

--- a/src/rust/qsoripper-core/src/space_weather/monitor.rs
+++ b/src/rust/qsoripper-core/src/space_weather/monitor.rs
@@ -81,7 +81,6 @@ impl SpaceWeatherMonitor {
                         fetched_at: Some(now_timestamp()),
                         status: SpaceWeatherStatus::Error as i32,
                         error_message: Some(error.to_string()),
-                        source_name: Some("NOAA SWPC".to_string()),
                         ..SpaceWeatherSnapshot::default()
                     }
                 }

--- a/src/rust/qsoripper-core/src/space_weather/noaa.rs
+++ b/src/rust/qsoripper-core/src/space_weather/noaa.rs
@@ -1,0 +1,483 @@
+//! NOAA SWPC current space weather provider.
+
+use std::{env, fmt, time::Duration};
+
+use chrono::NaiveDate;
+use prost_types::Timestamp;
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::proto::qsoripper::domain::{SpaceWeatherSnapshot, SpaceWeatherStatus};
+
+use super::provider::{SpaceWeatherProvider, SpaceWeatherProviderError};
+
+/// Environment variable that enables or disables NOAA current space weather fetching.
+pub const NOAA_SPACE_WEATHER_ENABLED_ENV_VAR: &str = "QSORIPPER_NOAA_SPACE_WEATHER_ENABLED";
+/// Environment variable that overrides the NOAA planetary K-index JSON URL.
+pub const NOAA_KP_INDEX_URL_ENV_VAR: &str = "QSORIPPER_NOAA_KP_INDEX_URL";
+/// Environment variable that overrides the NOAA daily solar indices text URL.
+pub const NOAA_SOLAR_INDICES_URL_ENV_VAR: &str = "QSORIPPER_NOAA_SOLAR_INDICES_URL";
+/// Environment variable that overrides the NOAA HTTP timeout in seconds.
+pub const NOAA_HTTP_TIMEOUT_SECONDS_ENV_VAR: &str = "QSORIPPER_NOAA_HTTP_TIMEOUT_SECONDS";
+/// Environment variable that overrides the snapshot refresh interval in seconds.
+pub const NOAA_REFRESH_INTERVAL_SECONDS_ENV_VAR: &str = "QSORIPPER_NOAA_REFRESH_INTERVAL_SECONDS";
+/// Environment variable that overrides the stale-after threshold in seconds.
+pub const NOAA_STALE_AFTER_SECONDS_ENV_VAR: &str = "QSORIPPER_NOAA_STALE_AFTER_SECONDS";
+
+/// Default NOAA planetary K-index endpoint.
+pub const DEFAULT_NOAA_KP_INDEX_URL: &str =
+    "https://services.swpc.noaa.gov/products/noaa-planetary-k-index.json";
+/// Default NOAA daily solar indices endpoint.
+pub const DEFAULT_NOAA_SOLAR_INDICES_URL: &str =
+    "https://services.swpc.noaa.gov/text/daily-solar-indices.txt";
+/// Default NOAA HTTP timeout.
+pub const DEFAULT_NOAA_HTTP_TIMEOUT_SECONDS: u64 = 8;
+/// Default refresh interval for current space weather snapshots.
+pub const DEFAULT_NOAA_REFRESH_INTERVAL_SECONDS: u64 = 900;
+/// Default stale-after threshold for current space weather snapshots.
+pub const DEFAULT_NOAA_STALE_AFTER_SECONDS: u64 = 3600;
+
+/// NOAA current space weather provider configuration.
+#[derive(Clone)]
+pub struct NoaaSpaceWeatherConfig {
+    enabled: bool,
+    kp_index_url: String,
+    solar_indices_url: String,
+    http_timeout: Duration,
+    refresh_interval: Duration,
+    stale_after: Duration,
+}
+
+impl fmt::Debug for NoaaSpaceWeatherConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("NoaaSpaceWeatherConfig")
+            .field("enabled", &self.enabled)
+            .field("kp_index_url", &self.kp_index_url)
+            .field("solar_indices_url", &self.solar_indices_url)
+            .field("http_timeout", &self.http_timeout)
+            .field("refresh_interval", &self.refresh_interval)
+            .field("stale_after", &self.stale_after)
+            .finish()
+    }
+}
+
+impl NoaaSpaceWeatherConfig {
+    /// Load provider configuration from environment variables.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NoaaSpaceWeatherConfigError` when integer-valued settings
+    /// cannot be parsed.
+    pub fn from_env() -> Result<Self, NoaaSpaceWeatherConfigError> {
+        Self::from_value_provider(|name| env::var(name).ok())
+    }
+
+    /// Load provider configuration from an arbitrary key/value source.
+    ///
+    /// # Errors
+    ///
+    /// Returns `NoaaSpaceWeatherConfigError` when integer-valued settings
+    /// cannot be parsed.
+    pub fn from_value_provider<F>(mut get_value: F) -> Result<Self, NoaaSpaceWeatherConfigError>
+    where
+        F: FnMut(&'static str) -> Option<String>,
+    {
+        let enabled =
+            optional_value_bool(NOAA_SPACE_WEATHER_ENABLED_ENV_VAR, true, &mut get_value)?;
+        let kp_index_url = optional_value(NOAA_KP_INDEX_URL_ENV_VAR, &mut get_value)
+            .unwrap_or_else(|| DEFAULT_NOAA_KP_INDEX_URL.to_string());
+        let solar_indices_url = optional_value(NOAA_SOLAR_INDICES_URL_ENV_VAR, &mut get_value)
+            .unwrap_or_else(|| DEFAULT_NOAA_SOLAR_INDICES_URL.to_string());
+        let http_timeout_seconds = optional_value_u64(
+            NOAA_HTTP_TIMEOUT_SECONDS_ENV_VAR,
+            DEFAULT_NOAA_HTTP_TIMEOUT_SECONDS,
+            &mut get_value,
+        )?;
+        let refresh_interval_seconds = optional_value_u64(
+            NOAA_REFRESH_INTERVAL_SECONDS_ENV_VAR,
+            DEFAULT_NOAA_REFRESH_INTERVAL_SECONDS,
+            &mut get_value,
+        )?;
+        let stale_after_seconds = optional_value_u64(
+            NOAA_STALE_AFTER_SECONDS_ENV_VAR,
+            DEFAULT_NOAA_STALE_AFTER_SECONDS,
+            &mut get_value,
+        )?;
+
+        Ok(Self {
+            enabled,
+            kp_index_url,
+            solar_indices_url,
+            http_timeout: Duration::from_secs(http_timeout_seconds),
+            refresh_interval: Duration::from_secs(refresh_interval_seconds),
+            stale_after: Duration::from_secs(stale_after_seconds),
+        })
+    }
+
+    /// Return whether space weather fetching is enabled.
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Return the refresh interval for cached snapshots.
+    #[must_use]
+    pub fn refresh_interval(&self) -> Duration {
+        self.refresh_interval
+    }
+
+    /// Return the stale-after threshold for cached snapshots.
+    #[must_use]
+    pub fn stale_after(&self) -> Duration {
+        self.stale_after
+    }
+}
+
+/// Errors while reading NOAA provider configuration.
+#[derive(Debug, thiserror::Error)]
+pub enum NoaaSpaceWeatherConfigError {
+    /// An environment variable could not be parsed as an integer.
+    #[error("Environment variable '{name}' has invalid integer value '{value}'.")]
+    InvalidInteger {
+        /// Environment variable name.
+        name: &'static str,
+        /// Raw value that failed integer parsing.
+        value: String,
+    },
+    /// An environment variable could not be parsed as a boolean.
+    #[error("Environment variable '{name}' has invalid boolean value '{value}'.")]
+    InvalidBoolean {
+        /// Environment variable name.
+        name: &'static str,
+        /// Raw value that failed boolean parsing.
+        value: String,
+    },
+}
+
+/// NOAA SWPC provider implementation.
+#[derive(Debug)]
+pub struct NoaaSpaceWeatherProvider {
+    config: NoaaSpaceWeatherConfig,
+    client: Client,
+}
+
+impl NoaaSpaceWeatherProvider {
+    /// Create a provider using validated configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns `SpaceWeatherProviderError::transport` when the HTTP client
+    /// cannot be created.
+    pub fn new(config: NoaaSpaceWeatherConfig) -> Result<Self, SpaceWeatherProviderError> {
+        let client = Client::builder()
+            .timeout(config.http_timeout)
+            .build()
+            .map_err(|error| {
+                SpaceWeatherProviderError::transport(format!(
+                    "Failed to create NOAA HTTP client: {error}"
+                ))
+            })?;
+
+        Ok(Self { config, client })
+    }
+
+    async fn fetch_kp_data(&self) -> Result<PlanetaryKIndexEntry, SpaceWeatherProviderError> {
+        let body = self
+            .client
+            .get(self.config.kp_index_url.as_str())
+            .send()
+            .await
+            .map_err(|error| {
+                SpaceWeatherProviderError::transport(format!(
+                    "Failed to fetch NOAA planetary K-index data: {error}"
+                ))
+            })?
+            .error_for_status()
+            .map_err(|error| {
+                SpaceWeatherProviderError::transport(format!(
+                    "NOAA planetary K-index request failed: {error}"
+                ))
+            })?
+            .text()
+            .await
+            .map_err(|error| {
+                SpaceWeatherProviderError::transport(format!(
+                    "Failed to read NOAA planetary K-index response: {error}"
+                ))
+            })?;
+        let entries =
+            serde_json::from_str::<Vec<PlanetaryKIndexEntry>>(&body).map_err(|error| {
+                SpaceWeatherProviderError::parse(format!(
+                    "Failed to parse NOAA planetary K-index JSON: {error}"
+                ))
+            })?;
+        entries.into_iter().last().ok_or_else(|| {
+            SpaceWeatherProviderError::parse("NOAA planetary K-index feed returned no entries.")
+        })
+    }
+
+    async fn fetch_solar_data(&self) -> Result<DailySolarIndices, SpaceWeatherProviderError> {
+        let body = self
+            .client
+            .get(self.config.solar_indices_url.as_str())
+            .send()
+            .await
+            .map_err(|error| {
+                SpaceWeatherProviderError::transport(format!(
+                    "Failed to fetch NOAA daily solar indices: {error}"
+                ))
+            })?
+            .error_for_status()
+            .map_err(|error| {
+                SpaceWeatherProviderError::transport(format!(
+                    "NOAA daily solar indices request failed: {error}"
+                ))
+            })?
+            .text()
+            .await
+            .map_err(|error| {
+                SpaceWeatherProviderError::transport(format!(
+                    "Failed to read NOAA daily solar indices response: {error}"
+                ))
+            })?;
+        parse_daily_solar_indices(&body)
+    }
+}
+
+#[tonic::async_trait]
+impl SpaceWeatherProvider for NoaaSpaceWeatherProvider {
+    async fn fetch_current(&self) -> Result<SpaceWeatherSnapshot, SpaceWeatherProviderError> {
+        if !self.config.enabled {
+            return Err(SpaceWeatherProviderError::disabled(
+                "NOAA space weather fetching is disabled.",
+            ));
+        }
+
+        let (kp, solar) = tokio::try_join!(self.fetch_kp_data(), self.fetch_solar_data())?;
+
+        Ok(SpaceWeatherSnapshot {
+            observed_at: Some(parse_noaa_timestamp(&kp.time_tag)?),
+            status: SpaceWeatherStatus::Current as i32,
+            planetary_k_index: Some(kp.kp),
+            planetary_a_index: Some(kp.a_running),
+            solar_flux_index: Some(solar.solar_flux_index),
+            sunspot_number: Some(solar.sunspot_number),
+            geomagnetic_storm_scale: geomagnetic_storm_scale(kp.kp),
+            source_name: Some("NOAA SWPC".to_string()),
+            ..SpaceWeatherSnapshot::default()
+        })
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct PlanetaryKIndexEntry {
+    time_tag: String,
+    #[serde(rename = "Kp")]
+    kp: f64,
+    a_running: u32,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct DailySolarIndices {
+    solar_flux_index: f64,
+    sunspot_number: u32,
+}
+
+fn geomagnetic_storm_scale(kp: f64) -> Option<u32> {
+    if kp >= 9.0 {
+        Some(5)
+    } else if kp >= 8.0 {
+        Some(4)
+    } else if kp >= 7.0 {
+        Some(3)
+    } else if kp >= 6.0 {
+        Some(2)
+    } else if kp >= 5.0 {
+        Some(1)
+    } else {
+        None
+    }
+}
+
+fn parse_noaa_timestamp(raw: &str) -> Result<Timestamp, SpaceWeatherProviderError> {
+    let timestamp =
+        chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%dT%H:%M:%S").map_err(|error| {
+            SpaceWeatherProviderError::parse(format!(
+                "Failed to parse NOAA K-index timestamp '{raw}': {error}"
+            ))
+        })?;
+    Ok(Timestamp {
+        seconds: timestamp.and_utc().timestamp(),
+        nanos: i32::try_from(timestamp.and_utc().timestamp_subsec_nanos()).unwrap_or(i32::MAX),
+    })
+}
+
+fn parse_daily_solar_indices(body: &str) -> Result<DailySolarIndices, SpaceWeatherProviderError> {
+    let line = body
+        .lines()
+        .rev()
+        .map(str::trim)
+        .find(|line| line.chars().next().is_some_and(|c| c.is_ascii_digit()))
+        .ok_or_else(|| {
+            SpaceWeatherProviderError::parse(
+                "NOAA daily solar indices feed returned no data lines.",
+            )
+        })?;
+    let columns: Vec<_> = line.split_whitespace().collect();
+    if columns.len() < 5 {
+        return Err(SpaceWeatherProviderError::parse(format!(
+            "NOAA daily solar indices line was missing expected columns: '{line}'"
+        )));
+    }
+
+    let year_raw = required_column(&columns, 0, line)?;
+    let month_raw = required_column(&columns, 1, line)?;
+    let day_raw = required_column(&columns, 2, line)?;
+    let solar_flux_raw = required_column(&columns, 3, line)?;
+    let sunspot_raw = required_column(&columns, 4, line)?;
+
+    let year = year_raw.parse::<i32>().map_err(|error| {
+        SpaceWeatherProviderError::parse(format!(
+            "Failed to parse NOAA solar indices year '{year_raw}': {error}"
+        ))
+    })?;
+    let month = month_raw.parse::<u32>().map_err(|error| {
+        SpaceWeatherProviderError::parse(format!(
+            "Failed to parse NOAA solar indices month '{month_raw}': {error}"
+        ))
+    })?;
+    let day = day_raw.parse::<u32>().map_err(|error| {
+        SpaceWeatherProviderError::parse(format!(
+            "Failed to parse NOAA solar indices day '{day_raw}': {error}"
+        ))
+    })?;
+    let solar_flux_index = solar_flux_raw.parse::<f64>().map_err(|error| {
+        SpaceWeatherProviderError::parse(format!(
+            "Failed to parse NOAA solar flux '{solar_flux_raw}': {error}"
+        ))
+    })?;
+    let sunspot_number = sunspot_raw.parse::<u32>().map_err(|error| {
+        SpaceWeatherProviderError::parse(format!(
+            "Failed to parse NOAA sunspot number '{sunspot_raw}': {error}"
+        ))
+    })?;
+
+    NaiveDate::from_ymd_opt(year, month, day).ok_or_else(|| {
+        SpaceWeatherProviderError::parse(format!(
+            "NOAA daily solar indices date '{year:04}-{month:02}-{day:02}' is invalid."
+        ))
+    })?;
+
+    Ok(DailySolarIndices {
+        solar_flux_index,
+        sunspot_number,
+    })
+}
+
+fn required_column<'a>(
+    columns: &'a [&str],
+    index: usize,
+    line: &str,
+) -> Result<&'a str, SpaceWeatherProviderError> {
+    columns.get(index).copied().ok_or_else(|| {
+        SpaceWeatherProviderError::parse(format!(
+            "NOAA daily solar indices line was missing column {index}: '{line}'"
+        ))
+    })
+}
+
+fn optional_value<F>(name: &'static str, get_value: &mut F) -> Option<String>
+where
+    F: FnMut(&'static str) -> Option<String>,
+{
+    get_value(name).and_then(|value| {
+        let trimmed = value.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
+}
+
+fn optional_value_u64<F>(
+    name: &'static str,
+    default_value: u64,
+    get_value: &mut F,
+) -> Result<u64, NoaaSpaceWeatherConfigError>
+where
+    F: FnMut(&'static str) -> Option<String>,
+{
+    optional_value(name, get_value).map_or(Ok(default_value), |value| {
+        value
+            .parse::<u64>()
+            .map_err(|_| NoaaSpaceWeatherConfigError::InvalidInteger { name, value })
+    })
+}
+
+fn optional_value_bool<F>(
+    name: &'static str,
+    default_value: bool,
+    get_value: &mut F,
+) -> Result<bool, NoaaSpaceWeatherConfigError>
+where
+    F: FnMut(&'static str) -> Option<String>,
+{
+    optional_value(name, get_value).map_or(Ok(default_value), |value| {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "y" | "on" => Ok(true),
+            "0" | "false" | "no" | "n" | "off" => Ok(false),
+            _ => Err(NoaaSpaceWeatherConfigError::InvalidBoolean { name, value }),
+        }
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_defaults_to_enabled_and_known_urls() {
+        let config = NoaaSpaceWeatherConfig::from_value_provider(|_| None).expect("config");
+
+        assert!(config.enabled());
+        assert_eq!(
+            Duration::from_secs(DEFAULT_NOAA_REFRESH_INTERVAL_SECONDS),
+            config.refresh_interval()
+        );
+        assert_eq!(
+            Duration::from_secs(DEFAULT_NOAA_STALE_AFTER_SECONDS),
+            config.stale_after()
+        );
+    }
+
+    #[test]
+    fn parse_daily_solar_indices_reads_last_data_row() {
+        let body = "\
+# header\n\
+2026 04 11   93     42      180      0    -999      *   2  0  0  1  0  0  0\n\
+2026 04 12   99     47      270      1    -999      *   6  0  0  0  0  0  0\n";
+
+        let parsed = parse_daily_solar_indices(body).expect("parsed solar data");
+
+        assert_eq!(
+            DailySolarIndices {
+                solar_flux_index: 99.0,
+                sunspot_number: 47
+            },
+            parsed
+        );
+    }
+
+    #[test]
+    fn parse_noaa_timestamp_accepts_k_index_timestamp() {
+        let timestamp = parse_noaa_timestamp("2026-04-13T18:00:00").expect("timestamp");
+
+        assert_eq!(1_776_103_200, timestamp.seconds);
+    }
+
+    #[test]
+    fn geomagnetic_storm_scale_is_empty_below_g1() {
+        assert_eq!(None, geomagnetic_storm_scale(4.67));
+        assert_eq!(Some(1), geomagnetic_storm_scale(5.0));
+        assert_eq!(Some(5), geomagnetic_storm_scale(9.0));
+    }
+}

--- a/src/rust/qsoripper-core/src/space_weather/provider.rs
+++ b/src/rust/qsoripper-core/src/space_weather/provider.rs
@@ -1,0 +1,126 @@
+//! Provider seam for current space weather data.
+
+use crate::proto::qsoripper::domain::SpaceWeatherSnapshot;
+
+/// Abstraction over an external current space weather provider.
+#[tonic::async_trait]
+pub trait SpaceWeatherProvider: Send + Sync {
+    /// Fetch a fresh normalized current space weather snapshot.
+    async fn fetch_current(&self) -> Result<SpaceWeatherSnapshot, SpaceWeatherProviderError>;
+}
+
+/// Stable provider error categories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpaceWeatherProviderErrorKind {
+    /// Provider is disabled by configuration.
+    Disabled,
+    /// Transport failed before a valid response was received.
+    Transport,
+    /// Provider returned a payload that could not be parsed or understood.
+    Parse,
+}
+
+/// Errors surfaced by the space weather provider layer.
+#[derive(Debug, Clone)]
+pub struct SpaceWeatherProviderError {
+    kind: SpaceWeatherProviderErrorKind,
+    message: String,
+}
+
+impl SpaceWeatherProviderError {
+    /// Provider is disabled.
+    #[must_use]
+    pub fn disabled(message: impl Into<String>) -> Self {
+        Self::new(SpaceWeatherProviderErrorKind::Disabled, message)
+    }
+
+    /// Provider transport failed.
+    #[must_use]
+    pub fn transport(message: impl Into<String>) -> Self {
+        Self::new(SpaceWeatherProviderErrorKind::Transport, message)
+    }
+
+    /// Provider returned an unexpected payload.
+    #[must_use]
+    pub fn parse(message: impl Into<String>) -> Self {
+        Self::new(SpaceWeatherProviderErrorKind::Parse, message)
+    }
+
+    fn new(kind: SpaceWeatherProviderErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    /// Returns whether the error class is suitable for retry handling.
+    #[must_use]
+    pub fn is_retryable(&self) -> bool {
+        matches!(self.kind, SpaceWeatherProviderErrorKind::Transport)
+    }
+}
+
+impl std::fmt::Display for SpaceWeatherProviderError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Space weather provider {} error: {}",
+            match self.kind {
+                SpaceWeatherProviderErrorKind::Disabled => "disabled",
+                SpaceWeatherProviderErrorKind::Transport => "transport",
+                SpaceWeatherProviderErrorKind::Parse => "parse",
+            },
+            self.message
+        )
+    }
+}
+
+impl std::error::Error for SpaceWeatherProviderError {}
+
+/// Provider used when space weather fetching is disabled.
+#[derive(Debug, Clone)]
+pub struct DisabledSpaceWeatherProvider {
+    reason: String,
+}
+
+impl DisabledSpaceWeatherProvider {
+    /// Create a disabled provider with a stable reason message.
+    #[must_use]
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl SpaceWeatherProvider for DisabledSpaceWeatherProvider {
+    async fn fetch_current(&self) -> Result<SpaceWeatherSnapshot, SpaceWeatherProviderError> {
+        Err(SpaceWeatherProviderError::disabled(self.reason.clone()))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retryable_errors_are_transport_only() {
+        assert!(SpaceWeatherProviderError::transport("offline").is_retryable());
+        assert!(!SpaceWeatherProviderError::disabled("off").is_retryable());
+        assert!(!SpaceWeatherProviderError::parse("bad").is_retryable());
+    }
+
+    #[tokio::test]
+    async fn disabled_provider_returns_disabled_error() {
+        let provider = DisabledSpaceWeatherProvider::new("disabled");
+
+        let error = provider.fetch_current().await.expect_err("error");
+
+        assert_eq!(
+            "Space weather provider disabled error: disabled",
+            error.to_string()
+        );
+    }
+}

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -22,16 +22,19 @@ use qsoripper_core::proto::qsoripper::services::{
     logbook_service_server::{LogbookService, LogbookServiceServer},
     lookup_service_server::{LookupService, LookupServiceServer},
     setup_service_server::SetupServiceServer,
+    space_weather_service_server::{SpaceWeatherService, SpaceWeatherServiceServer},
     station_profile_service_server::StationProfileServiceServer,
     AdifChunk, ApplyRuntimeConfigRequest, ApplyRuntimeConfigResponse, BatchLookupRequest,
     BatchLookupResponse, DeleteQsoRequest, DeleteQsoResponse, ExportAdifRequest,
-    ExportAdifResponse, GetCachedCallsignRequest, GetCachedCallsignResponse, GetDxccEntityRequest,
+    ExportAdifResponse, GetCachedCallsignRequest, GetCachedCallsignResponse,
+    GetCurrentSpaceWeatherRequest, GetCurrentSpaceWeatherResponse, GetDxccEntityRequest,
     GetDxccEntityResponse, GetQsoRequest, GetQsoResponse, GetRuntimeConfigRequest,
     GetRuntimeConfigResponse, GetSyncStatusRequest, GetSyncStatusResponse, ImportAdifRequest,
     ImportAdifResponse, ListQsosRequest, ListQsosResponse, LogQsoRequest, LogQsoResponse,
-    LookupRequest, LookupResponse, QsoSortOrder as ProtoQsoSortOrder, ResetRuntimeConfigRequest,
-    ResetRuntimeConfigResponse, StreamLookupRequest, StreamLookupResponse, SyncWithQrzRequest,
-    SyncWithQrzResponse, UpdateQsoRequest, UpdateQsoResponse,
+    LookupRequest, LookupResponse, QsoSortOrder as ProtoQsoSortOrder, RefreshSpaceWeatherRequest,
+    RefreshSpaceWeatherResponse, ResetRuntimeConfigRequest, ResetRuntimeConfigResponse,
+    StreamLookupRequest, StreamLookupResponse, SyncWithQrzRequest, SyncWithQrzResponse,
+    UpdateQsoRequest, UpdateQsoResponse,
 };
 use runtime_config::RuntimeConfigManager;
 use setup::{
@@ -68,6 +71,7 @@ where
     let setup_service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
     let station_profile_service =
         StationProfileControlSurface::new(setup_state.clone(), runtime_config.clone());
+    let space_weather_service = SpaceWeatherControlSurface::new(runtime_config.clone());
     let active_storage_backend = runtime_config.active_storage_backend().await;
     let setup_status = setup_state.status().await;
     let setup_completion = setup_completion_label(setup_status.setup_complete);
@@ -102,6 +106,7 @@ where
         .add_service(LookupServiceServer::new(lookup_service))
         .add_service(SetupServiceServer::new(setup_service))
         .add_service(StationProfileServiceServer::new(station_profile_service))
+        .add_service(SpaceWeatherServiceServer::new(space_weather_service))
         .add_service(DeveloperControlServiceServer::new(
             developer_control_service,
         ))
@@ -590,6 +595,50 @@ impl DeveloperControlService for DeveloperControlSurface {
     }
 }
 
+#[derive(Clone)]
+struct SpaceWeatherControlSurface {
+    runtime_config: Arc<RuntimeConfigManager>,
+}
+
+impl SpaceWeatherControlSurface {
+    fn new(runtime_config: Arc<RuntimeConfigManager>) -> Self {
+        Self { runtime_config }
+    }
+}
+
+#[tonic::async_trait]
+impl SpaceWeatherService for SpaceWeatherControlSurface {
+    async fn get_current_space_weather(
+        &self,
+        _request: Request<GetCurrentSpaceWeatherRequest>,
+    ) -> Result<Response<GetCurrentSpaceWeatherResponse>, Status> {
+        let snapshot = self
+            .runtime_config
+            .space_weather_monitor()
+            .await
+            .current_snapshot()
+            .await;
+        Ok(Response::new(GetCurrentSpaceWeatherResponse {
+            snapshot: Some(snapshot),
+        }))
+    }
+
+    async fn refresh_space_weather(
+        &self,
+        _request: Request<RefreshSpaceWeatherRequest>,
+    ) -> Result<Response<RefreshSpaceWeatherResponse>, Status> {
+        let snapshot = self
+            .runtime_config
+            .space_weather_monitor()
+            .await
+            .refresh_snapshot()
+            .await;
+        Ok(Response::new(RefreshSpaceWeatherResponse {
+            snapshot: Some(snapshot),
+        }))
+    }
+}
+
 #[derive(Debug, Clone)]
 struct ServerOptions {
     listen_address: SocketAddr,
@@ -817,7 +866,8 @@ mod tests {
         build_storage, legacy_qrz_user_agent_line_compatibility, load_dotenv_if_present,
         parse_storage_backend, run_server, sanitize_legacy_qrz_user_agent_contents,
         server_ready_message, server_starting_message, DeveloperLogbookService,
-        DeveloperLookupService, Server, ServerOptions, StorageBackendKind, StorageOptions,
+        DeveloperLookupService, Server, ServerOptions, SpaceWeatherControlSurface,
+        StorageBackendKind, StorageOptions,
     };
     use crate::runtime_config::{
         RuntimeConfigManager, SQLITE_PATH_ENV_VAR, STATION_CALLSIGN_ENV_VAR, STATION_GRID_ENV_VAR,
@@ -827,6 +877,7 @@ mod tests {
     use qsoripper_core::lookup::{
         QRZ_USER_AGENT_ENV_VAR, QRZ_XML_PASSWORD_ENV_VAR, QRZ_XML_USERNAME_ENV_VAR,
     };
+    use qsoripper_core::proto::qsoripper::domain::SpaceWeatherStatus;
     use qsoripper_core::proto::qsoripper::domain::{
         Band, LookupResult, LookupState, Mode, QsoRecord,
     };
@@ -835,10 +886,12 @@ mod tests {
         logbook_service_client::LogbookServiceClient,
         logbook_service_server::{LogbookService, LogbookServiceServer},
         lookup_service_server::LookupService,
+        space_weather_service_server::SpaceWeatherService,
         AdifChunk, BatchLookupRequest, DeleteQsoRequest, ExportAdifRequest,
-        GetCachedCallsignRequest, GetDxccEntityRequest, GetQsoRequest, GetSyncStatusRequest,
-        ImportAdifRequest, ImportAdifResponse, ListQsosRequest, LogQsoRequest, LookupRequest,
-        QsoSortOrder, StreamLookupRequest, UpdateQsoRequest,
+        GetCachedCallsignRequest, GetCurrentSpaceWeatherRequest, GetDxccEntityRequest,
+        GetQsoRequest, GetSyncStatusRequest, ImportAdifRequest, ImportAdifResponse,
+        ListQsosRequest, LogQsoRequest, LookupRequest, QsoSortOrder, RefreshSpaceWeatherRequest,
+        StreamLookupRequest, UpdateQsoRequest,
     };
     use tokio_stream::StreamExt;
     use tonic::transport::Channel;
@@ -846,11 +899,17 @@ mod tests {
 
     static PROCESS_STATE_LOCK: Mutex<()> = Mutex::new(());
 
-    const PROCESS_ENV_KEYS: [&str; 4] = [
+    const PROCESS_ENV_KEYS: [&str; 10] = [
         "QSORIPPER_SERVER_ADDR",
         "QSORIPPER_CONFIG_PATH",
         "QSORIPPER_STORAGE_BACKEND",
         "QSORIPPER_SQLITE_PATH",
+        "QSORIPPER_NOAA_SPACE_WEATHER_ENABLED",
+        "QSORIPPER_NOAA_KP_INDEX_URL",
+        "QSORIPPER_NOAA_SOLAR_INDICES_URL",
+        "QSORIPPER_NOAA_HTTP_TIMEOUT_SECONDS",
+        "QSORIPPER_NOAA_REFRESH_INTERVAL_SECONDS",
+        "QSORIPPER_NOAA_STALE_AFTER_SECONDS",
     ];
 
     struct ProcessStateGuard {
@@ -937,6 +996,56 @@ mod tests {
         }
 
         Arc::new(RuntimeConfigManager::new(startup_values).expect("runtime config"))
+    }
+
+    fn test_runtime_config_with_space_weather_enabled(enabled: bool) -> Arc<RuntimeConfigManager> {
+        let mut startup_values = BTreeMap::new();
+        startup_values.insert(
+            qsoripper_core::space_weather::NOAA_SPACE_WEATHER_ENABLED_ENV_VAR.to_string(),
+            enabled.to_string(),
+        );
+
+        Arc::new(RuntimeConfigManager::new(startup_values).expect("runtime config"))
+    }
+
+    #[tokio::test]
+    async fn get_current_space_weather_returns_disabled_snapshot_when_provider_is_disabled() {
+        let service =
+            SpaceWeatherControlSurface::new(test_runtime_config_with_space_weather_enabled(false));
+
+        let response = service
+            .get_current_space_weather(Request::new(GetCurrentSpaceWeatherRequest {}))
+            .await
+            .expect("space weather response")
+            .into_inner();
+        let snapshot = response.snapshot.expect("space weather snapshot");
+        let error_message = snapshot.error_message.expect("error message");
+
+        assert_eq!(SpaceWeatherStatus::Error as i32, snapshot.status);
+        assert!(
+            error_message.contains("disabled"),
+            "unexpected error message: {error_message}"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_space_weather_returns_disabled_snapshot_when_provider_is_disabled() {
+        let service =
+            SpaceWeatherControlSurface::new(test_runtime_config_with_space_weather_enabled(false));
+
+        let response = service
+            .refresh_space_weather(Request::new(RefreshSpaceWeatherRequest {}))
+            .await
+            .expect("space weather response")
+            .into_inner();
+        let snapshot = response.snapshot.expect("space weather snapshot");
+        let error_message = snapshot.error_message.expect("error message");
+
+        assert_eq!(SpaceWeatherStatus::Error as i32, snapshot.status);
+        assert!(
+            error_message.contains("disabled"),
+            "unexpected error message: {error_message}"
+        );
     }
 
     fn unique_sqlite_test_path(label: &str) -> PathBuf {

--- a/src/rust/qsoripper-server/src/runtime_config.rs
+++ b/src/rust/qsoripper-server/src/runtime_config.rs
@@ -16,6 +16,13 @@ use qsoripper_core::proto::qsoripper::services::{
     RuntimeConfigMutation, RuntimeConfigMutationKind, RuntimeConfigSnapshot, RuntimeConfigValue,
     RuntimeConfigValueKind,
 };
+use qsoripper_core::space_weather::{
+    DisabledSpaceWeatherProvider, NoaaSpaceWeatherConfig, NoaaSpaceWeatherProvider,
+    SpaceWeatherMonitor, SpaceWeatherProvider, NOAA_HTTP_TIMEOUT_SECONDS_ENV_VAR,
+    NOAA_KP_INDEX_URL_ENV_VAR, NOAA_REFRESH_INTERVAL_SECONDS_ENV_VAR,
+    NOAA_SOLAR_INDICES_URL_ENV_VAR, NOAA_SPACE_WEATHER_ENABLED_ENV_VAR,
+    NOAA_STALE_AFTER_SECONDS_ENV_VAR,
+};
 use tokio::sync::RwLock;
 
 use crate::station_profile_support::{
@@ -47,6 +54,7 @@ const REDACTED_VALUE: &str = "<redacted>";
 struct RuntimeBindings {
     logbook_engine: LogbookEngine,
     lookup_coordinator: Arc<LookupCoordinator>,
+    space_weather_monitor: Arc<SpaceWeatherMonitor>,
     active_storage_backend: String,
     lookup_provider_summary: String,
     active_station_profile: Option<StationProfile>,
@@ -152,6 +160,10 @@ impl RuntimeConfigManager {
 
     pub(crate) async fn lookup_coordinator(&self) -> Arc<LookupCoordinator> {
         self.bindings.read().await.lookup_coordinator.clone()
+    }
+
+    pub(crate) async fn space_weather_monitor(&self) -> Arc<SpaceWeatherMonitor> {
+        self.bindings.read().await.space_weather_monitor.clone()
     }
 
     pub(crate) async fn active_storage_backend(&self) -> String {
@@ -501,6 +513,62 @@ const SUPPORTED_FIELDS: &[ConfigFieldSpec] = &[
         allowed_values: BOOLEAN_ALLOWED_VALUES,
         default_value: Some("false"),
     },
+    ConfigFieldSpec {
+        key: NOAA_SPACE_WEATHER_ENABLED_ENV_VAR,
+        label: "NOAA space weather enabled",
+        description: "Enable live NOAA SWPC current space weather fetching.",
+        kind: RuntimeConfigValueKind::Boolean,
+        secret: false,
+        allowed_values: BOOLEAN_ALLOWED_VALUES,
+        default_value: Some("true"),
+    },
+    ConfigFieldSpec {
+        key: NOAA_KP_INDEX_URL_ENV_VAR,
+        label: "NOAA K-index URL",
+        description: "NOAA SWPC endpoint used for planetary K-index and running A-index data.",
+        kind: RuntimeConfigValueKind::String,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some(qsoripper_core::space_weather::DEFAULT_NOAA_KP_INDEX_URL),
+    },
+    ConfigFieldSpec {
+        key: NOAA_SOLAR_INDICES_URL_ENV_VAR,
+        label: "NOAA solar indices URL",
+        description: "NOAA SWPC endpoint used for daily solar flux and sunspot data.",
+        kind: RuntimeConfigValueKind::String,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some(qsoripper_core::space_weather::DEFAULT_NOAA_SOLAR_INDICES_URL),
+    },
+    ConfigFieldSpec {
+        key: NOAA_HTTP_TIMEOUT_SECONDS_ENV_VAR,
+        label: "NOAA HTTP timeout seconds",
+        description: "HTTP timeout used by live NOAA SWPC requests.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some("8"),
+    },
+    ConfigFieldSpec {
+        key: NOAA_REFRESH_INTERVAL_SECONDS_ENV_VAR,
+        label: "NOAA refresh interval seconds",
+        description:
+            "How long the engine caches a current space weather snapshot before refreshing.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some("900"),
+    },
+    ConfigFieldSpec {
+        key: NOAA_STALE_AFTER_SECONDS_ENV_VAR,
+        label: "NOAA stale after seconds",
+        description:
+            "When cached space weather data should be marked stale if refreshes fail or lag.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some("3600"),
+    },
 ];
 
 fn capture_supported_env() -> BTreeMap<String, String> {
@@ -582,6 +650,24 @@ fn normalize_value(key: &'static str, raw_value: &str) -> Result<String, String>
             .parse::<u32>()
             .map(|value| value.to_string())
             .map_err(|_| format!("'{key}' expects an integer value."))
+    } else if matches!(
+        key,
+        NOAA_HTTP_TIMEOUT_SECONDS_ENV_VAR
+            | NOAA_REFRESH_INTERVAL_SECONDS_ENV_VAR
+            | NOAA_STALE_AFTER_SECONDS_ENV_VAR
+    ) {
+        trimmed
+            .parse::<u64>()
+            .map(|value| value.to_string())
+            .map_err(|_| format!("'{key}' expects an integer value."))
+    } else if key == NOAA_SPACE_WEATHER_ENABLED_ENV_VAR {
+        parse_bool(trimmed).map(|value| {
+            if value {
+                "true".to_string()
+            } else {
+                "false".to_string()
+            }
+        })
     } else if is_station_positive_integer_key(key) {
         parse_positive_integer(key, trimmed).map(|value| value.to_string())
     } else if key == STATION_LATITUDE_ENV_VAR {
@@ -679,11 +765,13 @@ fn build_runtime_bindings(values: &BTreeMap<String, String>) -> Result<RuntimeBi
         provider,
         LookupCoordinatorConfig::default(),
     ));
+    let space_weather_monitor = build_space_weather_monitor(values);
     let active_station_profile = build_active_station_profile(values)?;
 
     Ok(RuntimeBindings {
         logbook_engine,
         lookup_coordinator,
+        space_weather_monitor,
         active_storage_backend,
         lookup_provider_summary,
         active_station_profile,
@@ -784,6 +872,33 @@ fn build_lookup_provider(values: &BTreeMap<String, String>) -> (Arc<dyn Callsign
                 format!("Disabled: {reason}"),
             )
         }
+    }
+}
+
+fn build_space_weather_monitor(values: &BTreeMap<String, String>) -> Arc<SpaceWeatherMonitor> {
+    match NoaaSpaceWeatherConfig::from_value_provider(|name| values.get(name).cloned()) {
+        Ok(config) => {
+            let provider: Arc<dyn SpaceWeatherProvider> = if config.enabled() {
+                match NoaaSpaceWeatherProvider::new(config.clone()) {
+                    Ok(provider) => Arc::new(provider),
+                    Err(error) => Arc::new(DisabledSpaceWeatherProvider::new(error.to_string())),
+                }
+            } else {
+                Arc::new(DisabledSpaceWeatherProvider::new(
+                    "NOAA space weather fetching is disabled.",
+                ))
+            };
+            Arc::new(SpaceWeatherMonitor::new(
+                provider,
+                config.refresh_interval(),
+                config.stale_after(),
+            ))
+        }
+        Err(error) => Arc::new(SpaceWeatherMonitor::new(
+            Arc::new(DisabledSpaceWeatherProvider::new(error.to_string())),
+            std::time::Duration::from_secs(900),
+            std::time::Duration::from_secs(3600),
+        )),
     }
 }
 


### PR DESCRIPTION
Implements the first NOAA space weather slice for #109.\n\nThis adds the new space weather proto contracts, a NOAA-backed Rust provider and cached monitor, server-side gRPC wiring, and a new CLI space-weather command with --refresh and --json support.