### PR TITLE
Add compact recent QSO grid to Avalonia GUI

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Install Buf CLI
         uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
 
       - name: Install cargo-deny
         run: |

--- a/src/dotnet/CodeCoverage.runsettings
+++ b/src/dotnet/CodeCoverage.runsettings
@@ -5,7 +5,7 @@
       <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
           <Format>cobertura</Format>
-          <Exclude>[*]QsoRipper.Domain.*,[*]QsoRipper.Services.*,[QsoRipper.DebugHost]*,[*]QsoRipper.Cli.Commands.*,[*]Program</Exclude>
+          <Exclude>[*]QsoRipper.Domain.*,[*]QsoRipper.Services.*,[QsoRipper.DebugHost]*,[*]QsoRipper.Cli.Commands.*,[*]Program,[*]QsoRipper.Gui.App,[*]QsoRipper.Gui.Views.*,[*]QsoRipper.Gui.ViewModels.LogFileStepViewModel,[*]QsoRipper.Gui.ViewModels.QrzStepViewModel,[*]QsoRipper.Gui.ViewModels.ReviewStepViewModel,[*]QsoRipper.Gui.ViewModels.SetupWizardViewModel,[*]QsoRipper.Gui.ViewModels.StationProfileStepViewModel,[*]QsoRipper.Gui.ViewModels.WizardStepViewModel</Exclude>
           <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
         </Configuration>
       </DataCollector>

--- a/src/dotnet/QsoRipper.Gui.Tests/QsoRipper.Gui.Tests.csproj
+++ b/src/dotnet/QsoRipper.Gui.Tests/QsoRipper.Gui.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QsoRipper.Gui\QsoRipper.Gui.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
@@ -1,0 +1,203 @@
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using QsoRipper.Domain;
+using QsoRipper.Gui.Services;
+using QsoRipper.Gui.ViewModels;
+using QsoRipper.Services;
+
+namespace QsoRipper.Gui.Tests;
+
+public class RecentQsoListViewModelTests
+{
+    [Fact]
+    public async Task RefreshAsyncLoadsRecentQsosAndSelectsFirstItem()
+    {
+        var engine = new FakeEngineClient
+        {
+            RecentQsos =
+            [
+                CreateQso("qso-1", "W1AW", Band._40M, Mode.Cw, 7025, "CN87", "First recent QSO", operatorName: "Alice", state: "WA", country: "United States", utcTimestamp: new DateTimeOffset(2026, 4, 13, 22, 16, 0, TimeSpan.Zero)),
+                CreateQso("qso-2", "K7RND", Band._20M, Mode.Ft8, 14074, "CN88", "Second recent QSO", operatorName: "Bob", state: "BC", country: "Canada", utcTimestamp: new DateTimeOffset(2026, 4, 13, 22, 15, 0, TimeSpan.Zero))
+            ]
+        };
+
+        var viewModel = new RecentQsoListViewModel(engine);
+
+        await viewModel.RefreshAsync();
+
+        Assert.True(viewModel.HasVisibleItems);
+        Assert.Equal(2, viewModel.VisibleItems.Count);
+        Assert.Equal("qso-1", viewModel.SelectedQso?.LocalId);
+        Assert.Equal("40M", viewModel.VisibleItems[0].Band);
+        Assert.Equal("CW", viewModel.VisibleItems[0].Mode);
+        Assert.Equal("Alice", viewModel.VisibleItems[0].OperatorName);
+        Assert.Equal("United States", viewModel.VisibleItems[0].Country);
+        Assert.Equal("Sorted by UTC time (descending)", viewModel.SortStatusText);
+        Assert.Equal("Showing 2 recent QSOs", viewModel.SummaryText);
+    }
+
+    [Fact]
+    public async Task SearchTextFiltersAcrossMultipleColumnsAsUserTypes()
+    {
+        var engine = new FakeEngineClient
+        {
+            RecentQsos =
+            [
+                CreateQso("qso-1", "W1AW", Band._20M, Mode.Ft8, 14074, "CN87", "CQ test", operatorName: "Alice", state: "WA", country: "United States"),
+                CreateQso("qso-2", "VE7ABC", Band._40M, Mode.Ssb, 7185, "CN88", "Morning ragchew", operatorName: "Bob", state: "BC", country: "Canada")
+            ]
+        };
+
+        var viewModel = new RecentQsoListViewModel(engine);
+        await viewModel.RefreshAsync();
+
+        viewModel.SearchText = "w1aw united 57";
+
+        Assert.Single(viewModel.VisibleItems);
+        Assert.Equal("qso-1", viewModel.VisibleItems[0].LocalId);
+        Assert.Equal("Showing 1 of 2 recent QSOs", viewModel.SummaryText);
+    }
+
+    [Fact]
+    public async Task RefreshAsyncKeepsPreviousRowsWhenEngineRefreshFails()
+    {
+        var engine = new FakeEngineClient
+        {
+            RecentQsos =
+            [
+                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States")
+            ]
+        };
+
+        var viewModel = new RecentQsoListViewModel(engine);
+        await viewModel.RefreshAsync();
+
+        engine.RefreshException = new RpcException(new Status(StatusCode.Unavailable, "Engine unavailable"));
+        await viewModel.RefreshAsync();
+
+        Assert.Single(viewModel.VisibleItems);
+        Assert.Equal("qso-1", viewModel.VisibleItems[0].LocalId);
+        Assert.Equal("Engine unavailable", viewModel.ErrorMessage);
+    }
+
+    [Fact]
+    public void MatchesSearchUsesAllTokensAgainstFormattedColumns()
+    {
+        var item = RecentQsoItemViewModel.FromQso(
+            CreateQso("qso-1", "W1AW", Band._40M, Mode.Cw, 7025, "CN87", "Evening CW", operatorName: "Alice", state: "WA", country: "United States"));
+
+        Assert.True(RecentQsoListViewModel.MatchesSearch(item, "alice 40m united"));
+        Assert.False(RecentQsoListViewModel.MatchesSearch(item, "alice 40m canada"));
+    }
+
+    [Fact]
+    public async Task ApplySortOrdersByCallsignAndTogglesDirection()
+    {
+        var engine = new FakeEngineClient
+        {
+            RecentQsos =
+            [
+                CreateQso("qso-2", "VE7ABC", Band._40M, Mode.Ssb, 7185, "CN88", "Second", operatorName: "Bob", state: "BC", country: "Canada"),
+                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "First", operatorName: "Alice", state: "WA", country: "United States")
+            ]
+        };
+
+        var viewModel = new RecentQsoListViewModel(engine);
+        await viewModel.RefreshAsync();
+
+        viewModel.ApplySort(RecentQsoSortColumn.Callsign);
+        Assert.Equal("VE7ABC", viewModel.VisibleItems[0].WorkedCallsign);
+        Assert.Equal("Call ↑", viewModel.CallsignHeaderText);
+
+        viewModel.ApplySort(RecentQsoSortColumn.Callsign);
+        Assert.Equal("W1AW", viewModel.VisibleItems[0].WorkedCallsign);
+        Assert.Equal("Call ↓", viewModel.CallsignHeaderText);
+    }
+
+    [Fact]
+    public async Task ReverseCurrentSortDirectionReversesTheCurrentSort()
+    {
+        var engine = new FakeEngineClient
+        {
+            RecentQsos =
+            [
+                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "First", operatorName: "Alice", state: "WA", country: "United States"),
+                CreateQso("qso-2", "K7RND", Band._40M, Mode.Ssb, 7185, "CN88", "Second", operatorName: "Bob", state: "BC", country: "Canada")
+            ]
+        };
+
+        var viewModel = new RecentQsoListViewModel(engine);
+        await viewModel.RefreshAsync();
+        viewModel.ApplySort(RecentQsoSortColumn.Country);
+
+        var firstAscending = viewModel.VisibleItems[0].Country;
+        viewModel.ReverseCurrentSortDirection();
+
+        Assert.NotEqual(firstAscending, viewModel.VisibleItems[0].Country);
+    }
+
+    private static QsoRecord CreateQso(
+        string localId,
+        string workedCallsign,
+        Band band,
+        Mode mode,
+        ulong frequencyKhz,
+        string grid,
+        string comment,
+        string? operatorName = null,
+        string? state = null,
+        string? country = null,
+        DateTimeOffset? utcTimestamp = null)
+    {
+        return new QsoRecord
+        {
+            LocalId = localId,
+            WorkedCallsign = workedCallsign,
+            StationCallsign = "K7RND",
+            UtcTimestamp = Timestamp.FromDateTimeOffset(utcTimestamp ?? new DateTimeOffset(2026, 4, 13, 22, 15, 0, TimeSpan.Zero)),
+            Band = band,
+            Mode = mode,
+            FrequencyKhz = frequencyKhz,
+            WorkedGrid = grid,
+            Comment = comment,
+            WorkedOperatorName = operatorName ?? string.Empty,
+            WorkedState = state ?? string.Empty,
+            WorkedCountry = country ?? string.Empty,
+            RstSent = new RstReport { Raw = "59" },
+            RstReceived = new RstReport { Raw = "57" },
+            SyncStatus = SyncStatus.LocalOnly
+        };
+    }
+
+    private sealed class FakeEngineClient : IEngineClient
+    {
+        public IReadOnlyList<QsoRecord> RecentQsos { get; set; } = [];
+
+        public RpcException? RefreshException { get; set; }
+
+        public Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<ValidateSetupStepResponse> ValidateStepAsync(ValidateSetupStepRequest request, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<TestQrzCredentialsResponse> TestQrzCredentialsAsync(string username, string password, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<SaveSetupResponse> SaveSetupAsync(SaveSetupRequest request, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default)
+        {
+            if (RefreshException is not null)
+            {
+                throw RefreshException;
+            }
+
+            return Task.FromResult(RecentQsos);
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/App.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/App.axaml.cs
@@ -2,8 +2,6 @@ using System;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
-using Grpc.Net.Client;
-using QsoRipper.Gui.Services;
 using QsoRipper.Gui.ViewModels;
 using QsoRipper.Gui.Views;
 
@@ -23,9 +21,7 @@ internal sealed partial class App : Application
             var endpoint = Environment.GetEnvironmentVariable("QSORIPPER_ENDPOINT")
                 ?? "http://127.0.0.1:50051";
 
-            var channel = GrpcChannel.ForAddress(endpoint);
-            var engineService = new EngineGrpcService(channel);
-            var mainVm = new MainWindowViewModel(engineService);
+            var mainVm = new MainWindowViewModel(endpoint);
 
             desktop.MainWindow = new MainWindow
             {

--- a/src/dotnet/QsoRipper.Gui/Properties/AssemblyInfo.cs
+++ b/src/dotnet/QsoRipper.Gui/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("QsoRipper.Gui.Tests")]

--- a/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Grpc.Core;
 using Grpc.Net.Client;
+using QsoRipper.Domain;
 using QsoRipper.Services;
 
 namespace QsoRipper.Gui.Services;
@@ -9,15 +12,17 @@ namespace QsoRipper.Gui.Services;
 /// <summary>
 /// Thin wrapper over gRPC SetupService client for the GUI layer.
 /// </summary>
-internal sealed class EngineGrpcService : IDisposable
+internal sealed class EngineGrpcService : IEngineClient, IDisposable
 {
     private readonly GrpcChannel _channel;
     private readonly SetupService.SetupServiceClient _setupClient;
+    private readonly LogbookService.LogbookServiceClient _logbookClient;
 
     public EngineGrpcService(GrpcChannel channel)
     {
         _channel = channel;
         _setupClient = new SetupService.SetupServiceClient(channel);
+        _logbookClient = new LogbookService.LogbookServiceClient(channel);
     }
 
     public async Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default)
@@ -58,6 +63,30 @@ internal sealed class EngineGrpcService : IDisposable
     {
         return await _setupClient.GetSetupStatusAsync(
             new GetSetupStatusRequest(), cancellationToken: ct);
+    }
+
+    public async Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
+
+        var recentQsos = new List<QsoRecord>();
+        using var call = _logbookClient.ListQsos(
+            new ListQsosRequest
+            {
+                Limit = (uint)limit,
+                Sort = QsoSortOrder.NewestFirst
+            },
+            cancellationToken: ct);
+
+        await foreach (var response in call.ResponseStream.ReadAllAsync(ct))
+        {
+            if (response.Qso is not null)
+            {
+                recentQsos.Add(response.Qso);
+            }
+        }
+
+        return recentQsos;
     }
 
     public void Dispose()

--- a/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using QsoRipper.Domain;
+using QsoRipper.Services;
+
+namespace QsoRipper.Gui.Services;
+
+internal interface IEngineClient
+{
+    Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default);
+
+    Task<ValidateSetupStepResponse> ValidateStepAsync(
+        ValidateSetupStepRequest request,
+        CancellationToken ct = default);
+
+    Task<TestQrzCredentialsResponse> TestQrzCredentialsAsync(
+        string username,
+        string password,
+        CancellationToken ct = default);
+
+    Task<SaveSetupResponse> SaveSetupAsync(
+        SaveSetupRequest request,
+        CancellationToken ct = default);
+
+    Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default);
+
+    Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default);
+}

--- a/src/dotnet/QsoRipper.Gui/Utilities/ProtoEnumDisplay.cs
+++ b/src/dotnet/QsoRipper.Gui/Utilities/ProtoEnumDisplay.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Google.Protobuf.Reflection;
+using QsoRipper.Domain;
+
+namespace QsoRipper.Gui.Utilities;
+
+internal static class ProtoEnumDisplay
+{
+    public static string ForBand(Band band) =>
+        band == Band.Unspecified ? "-" : FormatEnumValue(band, "BAND");
+
+    public static string ForMode(Mode mode) =>
+        mode == Mode.Unspecified ? "-" : FormatEnumValue(mode, "MODE");
+
+    private static string FormatEnumValue<TEnum>(TEnum value, string prefix)
+        where TEnum : struct, Enum
+    {
+        var field = typeof(TEnum).GetField(value.ToString());
+        var originalName = field?.GetCustomAttribute<OriginalNameAttribute>()?.Name ?? value.ToString().ToUpperInvariant();
+
+        if (originalName.StartsWith(prefix + "_", StringComparison.Ordinal))
+        {
+            originalName = originalName[(prefix.Length + 1)..];
+        }
+
+        return originalName.Replace('_', '.');
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -1,15 +1,20 @@
+using System.Globalization;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Grpc.Net.Client;
 using QsoRipper.Gui.Services;
 
 namespace QsoRipper.Gui.ViewModels;
 
-internal sealed partial class MainWindowViewModel : ObservableObject
+internal sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 {
-    private readonly EngineGrpcService _engine;
+    private readonly IEngineClient _engine;
+    private readonly DispatcherTimer _utcTimer;
+    private bool _setupCompleteBeforeWizard;
 
     [ObservableProperty]
     private bool _isWizardOpen;
@@ -18,15 +23,38 @@ internal sealed partial class MainWindowViewModel : ObservableObject
     private SetupWizardViewModel? _wizardViewModel;
 
     [ObservableProperty]
-    private string _statusMessage = "Checking engine connection…";
+    private string _statusMessage = "Checking engine connection...";
 
     [ObservableProperty]
     private bool _isSetupIncomplete;
 
-    public MainWindowViewModel(EngineGrpcService engine)
+    [ObservableProperty]
+    private string _currentUtcTime = string.Empty;
+
+    [ObservableProperty]
+    private string _currentUtcDate = string.Empty;
+
+    internal MainWindowViewModel(string endpoint)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(endpoint);
+
+        _engine = new EngineGrpcService(GrpcChannel.ForAddress(endpoint));
+        RecentQsos = new RecentQsoListViewModel(_engine);
+        UpdateUtcClock();
+        _utcTimer = CreateUtcTimer();
+    }
+
+    internal MainWindowViewModel(IEngineClient engine)
     {
         _engine = engine;
+        RecentQsos = new RecentQsoListViewModel(engine);
+        UpdateUtcClock();
+        _utcTimer = CreateUtcTimer();
     }
+
+    public RecentQsoListViewModel RecentQsos { get; }
+
+    public event EventHandler? SearchFocusRequested;
 
     /// <summary>
     /// Called after the main window has loaded. Checks first-run state.
@@ -39,12 +67,15 @@ internal sealed partial class MainWindowViewModel : ObservableObject
             if (state.Status.IsFirstRun || !state.Status.SetupComplete)
             {
                 IsSetupIncomplete = !state.Status.SetupComplete;
+                StatusMessage = IsSetupIncomplete
+                    ? "Setup incomplete - finish settings to start logging."
+                    : "Welcome to QsoRipper.";
                 await OpenWizardAsync();
             }
             else
             {
-                StatusMessage = "Ready — setup complete.";
                 IsSetupIncomplete = false;
+                await ActivateDashboardAsync(focusSearch: true);
             }
         }
         catch (Grpc.Core.RpcException)
@@ -56,10 +87,20 @@ internal sealed partial class MainWindowViewModel : ObservableObject
     [RelayCommand]
     private async Task OpenWizardAsync()
     {
+        _setupCompleteBeforeWizard = !IsSetupIncomplete;
         var vm = new SetupWizardViewModel(_engine, this);
         WizardViewModel = vm;
         IsWizardOpen = true;
         await vm.LoadStateAsync();
+    }
+
+    [RelayCommand]
+    private void FocusSearch()
+    {
+        if (!IsWizardOpen)
+        {
+            SearchFocusRequested?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     [RelayCommand]
@@ -71,13 +112,78 @@ internal sealed partial class MainWindowViewModel : ObservableObject
         }
     }
 
+    internal void CancelWizard()
+    {
+        IsWizardOpen = false;
+        WizardViewModel = null;
+        IsSetupIncomplete = !_setupCompleteBeforeWizard;
+        StatusMessage = _setupCompleteBeforeWizard
+            ? "Ready - setup complete."
+            : "Setup incomplete - open Settings to finish.";
+
+        if (_setupCompleteBeforeWizard)
+        {
+            _ = ActivateDashboardAsync(focusSearch: true);
+        }
+    }
+
     internal void CloseWizard(bool setupComplete)
     {
         IsWizardOpen = false;
         WizardViewModel = null;
         IsSetupIncomplete = !setupComplete;
         StatusMessage = setupComplete
-            ? "Ready — setup complete."
-            : "Setup incomplete — open Settings to finish.";
+            ? "Ready - setup complete."
+            : "Setup incomplete - open Settings to finish.";
+
+        if (setupComplete)
+        {
+            _ = ActivateDashboardAsync(focusSearch: true);
+        }
+    }
+
+    public void Dispose()
+    {
+        _utcTimer.Stop();
+        _utcTimer.Tick -= UtcTimerOnTick;
+
+        if (_engine is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+
+    private async Task ActivateDashboardAsync(bool focusSearch)
+    {
+        StatusMessage = "Ready - setup complete.";
+        await RecentQsos.RefreshAsync();
+
+        if (focusSearch && !IsWizardOpen)
+        {
+            SearchFocusRequested?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    private void UtcTimerOnTick(object? sender, EventArgs e)
+    {
+        UpdateUtcClock();
+    }
+
+    private void UpdateUtcClock()
+    {
+        var utcNow = DateTimeOffset.UtcNow;
+        CurrentUtcTime = utcNow.ToString("HH:mm:ss 'UTC'", CultureInfo.InvariantCulture);
+        CurrentUtcDate = utcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+
+    private DispatcherTimer CreateUtcTimer()
+    {
+        var timer = new DispatcherTimer
+        {
+            Interval = TimeSpan.FromSeconds(1)
+        };
+        timer.Tick += UtcTimerOnTick;
+        timer.Start();
+        return timer;
     }
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/QrzStepViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/QrzStepViewModel.cs
@@ -8,7 +8,7 @@ namespace QsoRipper.Gui.ViewModels;
 
 internal sealed partial class QrzStepViewModel : WizardStepViewModel
 {
-    private readonly EngineGrpcService _engine;
+    private readonly IEngineClient _engine;
 
     public override string Title => "QRZ (optional)";
     public override string Description =>
@@ -30,7 +30,7 @@ internal sealed partial class QrzStepViewModel : WizardStepViewModel
     [ObservableProperty]
     private bool _testSucceeded;
 
-    public QrzStepViewModel(EngineGrpcService engine)
+    public QrzStepViewModel(IEngineClient engine)
     {
         _engine = engine;
     }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
@@ -1,0 +1,231 @@
+using System.Globalization;
+using System.Linq;
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Domain;
+using QsoRipper.Gui.Utilities;
+
+namespace QsoRipper.Gui.ViewModels;
+
+internal sealed class RecentQsoItemViewModel
+{
+    public string LocalId { get; init; } = string.Empty;
+
+    public string UtcDisplay { get; init; } = "-";
+
+    public string WorkedCallsign { get; init; } = "-";
+
+    public string Band { get; init; } = "-";
+
+    public string Mode { get; init; } = "-";
+
+    public string Country { get; init; } = "-";
+
+    public string OperatorName { get; init; } = "-";
+
+    public string Frequency { get; init; } = "-";
+
+    public string RstSent { get; init; } = "-";
+
+    public string RstReceived { get; init; } = "-";
+
+    public string Grid { get; init; } = "-";
+
+    public string Comment { get; init; } = "-";
+
+    public string UtcEndDisplay { get; init; } = "-";
+
+    public string SyncStatus { get; init; } = "-";
+
+    internal string SearchDocument { get; init; } = string.Empty;
+
+    internal DateTimeOffset UtcSortKey { get; init; }
+
+    internal string CallsignSortKey { get; init; } = string.Empty;
+
+    internal string BandSortKey { get; init; } = string.Empty;
+
+    internal string ModeSortKey { get; init; } = string.Empty;
+
+    internal string CountrySortKey { get; init; } = string.Empty;
+
+    internal string NameSortKey { get; init; } = string.Empty;
+
+    internal ulong FrequencySortKey { get; init; }
+
+    internal string RstSentSortKey { get; init; } = string.Empty;
+
+    internal string RstReceivedSortKey { get; init; } = string.Empty;
+
+    internal string GridSortKey { get; init; } = string.Empty;
+
+    internal string CommentSortKey { get; init; } = string.Empty;
+
+    internal DateTimeOffset UtcEndSortKey { get; init; }
+
+    internal string SyncStatusSortKey { get; init; } = string.Empty;
+
+    public static RecentQsoItemViewModel FromQso(QsoRecord qso)
+    {
+        ArgumentNullException.ThrowIfNull(qso);
+
+        var utcSortKey = qso.UtcTimestamp?.ToDateTimeOffset().ToUniversalTime() ?? DateTimeOffset.MinValue;
+        var utcEndSortKey = qso.UtcEndTimestamp?.ToDateTimeOffset().ToUniversalTime() ?? DateTimeOffset.MinValue;
+        var band = ProtoEnumDisplay.ForBand(qso.Band);
+        var mode = ProtoEnumDisplay.ForMode(qso.Mode);
+        var country = BuildCountry(qso);
+        var operatorName = BuildOperatorName(qso);
+        var grid = DisplayOrDash(qso.WorkedGrid);
+        var frequency = qso.HasFrequencyKhz
+            ? qso.FrequencyKhz.ToString("N0", CultureInfo.InvariantCulture)
+            : "-";
+        var rstSent = DisplayOrDash(qso.RstSent?.Raw);
+        var rstReceived = DisplayOrDash(qso.RstReceived?.Raw);
+        var comment = BuildComment(qso);
+        var syncStatus = BuildSyncStatus(qso.SyncStatus);
+
+        return new RecentQsoItemViewModel
+        {
+            LocalId = qso.LocalId,
+            UtcDisplay = FormatTimestamp(qso.UtcTimestamp),
+            WorkedCallsign = DisplayOrDash(qso.WorkedCallsign),
+            Band = band,
+            Mode = mode,
+            Country = country,
+            OperatorName = operatorName,
+            Frequency = frequency,
+            RstSent = rstSent,
+            RstReceived = rstReceived,
+            Grid = grid,
+            Comment = comment,
+            UtcEndDisplay = FormatTimestamp(qso.UtcEndTimestamp),
+            SyncStatus = syncStatus,
+            SearchDocument = BuildSearchDocument(
+                qso.WorkedCallsign,
+                operatorName,
+                band,
+                mode,
+                qso.Submode,
+                frequency,
+                qso.WorkedCountry,
+                qso.WorkedState,
+                qso.WorkedCounty,
+                qso.WorkedContinent,
+                qso.WorkedDxcc.ToString(CultureInfo.InvariantCulture),
+                qso.WorkedCqZone.ToString(CultureInfo.InvariantCulture),
+                qso.WorkedItuZone.ToString(CultureInfo.InvariantCulture),
+                grid,
+                rstSent,
+                rstReceived,
+                qso.TxPower,
+                qso.ContestId,
+                qso.SerialSent,
+                qso.SerialReceived,
+                qso.ExchangeSent,
+                qso.ExchangeReceived,
+                qso.PropMode,
+                qso.SatName,
+                qso.SatMode,
+                qso.WorkedIota,
+                qso.WorkedArrlSection,
+                comment,
+                syncStatus,
+                FormatTimestamp(qso.UtcTimestamp),
+                FormatTimestamp(qso.UtcEndTimestamp)),
+            UtcSortKey = utcSortKey,
+            CallsignSortKey = NormalizeSortValue(qso.WorkedCallsign),
+            BandSortKey = NormalizeSortValue(band),
+            ModeSortKey = NormalizeSortValue(mode),
+            CountrySortKey = NormalizeSortValue(country),
+            NameSortKey = NormalizeSortValue(operatorName),
+            FrequencySortKey = qso.HasFrequencyKhz ? qso.FrequencyKhz : 0,
+            RstSentSortKey = NormalizeSortValue(rstSent),
+            RstReceivedSortKey = NormalizeSortValue(rstReceived),
+            GridSortKey = NormalizeSortValue(grid),
+            CommentSortKey = NormalizeSortValue(comment),
+            UtcEndSortKey = utcEndSortKey,
+            SyncStatusSortKey = NormalizeSortValue(syncStatus)
+        };
+    }
+
+    private static string BuildComment(QsoRecord qso)
+    {
+        var parts = new[]
+            {
+                TrimOrNull(qso.Comment),
+                TrimOrNull(qso.Notes),
+                TrimOrNull(qso.ContestId)
+            }
+            .Where(static value => value is not null)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return parts.Length == 0 ? "-" : string.Join(" / ", parts!);
+    }
+
+    private static string BuildCountry(QsoRecord qso)
+    {
+        return FirstNonBlank(
+                   qso.WorkedCountry,
+                   qso.WorkedState,
+                   qso.WorkedCounty,
+                   qso.WorkedContinent)
+               ?? "-";
+    }
+
+    private static string BuildOperatorName(QsoRecord qso) =>
+        FirstNonBlank(qso.WorkedOperatorName, qso.WorkedOperatorCallsign) ?? "-";
+
+    private static string BuildSearchDocument(params string?[] values)
+    {
+        return string.Join(
+                ' ',
+                values
+                    .Where(static value => !string.IsNullOrWhiteSpace(value))
+                    .Select(static value => value!.Trim()))
+            .ToUpperInvariant();
+    }
+
+    private static string BuildSyncStatus(SyncStatus status)
+    {
+        return status switch
+        {
+            QsoRipper.Domain.SyncStatus.LocalOnly => "Local",
+            QsoRipper.Domain.SyncStatus.Synced => "Synced",
+            QsoRipper.Domain.SyncStatus.Modified => "Modified",
+            QsoRipper.Domain.SyncStatus.Conflict => "Conflict",
+            _ => "-"
+        };
+    }
+
+    private static string DisplayOrDash(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? "-" : value.Trim();
+
+    private static string? FirstNonBlank(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            var trimmed = TrimOrNull(value);
+            if (trimmed is not null)
+            {
+                return trimmed;
+            }
+        }
+
+        return null;
+    }
+
+    private static string FormatTimestamp(Timestamp? timestamp)
+    {
+        return timestamp is null
+            ? "-"
+            : timestamp.ToDateTimeOffset().ToUniversalTime().ToString("yy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+    }
+
+    private static string NormalizeSortValue(string? value) =>
+        string.IsNullOrWhiteSpace(value) || value == "-"
+            ? string.Empty
+            : value.Trim().ToUpperInvariant();
+
+    private static string? TrimOrNull(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -1,0 +1,353 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Grpc.Core;
+using QsoRipper.Gui.Services;
+
+namespace QsoRipper.Gui.ViewModels;
+
+internal sealed partial class RecentQsoListViewModel : ObservableObject
+{
+    private const int DefaultLimit = 500;
+
+    private readonly IEngineClient _engine;
+    private readonly List<RecentQsoItemViewModel> _allItems = [];
+
+    public RecentQsoListViewModel(IEngineClient engine)
+    {
+        _engine = engine;
+    }
+
+    public ObservableCollection<RecentQsoItemViewModel> VisibleItems { get; } = [];
+
+    public bool HasVisibleItems => VisibleItems.Count > 0;
+
+    public string EmptyStateMessage
+    {
+        get
+        {
+            if (!HasLoaded)
+            {
+                return "Recent QSOs will appear here after setup completes.";
+            }
+
+            if (!string.IsNullOrWhiteSpace(ErrorMessage) && _allItems.Count == 0)
+            {
+                return ErrorMessage;
+            }
+
+            if (!string.IsNullOrWhiteSpace(SearchText))
+            {
+                return "No recent QSOs match the current search.";
+            }
+
+            return "No QSOs have been logged yet.";
+        }
+    }
+
+    public string LastLoadedText => LastLoadedAtUtc is null
+        ? "Not loaded yet"
+        : $"Updated {LastLoadedAtUtc.Value:HH:mm:ss} UTC";
+
+    public string SortStatusText => $"Sorted by {GetSortLabel(CurrentSortColumn)} ({(SortAscending ? "ascending" : "descending")})";
+
+    public string UtcHeaderText => BuildHeaderText("UTC", RecentQsoSortColumn.Utc);
+
+    public string CallsignHeaderText => BuildHeaderText("Call", RecentQsoSortColumn.Callsign);
+
+    public string BandHeaderText => BuildHeaderText("Band", RecentQsoSortColumn.Band);
+
+    public string ModeHeaderText => BuildHeaderText("Mode", RecentQsoSortColumn.Mode);
+
+    public string CountryHeaderText => BuildHeaderText("Country", RecentQsoSortColumn.Country);
+
+    public string NameHeaderText => BuildHeaderText("Name", RecentQsoSortColumn.Name);
+
+    public string FrequencyHeaderText => BuildHeaderText("Freq", RecentQsoSortColumn.Frequency);
+
+    public string RstSentHeaderText => BuildHeaderText("S", RecentQsoSortColumn.RstSent);
+
+    public string RstReceivedHeaderText => BuildHeaderText("R", RecentQsoSortColumn.RstReceived);
+
+    public string GridHeaderText => BuildHeaderText("Grid", RecentQsoSortColumn.Grid);
+
+    public string CommentHeaderText => BuildHeaderText("Comment", RecentQsoSortColumn.Comment);
+
+    public string UtcEndHeaderText => BuildHeaderText("End", RecentQsoSortColumn.UtcEnd);
+
+    public string SyncHeaderText => BuildHeaderText("Sync", RecentQsoSortColumn.Sync);
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RefreshCommand))]
+    [NotifyPropertyChangedFor(nameof(EmptyStateMessage))]
+    private bool _isLoading;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(EmptyStateMessage))]
+    private string? _errorMessage;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(EmptyStateMessage))]
+    private bool _hasLoaded;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(LastLoadedText))]
+    private DateTimeOffset? _lastLoadedAtUtc;
+
+    [ObservableProperty]
+    private string _searchText = string.Empty;
+
+    [ObservableProperty]
+    private string _summaryText = "Recent QSOs will appear here after setup completes.";
+
+    [ObservableProperty]
+    private RecentQsoItemViewModel? _selectedQso;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SortStatusText))]
+    [NotifyPropertyChangedFor(nameof(UtcHeaderText))]
+    [NotifyPropertyChangedFor(nameof(CallsignHeaderText))]
+    [NotifyPropertyChangedFor(nameof(BandHeaderText))]
+    [NotifyPropertyChangedFor(nameof(ModeHeaderText))]
+    [NotifyPropertyChangedFor(nameof(CountryHeaderText))]
+    [NotifyPropertyChangedFor(nameof(NameHeaderText))]
+    [NotifyPropertyChangedFor(nameof(FrequencyHeaderText))]
+    [NotifyPropertyChangedFor(nameof(RstSentHeaderText))]
+    [NotifyPropertyChangedFor(nameof(RstReceivedHeaderText))]
+    [NotifyPropertyChangedFor(nameof(GridHeaderText))]
+    [NotifyPropertyChangedFor(nameof(CommentHeaderText))]
+    [NotifyPropertyChangedFor(nameof(UtcEndHeaderText))]
+    [NotifyPropertyChangedFor(nameof(SyncHeaderText))]
+    private RecentQsoSortColumn _currentSortColumn = RecentQsoSortColumn.Utc;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SortStatusText))]
+    [NotifyPropertyChangedFor(nameof(UtcHeaderText))]
+    [NotifyPropertyChangedFor(nameof(CallsignHeaderText))]
+    [NotifyPropertyChangedFor(nameof(BandHeaderText))]
+    [NotifyPropertyChangedFor(nameof(ModeHeaderText))]
+    [NotifyPropertyChangedFor(nameof(CountryHeaderText))]
+    [NotifyPropertyChangedFor(nameof(NameHeaderText))]
+    [NotifyPropertyChangedFor(nameof(FrequencyHeaderText))]
+    [NotifyPropertyChangedFor(nameof(RstSentHeaderText))]
+    [NotifyPropertyChangedFor(nameof(RstReceivedHeaderText))]
+    [NotifyPropertyChangedFor(nameof(GridHeaderText))]
+    [NotifyPropertyChangedFor(nameof(CommentHeaderText))]
+    [NotifyPropertyChangedFor(nameof(UtcEndHeaderText))]
+    [NotifyPropertyChangedFor(nameof(SyncHeaderText))]
+    private bool _sortAscending;
+
+    partial void OnSearchTextChanged(string value)
+    {
+        ApplyFilter();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanRefresh))]
+    internal async Task RefreshAsync()
+    {
+        IsLoading = true;
+        ErrorMessage = null;
+
+        try
+        {
+            var selectedLocalId = SelectedQso?.LocalId;
+            var qsos = await _engine.ListRecentQsosAsync(DefaultLimit);
+
+            _allItems.Clear();
+            _allItems.AddRange(qsos.Select(RecentQsoItemViewModel.FromQso));
+
+            HasLoaded = true;
+            LastLoadedAtUtc = DateTimeOffset.UtcNow;
+            ApplyFilter(selectedLocalId);
+        }
+        catch (RpcException ex)
+        {
+            HasLoaded = true;
+            ErrorMessage = string.IsNullOrWhiteSpace(ex.Status.Detail)
+                ? $"Recent QSOs could not be loaded ({ex.StatusCode})."
+                : ex.Status.Detail;
+            ApplyFilter();
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    internal static bool MatchesSearch(RecentQsoItemViewModel item, string? searchText)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+
+        if (string.IsNullOrWhiteSpace(searchText))
+        {
+            return true;
+        }
+
+        var searchTokens = searchText
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(static token => token.ToUpperInvariant())
+            .ToArray();
+
+        return searchTokens.All(token => item.SearchDocument.Contains(token, StringComparison.Ordinal));
+    }
+
+    [RelayCommand]
+    private void ReverseSortDirection()
+    {
+        ReverseCurrentSortDirection();
+    }
+
+    [RelayCommand]
+    private void SortByColumn(RecentQsoSortColumn column)
+    {
+        ApplySort(column);
+    }
+
+    internal void ApplySort(RecentQsoSortColumn column)
+    {
+        if (CurrentSortColumn == column)
+        {
+            SortAscending = !SortAscending;
+        }
+        else
+        {
+            CurrentSortColumn = column;
+            SortAscending = GetDefaultSortAscending(column);
+        }
+
+        ApplyFilter();
+    }
+
+    internal void ReverseCurrentSortDirection()
+    {
+        SortAscending = !SortAscending;
+        ApplyFilter();
+    }
+
+    private bool CanRefresh() => !IsLoading;
+
+    private void ApplyFilter(string? preferredLocalId = null)
+    {
+        var selectedLocalId = preferredLocalId ?? SelectedQso?.LocalId;
+        var filteredItems = SortItems(_allItems.Where(item => MatchesSearch(item, SearchText))).ToArray();
+
+        VisibleItems.Clear();
+        foreach (var item in filteredItems)
+        {
+            VisibleItems.Add(item);
+        }
+
+        SelectedQso = filteredItems.FirstOrDefault(item => string.Equals(item.LocalId, selectedLocalId, StringComparison.Ordinal))
+            ?? filteredItems.FirstOrDefault();
+
+        SummaryText = BuildSummaryText(filteredItems.Length);
+        OnPropertyChanged(nameof(HasVisibleItems));
+        OnPropertyChanged(nameof(EmptyStateMessage));
+    }
+
+    private string BuildHeaderText(string label, RecentQsoSortColumn column)
+    {
+        return CurrentSortColumn == column
+            ? $"{label} {(SortAscending ? '\u2191' : '\u2193')}"
+            : label;
+    }
+
+    private string BuildSummaryText(int filteredCount)
+    {
+        if (!HasLoaded)
+        {
+            return "Recent QSOs will appear here after setup completes.";
+        }
+
+        if (!string.IsNullOrWhiteSpace(ErrorMessage) && _allItems.Count == 0)
+        {
+            return "Recent QSOs unavailable";
+        }
+
+        if (_allItems.Count == 0)
+        {
+            return "No QSOs logged yet";
+        }
+
+        return filteredCount == _allItems.Count
+            ? $"Showing {_allItems.Count} recent QSOs"
+            : $"Showing {filteredCount} of {_allItems.Count} recent QSOs";
+    }
+
+    private static bool GetDefaultSortAscending(RecentQsoSortColumn column) => column switch
+    {
+        RecentQsoSortColumn.Utc => false,
+        RecentQsoSortColumn.UtcEnd => false,
+        _ => true
+    };
+
+    private static string GetSortLabel(RecentQsoSortColumn column) => column switch
+    {
+        RecentQsoSortColumn.Utc => "UTC time",
+        RecentQsoSortColumn.Callsign => "callsign",
+        RecentQsoSortColumn.Band => "band",
+        RecentQsoSortColumn.Mode => "mode",
+        RecentQsoSortColumn.Country => "country",
+        RecentQsoSortColumn.Name => "name",
+        RecentQsoSortColumn.Frequency => "frequency",
+        RecentQsoSortColumn.RstSent => "RST sent",
+        RecentQsoSortColumn.RstReceived => "RST received",
+        RecentQsoSortColumn.Grid => "grid",
+        RecentQsoSortColumn.Comment => "comment",
+        RecentQsoSortColumn.UtcEnd => "end time",
+        RecentQsoSortColumn.Sync => "sync",
+        _ => "recent QSOs"
+    };
+
+    private IEnumerable<RecentQsoItemViewModel> SortItems(IEnumerable<RecentQsoItemViewModel> items)
+    {
+        var ordered = CurrentSortColumn switch
+        {
+            RecentQsoSortColumn.Utc => SortAscending
+                ? items.OrderBy(item => item.UtcSortKey)
+                : items.OrderByDescending(item => item.UtcSortKey),
+            RecentQsoSortColumn.Callsign => SortAscending
+                ? items.OrderBy(item => item.CallsignSortKey, StringComparer.Ordinal)
+                : items.OrderByDescending(item => item.CallsignSortKey, StringComparer.Ordinal),
+            RecentQsoSortColumn.Band => SortAscending
+                ? items.OrderBy(item => item.BandSortKey, StringComparer.Ordinal)
+                : items.OrderByDescending(item => item.BandSortKey, StringComparer.Ordinal),
+            RecentQsoSortColumn.Mode => SortAscending
+                ? items.OrderBy(item => item.ModeSortKey, StringComparer.Ordinal)
+                : items.OrderByDescending(item => item.ModeSortKey, StringComparer.Ordinal),
+            RecentQsoSortColumn.Country => SortAscending
+                ? items.OrderBy(item => item.CountrySortKey, StringComparer.Ordinal)
+                : items.OrderByDescending(item => item.CountrySortKey, StringComparer.Ordinal),
+            RecentQsoSortColumn.Name => SortAscending
+                ? items.OrderBy(item => item.NameSortKey, StringComparer.Ordinal)
+                : items.OrderByDescending(item => item.NameSortKey, StringComparer.Ordinal),
+            RecentQsoSortColumn.Frequency => SortAscending
+                ? items.OrderBy(item => item.FrequencySortKey)
+                : items.OrderByDescending(item => item.FrequencySortKey),
+            RecentQsoSortColumn.RstSent => SortAscending
+                ? items.OrderBy(item => item.RstSentSortKey, StringComparer.Ordinal)
+                : items.OrderByDescending(item => item.RstSentSortKey, StringComparer.Ordinal),
+            RecentQsoSortColumn.RstReceived => SortAscending
+                ? items.OrderBy(item => item.RstReceivedSortKey, StringComparer.Ordinal)
+                : items.OrderByDescending(item => item.RstReceivedSortKey, StringComparer.Ordinal),
+            RecentQsoSortColumn.Grid => SortAscending
+                ? items.OrderBy(item => item.GridSortKey, StringComparer.Ordinal)
+                : items.OrderByDescending(item => item.GridSortKey, StringComparer.Ordinal),
+            RecentQsoSortColumn.Comment => SortAscending
+                ? items.OrderBy(item => item.CommentSortKey, StringComparer.Ordinal)
+                : items.OrderByDescending(item => item.CommentSortKey, StringComparer.Ordinal),
+            RecentQsoSortColumn.UtcEnd => SortAscending
+                ? items.OrderBy(item => item.UtcEndSortKey)
+                : items.OrderByDescending(item => item.UtcEndSortKey),
+            RecentQsoSortColumn.Sync => SortAscending
+                ? items.OrderBy(item => item.SyncStatusSortKey, StringComparer.Ordinal)
+                : items.OrderByDescending(item => item.SyncStatusSortKey, StringComparer.Ordinal),
+            _ => items.OrderByDescending(item => item.UtcSortKey)
+        };
+
+        return ordered
+            .ThenByDescending(item => item.UtcSortKey)
+            .ThenBy(item => item.CallsignSortKey, StringComparer.Ordinal);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoSortColumn.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoSortColumn.cs
@@ -1,0 +1,18 @@
+namespace QsoRipper.Gui.ViewModels;
+
+internal enum RecentQsoSortColumn
+{
+    Utc,
+    Callsign,
+    Band,
+    Mode,
+    Country,
+    Name,
+    Frequency,
+    RstSent,
+    RstReceived,
+    Grid,
+    Comment,
+    UtcEnd,
+    Sync
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/SetupWizardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/SetupWizardViewModel.cs
@@ -12,7 +12,7 @@ namespace QsoRipper.Gui.ViewModels;
 
 internal sealed partial class SetupWizardViewModel : ObservableObject
 {
-    private readonly EngineGrpcService _engine;
+    private readonly IEngineClient _engine;
     private readonly MainWindowViewModel _owner;
 
     public ObservableCollection<WizardStepViewModel> Steps { get; } = [];
@@ -39,7 +39,7 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
     public bool CanGoBack => CurrentStepIndex > 0;
     public bool IsLastStep => CurrentStepIndex == Steps.Count - 1;
 
-    public SetupWizardViewModel(EngineGrpcService engine, MainWindowViewModel owner)
+    public SetupWizardViewModel(IEngineClient engine, MainWindowViewModel owner)
     {
         _engine = engine;
         _owner = owner;
@@ -220,7 +220,7 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
     [RelayCommand]
     private void Cancel()
     {
-        _owner.CloseWizard(setupComplete: false);
+        _owner.CancelWizard();
     }
 
     [RelayCommand]

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -4,40 +4,540 @@
         xmlns:v="using:QsoRipper.Gui.Views"
         x:Class="QsoRipper.Gui.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
-        Title="QsoRipper" Width="1120" Height="720"
-        MinWidth="960" MinHeight="640"
+        Title="QsoRipper" Width="1500" Height="820"
+        MinWidth="1380" MinHeight="700"
         WindowStartupLocation="CenterScreen"
         Icon="avares://QsoRipper.Gui/Assets/qsoripper.ico">
 
   <Window.KeyBindings>
     <KeyBinding Gesture="Ctrl+OemComma" Command="{Binding OpenWizardCommand}" />
     <KeyBinding Gesture="Alt+X" Command="{Binding ExitCommand}" />
+    <KeyBinding Gesture="Ctrl+F" Command="{Binding FocusSearchCommand}" />
+    <KeyBinding Gesture="F5" Command="{Binding RecentQsos.RefreshCommand}" />
+    <KeyBinding Gesture="Ctrl+Shift+T"
+                Command="{Binding RecentQsos.SortByColumnCommand}"
+                CommandParameter="{x:Static vm:RecentQsoSortColumn.Utc}" />
+    <KeyBinding Gesture="Ctrl+Shift+C"
+                Command="{Binding RecentQsos.SortByColumnCommand}"
+                CommandParameter="{x:Static vm:RecentQsoSortColumn.Callsign}" />
+    <KeyBinding Gesture="Ctrl+Shift+B"
+                Command="{Binding RecentQsos.SortByColumnCommand}"
+                CommandParameter="{x:Static vm:RecentQsoSortColumn.Band}" />
+    <KeyBinding Gesture="Ctrl+Shift+M"
+                Command="{Binding RecentQsos.SortByColumnCommand}"
+                CommandParameter="{x:Static vm:RecentQsoSortColumn.Mode}" />
+    <KeyBinding Gesture="Ctrl+Shift+L"
+                Command="{Binding RecentQsos.SortByColumnCommand}"
+                CommandParameter="{x:Static vm:RecentQsoSortColumn.Country}" />
+    <KeyBinding Gesture="Ctrl+Shift+N"
+                Command="{Binding RecentQsos.SortByColumnCommand}"
+                CommandParameter="{x:Static vm:RecentQsoSortColumn.Name}" />
+    <KeyBinding Gesture="Ctrl+Shift+F"
+                Command="{Binding RecentQsos.SortByColumnCommand}"
+                CommandParameter="{x:Static vm:RecentQsoSortColumn.Frequency}" />
+    <KeyBinding Gesture="Ctrl+Shift+G"
+                Command="{Binding RecentQsos.SortByColumnCommand}"
+                CommandParameter="{x:Static vm:RecentQsoSortColumn.Grid}" />
+    <KeyBinding Gesture="Ctrl+Shift+E"
+                Command="{Binding RecentQsos.SortByColumnCommand}"
+                CommandParameter="{x:Static vm:RecentQsoSortColumn.UtcEnd}" />
+    <KeyBinding Gesture="Ctrl+Shift+S"
+                Command="{Binding RecentQsos.SortByColumnCommand}"
+                CommandParameter="{x:Static vm:RecentQsoSortColumn.Sync}" />
+    <KeyBinding Gesture="Ctrl+Shift+O"
+                Command="{Binding RecentQsos.SortByColumnCommand}"
+                CommandParameter="{x:Static vm:RecentQsoSortColumn.Comment}" />
+    <KeyBinding Gesture="Ctrl+Shift+D"
+                Command="{Binding RecentQsos.ReverseSortDirectionCommand}" />
   </Window.KeyBindings>
+
+  <Window.Styles>
+    <Style Selector="Border.qsoCell">
+      <Setter Property="BorderBrush"
+              Value="{DynamicResource SystemControlForegroundBaseLowBrush}" />
+      <Setter Property="BorderThickness"
+              Value="0,0,1,0" />
+      <Setter Property="Padding"
+              Value="0,0,5,0" />
+    </Style>
+
+    <Style Selector="Border.qsoCellLast">
+      <Setter Property="Padding"
+              Value="0" />
+    </Style>
+  </Window.Styles>
 
   <DockPanel>
     <!-- Menu bar — always on top, never covered by overlay -->
-      <Menu DockPanel.Dock="Top">
-        <MenuItem x:Name="FileMenuItem" Header="_File">
-          <MenuItem Header="_Settings" InputGesture="Ctrl+OemComma"
-                    Command="{Binding OpenWizardCommand}" />
+    <Menu DockPanel.Dock="Top">
+      <MenuItem x:Name="FileMenuItem" Header="_File">
+        <MenuItem Header="_Settings" InputGesture="Ctrl+OemComma"
+                  Command="{Binding OpenWizardCommand}" />
+        <Separator />
+        <MenuItem Header="E_xit" InputGesture="Alt+X" Command="{Binding ExitCommand}" />
+      </MenuItem>
+      <MenuItem Header="_View">
+        <MenuItem Header="_Find Recent QSOs" InputGesture="Ctrl+F"
+                  Command="{Binding FocusSearchCommand}" />
+        <MenuItem Header="_Refresh Recent QSOs" InputGesture="F5"
+                  Command="{Binding RecentQsos.RefreshCommand}" />
+        <Separator />
+        <MenuItem Header="_Sort Recent QSOs">
+          <MenuItem Header="_Time" InputGesture="Ctrl+Shift+T"
+                    Command="{Binding RecentQsos.SortByColumnCommand}"
+                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Utc}" />
+          <MenuItem Header="_Call" InputGesture="Ctrl+Shift+C"
+                    Command="{Binding RecentQsos.SortByColumnCommand}"
+                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Callsign}" />
+          <MenuItem Header="_Band" InputGesture="Ctrl+Shift+B"
+                    Command="{Binding RecentQsos.SortByColumnCommand}"
+                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Band}" />
+          <MenuItem Header="_Mode" InputGesture="Ctrl+Shift+M"
+                    Command="{Binding RecentQsos.SortByColumnCommand}"
+                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Mode}" />
+          <MenuItem Header="_Country" InputGesture="Ctrl+Shift+L"
+                    Command="{Binding RecentQsos.SortByColumnCommand}"
+                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Country}" />
+          <MenuItem Header="_Name" InputGesture="Ctrl+Shift+N"
+                    Command="{Binding RecentQsos.SortByColumnCommand}"
+                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Name}" />
+          <MenuItem Header="_Frequency" InputGesture="Ctrl+Shift+F"
+                    Command="{Binding RecentQsos.SortByColumnCommand}"
+                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Frequency}" />
+          <MenuItem Header="_Grid" InputGesture="Ctrl+Shift+G"
+                    Command="{Binding RecentQsos.SortByColumnCommand}"
+                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Grid}" />
+          <MenuItem Header="_End Time" InputGesture="Ctrl+Shift+E"
+                    Command="{Binding RecentQsos.SortByColumnCommand}"
+                    CommandParameter="{x:Static vm:RecentQsoSortColumn.UtcEnd}" />
+          <MenuItem Header="_Sync" InputGesture="Ctrl+Shift+S"
+                    Command="{Binding RecentQsos.SortByColumnCommand}"
+                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Sync}" />
+          <MenuItem Header="C_omment" InputGesture="Ctrl+Shift+O"
+                    Command="{Binding RecentQsos.SortByColumnCommand}"
+                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Comment}" />
           <Separator />
-          <MenuItem Header="E_xit" InputGesture="Alt+X" Command="{Binding ExitCommand}" />
+          <MenuItem Header="_Reverse Direction" InputGesture="Ctrl+Shift+D"
+                    Command="{Binding RecentQsos.ReverseSortDirectionCommand}" />
         </MenuItem>
-      </Menu>
+      </MenuItem>
+    </Menu>
 
     <!-- Content area with optional wizard overlay -->
     <Panel>
-      <StackPanel VerticalAlignment="Center" HorizontalAlignment="Center" Spacing="12"
-                  IsEnabled="{Binding !IsWizardOpen}">
-        <TextBlock Text="{Binding StatusMessage}"
-                   FontSize="16" HorizontalAlignment="Center" />
+      <Grid Margin="24"
+            RowDefinitions="Auto,Auto,Auto,*"
+            RowSpacing="16"
+            IsEnabled="{Binding !IsWizardOpen}">
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto" ColumnSpacing="16">
+          <Border Padding="20,18"
+                  CornerRadius="12"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                  BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                  BorderThickness="1">
+            <StackPanel Spacing="6">
+              <TextBlock Text="QsoRipper"
+                         FontSize="28"
+                         FontWeight="SemiBold" />
+              <TextBlock Text="{Binding StatusMessage}"
+                         FontSize="15"
+                         Opacity="0.72"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+          </Border>
 
-        <Button Content="Open Settings…"
-                Command="{Binding OpenWizardCommand}"
-                HorizontalAlignment="Center"
-                IsVisible="{Binding IsSetupIncomplete}"
-                Classes="accent" />
-      </StackPanel>
+          <Border Grid.Column="1"
+                  Padding="20,16"
+                  CornerRadius="12"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                  BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                  BorderThickness="1">
+            <StackPanel Spacing="2"
+                        HorizontalAlignment="Right">
+              <TextBlock Text="CURRENT UTC"
+                         FontSize="11"
+                         FontWeight="SemiBold"
+                         Opacity="0.62"
+                         HorizontalAlignment="Right" />
+              <TextBlock Text="{Binding CurrentUtcTime}"
+                         FontSize="30"
+                         FontWeight="Bold"
+                         FontFamily="Cascadia Mono, Consolas, monospace"
+                         HorizontalAlignment="Right" />
+              <TextBlock Text="{Binding CurrentUtcDate}"
+                         Opacity="0.72"
+                         HorizontalAlignment="Right" />
+            </StackPanel>
+          </Border>
+        </Grid>
+
+        <Border Grid.Row="1"
+                Padding="16,12"
+                CornerRadius="12"
+                Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                BorderThickness="1"
+                IsVisible="{Binding IsSetupIncomplete}">
+          <DockPanel LastChildFill="False">
+            <TextBlock Text="Setup incomplete - finish settings before you start logging."
+                       VerticalAlignment="Center"
+                       TextWrapping="Wrap" />
+            <Button DockPanel.Dock="Right"
+                    Content="Open Settings (Ctrl+,)"
+                    Command="{Binding OpenWizardCommand}"
+                    Classes="accent"
+                    Margin="12,0,0,0" />
+          </DockPanel>
+        </Border>
+
+        <Border Grid.Row="2"
+                Padding="16"
+                CornerRadius="12"
+                Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                BorderThickness="1">
+          <Grid ColumnDefinitions="*,Auto"
+                RowDefinitions="Auto,Auto,Auto"
+                ColumnSpacing="12"
+                RowSpacing="12">
+            <StackPanel Spacing="4">
+              <TextBlock Text="Recent QSOs"
+                         FontSize="18"
+                         FontWeight="SemiBold" />
+              <TextBlock Text="{Binding RecentQsos.SummaryText}"
+                          Opacity="0.68" />
+              <TextBlock Text="{Binding RecentQsos.SortStatusText}"
+                         FontSize="12"
+                         Opacity="0.62" />
+              <TextBlock Text="Sort: T time, C call, B band, M mode, L country, N name, F freq, G grid, E end, S sync, O comment, D reverse"
+                         FontSize="11"
+                         Opacity="0.52"
+                         TextWrapping="Wrap" />
+            </StackPanel>
+
+            <TextBlock Grid.Column="1"
+                       Text="{Binding RecentQsos.LastLoadedText}"
+                       VerticalAlignment="Center"
+                       Opacity="0.68"
+                       HorizontalAlignment="Right" />
+
+            <TextBox x:Name="RecentQsoSearchBox"
+                     Grid.Row="1"
+                     PlaceholderText="Search callsign, band, mode, country, name, grid, reports, comment, contest, and sync"
+                     Text="{Binding RecentQsos.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                     MinWidth="420" />
+
+            <Button Grid.Row="1"
+                    Grid.Column="1"
+                    Content="Refresh (F5)"
+                    Command="{Binding RecentQsos.RefreshCommand}"
+                    Classes="accent"
+                    MinWidth="130" />
+
+            <TextBlock Grid.Row="2"
+                       Grid.ColumnSpan="2"
+                       Text="{Binding RecentQsos.ErrorMessage}"
+                       Foreground="IndianRed"
+                       TextWrapping="Wrap"
+                       IsVisible="{Binding RecentQsos.ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+          </Grid>
+        </Border>
+
+        <Border Grid.Row="3"
+                CornerRadius="12"
+                Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                BorderThickness="1"
+                ClipToBounds="True">
+          <Grid RowDefinitions="Auto,*">
+            <Border Padding="12,10"
+                    BorderThickness="0,0,0,1"
+                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}">
+              <Grid ColumnDefinitions="112,82,52,52,110,130,82,50,50,72,*,112,70"
+                    ColumnSpacing="0">
+                <Border Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.UtcHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Utc}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by UTC (Ctrl+Shift+T)" />
+                </Border>
+                <Border Grid.Column="1" Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.CallsignHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Callsign}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by call (Ctrl+Shift+C)" />
+                </Border>
+                <Border Grid.Column="2" Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.BandHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Band}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by band (Ctrl+Shift+B)" />
+                </Border>
+                <Border Grid.Column="3" Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.ModeHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Mode}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by mode (Ctrl+Shift+M)" />
+                </Border>
+                <Border Grid.Column="4" Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.CountryHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Country}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by country (Ctrl+Shift+L)" />
+                </Border>
+                <Border Grid.Column="5" Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.NameHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Name}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by name (Ctrl+Shift+N)" />
+                </Border>
+                <Border Grid.Column="6" Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.FrequencyHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Frequency}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by frequency (Ctrl+Shift+F)" />
+                </Border>
+                <Border Grid.Column="7" Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.RstSentHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.RstSent}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by sent report" />
+                </Border>
+                <Border Grid.Column="8" Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.RstReceivedHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.RstReceived}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by received report" />
+                </Border>
+                <Border Grid.Column="9" Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.GridHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Grid}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by grid (Ctrl+Shift+G)" />
+                </Border>
+                <Border Grid.Column="10" Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.CommentHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Comment}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by comment (Ctrl+Shift+O)" />
+                </Border>
+                <Border Grid.Column="11" Classes="qsoCell">
+                  <Button Content="{Binding RecentQsos.UtcEndHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.UtcEnd}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by end time (Ctrl+Shift+E)" />
+                </Border>
+                <Border Grid.Column="12" Classes="qsoCellLast">
+                  <Button Content="{Binding RecentQsos.SyncHeaderText}"
+                          Command="{Binding RecentQsos.SortByColumnCommand}"
+                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Sync}"
+                          Background="Transparent"
+                          BorderBrush="Transparent"
+                          BorderThickness="0"
+                          Padding="0"
+                          HorizontalContentAlignment="Left"
+                          FontWeight="SemiBold"
+                          ToolTip.Tip="Sort by sync (Ctrl+Shift+S)" />
+                </Border>
+              </Grid>
+            </Border>
+
+            <Grid Grid.Row="1">
+              <ListBox ItemsSource="{Binding RecentQsos.VisibleItems}"
+                       SelectedItem="{Binding RecentQsos.SelectedQso, Mode=TwoWay}"
+                       Classes="qsoList"
+                       BorderThickness="0"
+                       Background="Transparent"
+                       IsVisible="{Binding RecentQsos.HasVisibleItems}">
+                <ListBox.Styles>
+                  <Style Selector="ListBoxItem">
+                    <Setter Property="Padding" Value="0" />
+                    <Setter Property="Margin" Value="0" />
+                    <Setter Property="MinHeight" Value="0" />
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                  </Style>
+                </ListBox.Styles>
+                <ListBox.ItemTemplate>
+                  <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                    <Border Padding="6,1"
+                            BorderThickness="0,0,0,1"
+                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
+                      <Grid ColumnDefinitions="112,82,52,52,110,130,82,50,50,72,*,112,70"
+                            ColumnSpacing="0">
+                        <Border Classes="qsoCell">
+                          <TextBlock Text="{Binding UtcDisplay}"
+                                     FontFamily="Cascadia Mono, Consolas, monospace"
+                                     VerticalAlignment="Center"
+                                     FontSize="12" />
+                        </Border>
+                        <Border Grid.Column="1" Classes="qsoCell">
+                          <TextBlock Text="{Binding WorkedCallsign}"
+                                     FontWeight="SemiBold"
+                                     VerticalAlignment="Center"
+                                     FontSize="12"
+                                     TextTrimming="CharacterEllipsis" />
+                        </Border>
+                        <Border Grid.Column="2" Classes="qsoCell">
+                          <TextBlock Text="{Binding Band}"
+                                     VerticalAlignment="Center"
+                                     FontSize="12"
+                                     TextTrimming="CharacterEllipsis" />
+                        </Border>
+                        <Border Grid.Column="3" Classes="qsoCell">
+                          <TextBlock Text="{Binding Mode}"
+                                     VerticalAlignment="Center"
+                                     FontSize="12"
+                                     TextTrimming="CharacterEllipsis" />
+                        </Border>
+                        <Border Grid.Column="4" Classes="qsoCell">
+                          <TextBlock Text="{Binding Country}"
+                                     VerticalAlignment="Center"
+                                     FontSize="12"
+                                     TextTrimming="CharacterEllipsis" />
+                        </Border>
+                        <Border Grid.Column="5" Classes="qsoCell">
+                          <TextBlock Text="{Binding OperatorName}"
+                                     VerticalAlignment="Center"
+                                     FontSize="12"
+                                     TextTrimming="CharacterEllipsis" />
+                        </Border>
+                        <Border Grid.Column="6" Classes="qsoCell">
+                          <TextBlock Text="{Binding Frequency}"
+                                     VerticalAlignment="Center"
+                                     FontSize="12" />
+                        </Border>
+                        <Border Grid.Column="7" Classes="qsoCell">
+                          <TextBlock Text="{Binding RstSent}"
+                                     VerticalAlignment="Center"
+                                     FontSize="12" />
+                        </Border>
+                        <Border Grid.Column="8" Classes="qsoCell">
+                          <TextBlock Text="{Binding RstReceived}"
+                                     VerticalAlignment="Center"
+                                     FontSize="12" />
+                        </Border>
+                        <Border Grid.Column="9" Classes="qsoCell">
+                          <TextBlock Text="{Binding Grid}"
+                                     VerticalAlignment="Center"
+                                     FontSize="12"
+                                     TextTrimming="CharacterEllipsis" />
+                        </Border>
+                        <Border Grid.Column="10" Classes="qsoCell">
+                          <TextBlock Text="{Binding Comment}"
+                                     VerticalAlignment="Center"
+                                     FontSize="12"
+                                     TextWrapping="NoWrap"
+                                     TextTrimming="CharacterEllipsis" />
+                        </Border>
+                        <Border Grid.Column="11" Classes="qsoCell">
+                          <TextBlock Text="{Binding UtcEndDisplay}"
+                                     VerticalAlignment="Center"
+                                     FontSize="12"
+                                     FontFamily="Cascadia Mono, Consolas, monospace" />
+                        </Border>
+                        <Border Grid.Column="12" Classes="qsoCellLast">
+                          <TextBlock Text="{Binding SyncStatus}"
+                                     VerticalAlignment="Center"
+                                     FontSize="12"
+                                     TextTrimming="CharacterEllipsis" />
+                        </Border>
+                      </Grid>
+                    </Border>
+                  </DataTemplate>
+                </ListBox.ItemTemplate>
+              </ListBox>
+
+              <StackPanel HorizontalAlignment="Center"
+                          VerticalAlignment="Center"
+                          Spacing="8"
+                          Margin="24"
+                          IsVisible="{Binding !RecentQsos.HasVisibleItems}">
+                <TextBlock Text="{Binding RecentQsos.EmptyStateMessage}"
+                           HorizontalAlignment="Center"
+                           TextAlignment="Center"
+                           TextWrapping="Wrap"
+                           Opacity="0.72" />
+              </StackPanel>
+
+              <ProgressBar IsIndeterminate="True"
+                           IsVisible="{Binding RecentQsos.IsLoading}"
+                           VerticalAlignment="Top" />
+            </Grid>
+          </Grid>
+        </Border>
+      </Grid>
 
       <!-- Wizard overlay — covers content area only, not the menu bar -->
       <Border IsVisible="{Binding IsWizardOpen}"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -6,12 +6,16 @@ namespace QsoRipper.Gui.Views;
 internal sealed partial class MainWindow : Window
 {
     private readonly MenuItem? _fileMenuItem;
+    private readonly TextBox? _recentQsoSearchBox;
+    private ViewModels.MainWindowViewModel? _viewModel;
     private bool _menuAccessKeysPrimed;
 
     public MainWindow()
     {
         InitializeComponent();
         _fileMenuItem = this.FindControl<MenuItem>("FileMenuItem");
+        _recentQsoSearchBox = this.FindControl<TextBox>("RecentQsoSearchBox");
+        DataContextChanged += OnDataContextChanged;
     }
 
     protected override async void OnOpened(System.EventArgs e)
@@ -22,6 +26,22 @@ internal sealed partial class MainWindow : Window
         {
             await vm.CheckFirstRunAsync();
         }
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        if (_viewModel is not null)
+        {
+            _viewModel.SearchFocusRequested -= OnSearchFocusRequested;
+            _viewModel = null;
+        }
+
+        if (DataContext is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+
+        base.OnClosed(e);
     }
 
     private void PrimeMenuAccessKeys()
@@ -43,5 +63,40 @@ internal sealed partial class MainWindow : Window
                     DispatcherPriority.Background);
             },
             DispatcherPriority.Background);
+    }
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (_viewModel is not null)
+        {
+            _viewModel.SearchFocusRequested -= OnSearchFocusRequested;
+        }
+
+        _viewModel = DataContext as ViewModels.MainWindowViewModel;
+        if (_viewModel is not null)
+        {
+            _viewModel.SearchFocusRequested += OnSearchFocusRequested;
+        }
+    }
+
+    private void OnSearchFocusRequested(object? sender, EventArgs e)
+    {
+        FocusRecentQsoSearchBox();
+    }
+
+    private void FocusRecentQsoSearchBox()
+    {
+        if (_recentQsoSearchBox is null)
+        {
+            return;
+        }
+
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                _recentQsoSearchBox.Focus();
+                _recentQsoSearchBox.SelectAll();
+            },
+            DispatcherPriority.Input);
     }
 }

--- a/src/dotnet/QsoRipper.slnx
+++ b/src/dotnet/QsoRipper.slnx
@@ -5,4 +5,5 @@
   <Project Path="QsoRipper.DebugHost/QsoRipper.DebugHost.csproj" />
   <Project Path="QsoRipper.DebugHost.Tests/QsoRipper.DebugHost.Tests.csproj" />
   <Project Path="QsoRipper.Gui/QsoRipper.Gui.csproj" />
+  <Project Path="QsoRipper.Gui.Tests/QsoRipper.Gui.Tests.csproj" />
 </Solution>


### PR DESCRIPTION
## Summary
- add a live UTC dashboard and recent QSO list backed by the real ListQsos gRPC surface
- add local search, sortable headers, and keyboard shortcuts for refresh, focus, and column sorting
- densify the list into a tighter logger-style grid and add GUI tests for loading, filtering, refresh errors, and sorting