### PR TITLE
Clamp GUI window to screen working area

### DIFF
--- a/src/dotnet/QsoRipper.Gui.Tests/ResponsiveWindowLayoutTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/ResponsiveWindowLayoutTests.cs
@@ -1,0 +1,61 @@
+using Avalonia;
+using QsoRipper.Gui.Utilities;
+
+namespace QsoRipper.Gui.Tests;
+
+public class ResponsiveWindowLayoutTests
+{
+    [Fact]
+    public void ClampToWorkingAreaKeepsPreferredSizeWhenWorkingAreaIsLargeEnough()
+    {
+        var layout = ResponsiveWindowLayout.ClampToWorkingArea(
+            preferredWidth: 1280,
+            preferredHeight: 760,
+            preferredMinWidth: 1024,
+            preferredMinHeight: 640,
+            workingArea: new PixelRect(0, 0, 1920, 1080),
+            scaling: 1);
+
+        Assert.Equal(1280, layout.Width);
+        Assert.Equal(760, layout.Height);
+        Assert.Equal(1024, layout.MinWidth);
+        Assert.Equal(640, layout.MinHeight);
+        Assert.Equal(new PixelPoint(320, 160), layout.Position);
+    }
+
+    [Fact]
+    public void ClampToWorkingAreaShrinksWindowAndMinimumsOnSmallDisplay()
+    {
+        var layout = ResponsiveWindowLayout.ClampToWorkingArea(
+            preferredWidth: 1280,
+            preferredHeight: 760,
+            preferredMinWidth: 1024,
+            preferredMinHeight: 640,
+            workingArea: new PixelRect(0, 0, 1366, 768),
+            scaling: 1);
+
+        Assert.Equal(1024, layout.MinWidth);
+        Assert.Equal(640, layout.MinHeight);
+        Assert.Equal(1280, layout.Width);
+        Assert.Equal(736, layout.Height);
+        Assert.Equal(new PixelPoint(43, 16), layout.Position);
+    }
+
+    [Fact]
+    public void ClampToWorkingAreaAccountsForMonitorScaling()
+    {
+        var layout = ResponsiveWindowLayout.ClampToWorkingArea(
+            preferredWidth: 1280,
+            preferredHeight: 760,
+            preferredMinWidth: 1024,
+            preferredMinHeight: 640,
+            workingArea: new PixelRect(0, 0, 1920, 1080),
+            scaling: 1.5);
+
+        Assert.Equal(1248, layout.Width);
+        Assert.Equal(688, layout.Height);
+        Assert.Equal(1024, layout.MinWidth);
+        Assert.Equal(640, layout.MinHeight);
+        Assert.Equal(new PixelPoint(24, 24), layout.Position);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Utilities/ResponsiveWindowLayout.cs
+++ b/src/dotnet/QsoRipper.Gui/Utilities/ResponsiveWindowLayout.cs
@@ -1,0 +1,44 @@
+using Avalonia;
+
+namespace QsoRipper.Gui.Utilities;
+
+internal static class ResponsiveWindowLayout
+{
+    private const double SafeInsetDip = 16;
+
+    public static WindowLayout ClampToWorkingArea(
+        double preferredWidth,
+        double preferredHeight,
+        double preferredMinWidth,
+        double preferredMinHeight,
+        PixelRect workingArea,
+        double scaling)
+    {
+        if (scaling <= 0)
+        {
+            scaling = 1;
+        }
+
+        var availableWidth = Math.Max(1, (workingArea.Width / scaling) - (SafeInsetDip * 2));
+        var availableHeight = Math.Max(1, (workingArea.Height / scaling) - (SafeInsetDip * 2));
+
+        var minWidth = Math.Min(preferredMinWidth, availableWidth);
+        var minHeight = Math.Min(preferredMinHeight, availableHeight);
+        var width = Math.Max(minWidth, Math.Min(preferredWidth, availableWidth));
+        var height = Math.Max(minHeight, Math.Min(preferredHeight, availableHeight));
+
+        var widthPixels = (int)Math.Round(width * scaling);
+        var heightPixels = (int)Math.Round(height * scaling);
+        var x = workingArea.X + Math.Max(0, (workingArea.Width - widthPixels) / 2);
+        var y = workingArea.Y + Math.Max(0, (workingArea.Height - heightPixels) / 2);
+
+        return new WindowLayout(width, height, minWidth, minHeight, new PixelPoint(x, y));
+    }
+}
+
+internal readonly record struct WindowLayout(
+    double Width,
+    double Height,
+    double MinWidth,
+    double MinHeight,
+    PixelPoint Position);

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -4,8 +4,8 @@
         xmlns:v="using:QsoRipper.Gui.Views"
         x:Class="QsoRipper.Gui.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
-        Title="QsoRipper" Width="1500" Height="820"
-        MinWidth="1380" MinHeight="700"
+        Title="QsoRipper" Width="1280" Height="760"
+        MinWidth="1024" MinHeight="640"
         WindowStartupLocation="CenterScreen"
         Icon="avares://QsoRipper.Gui/Assets/qsoripper.ico">
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -1,5 +1,7 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
+using QsoRipper.Gui.Utilities;
 
 namespace QsoRipper.Gui.Views;
 
@@ -7,12 +9,20 @@ internal sealed partial class MainWindow : Window
 {
     private readonly MenuItem? _fileMenuItem;
     private readonly TextBox? _recentQsoSearchBox;
+    private readonly double _preferredWidth;
+    private readonly double _preferredHeight;
+    private readonly double _preferredMinWidth;
+    private readonly double _preferredMinHeight;
     private ViewModels.MainWindowViewModel? _viewModel;
     private bool _menuAccessKeysPrimed;
 
     public MainWindow()
     {
         InitializeComponent();
+        _preferredWidth = Width;
+        _preferredHeight = Height;
+        _preferredMinWidth = MinWidth;
+        _preferredMinHeight = MinHeight;
         _fileMenuItem = this.FindControl<MenuItem>("FileMenuItem");
         _recentQsoSearchBox = this.FindControl<TextBox>("RecentQsoSearchBox");
         DataContextChanged += OnDataContextChanged;
@@ -21,6 +31,7 @@ internal sealed partial class MainWindow : Window
     protected override async void OnOpened(System.EventArgs e)
     {
         base.OnOpened(e);
+        ClampToCurrentScreen();
         PrimeMenuAccessKeys();
         if (DataContext is ViewModels.MainWindowViewModel vm)
         {
@@ -98,5 +109,28 @@ internal sealed partial class MainWindow : Window
                 _recentQsoSearchBox.SelectAll();
             },
             DispatcherPriority.Input);
+    }
+
+    private void ClampToCurrentScreen()
+    {
+        var screen = Screens.ScreenFromWindow(this) ?? Screens.Primary;
+        if (screen is null)
+        {
+            return;
+        }
+
+        var layout = ResponsiveWindowLayout.ClampToWorkingArea(
+            _preferredWidth,
+            _preferredHeight,
+            _preferredMinWidth,
+            _preferredMinHeight,
+            screen.WorkingArea,
+            screen.Scaling);
+
+        MinWidth = layout.MinWidth;
+        MinHeight = layout.MinHeight;
+        Width = layout.Width;
+        Height = layout.Height;
+        Position = layout.Position;
     }
 }


### PR DESCRIPTION
## Summary
- clamp the Avalonia main window to the current monitor working area using monitor scaling
- reduce the default and minimum startup size to safer laptop-friendly values
- add regression tests for large, small, and scaled-display window layout calculations

Fixes #112.