### PR TITLE
Implement end-to-end QRZ logbook bidirectional sync

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,14 @@ QSORIPPER_QRZ_XML_PASSWORD=REPLACE_WITH_QRZ_PASSWORD
 QSORIPPER_QRZ_HTTP_TIMEOUT_SECONDS=8
 QSORIPPER_QRZ_MAX_RETRIES=2
 
+# QRZ logbook sync configuration
+# Whether automatic periodic sync with QRZ logbook is enabled.
+# QSORIPPER_SYNC_AUTO_ENABLED=false
+# Interval between automatic syncs, in seconds (default: 300 = 5 minutes).
+# QSORIPPER_SYNC_INTERVAL_SECONDS=300
+# How to handle conflicting records during sync: last_write_wins or flag_for_review.
+# QSORIPPER_SYNC_CONFLICT_POLICY=last_write_wins
+
 # Optional active station profile used as the base snapshot for newly logged QSOs.
 # QSORIPPER_STATION_PROFILE_NAME=Home
 # QSORIPPER_STATION_CALLSIGN=K7DBG

--- a/proto/domain/conflict_policy.proto
+++ b/proto/domain/conflict_policy.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package qsoripper.domain;
+
+option csharp_namespace = "QsoRipper.Domain";
+
+// Controls how conflicts between local and remote QSO records are resolved
+// during a QRZ logbook sync.
+enum ConflictPolicy {
+  // Newer record wins based on UTC timestamp comparison.
+  CONFLICT_POLICY_LAST_WRITE_WINS = 0;
+  // Both versions are preserved and the local record is flagged as
+  // SYNC_STATUS_CONFLICT for manual review.
+  CONFLICT_POLICY_FLAG_FOR_REVIEW = 1;
+}

--- a/proto/domain/sync_config.proto
+++ b/proto/domain/sync_config.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package qsoripper.domain;
+
+option csharp_namespace = "QsoRipper.Domain";
+
+import "domain/conflict_policy.proto";
+
+// Persisted configuration governing automatic and manual QRZ logbook sync.
+message SyncConfig {
+  // Whether the engine should automatically sync on a periodic schedule.
+  bool auto_sync_enabled = 1;
+  // Interval between automatic syncs, in seconds. Default: 300 (5 minutes).
+  uint32 sync_interval_seconds = 2;
+  // How to handle conflicting records during sync.
+  ConflictPolicy conflict_policy = 3;
+}

--- a/proto/services/get_sync_status_response.proto
+++ b/proto/services/get_sync_status_response.proto
@@ -12,4 +12,12 @@ message GetSyncStatusResponse {
   uint32 pending_upload = 3;
   optional google.protobuf.Timestamp last_sync = 4;
   optional string qrz_logbook_owner = 5;
+  // True when a background or manual sync is currently running.
+  bool is_syncing = 6;
+  // Scheduled time of the next automatic sync, if auto-sync is enabled.
+  optional google.protobuf.Timestamp next_sync = 7;
+  // True when periodic automatic sync is enabled and an API key is configured.
+  bool auto_sync_enabled = 8;
+  // Human-readable error from the most recent sync attempt, if it failed.
+  optional string last_sync_error = 9;
 }

--- a/proto/services/save_setup_request.proto
+++ b/proto/services/save_setup_request.proto
@@ -5,6 +5,7 @@ package qsoripper.services;
 option csharp_namespace = "QsoRipper.Services";
 
 import "domain/station_profile.proto";
+import "domain/sync_config.proto";
 import "services/storage_backend.proto";
 
 message SaveSetupRequest {
@@ -16,4 +17,8 @@ message SaveSetupRequest {
   optional string qrz_xml_username = 4;
   optional string qrz_xml_password = 5;
   optional string log_file_path = 6;
+  // QRZ logbook API key for bidirectional sync with logbook.qrz.com.
+  optional string qrz_logbook_api_key = 7;
+  // Sync behaviour configuration. Omit to leave unchanged.
+  optional qsoripper.domain.SyncConfig sync_config = 8;
 }

--- a/proto/services/setup_service.proto
+++ b/proto/services/setup_service.proto
@@ -12,6 +12,8 @@ import "services/save_setup_request.proto";
 import "services/save_setup_response.proto";
 import "services/test_qrz_credentials_request.proto";
 import "services/test_qrz_credentials_response.proto";
+import "services/test_qrz_logbook_credentials_request.proto";
+import "services/test_qrz_logbook_credentials_response.proto";
 import "services/validate_setup_step_request.proto";
 import "services/validate_setup_step_response.proto";
 
@@ -40,4 +42,7 @@ service SetupService {
 
   // Test QRZ XML credentials by performing a live login attempt.
   rpc TestQrzCredentials(TestQrzCredentialsRequest) returns (TestQrzCredentialsResponse);
+
+  // Test a QRZ logbook API key by calling the logbook STATUS endpoint.
+  rpc TestQrzLogbookCredentials(TestQrzLogbookCredentialsRequest) returns (TestQrzLogbookCredentialsResponse);
 }

--- a/proto/services/setup_status.proto
+++ b/proto/services/setup_status.proto
@@ -5,6 +5,7 @@ package qsoripper.services;
 option csharp_namespace = "QsoRipper.Services";
 
 import "domain/station_profile.proto";
+import "domain/sync_config.proto";
 import "services/storage_backend.proto";
 
 message SetupStatus {
@@ -28,4 +29,8 @@ message SetupStatus {
   string suggested_log_file_path = 15;
   // True when no config file exists and setup has never been completed.
   bool is_first_run = 16;
+  // True when a QRZ logbook API key has been configured.
+  bool has_qrz_logbook_api_key = 17;
+  // Current sync configuration, if set.
+  optional qsoripper.domain.SyncConfig sync_config = 18;
 }

--- a/proto/services/test_qrz_logbook_credentials_request.proto
+++ b/proto/services/test_qrz_logbook_credentials_request.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+// Test QRZ logbook API key by querying the logbook STATUS endpoint.
+message TestQrzLogbookCredentialsRequest {
+  string api_key = 1;
+}

--- a/proto/services/test_qrz_logbook_credentials_response.proto
+++ b/proto/services/test_qrz_logbook_credentials_response.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+message TestQrzLogbookCredentialsResponse {
+  // True when the API key is valid and the logbook STATUS call succeeded.
+  bool success = 1;
+  // Human-readable error message when the test failed.
+  string error_message = 2;
+  // Number of QSOs reported by the QRZ logbook, if available.
+  optional uint32 qso_count = 3;
+  // Logbook owner callsign returned by QRZ, if available.
+  optional string logbook_owner = 4;
+}

--- a/src/dotnet/Directory.Packages.props
+++ b/src/dotnet/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
 
   <ItemGroup>
+    <PackageVersion Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
     <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />

--- a/src/dotnet/QsoRipper.Cli/CliArgumentParser.cs
+++ b/src/dotnet/QsoRipper.Cli/CliArgumentParser.cs
@@ -14,6 +14,7 @@ internal static class CliArgumentParser
         var skipCache = false;
         var jsonOutput = false;
         var refresh = false;
+        var force = false;
         var setupStatus = false;
         var setupFromEnv = false;
 
@@ -54,6 +55,12 @@ internal static class CliArgumentParser
             if (arg is "--refresh")
             {
                 refresh = true;
+                continue;
+            }
+
+            if (arg is "--force")
+            {
+                force = true;
                 continue;
             }
 
@@ -100,6 +107,7 @@ internal static class CliArgumentParser
             SkipCache: skipCache,
             JsonOutput: jsonOutput,
             Refresh: refresh,
+            Force: force,
             SetupStatus: setupStatus,
             SetupFromEnv: setupFromEnv,
             RemainingArgs: remaining.ToArray());

--- a/src/dotnet/QsoRipper.Cli/CliArguments.cs
+++ b/src/dotnet/QsoRipper.Cli/CliArguments.cs
@@ -9,6 +9,7 @@ internal sealed record CliArguments(
     bool SkipCache = false,
     bool JsonOutput = false,
     bool Refresh = false,
+    bool Force = false,
     bool SetupStatus = false,
     bool SetupFromEnv = false,
     string[] RemainingArgs = default!)

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -27,6 +27,9 @@ internal static class CliHelpText
 
             Engine:
               status                           Show sync status and QSO counts
+              sync [--force]                   Sync with QRZ logbook (--force = full sync)
+              sync-status                      Detailed sync status and scheduling info
+              test-logbook [--api-key <key>]   Test QRZ logbook API key
               config [--set KEY=VALUE]         View or modify runtime config
               setup [--status | --from-env]    Interactive setup wizard or headless config
 
@@ -175,6 +178,27 @@ internal static class CliHelpText
                 Usage: status
 
                 Show engine sync status and QSO counts.
+                """,
+            "sync" => """
+                Usage: sync [--force]
+
+                Trigger a sync with the QRZ logbook. Shows streaming progress updates.
+
+                  --force              Run a full sync instead of incremental
+                """,
+            "sync-status" => """
+                Usage: sync-status
+
+                Show detailed sync status: local/QRZ counts, pending uploads,
+                auto-sync scheduling, and last error.
+                """,
+            "test-logbook" => """
+                Usage: test-logbook [--api-key <key>]
+
+                Test QRZ logbook API key by querying the logbook STATUS endpoint.
+                Uses the configured key if --api-key is not provided.
+
+                  --api-key <key>      API key to test (optional)
                 """,
             _ => $"No help available for '{command}'."
         };

--- a/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
@@ -51,6 +51,7 @@ internal static class SetupCommand
         Console.WriteLine($"Setup complete:    {status.SetupComplete}");
         Console.WriteLine($"Config path:       {status.ConfigPath}");
         Console.WriteLine($"QRZ username:      {status.QrzXmlUsername ?? "(not set)"}");
+        Console.WriteLine($"QRZ Logbook key:   {(status.HasQrzLogbookApiKey ? "(configured)" : "(not set)")}");
         Console.WriteLine($"Station profile:   {status.HasStationProfile}");
 #pragma warning disable CS0612 // Type or member is obsolete
         Console.WriteLine($"Storage backend:   {status.StorageBackend}");
@@ -76,6 +77,9 @@ internal static class SetupCommand
         var grid = Environment.GetEnvironmentVariable("QSORIPPER_GRID");
         var qrzUsername = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_USERNAME");
         var qrzPassword = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_PASSWORD");
+        var qrzLogbookApiKey = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_LOGBOOK_API_KEY");
+        var autoSyncEnv = Environment.GetEnvironmentVariable("QSORIPPER_AUTO_SYNC");
+        var syncIntervalEnv = Environment.GetEnvironmentVariable("QSORIPPER_SYNC_INTERVAL");
 
         // If no log file path, fetch the suggested one from the engine.
         if (string.IsNullOrWhiteSpace(logFilePath))
@@ -142,6 +146,15 @@ internal static class SetupCommand
             }
         }
 
+        // Validate sync interval bounds if provided.
+        if (!string.IsNullOrWhiteSpace(syncIntervalEnv)
+            && int.TryParse(syncIntervalEnv, System.Globalization.CultureInfo.InvariantCulture, out var syncInterval)
+            && syncInterval is < 60 or > 3600)
+        {
+            Console.Error.WriteLine("Error: QSORIPPER_SYNC_INTERVAL must be between 60 and 3600 seconds.");
+            return 1;
+        }
+
         // Save.
         var saveRequest = new SaveSetupRequest
         {
@@ -157,6 +170,33 @@ internal static class SetupCommand
         if (!string.IsNullOrWhiteSpace(qrzPassword))
         {
             saveRequest.QrzXmlPassword = qrzPassword;
+        }
+
+        if (!string.IsNullOrWhiteSpace(qrzLogbookApiKey))
+        {
+            saveRequest.QrzLogbookApiKey = qrzLogbookApiKey;
+        }
+
+        // Include sync config when a logbook API key is provided.
+        if (!string.IsNullOrWhiteSpace(qrzLogbookApiKey))
+        {
+            var autoSync = !string.IsNullOrWhiteSpace(autoSyncEnv)
+                && (autoSyncEnv.Equals("true", StringComparison.OrdinalIgnoreCase)
+                    || autoSyncEnv.Equals("yes", StringComparison.OrdinalIgnoreCase)
+                    || autoSyncEnv == "1");
+
+            uint intervalSeconds = 300;
+            if (!string.IsNullOrWhiteSpace(syncIntervalEnv)
+                && uint.TryParse(syncIntervalEnv, System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+            {
+                intervalSeconds = parsed;
+            }
+
+            saveRequest.SyncConfig = new QsoRipper.Domain.SyncConfig
+            {
+                AutoSyncEnabled = autoSync,
+                SyncIntervalSeconds = intervalSeconds,
+            };
         }
 
         var saveResponse = await client.SaveSetupAsync(saveRequest);
@@ -195,7 +235,7 @@ internal static class SetupCommand
 
         // ── Step 1: Log File Path ──────────────────────────────────
         Console.WriteLine();
-        Console.WriteLine("Step 1 of 4: Log File Path");
+        Console.WriteLine("Step 1 of 5: Log File Path");
         Console.WriteLine(new string('-', 30));
 
         var suggestedPath = status.SuggestedLogFilePath;
@@ -232,7 +272,7 @@ internal static class SetupCommand
 
         // ── Step 2: Station Profile ────────────────────────────────
         Console.WriteLine();
-        Console.WriteLine("Step 2 of 4: Station Profile");
+        Console.WriteLine("Step 2 of 5: Station Profile");
         Console.WriteLine(new string('-', 30));
 
         var existingProfile = status.StationProfile;
@@ -294,7 +334,7 @@ internal static class SetupCommand
 
         // ── Step 3: QRZ Integration (Optional) ────────────────────
         Console.WriteLine();
-        Console.WriteLine("Step 3 of 4: QRZ Integration (Optional)");
+        Console.WriteLine("Step 3 of 5: QRZ Integration (Optional)");
         Console.WriteLine(new string('-', 30));
 
         string? qrzUsername = null;
@@ -379,9 +419,68 @@ internal static class SetupCommand
             }
         }
 
-        // ── Step 4: Review & Save ──────────────────────────────────
+        // ── Step 4: QRZ Logbook (Optional) ────────────────────────
         Console.WriteLine();
-        Console.WriteLine("Step 4 of 4: Review & Save");
+        Console.WriteLine("Step 4 of 5: QRZ Logbook (Optional)");
+        Console.WriteLine(new string('-', 30));
+        Console.WriteLine("  Enter your QRZ.com Logbook API key for bidirectional sync.");
+        Console.WriteLine("  You can find this at qrz.com → Logbook → Settings → API Key.");
+
+        string? qrzLogbookApiKey = null;
+        var autoSyncEnabled = false;
+        uint syncIntervalSeconds = 300;
+
+        var hasExistingLogbookKey = status.HasQrzLogbookApiKey;
+        if (hasExistingLogbookKey)
+        {
+            Console.WriteLine("  A logbook API key is already configured.");
+        }
+
+        var setupLogbook = PromptYesNo("Set up QRZ Logbook sync?", defaultYes: false);
+
+        if (setupLogbook)
+        {
+            if (hasExistingLogbookKey)
+            {
+                Console.WriteLine("  Leave blank to keep the existing key.");
+            }
+
+            qrzLogbookApiKey = PromptField("QRZ Logbook API key", "");
+
+            if (string.IsNullOrWhiteSpace(qrzLogbookApiKey))
+            {
+                qrzLogbookApiKey = null;
+                if (!hasExistingLogbookKey)
+                {
+                    Console.WriteLine("  No API key entered. Skipping logbook sync.");
+                }
+            }
+
+            if (!string.IsNullOrWhiteSpace(qrzLogbookApiKey) || hasExistingLogbookKey)
+            {
+                autoSyncEnabled = PromptYesNo("Enable automatic sync?", defaultYes: false);
+
+                if (autoSyncEnabled)
+                {
+                    while (true)
+                    {
+                        var intervalInput = PromptField("Sync interval (seconds)", "300");
+                        if (uint.TryParse(intervalInput, System.Globalization.CultureInfo.InvariantCulture, out var parsed)
+                            && parsed is >= 60 and <= 3600)
+                        {
+                            syncIntervalSeconds = parsed;
+                            break;
+                        }
+
+                        Console.WriteLine("  Sync interval must be between 60 and 3600 seconds.");
+                    }
+                }
+            }
+        }
+
+        // ── Step 5: Review & Save ──────────────────────────────────
+        Console.WriteLine();
+        Console.WriteLine("Step 5 of 5: Review & Save");
         Console.WriteLine(new string('-', 30));
         Console.WriteLine();
         Console.WriteLine($"  Log file path:       {logFilePath}");
@@ -391,6 +490,8 @@ internal static class SetupCommand
         Console.WriteLine($"  Grid square:         {(string.IsNullOrWhiteSpace(grid) ? "(not set)" : grid)}");
         Console.WriteLine($"  QRZ username:        {(string.IsNullOrWhiteSpace(qrzUsername) ? "(not set)" : qrzUsername)}");
         Console.WriteLine($"  QRZ password:        {(string.IsNullOrWhiteSpace(qrzPassword) ? "(not set)" : "********")}");
+        Console.WriteLine($"  QRZ Logbook key:     {(string.IsNullOrWhiteSpace(qrzLogbookApiKey) ? hasExistingLogbookKey ? "(configured)" : "(not set)" : "********")}");
+        Console.WriteLine($"  Auto-sync:           {(autoSyncEnabled ? $"enabled (every {syncIntervalSeconds}s)" : "disabled")}");
         Console.WriteLine();
 
         var save = PromptYesNo("Save and apply?", defaultYes: true);
@@ -427,6 +528,21 @@ internal static class SetupCommand
         if (!string.IsNullOrWhiteSpace(qrzPassword))
         {
             saveRequest.QrzXmlPassword = qrzPassword;
+        }
+
+        if (!string.IsNullOrWhiteSpace(qrzLogbookApiKey))
+        {
+            saveRequest.QrzLogbookApiKey = qrzLogbookApiKey;
+        }
+
+        // Include sync config when the logbook feature is in use.
+        if (!string.IsNullOrWhiteSpace(qrzLogbookApiKey) || hasExistingLogbookKey)
+        {
+            saveRequest.SyncConfig = new QsoRipper.Domain.SyncConfig
+            {
+                AutoSyncEnabled = autoSyncEnabled,
+                SyncIntervalSeconds = syncIntervalSeconds,
+            };
         }
 
         var saveResponse = await client.SaveSetupAsync(saveRequest);

--- a/src/dotnet/QsoRipper.Cli/Commands/SyncCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SyncCommand.cs
@@ -1,0 +1,48 @@
+using Grpc.Net.Client;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli.Commands;
+
+internal static class SyncCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel, bool force)
+    {
+        var client = new LogbookService.LogbookServiceClient(channel);
+        var request = new SyncWithQrzRequest { FullSync = force };
+        using var call = client.SyncWithQrz(request);
+
+        SyncWithQrzResponse? last = null;
+
+        while (await call.ResponseStream.MoveNext(CancellationToken.None))
+        {
+            var update = call.ResponseStream.Current;
+
+            if (update.HasCurrentAction)
+            {
+                Console.WriteLine(update.CurrentAction);
+            }
+
+            last = update;
+        }
+
+        if (last is null)
+        {
+            Console.Error.WriteLine("No response received from engine.");
+            return 1;
+        }
+
+        if (last.HasError)
+        {
+            Console.Error.WriteLine($"Sync failed: {last.Error}");
+            return 1;
+        }
+
+        Console.WriteLine();
+        Console.WriteLine($"Downloaded:  {last.DownloadedRecords}");
+        Console.WriteLine($"Uploaded:    {last.UploadedRecords}");
+        Console.WriteLine($"Conflicts:   {last.ConflictRecords}");
+        Console.WriteLine($"Total:       {last.TotalRecords}");
+
+        return 0;
+    }
+}

--- a/src/dotnet/QsoRipper.Cli/Commands/SyncStatusCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SyncStatusCommand.cs
@@ -1,0 +1,52 @@
+using Grpc.Net.Client;
+using QsoRipper.Cli;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli.Commands;
+
+internal static class SyncStatusCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel, bool jsonOutput = false)
+    {
+        var client = new LogbookService.LogbookServiceClient(channel);
+        var response = await client.GetSyncStatusAsync(new GetSyncStatusRequest());
+
+        if (jsonOutput)
+        {
+            JsonOutput.Print(response);
+            return 0;
+        }
+
+        Console.WriteLine($"Local QSOs:       {response.LocalQsoCount}");
+        Console.WriteLine($"QRZ QSOs:         {response.QrzQsoCount}");
+        Console.WriteLine($"Pending upload:   {response.PendingUpload}");
+        Console.WriteLine($"Auto-sync:        {(response.AutoSyncEnabled ? "enabled" : "disabled")}");
+        Console.WriteLine($"Syncing now:      {(response.IsSyncing ? "yes" : "no")}");
+
+        if (response.LastSync is not null)
+        {
+            Console.WriteLine($"Last sync:        {response.LastSync.ToDateTime():u}");
+        }
+        else
+        {
+            Console.WriteLine("Last sync:        never");
+        }
+
+        if (response.NextSync is not null)
+        {
+            Console.WriteLine($"Next sync:        {response.NextSync.ToDateTime():u}");
+        }
+
+        if (response.HasQrzLogbookOwner)
+        {
+            Console.WriteLine($"QRZ owner:        {response.QrzLogbookOwner}");
+        }
+
+        if (response.HasLastSyncError)
+        {
+            Console.WriteLine($"Last error:       {response.LastSyncError}");
+        }
+
+        return 0;
+    }
+}

--- a/src/dotnet/QsoRipper.Cli/Commands/TestLogbookCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/TestLogbookCommand.cs
@@ -1,0 +1,50 @@
+using Grpc.Net.Client;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli.Commands;
+
+internal static class TestLogbookCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel, string[] args)
+    {
+        string? apiKey = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            if (args[i] is "--api-key" && i < args.Length - 1)
+            {
+                apiKey = args[++i];
+            }
+        }
+
+        var client = new SetupService.SetupServiceClient(channel);
+        var request = new TestQrzLogbookCredentialsRequest();
+
+        if (apiKey is not null)
+        {
+            request.ApiKey = apiKey;
+        }
+
+        var response = await client.TestQrzLogbookCredentialsAsync(request);
+
+        if (!response.Success)
+        {
+            Console.Error.WriteLine($"Logbook test failed: {response.ErrorMessage}");
+            return 1;
+        }
+
+        Console.WriteLine("Logbook credentials OK");
+
+        if (response.HasLogbookOwner)
+        {
+            Console.WriteLine($"Owner:     {response.LogbookOwner}");
+        }
+
+        if (response.HasQsoCount)
+        {
+            Console.WriteLine($"QSO count: {response.QsoCount}");
+        }
+
+        return 0;
+    }
+}

--- a/src/dotnet/QsoRipper.Cli/Program.cs
+++ b/src/dotnet/QsoRipper.Cli/Program.cs
@@ -46,6 +46,9 @@ try
         "export" => await ExportAdifCommand.RunAsync(channel, arguments.RemainingArgs),
         "config" => await ConfigCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput),
         "setup" => await SetupCommand.RunAsync(channel, arguments),
+        "sync" => await SyncCommand.RunAsync(channel, arguments.Force),
+        "sync-status" => await SyncStatusCommand.RunAsync(channel, arguments.JsonOutput),
+        "test-logbook" => await TestLogbookCommand.RunAsync(channel, arguments.RemainingArgs),
         _ => ShowHelp($"Unknown command: {arguments.Command}")
     };
 }

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/LogbookInterop.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/LogbookInterop.razor
@@ -219,6 +219,50 @@
     <div class="card-body">
         <div class="d-flex justify-content-between align-items-center mb-3 gap-3 flex-wrap">
             <div>
+                <h2 class="h5 mb-1">Test QRZ Logbook API Key</h2>
+                <div class="small text-muted">
+                    Validate a QRZ logbook API key via <code>TestQrzLogbookCredentials</code>.
+                    Uses the configured key if left blank.
+                </div>
+            </div>
+            <div class="d-flex gap-2 align-items-center">
+                <input type="password"
+                       class="form-control form-control-sm"
+                       style="width: 280px"
+                       placeholder="API key (blank = use configured)"
+                       @bind="testApiKey" />
+                <button class="btn btn-outline-primary"
+                        type="button"
+                        @onclick="TestLogbookCredentialsAsync"
+                        disabled="@isTestingCredentials">
+                    @(isTestingCredentials ? "Testing..." : "Test key")
+                </button>
+            </div>
+        </div>
+
+        @if (!string.IsNullOrWhiteSpace(testCredentialsError))
+        {
+            <div class="alert alert-danger">@testCredentialsError</div>
+        }
+
+        @if (testCredentialsPayload is not null)
+        {
+            <PayloadCard Title="TestQrzLogbookCredentials response"
+                         Payload="@testCredentialsPayload.Json" />
+        }
+        else if (!isTestingCredentials)
+        {
+            <p class="text-muted mb-0">
+                No credential test run yet. Enter an API key or leave blank to use the engine's configured key.
+            </p>
+        }
+    </div>
+</div>
+
+<div class="card shadow-sm mt-4">
+    <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3 gap-3 flex-wrap">
+            <div>
                 <h2 class="h5 mb-1">QRZ sync</h2>
                 <div class="small text-muted">
                     Stream live <code>SyncWithQrz</code> progress frames and then refresh <code>GetSyncStatus</code>
@@ -347,6 +391,10 @@
     private string? importErrorMessage;
     private string? exportErrorMessage;
     private string? syncErrorMessage;
+    private string testApiKey = string.Empty;
+    private bool isTestingCredentials;
+    private string? testCredentialsError;
+    private ProtoPayloadView? testCredentialsPayload;
     private AdifImportInvocationResult? importResult;
     private AdifExportInvocationResult? exportResult;
     private QrzSyncInvocationResult? syncResult;
@@ -476,6 +524,22 @@
         var (response, errorMessage) = await LogbookInteropWorkbenchService.GetSyncStatusAsync();
         syncStatusPayload = response is null ? null : ProtoJsonService.Describe(response);
         syncErrorMessage = errorMessage;
+    }
+
+    private async Task TestLogbookCredentialsAsync()
+    {
+        isTestingCredentials = true;
+        try
+        {
+            testCredentialsError = null;
+            var (response, errorMessage) = await LogbookInteropWorkbenchService.TestLogbookCredentialsAsync(testApiKey);
+            testCredentialsPayload = response is null ? null : ProtoJsonService.Describe(response);
+            testCredentialsError = errorMessage;
+        }
+        finally
+        {
+            isTestingCredentials = false;
+        }
     }
 
     private async Task RunSyncAsync()

--- a/src/dotnet/QsoRipper.DebugHost/Services/LogbookInteropWorkbenchService.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Services/LogbookInteropWorkbenchService.cs
@@ -219,6 +219,28 @@ internal sealed class LogbookInteropWorkbenchService
         }
     }
 
+    public async Task<(TestQrzLogbookCredentialsResponse? Response, string? ErrorMessage)> TestLogbookCredentialsAsync(
+        string apiKey,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var client = _clientFactory.CreateSetupClient();
+            var response = await client.TestQrzLogbookCredentialsAsync(
+                new TestQrzLogbookCredentialsRequest { ApiKey = apiKey },
+                cancellationToken: cancellationToken);
+            return (response, null);
+        }
+        catch (RpcException ex)
+        {
+            return (null, ex.Status.Detail);
+        }
+        catch (OperationCanceledException ex)
+        {
+            return (null, ex.Message);
+        }
+    }
+
     internal static async IAsyncEnumerable<ImportAdifRequest> CreateImportRequestsAsync(
         Stream input,
         bool refresh = false,

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoGridLayoutStoreTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoGridLayoutStoreTests.cs
@@ -1,0 +1,69 @@
+using QsoRipper.Gui.Utilities;
+using QsoRipper.Gui.ViewModels;
+
+namespace QsoRipper.Gui.Tests;
+
+public sealed class RecentQsoGridLayoutStoreTests
+{
+    [Fact]
+    public void LoadReturnsNullWhenLayoutFileIsMissing()
+    {
+        var layoutPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "grid-layout.json");
+        var store = new RecentQsoGridLayoutStore(layoutPath);
+
+        Assert.Null(store.Load());
+    }
+
+    [Fact]
+    public void SaveAndLoadRoundTripsGridLayout()
+    {
+        var layoutDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var layoutPath = Path.Combine(layoutDirectory, "grid-layout.json");
+        var store = new RecentQsoGridLayoutStore(layoutPath);
+        var expected = new RecentQsoGridLayoutState
+        {
+            SortColumn = RecentQsoSortColumn.Callsign,
+            SortAscending = true,
+            GridFontSize = 14,
+            Columns =
+            [
+                new RecentQsoGridColumnState
+                {
+                    Column = RecentQsoGridColumn.Utc,
+                    DisplayIndex = 0,
+                    IsVisible = true,
+                    Width = 104,
+                },
+                new RecentQsoGridColumnState
+                {
+                    Column = RecentQsoGridColumn.Note,
+                    DisplayIndex = 13,
+                    IsVisible = true,
+                    Width = 220,
+                }
+            ]
+        };
+
+        try
+        {
+            store.Save(expected);
+
+            var actual = store.Load();
+
+            Assert.NotNull(actual);
+            Assert.Equal(RecentQsoSortColumn.Callsign, actual.SortColumn);
+            Assert.True(actual.SortAscending);
+            Assert.Equal(14, actual.GridFontSize);
+            Assert.Equal(2, actual.Columns.Count);
+            Assert.Equal(RecentQsoGridColumn.Note, actual.Columns[1].Column);
+            Assert.Equal(220, actual.Columns[1].Width);
+        }
+        finally
+        {
+            if (Directory.Exists(layoutDirectory))
+            {
+                Directory.Delete(layoutDirectory, recursive: true);
+            }
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
@@ -388,6 +388,9 @@ public class RecentQsoListViewModelTests
         public Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default) =>
             throw new NotImplementedException();
 
+        public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
         public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default)
         {
             if (RefreshException is not null)
@@ -403,5 +406,11 @@ public class RecentQsoListViewModelTests
             UpdatedQsos.Add(qso.Clone());
             return Task.FromResult(new UpdateQsoResponse { Success = true });
         }
+
+        public Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default) =>
+            Task.FromResult(new SyncWithQrzResponse());
+
+        public Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default) =>
+            Task.FromResult(new GetSyncStatusResponse());
     }
 }

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
@@ -10,14 +10,43 @@ namespace QsoRipper.Gui.Tests;
 public class RecentQsoListViewModelTests
 {
     [Fact]
-    public async Task RefreshAsyncLoadsRecentQsosAndSelectsFirstItem()
+    public async Task RefreshAsyncLoadsDenseColumnsAndSelectsFirstItem()
     {
         var engine = new FakeEngineClient
         {
             RecentQsos =
             [
-                CreateQso("qso-1", "W1AW", Band._40M, Mode.Cw, 7025, "CN87", "First recent QSO", operatorName: "Alice", state: "WA", country: "United States", utcTimestamp: new DateTimeOffset(2026, 4, 13, 22, 16, 0, TimeSpan.Zero)),
-                CreateQso("qso-2", "K7RND", Band._20M, Mode.Ft8, 14074, "CN88", "Second recent QSO", operatorName: "Bob", state: "BC", country: "Canada", utcTimestamp: new DateTimeOffset(2026, 4, 13, 22, 15, 0, TimeSpan.Zero))
+                CreateQso(
+                    "qso-1",
+                    "W1AW",
+                    Band._40M,
+                    Mode.Cw,
+                    7025,
+                    "CN87",
+                    "First recent QSO",
+                    operatorName: "Alice",
+                    state: "WA",
+                    country: "United States",
+                    dxcc: 291,
+                    contestId: "CQ-WW",
+                    exchangeReceived: "WA",
+                    utcTimestamp: new DateTimeOffset(2026, 4, 13, 22, 16, 0, TimeSpan.Zero)),
+                CreateQso(
+                    "qso-2",
+                    "K7RND",
+                    Band._20M,
+                    Mode.Ft8,
+                    14074,
+                    "CN88",
+                    "Second recent QSO",
+                    operatorName: "Bob",
+                    state: "BC",
+                    country: "Canada",
+                    dxcc: 1,
+                    contestId: "POTA",
+                    exchangeReceived: "BC",
+                    utcTimestamp: new DateTimeOffset(2026, 4, 13, 22, 15, 0, TimeSpan.Zero),
+                    syncStatus: SyncStatus.Synced)
             ]
         };
 
@@ -32,30 +61,120 @@ public class RecentQsoListViewModelTests
         Assert.Equal("CW", viewModel.VisibleItems[0].Mode);
         Assert.Equal("Alice", viewModel.VisibleItems[0].OperatorName);
         Assert.Equal("United States", viewModel.VisibleItems[0].Country);
-        Assert.Equal("Sorted by UTC time (descending)", viewModel.SortStatusText);
-        Assert.Equal("Showing 2 recent QSOs", viewModel.SummaryText);
+        Assert.Equal("59/57", viewModel.VisibleItems[0].Rst);
+        Assert.Equal("291", viewModel.VisibleItems[0].Dxcc);
+        Assert.Equal("WA", viewModel.VisibleItems[0].Exchange);
+        Assert.Equal("CQ-WW", viewModel.VisibleItems[0].Contest);
+        Assert.Equal("K7RND", viewModel.VisibleItems[0].Station);
+        Assert.Equal("Sort: UTC time desc", viewModel.SortStatusText);
+        Assert.Equal("2 QSOs", viewModel.CountStatusText);
+        Assert.Equal("No filter", viewModel.FilterStatusText);
+        Assert.Equal("Sync local", viewModel.TopSyncIndicatorText);
     }
 
     [Fact]
-    public async Task SearchTextFiltersAcrossMultipleColumnsAsUserTypes()
+    public async Task SearchTextFiltersAcrossMultipleColumnsAndTracksTokens()
     {
         var engine = new FakeEngineClient
         {
             RecentQsos =
             [
-                CreateQso("qso-1", "W1AW", Band._20M, Mode.Ft8, 14074, "CN87", "CQ test", operatorName: "Alice", state: "WA", country: "United States"),
-                CreateQso("qso-2", "VE7ABC", Band._40M, Mode.Ssb, 7185, "CN88", "Morning ragchew", operatorName: "Bob", state: "BC", country: "Canada")
+                CreateQso(
+                    "qso-1",
+                    "W1AW",
+                    Band._20M,
+                    Mode.Ft8,
+                    14074,
+                    "CN87",
+                    "CQ test",
+                    operatorName: "Alice",
+                    state: "WA",
+                    country: "United States",
+                    contestId: "POTA",
+                    exchangeReceived: "WA"),
+                CreateQso(
+                    "qso-2",
+                    "VE7ABC",
+                    Band._40M,
+                    Mode.Ssb,
+                    7185,
+                    "CN88",
+                    "Morning ragchew",
+                    operatorName: "Bob",
+                    state: "BC",
+                    country: "Canada",
+                    contestId: "CQ-WW",
+                    exchangeReceived: "BC")
             ]
         };
 
         var viewModel = new RecentQsoListViewModel(engine);
         await viewModel.RefreshAsync();
 
-        viewModel.SearchText = "w1aw united 57";
+        viewModel.SearchText = "call:w1aw contest:pota wa";
 
         Assert.Single(viewModel.VisibleItems);
         Assert.Equal("qso-1", viewModel.VisibleItems[0].LocalId);
-        Assert.Equal("Showing 1 of 2 recent QSOs", viewModel.SummaryText);
+        Assert.Equal(3, viewModel.ActiveFilterTokens.Count);
+        Assert.Equal("1 filtered", viewModel.FilterStatusText);
+    }
+
+    [Fact]
+    public async Task SaveEditsAsyncUpdatesDirtyRowsAndClearsPendingEdits()
+    {
+        var original = CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States");
+        var updated = original.Clone();
+        updated.Comment = "Updated note";
+
+        var engine = new FakeEngineClient
+        {
+            RecentQsos = [original]
+        };
+
+        var viewModel = new RecentQsoListViewModel(engine);
+        await viewModel.RefreshAsync();
+
+        viewModel.SelectedQso!.BeginEdit();
+        viewModel.SelectedQso.Note = "Updated note";
+        viewModel.SelectedQso.EndEdit();
+
+        Assert.Equal(1, viewModel.PendingEditCount);
+        Assert.False(viewModel.RefreshCommand.CanExecute(null));
+
+        engine.RecentQsos = [updated];
+        await viewModel.SaveEditsCommand.ExecuteAsync(null);
+
+        Assert.Single(engine.UpdatedQsos);
+        Assert.Equal("Updated note", engine.UpdatedQsos[0].Comment);
+        Assert.Equal(0, viewModel.PendingEditCount);
+        Assert.Equal("No pending edits", viewModel.EditStatusText);
+        Assert.Equal("Updated note", viewModel.SelectedQso?.Note);
+    }
+
+    [Fact]
+    public async Task SaveEditsAsyncRejectsInvalidBandAndKeepsDirtyRow()
+    {
+        var engine = new FakeEngineClient
+        {
+            RecentQsos =
+            [
+                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States")
+            ]
+        };
+
+        var viewModel = new RecentQsoListViewModel(engine);
+        await viewModel.RefreshAsync();
+
+        viewModel.SelectedQso!.BeginEdit();
+        viewModel.SelectedQso.Band = "bogus";
+        viewModel.SelectedQso.EndEdit();
+
+        await viewModel.SaveEditsCommand.ExecuteAsync(null);
+
+        Assert.Equal("Invalid band: bogus.", viewModel.ErrorMessage);
+        Assert.Empty(engine.UpdatedQsos);
+        Assert.Equal(1, viewModel.PendingEditCount);
+        Assert.True(viewModel.SelectedQso?.IsDirty);
     }
 
     [Fact]
@@ -81,13 +200,25 @@ public class RecentQsoListViewModelTests
     }
 
     [Fact]
-    public void MatchesSearchUsesAllTokensAgainstFormattedColumns()
+    public void MatchesSearchSupportsFieldTokensAgainstDenseColumns()
     {
         var item = RecentQsoItemViewModel.FromQso(
-            CreateQso("qso-1", "W1AW", Band._40M, Mode.Cw, 7025, "CN87", "Evening CW", operatorName: "Alice", state: "WA", country: "United States"));
+            CreateQso(
+                "qso-1",
+                "W1AW",
+                Band._40M,
+                Mode.Cw,
+                7025,
+                "CN87",
+                "Evening CW",
+                operatorName: "Alice",
+                state: "WA",
+                country: "United States",
+                contestId: "CQ-WW",
+                exchangeReceived: "WA"));
 
-        Assert.True(RecentQsoListViewModel.MatchesSearch(item, "alice 40m united"));
-        Assert.False(RecentQsoListViewModel.MatchesSearch(item, "alice 40m canada"));
+        Assert.True(RecentQsoListViewModel.MatchesSearch(item, "call:w1aw band:40m contest:cq note:evening"));
+        Assert.False(RecentQsoListViewModel.MatchesSearch(item, "call:w1aw band:20m"));
     }
 
     [Fact]
@@ -107,11 +238,11 @@ public class RecentQsoListViewModelTests
 
         viewModel.ApplySort(RecentQsoSortColumn.Callsign);
         Assert.Equal("VE7ABC", viewModel.VisibleItems[0].WorkedCallsign);
-        Assert.Equal("Call ↑", viewModel.CallsignHeaderText);
+        Assert.Equal("Sort: callsign asc", viewModel.SortStatusText);
 
         viewModel.ApplySort(RecentQsoSortColumn.Callsign);
         Assert.Equal("W1AW", viewModel.VisibleItems[0].WorkedCallsign);
-        Assert.Equal("Call ↓", viewModel.CallsignHeaderText);
+        Assert.Equal("Sort: callsign desc", viewModel.SortStatusText);
     }
 
     [Fact]
@@ -136,6 +267,62 @@ public class RecentQsoListViewModelTests
         Assert.NotEqual(firstAscending, viewModel.VisibleItems[0].Country);
     }
 
+    [Fact]
+    public async Task SyncSummaryReflectsMixedStatuses()
+    {
+        var engine = new FakeEngineClient
+        {
+            RecentQsos =
+            [
+                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "First", syncStatus: SyncStatus.LocalOnly),
+                CreateQso("qso-2", "K7RND", Band._40M, Mode.Ssb, 7185, "CN88", "Second", syncStatus: SyncStatus.Modified),
+                CreateQso("qso-3", "VE7ABC", Band._15M, Mode.Ft8, 21074, "CN89", "Third", syncStatus: SyncStatus.Conflict),
+                CreateQso("qso-4", "N0CALL", Band._10M, Mode.Ssb, 28450, "EN34", "Fourth", syncStatus: SyncStatus.Synced),
+            ]
+        };
+
+        var viewModel = new RecentQsoListViewModel(engine);
+        await viewModel.RefreshAsync();
+
+        Assert.Equal("Sync: 1 local | 1 modified | 1 conflict | 1 synced", viewModel.SyncSummaryText);
+        Assert.Equal("Sync conflict", viewModel.TopSyncIndicatorText);
+    }
+
+    [Fact]
+    public void CancelEditRestoresSnapshotAndClearsDirtyState()
+    {
+        var item = RecentQsoItemViewModel.FromQso(
+            CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States"));
+
+        item.BeginEdit();
+        item.WorkedCallsign = "VE7ABC";
+        item.CancelEdit();
+
+        Assert.Equal("W1AW", item.WorkedCallsign);
+        Assert.False(item.IsDirty);
+    }
+
+    [Fact]
+    public void AdjustZoomClampsFontSizeAndUpdatesStatus()
+    {
+        var viewModel = new RecentQsoListViewModel(new FakeEngineClient());
+
+        Assert.Equal(12, viewModel.GridFontSize);
+        Assert.Equal("Zoom 100%", viewModel.GridZoomStatusText);
+
+        Assert.True(viewModel.AdjustZoom(1));
+        Assert.Equal(13, viewModel.GridFontSize);
+        Assert.Equal("Zoom 108%", viewModel.GridZoomStatusText);
+
+        viewModel.ApplyPersistedGridFontSize(99);
+        Assert.Equal(18, viewModel.GridFontSize);
+
+        Assert.False(viewModel.AdjustZoom(1));
+
+        viewModel.ResetGridZoom();
+        Assert.Equal(12, viewModel.GridFontSize);
+    }
+
     private static QsoRecord CreateQso(
         string localId,
         string workedCallsign,
@@ -147,7 +334,12 @@ public class RecentQsoListViewModelTests
         string? operatorName = null,
         string? state = null,
         string? country = null,
-        DateTimeOffset? utcTimestamp = null)
+        uint dxcc = 0,
+        string? contestId = null,
+        string? exchangeReceived = null,
+        string? notes = null,
+        DateTimeOffset? utcTimestamp = null,
+        SyncStatus syncStatus = SyncStatus.LocalOnly)
     {
         return new QsoRecord
         {
@@ -160,12 +352,16 @@ public class RecentQsoListViewModelTests
             FrequencyKhz = frequencyKhz,
             WorkedGrid = grid,
             Comment = comment,
+            Notes = notes ?? string.Empty,
+            ContestId = contestId ?? string.Empty,
+            ExchangeReceived = exchangeReceived ?? string.Empty,
             WorkedOperatorName = operatorName ?? string.Empty,
             WorkedState = state ?? string.Empty,
             WorkedCountry = country ?? string.Empty,
+            WorkedDxcc = dxcc,
             RstSent = new RstReport { Raw = "59" },
             RstReceived = new RstReport { Raw = "57" },
-            SyncStatus = SyncStatus.LocalOnly
+            SyncStatus = syncStatus
         };
     }
 
@@ -174,6 +370,8 @@ public class RecentQsoListViewModelTests
         public IReadOnlyList<QsoRecord> RecentQsos { get; set; } = [];
 
         public RpcException? RefreshException { get; set; }
+
+        public List<QsoRecord> UpdatedQsos { get; } = [];
 
         public Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default) =>
             throw new NotImplementedException();
@@ -198,6 +396,12 @@ public class RecentQsoListViewModelTests
             }
 
             return Task.FromResult(RecentQsos);
+        }
+
+        public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default)
+        {
+            UpdatedQsos.Add(qso.Clone());
+            return Task.FromResult(new UpdateQsoResponse { Success = true });
         }
     }
 }

--- a/src/dotnet/QsoRipper.Gui.Tests/ResponsiveWindowLayoutTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/ResponsiveWindowLayoutTests.cs
@@ -1,0 +1,61 @@
+using Avalonia;
+using QsoRipper.Gui.Utilities;
+
+namespace QsoRipper.Gui.Tests;
+
+public class ResponsiveWindowLayoutTests
+{
+    [Fact]
+    public void ClampToWorkingAreaKeepsPreferredSizeWhenWorkingAreaIsLargeEnough()
+    {
+        var layout = ResponsiveWindowLayout.ClampToWorkingArea(
+            preferredWidth: 1280,
+            preferredHeight: 760,
+            preferredMinWidth: 1024,
+            preferredMinHeight: 640,
+            workingArea: new PixelRect(0, 0, 1920, 1080),
+            scaling: 1);
+
+        Assert.Equal(1280, layout.Width);
+        Assert.Equal(760, layout.Height);
+        Assert.Equal(1024, layout.MinWidth);
+        Assert.Equal(640, layout.MinHeight);
+        Assert.Equal(new PixelPoint(320, 160), layout.Position);
+    }
+
+    [Fact]
+    public void ClampToWorkingAreaShrinksWindowAndMinimumsOnSmallDisplay()
+    {
+        var layout = ResponsiveWindowLayout.ClampToWorkingArea(
+            preferredWidth: 1280,
+            preferredHeight: 760,
+            preferredMinWidth: 1024,
+            preferredMinHeight: 640,
+            workingArea: new PixelRect(0, 0, 1366, 768),
+            scaling: 1);
+
+        Assert.Equal(1024, layout.MinWidth);
+        Assert.Equal(640, layout.MinHeight);
+        Assert.Equal(1280, layout.Width);
+        Assert.Equal(736, layout.Height);
+        Assert.Equal(new PixelPoint(43, 16), layout.Position);
+    }
+
+    [Fact]
+    public void ClampToWorkingAreaAccountsForMonitorScaling()
+    {
+        var layout = ResponsiveWindowLayout.ClampToWorkingArea(
+            preferredWidth: 1280,
+            preferredHeight: 760,
+            preferredMinWidth: 1024,
+            preferredMinHeight: 640,
+            workingArea: new PixelRect(0, 0, 1920, 1080),
+            scaling: 1.5);
+
+        Assert.Equal(1248, layout.Width);
+        Assert.Equal(688, layout.Height);
+        Assert.Equal(1024, layout.MinWidth);
+        Assert.Equal(640, layout.MinHeight);
+        Assert.Equal(new PixelPoint(24, 24), layout.Position);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/App.axaml
+++ b/src/dotnet/QsoRipper.Gui/App.axaml
@@ -4,5 +4,6 @@
              RequestedThemeVariant="Default">
   <Application.Styles>
     <FluentTheme />
+    <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
   </Application.Styles>
 </Application>

--- a/src/dotnet/QsoRipper.Gui/QsoRipper.Gui.csproj
+++ b/src/dotnet/QsoRipper.Gui/QsoRipper.Gui.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Avalonia.Controls.DataGrid" />
     <PackageReference Include="Avalonia.Desktop" />
     <PackageReference Include="Avalonia.Themes.Fluent" />
     <PackageReference Include="CommunityToolkit.Mvvm" />

--- a/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
@@ -89,6 +89,22 @@ internal sealed class EngineGrpcService : IEngineClient, IDisposable
         return recentQsos;
     }
 
+    public async Task<UpdateQsoResponse> UpdateQsoAsync(
+        QsoRecord qso,
+        bool syncToQrz = false,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(qso);
+
+        return await _logbookClient.UpdateQsoAsync(
+            new UpdateQsoRequest
+            {
+                Qso = qso,
+                SyncToQrz = syncToQrz
+            },
+            cancellationToken: ct);
+    }
+
     public void Dispose()
     {
         _channel.Dispose();

--- a/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
@@ -65,6 +65,18 @@ internal sealed class EngineGrpcService : IEngineClient, IDisposable
             new GetSetupStatusRequest(), cancellationToken: ct);
     }
 
+    public async Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(
+        string apiKey,
+        CancellationToken ct = default)
+    {
+        return await _setupClient.TestQrzLogbookCredentialsAsync(
+            new TestQrzLogbookCredentialsRequest
+            {
+                ApiKey = apiKey,
+            },
+            cancellationToken: ct);
+    }
+
     public async Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default)
     {
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
@@ -103,6 +115,27 @@ internal sealed class EngineGrpcService : IEngineClient, IDisposable
                 SyncToQrz = syncToQrz
             },
             cancellationToken: ct);
+    }
+
+    public async Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default)
+    {
+        using var call = _logbookClient.SyncWithQrz(
+            new SyncWithQrzRequest(),
+            cancellationToken: ct);
+
+        SyncWithQrzResponse? last = null;
+        await foreach (var response in call.ResponseStream.ReadAllAsync(ct))
+        {
+            last = response;
+        }
+
+        return last ?? new SyncWithQrzResponse();
+    }
+
+    public async Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default)
+    {
+        return await _logbookClient.GetSyncStatusAsync(
+            new GetSyncStatusRequest(), cancellationToken: ct);
     }
 
     public void Dispose()

--- a/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
@@ -25,10 +25,18 @@ internal interface IEngineClient
 
     Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default);
 
+    Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(
+        string apiKey,
+        CancellationToken ct = default);
+
     Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default);
 
     Task<UpdateQsoResponse> UpdateQsoAsync(
         QsoRecord qso,
         bool syncToQrz = false,
         CancellationToken ct = default);
+
+    Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default);
+
+    Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default);
 }

--- a/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
@@ -26,4 +26,9 @@ internal interface IEngineClient
     Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default);
 
     Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default);
+
+    Task<UpdateQsoResponse> UpdateQsoAsync(
+        QsoRecord qso,
+        bool syncToQrz = false,
+        CancellationToken ct = default);
 }

--- a/src/dotnet/QsoRipper.Gui/Utilities/ProtoEnumDisplay.cs
+++ b/src/dotnet/QsoRipper.Gui/Utilities/ProtoEnumDisplay.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using Google.Protobuf.Reflection;
 using QsoRipper.Domain;
@@ -12,6 +14,12 @@ internal static class ProtoEnumDisplay
     public static string ForMode(Mode mode) =>
         mode == Mode.Unspecified ? "-" : FormatEnumValue(mode, "MODE");
 
+    public static bool TryParseBand(string? value, out Band band) =>
+        TryParseEnum(value, Band.Unspecified, ForBand, out band);
+
+    public static bool TryParseMode(string? value, out Mode mode) =>
+        TryParseEnum(value, Mode.Unspecified, ForMode, out mode);
+
     private static string FormatEnumValue<TEnum>(TEnum value, string prefix)
         where TEnum : struct, Enum
     {
@@ -24,5 +32,47 @@ internal static class ProtoEnumDisplay
         }
 
         return originalName.Replace('_', '.');
+    }
+
+    private static bool TryParseEnum<TEnum>(
+        string? value,
+        TEnum unspecified,
+        Func<TEnum, string> formatter,
+        out TEnum parsedValue)
+        where TEnum : struct, Enum
+    {
+        var normalizedInput = NormalizeToken(value);
+        if (normalizedInput.Length == 0)
+        {
+            parsedValue = unspecified;
+            return false;
+        }
+
+        foreach (var candidate in Enum.GetValues<TEnum>())
+        {
+            if (EqualityComparer<TEnum>.Default.Equals(candidate, unspecified))
+            {
+                continue;
+            }
+
+            if (NormalizeToken(formatter(candidate)) == normalizedInput)
+            {
+                parsedValue = candidate;
+                return true;
+            }
+        }
+
+        parsedValue = unspecified;
+        return false;
+    }
+
+    private static string NormalizeToken(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        return string.Concat(value.Where(char.IsLetterOrDigit)).ToUpperInvariant();
     }
 }

--- a/src/dotnet/QsoRipper.Gui/Utilities/RecentQsoGridLayoutStore.cs
+++ b/src/dotnet/QsoRipper.Gui/Utilities/RecentQsoGridLayoutStore.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using QsoRipper.Gui.ViewModels;
+
+namespace QsoRipper.Gui.Utilities;
+
+internal sealed class RecentQsoGridLayoutStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly string _filePath;
+
+    public RecentQsoGridLayoutStore(string? filePath = null)
+    {
+        _filePath = string.IsNullOrWhiteSpace(filePath)
+            ? GetDefaultFilePath()
+            : filePath;
+    }
+
+    public RecentQsoGridLayoutState? Load()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(_filePath);
+            return JsonSerializer.Deserialize<RecentQsoGridLayoutState>(stream, JsonOptions);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public void Save(RecentQsoGridLayoutState state)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var stream = File.Create(_filePath);
+        JsonSerializer.Serialize(stream, state, JsonOptions);
+    }
+
+    private static string GetDefaultFilePath()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(localAppData, "QsoRipper", "recent-qso-grid-layout.json");
+    }
+}
+
+internal sealed class RecentQsoGridLayoutState
+{
+    public RecentQsoSortColumn SortColumn { get; set; } = RecentQsoSortColumn.Utc;
+
+    public bool SortAscending { get; set; }
+
+    public double GridFontSize { get; set; } = 12;
+
+    public List<RecentQsoGridColumnState> Columns { get; set; } = [];
+}
+
+internal sealed class RecentQsoGridColumnState
+{
+    public RecentQsoGridColumn Column { get; set; }
+
+    public bool IsVisible { get; set; } = true;
+
+    public int DisplayIndex { get; set; }
+
+    public double Width { get; set; }
+}

--- a/src/dotnet/QsoRipper.Gui/Utilities/ResponsiveWindowLayout.cs
+++ b/src/dotnet/QsoRipper.Gui/Utilities/ResponsiveWindowLayout.cs
@@ -1,0 +1,44 @@
+using Avalonia;
+
+namespace QsoRipper.Gui.Utilities;
+
+internal static class ResponsiveWindowLayout
+{
+    private const double SafeInsetDip = 16;
+
+    public static WindowLayout ClampToWorkingArea(
+        double preferredWidth,
+        double preferredHeight,
+        double preferredMinWidth,
+        double preferredMinHeight,
+        PixelRect workingArea,
+        double scaling)
+    {
+        if (scaling <= 0)
+        {
+            scaling = 1;
+        }
+
+        var availableWidth = Math.Max(1, (workingArea.Width / scaling) - (SafeInsetDip * 2));
+        var availableHeight = Math.Max(1, (workingArea.Height / scaling) - (SafeInsetDip * 2));
+
+        var minWidth = Math.Min(preferredMinWidth, availableWidth);
+        var minHeight = Math.Min(preferredMinHeight, availableHeight);
+        var width = Math.Max(minWidth, Math.Min(preferredWidth, availableWidth));
+        var height = Math.Max(minHeight, Math.Min(preferredHeight, availableHeight));
+
+        var widthPixels = (int)Math.Round(width * scaling);
+        var heightPixels = (int)Math.Round(height * scaling);
+        var x = workingArea.X + Math.Max(0, (workingArea.Width - widthPixels) / 2);
+        var y = workingArea.Y + Math.Max(0, (workingArea.Height - heightPixels) / 2);
+
+        return new WindowLayout(width, height, minWidth, minHeight, new PixelPoint(x, y));
+    }
+}
+
+internal readonly record struct WindowLayout(
+    double Width,
+    double Height,
+    double MinWidth,
+    double MinHeight,
+    PixelPoint Position);

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -145,14 +145,21 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         try
         {
             var response = await _engine.SyncWithQrzAsync();
+
+            if (!string.IsNullOrEmpty(response.Error))
+            {
+                SyncStatusText = $"Sync error: {response.Error}";
+                return;
+            }
+
             var up = response.UploadedRecords;
             var down = response.DownloadedRecords;
             SyncStatusText = $"Synced: \u2191{up} \u2193{down}";
             await RecentQsos.RefreshAsync();
         }
-        catch (Grpc.Core.RpcException)
+        catch (Grpc.Core.RpcException ex)
         {
-            SyncStatusText = "Sync failed";
+            SyncStatusText = $"Sync failed: {ex.Status.Detail}";
         }
         finally
         {

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -19,6 +19,9 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     private bool _setupCompleteBeforeWizard;
 
     [ObservableProperty]
+    private bool _isSettingsOpen;
+
+    [ObservableProperty]
     private bool _isWizardOpen;
 
     [ObservableProperty]
@@ -41,6 +44,12 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 
     [ObservableProperty]
     private bool _isInspectorOpen;
+
+    [ObservableProperty]
+    private bool _isSyncing;
+
+    [ObservableProperty]
+    private string _syncStatusText = "Sync: never";
 
     [ObservableProperty]
     private bool _isSortChooserOpen;
@@ -77,6 +86,12 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     public event EventHandler? SearchFocusRequested;
 
     /// <summary>
+    /// Raised when the user requests the Settings dialog. The View subscribes to
+    /// this event and opens the modal <see cref="Views.SettingsView"/>.
+    /// </summary>
+    internal event EventHandler? SettingsRequested;
+
+    /// <summary>
     /// Called after the main window has loaded. Checks first-run state.
     /// </summary>
     public async Task CheckFirstRunAsync()
@@ -85,15 +100,15 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         {
             var state = await _engine.GetWizardStateAsync();
             ApplySetupContext(state);
-            if (state.Status.IsFirstRun || !state.Status.SetupComplete)
+            IsSetupIncomplete = !state.Status.SetupComplete;
+
+            if (state.Status.IsFirstRun)
             {
-                IsSetupIncomplete = !state.Status.SetupComplete;
-                StatusMessage = IsSetupIncomplete ? "Setup incomplete" : "Welcome";
+                StatusMessage = "Welcome";
                 await OpenWizardAsync();
             }
             else
             {
-                IsSetupIncomplete = false;
                 await ActivateDashboardAsync(focusSearch: true);
             }
         }
@@ -111,6 +126,66 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         WizardViewModel = vm;
         IsWizardOpen = true;
         await vm.LoadStateAsync();
+    }
+
+    [RelayCommand]
+    private void OpenSettings()
+    {
+        if (!IsWizardOpen && !IsSettingsOpen)
+        {
+            SettingsRequested?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanSyncNow))]
+    private async Task SyncNowAsync()
+    {
+        IsSyncing = true;
+        SyncStatusText = "Syncing\u2026";
+        try
+        {
+            var response = await _engine.SyncWithQrzAsync();
+            var up = response.UploadedRecords;
+            var down = response.DownloadedRecords;
+            SyncStatusText = $"Synced: \u2191{up} \u2193{down}";
+            await RecentQsos.RefreshAsync();
+        }
+        catch (Grpc.Core.RpcException)
+        {
+            SyncStatusText = "Sync failed";
+        }
+        finally
+        {
+            IsSyncing = false;
+        }
+    }
+
+    private bool CanSyncNow() => !IsSyncing && !IsWizardOpen;
+
+    partial void OnIsSyncingChanged(bool value) => SyncNowCommand.NotifyCanExecuteChanged();
+
+    partial void OnIsWizardOpenChanged(bool value)
+    {
+        SyncNowCommand.NotifyCanExecuteChanged();
+    }
+
+    /// <summary>
+    /// Creates a <see cref="SettingsViewModel"/> wired to the shared engine client.
+    /// Called by the View layer when handling <see cref="SettingsRequested"/>.
+    /// </summary>
+    internal SettingsViewModel CreateSettingsViewModel() => new(_engine);
+
+    /// <summary>
+    /// Called by the View layer after the Settings dialog closes.
+    /// </summary>
+    internal async Task OnSettingsClosedAsync(bool didSave)
+    {
+        IsSettingsOpen = false;
+        if (didSave)
+        {
+            await RefreshSetupContextAsync();
+            await ActivateDashboardAsync(focusSearch: false);
+        }
     }
 
     [RelayCommand]
@@ -212,6 +287,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     {
         StatusMessage = "Ready";
         await RecentQsos.RefreshAsync();
+        await RefreshSyncStatusAsync();
 
         if (focusSearch && !IsWizardOpen)
         {
@@ -287,5 +363,36 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         return string.IsNullOrWhiteSpace(stationCallsign)
             ? "Station: -"
             : $"Station: {stationCallsign.Trim()}";
+    }
+
+    private async Task RefreshSyncStatusAsync()
+    {
+        try
+        {
+            var status = await _engine.GetSyncStatusAsync();
+            if (status.IsSyncing)
+            {
+                SyncStatusText = "Syncing\u2026";
+            }
+            else if (status.LastSync is not null)
+            {
+                var elapsed = DateTimeOffset.UtcNow - status.LastSync.ToDateTimeOffset();
+                SyncStatusText = elapsed.TotalMinutes < 1
+                    ? "Last sync: just now"
+                    : elapsed.TotalHours < 1
+                        ? $"Last sync: {(int)elapsed.TotalMinutes}m ago"
+                        : elapsed.TotalDays < 1
+                            ? $"Last sync: {(int)elapsed.TotalHours}h ago"
+                            : $"Last sync: {(int)elapsed.TotalDays}d ago";
+            }
+            else
+            {
+                SyncStatusText = "Sync: never";
+            }
+        }
+        catch (Grpc.Core.RpcException)
+        {
+            // Sync status unavailable — leave current text unchanged.
+        }
     }
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,6 @@
 using System.Globalization;
+using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -27,6 +29,24 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 
     [ObservableProperty]
     private bool _isSetupIncomplete;
+
+    [ObservableProperty]
+    private string _activeLogText = "Log: -";
+
+    [ObservableProperty]
+    private string _activeProfileText = "Profile: -";
+
+    [ObservableProperty]
+    private string _activeStationText = "Station: -";
+
+    [ObservableProperty]
+    private bool _isInspectorOpen;
+
+    [ObservableProperty]
+    private bool _isSortChooserOpen;
+
+    [ObservableProperty]
+    private bool _isColumnChooserOpen;
 
     [ObservableProperty]
     private string _currentUtcTime = string.Empty;
@@ -64,12 +84,11 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         try
         {
             var state = await _engine.GetWizardStateAsync();
+            ApplySetupContext(state);
             if (state.Status.IsFirstRun || !state.Status.SetupComplete)
             {
                 IsSetupIncomplete = !state.Status.SetupComplete;
-                StatusMessage = IsSetupIncomplete
-                    ? "Setup incomplete - finish settings to start logging."
-                    : "Welcome to QsoRipper.";
+                StatusMessage = IsSetupIncomplete ? "Setup incomplete" : "Welcome";
                 await OpenWizardAsync();
             }
             else
@@ -80,7 +99,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         }
         catch (Grpc.Core.RpcException)
         {
-            StatusMessage = "Cannot connect to engine at 127.0.0.1:50051. Is the engine running?";
+            StatusMessage = "Engine unavailable";
         }
     }
 
@@ -99,8 +118,42 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     {
         if (!IsWizardOpen)
         {
+            CloseTransientPanels();
             SearchFocusRequested?.Invoke(this, EventArgs.Empty);
         }
+    }
+
+    [RelayCommand]
+    private void ToggleInspector()
+    {
+        IsInspectorOpen = !IsInspectorOpen;
+    }
+
+    [RelayCommand]
+    private void ToggleSortChooser()
+    {
+        IsSortChooserOpen = !IsSortChooserOpen;
+        if (IsSortChooserOpen)
+        {
+            IsColumnChooserOpen = false;
+        }
+    }
+
+    [RelayCommand]
+    private void ToggleColumnChooser()
+    {
+        IsColumnChooserOpen = !IsColumnChooserOpen;
+        if (IsColumnChooserOpen)
+        {
+            IsSortChooserOpen = false;
+        }
+    }
+
+    [RelayCommand]
+    private void CloseTransientPanels()
+    {
+        IsSortChooserOpen = false;
+        IsColumnChooserOpen = false;
     }
 
     [RelayCommand]
@@ -118,8 +171,8 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         WizardViewModel = null;
         IsSetupIncomplete = !_setupCompleteBeforeWizard;
         StatusMessage = _setupCompleteBeforeWizard
-            ? "Ready - setup complete."
-            : "Setup incomplete - open Settings to finish.";
+            ? "Ready"
+            : "Setup incomplete";
 
         if (_setupCompleteBeforeWizard)
         {
@@ -133,8 +186,10 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         WizardViewModel = null;
         IsSetupIncomplete = !setupComplete;
         StatusMessage = setupComplete
-            ? "Ready - setup complete."
-            : "Setup incomplete - open Settings to finish.";
+            ? "Ready"
+            : "Setup incomplete";
+
+        _ = RefreshSetupContextAsync();
 
         if (setupComplete)
         {
@@ -155,7 +210,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 
     private async Task ActivateDashboardAsync(bool focusSearch)
     {
-        StatusMessage = "Ready - setup complete.";
+        StatusMessage = "Ready";
         await RecentQsos.RefreshAsync();
 
         if (focusSearch && !IsWizardOpen)
@@ -185,5 +240,52 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         timer.Tick += UtcTimerOnTick;
         timer.Start();
         return timer;
+    }
+
+    private async Task RefreshSetupContextAsync()
+    {
+        try
+        {
+            ApplySetupContext(await _engine.GetWizardStateAsync());
+        }
+        catch (Grpc.Core.RpcException)
+        {
+            StatusMessage = "Engine unavailable";
+        }
+    }
+
+    private void ApplySetupContext(QsoRipper.Services.GetSetupWizardStateResponse state)
+    {
+        var activeProfile = state.StationProfiles.FirstOrDefault(profile => profile.IsActive)?.Profile
+            ?? state.Status.StationProfile;
+        ActiveLogText = BuildLogText(state.Status.LogFilePath);
+        ActiveProfileText = BuildProfileText(activeProfile);
+        ActiveStationText = BuildStationText(activeProfile);
+    }
+
+    private static string BuildLogText(string? logFilePath)
+    {
+        if (string.IsNullOrWhiteSpace(logFilePath))
+        {
+            return "Log: -";
+        }
+
+        return $"Log: {Path.GetFileNameWithoutExtension(logFilePath.Trim())}";
+    }
+
+    private static string BuildProfileText(QsoRipper.Domain.StationProfile? profile)
+    {
+        var profileName = profile?.ProfileName;
+        return string.IsNullOrWhiteSpace(profileName)
+            ? "Profile: Default"
+            : $"Profile: {profileName.Trim()}";
+    }
+
+    private static string BuildStationText(QsoRipper.Domain.StationProfile? profile)
+    {
+        var stationCallsign = profile?.StationCallsign;
+        return string.IsNullOrWhiteSpace(stationCallsign)
+            ? "Station: -"
+            : $"Station: {stationCallsign.Trim()}";
     }
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/QrzLogbookStepViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/QrzLogbookStepViewModel.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace QsoRipper.Gui.ViewModels;
+
+internal sealed partial class QrzLogbookStepViewModel : WizardStepViewModel
+{
+    public override string Title => "QRZ Logbook (optional)";
+
+    public override string Description =>
+        "Configure your QRZ.com Logbook API key for bidirectional sync.";
+
+    public override bool IsSkippable => true;
+
+    [ObservableProperty]
+    private string? _apiKey;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsSyncIntervalEnabled))]
+    private bool _autoSyncEnabled;
+
+    [ObservableProperty]
+    private int _syncIntervalSeconds = 300;
+
+    public bool IsSyncIntervalEnabled => AutoSyncEnabled;
+
+    /// <summary>
+    /// True when a key was already configured on the server (we never receive the actual secret).
+    /// </summary>
+    [ObservableProperty]
+    private bool _hasExistingKey;
+
+    public override Dictionary<string, string> GetFields()
+    {
+        return new Dictionary<string, string>
+        {
+            ["qrz_logbook_api_key"] = HasExistingKey && string.IsNullOrWhiteSpace(ApiKey)
+                ? "(configured)"
+                : ApiKey ?? string.Empty,
+            ["auto_sync_enabled"] = AutoSyncEnabled.ToString(CultureInfo.InvariantCulture),
+            ["sync_interval_seconds"] = SyncIntervalSeconds.ToString(CultureInfo.InvariantCulture),
+        };
+    }
+
+    /// <summary>
+    /// Client-side validation for the QRZ Logbook step.
+    /// Returns <see langword="true"/> when the step is valid.
+    /// </summary>
+    public bool ValidateLocally()
+    {
+        if (AutoSyncEnabled && SyncIntervalSeconds is < 60 or > 3600)
+        {
+            ValidationSummary = "Sync interval must be between 60 and 3600 seconds.";
+            return false;
+        }
+
+        ClearErrors();
+        return true;
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoColumnOptionViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoColumnOptionViewModel.cs
@@ -1,0 +1,23 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace QsoRipper.Gui.ViewModels;
+
+internal sealed partial class RecentQsoColumnOptionViewModel : ObservableObject
+{
+    public RecentQsoColumnOptionViewModel(
+        RecentQsoGridColumn column,
+        string label,
+        bool isVisible)
+    {
+        Column = column;
+        Label = label;
+        _isVisible = isVisible;
+    }
+
+    public RecentQsoGridColumn Column { get; }
+
+    public string Label { get; }
+
+    [ObservableProperty]
+    private bool _isVisible;
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoGridColumn.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoGridColumn.cs
@@ -1,6 +1,6 @@
 namespace QsoRipper.Gui.ViewModels;
 
-internal enum RecentQsoSortColumn
+internal enum RecentQsoGridColumn
 {
     Utc,
     Callsign,

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
@@ -1,159 +1,616 @@
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
 using QsoRipper.Gui.Utilities;
 
 namespace QsoRipper.Gui.ViewModels;
 
-internal sealed class RecentQsoItemViewModel
+internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
 {
-    public string LocalId { get; init; } = string.Empty;
+    private static readonly string[] TimestampFormats =
+    [
+        "yy-MM-dd HH:mm",
+        "yyyy-MM-dd HH:mm",
+        "yyyy-MM-dd HH:mm:ss",
+        "yyyy-MM-ddTHH:mm",
+        "yyyy-MM-ddTHH:mm:ss",
+        "yyyy-MM-ddTHH:mm:ssZ",
+        "yyyy-MM-ddTHH:mm:ss.fffZ",
+        "o"
+    ];
 
-    public string UtcDisplay { get; init; } = "-";
+    private QsoRecord _sourceQso = new();
+    private EditableQsoState? _editSnapshot;
+    private string _utcDisplay = "-";
+    private string _workedCallsign = "-";
+    private string _band = "-";
+    private string _mode = "-";
+    private string _country = "-";
+    private string _operatorName = "-";
+    private string _frequency = "-";
+    private string _rst = "-";
+    private string _dxcc = "-";
+    private string _grid = "-";
+    private string _exchange = "-";
+    private string _contest = "-";
+    private string _station = "-";
+    private string _note = "-";
+    private string _utcEndDisplay = "-";
+    private string _cqZone = "-";
+    private string _ituZone = "-";
+    private string _qth = "-";
+    private string _syncStatus = "-";
+    private bool _isDirty;
 
-    public string WorkedCallsign { get; init; } = "-";
+    public string LocalId => _sourceQso.LocalId;
 
-    public string Band { get; init; } = "-";
+    public string UtcDisplay
+    {
+        get => _utcDisplay;
+        set => SetProperty(ref _utcDisplay, value);
+    }
 
-    public string Mode { get; init; } = "-";
+    public string WorkedCallsign
+    {
+        get => _workedCallsign;
+        set => SetProperty(ref _workedCallsign, value);
+    }
 
-    public string Country { get; init; } = "-";
+    public string Band
+    {
+        get => _band;
+        set => SetProperty(ref _band, value);
+    }
 
-    public string OperatorName { get; init; } = "-";
+    public string Mode
+    {
+        get => _mode;
+        set => SetProperty(ref _mode, value);
+    }
 
-    public string Frequency { get; init; } = "-";
+    public string Country
+    {
+        get => _country;
+        set => SetProperty(ref _country, value);
+    }
 
-    public string RstSent { get; init; } = "-";
+    public string OperatorName
+    {
+        get => _operatorName;
+        set => SetProperty(ref _operatorName, value);
+    }
 
-    public string RstReceived { get; init; } = "-";
+    public string Frequency
+    {
+        get => _frequency;
+        set => SetProperty(ref _frequency, value);
+    }
 
-    public string Grid { get; init; } = "-";
+    public string Rst
+    {
+        get => _rst;
+        set => SetProperty(ref _rst, value);
+    }
 
-    public string Comment { get; init; } = "-";
+    public string RstSent => SplitCombinedReport(Rst).Sent;
 
-    public string UtcEndDisplay { get; init; } = "-";
+    public string RstReceived => SplitCombinedReport(Rst).Received;
 
-    public string SyncStatus { get; init; } = "-";
+    public string Dxcc
+    {
+        get => _dxcc;
+        set => SetProperty(ref _dxcc, value);
+    }
 
-    internal string SearchDocument { get; init; } = string.Empty;
+    public string Grid
+    {
+        get => _grid;
+        set => SetProperty(ref _grid, value);
+    }
 
-    internal DateTimeOffset UtcSortKey { get; init; }
+    public string Exchange
+    {
+        get => _exchange;
+        set => SetProperty(ref _exchange, value);
+    }
 
-    internal string CallsignSortKey { get; init; } = string.Empty;
+    public string Contest
+    {
+        get => _contest;
+        set => SetProperty(ref _contest, value);
+    }
 
-    internal string BandSortKey { get; init; } = string.Empty;
+    public string Station
+    {
+        get => _station;
+        set => SetProperty(ref _station, value);
+    }
 
-    internal string ModeSortKey { get; init; } = string.Empty;
+    public string Note
+    {
+        get => _note;
+        set => SetProperty(ref _note, value);
+    }
 
-    internal string CountrySortKey { get; init; } = string.Empty;
+    public string UtcEndDisplay
+    {
+        get => _utcEndDisplay;
+        set => SetProperty(ref _utcEndDisplay, value);
+    }
 
-    internal string NameSortKey { get; init; } = string.Empty;
+    public string CqZone
+    {
+        get => _cqZone;
+        set => SetProperty(ref _cqZone, value);
+    }
 
-    internal ulong FrequencySortKey { get; init; }
+    public string ItuZone
+    {
+        get => _ituZone;
+        set => SetProperty(ref _ituZone, value);
+    }
 
-    internal string RstSentSortKey { get; init; } = string.Empty;
+    public string Qth
+    {
+        get => _qth;
+        private set => SetProperty(ref _qth, value);
+    }
 
-    internal string RstReceivedSortKey { get; init; } = string.Empty;
+    public string SyncStatus
+    {
+        get => _syncStatus;
+        private set => SetProperty(ref _syncStatus, value);
+    }
 
-    internal string GridSortKey { get; init; } = string.Empty;
+    public bool IsDirty
+    {
+        get => _isDirty;
+        private set => SetProperty(ref _isDirty, value);
+    }
 
-    internal string CommentSortKey { get; init; } = string.Empty;
+    internal string SearchDocument => BuildSearchDocument(
+        WorkedCallsign,
+        OperatorName,
+        Band,
+        Mode,
+        _sourceQso.Submode,
+        Frequency,
+        Country,
+        Grid,
+        Qth,
+        Rst,
+        RstSent,
+        RstReceived,
+        Dxcc,
+        Contest,
+        Exchange,
+        Station,
+        Note,
+        CqZone,
+        ItuZone,
+        SyncStatus,
+        _sourceQso.WorkedState,
+        _sourceQso.WorkedCounty,
+        _sourceQso.WorkedContinent,
+        _sourceQso.TxPower,
+        _sourceQso.SerialSent,
+        _sourceQso.SerialReceived,
+        _sourceQso.ExchangeSent,
+        _sourceQso.ExchangeReceived,
+        _sourceQso.PropMode,
+        _sourceQso.SatName,
+        _sourceQso.SatMode,
+        _sourceQso.WorkedIota,
+        _sourceQso.WorkedArrlSection,
+        UtcDisplay,
+        UtcEndDisplay);
 
-    internal DateTimeOffset UtcEndSortKey { get; init; }
+    public DateTimeOffset UtcSortKey =>
+        TryParseTimestamp(UtcDisplay, required: false, out var timestamp)
+            ? timestamp
+            : DateTimeOffset.MinValue;
 
-    internal string SyncStatusSortKey { get; init; } = string.Empty;
+    public ulong FrequencySortKey =>
+        TryParseFrequency(Frequency, out var frequency)
+            ? frequency
+            : 0;
+
+    public uint DxccSortKey =>
+        TryParseOptionalUInt(Dxcc, out var dxcc)
+            ? dxcc
+            : 0;
+
+    public DateTimeOffset UtcEndSortKey =>
+        TryParseTimestamp(UtcEndDisplay, required: false, out var timestamp)
+            ? timestamp
+            : DateTimeOffset.MinValue;
 
     public static RecentQsoItemViewModel FromQso(QsoRecord qso)
     {
         ArgumentNullException.ThrowIfNull(qso);
 
-        var utcSortKey = qso.UtcTimestamp?.ToDateTimeOffset().ToUniversalTime() ?? DateTimeOffset.MinValue;
-        var utcEndSortKey = qso.UtcEndTimestamp?.ToDateTimeOffset().ToUniversalTime() ?? DateTimeOffset.MinValue;
-        var band = ProtoEnumDisplay.ForBand(qso.Band);
-        var mode = ProtoEnumDisplay.ForMode(qso.Mode);
-        var country = BuildCountry(qso);
-        var operatorName = BuildOperatorName(qso);
-        var grid = DisplayOrDash(qso.WorkedGrid);
-        var frequency = qso.HasFrequencyKhz
-            ? qso.FrequencyKhz.ToString("N0", CultureInfo.InvariantCulture)
-            : "-";
-        var rstSent = DisplayOrDash(qso.RstSent?.Raw);
-        var rstReceived = DisplayOrDash(qso.RstReceived?.Raw);
-        var comment = BuildComment(qso);
-        var syncStatus = BuildSyncStatus(qso.SyncStatus);
+        var item = new RecentQsoItemViewModel();
+        item.LoadSourceQso(qso);
+        return item;
+    }
 
-        return new RecentQsoItemViewModel
+    public void BeginEdit()
+    {
+        _editSnapshot ??= CaptureState();
+    }
+
+    public void CancelEdit()
+    {
+        if (_editSnapshot is not { } snapshot)
         {
-            LocalId = qso.LocalId,
-            UtcDisplay = FormatTimestamp(qso.UtcTimestamp),
-            WorkedCallsign = DisplayOrDash(qso.WorkedCallsign),
-            Band = band,
-            Mode = mode,
-            Country = country,
-            OperatorName = operatorName,
-            Frequency = frequency,
-            RstSent = rstSent,
-            RstReceived = rstReceived,
-            Grid = grid,
-            Comment = comment,
-            UtcEndDisplay = FormatTimestamp(qso.UtcEndTimestamp),
-            SyncStatus = syncStatus,
-            SearchDocument = BuildSearchDocument(
-                qso.WorkedCallsign,
-                operatorName,
-                band,
-                mode,
-                qso.Submode,
-                frequency,
-                qso.WorkedCountry,
-                qso.WorkedState,
-                qso.WorkedCounty,
-                qso.WorkedContinent,
-                qso.WorkedDxcc.ToString(CultureInfo.InvariantCulture),
-                qso.WorkedCqZone.ToString(CultureInfo.InvariantCulture),
-                qso.WorkedItuZone.ToString(CultureInfo.InvariantCulture),
-                grid,
-                rstSent,
-                rstReceived,
-                qso.TxPower,
-                qso.ContestId,
-                qso.SerialSent,
-                qso.SerialReceived,
-                qso.ExchangeSent,
-                qso.ExchangeReceived,
-                qso.PropMode,
-                qso.SatName,
-                qso.SatMode,
-                qso.WorkedIota,
-                qso.WorkedArrlSection,
-                comment,
-                syncStatus,
-                FormatTimestamp(qso.UtcTimestamp),
-                FormatTimestamp(qso.UtcEndTimestamp)),
-            UtcSortKey = utcSortKey,
-            CallsignSortKey = NormalizeSortValue(qso.WorkedCallsign),
-            BandSortKey = NormalizeSortValue(band),
-            ModeSortKey = NormalizeSortValue(mode),
-            CountrySortKey = NormalizeSortValue(country),
-            NameSortKey = NormalizeSortValue(operatorName),
-            FrequencySortKey = qso.HasFrequencyKhz ? qso.FrequencyKhz : 0,
-            RstSentSortKey = NormalizeSortValue(rstSent),
-            RstReceivedSortKey = NormalizeSortValue(rstReceived),
-            GridSortKey = NormalizeSortValue(grid),
-            CommentSortKey = NormalizeSortValue(comment),
-            UtcEndSortKey = utcEndSortKey,
-            SyncStatusSortKey = NormalizeSortValue(syncStatus)
+            return;
+        }
+
+        _editSnapshot = null;
+        ApplyState(snapshot);
+        RecomputeDirty();
+    }
+
+    public void EndEdit()
+    {
+        _editSnapshot = null;
+        RecomputeDirty();
+    }
+
+    internal void AcceptSavedChanges(QsoRecord qso)
+    {
+        ArgumentNullException.ThrowIfNull(qso);
+
+        _sourceQso = qso.Clone();
+        _editSnapshot = null;
+        Qth = BuildQth(_sourceQso);
+        SyncStatus = BuildSyncStatus(_sourceQso.SyncStatus);
+        RecomputeDirty();
+    }
+
+    internal bool MatchesFieldToken(string key, string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        var normalizedValue = NormalizeSearchValue(value);
+        return key switch
+        {
+            "CALL" or "CALLSIGN" => ContainsNormalized(WorkedCallsign, normalizedValue),
+            "BAND" => ContainsNormalized(Band, normalizedValue),
+            "MODE" => ContainsNormalized(Mode, normalizedValue),
+            "FREQ" or "FREQUENCY" => ContainsNormalized(Frequency, normalizedValue),
+            "RST" => ContainsNormalized(Rst, normalizedValue)
+                || ContainsNormalized(RstSent, normalizedValue)
+                || ContainsNormalized(RstReceived, normalizedValue),
+            "DXCC" => ContainsNormalized(Dxcc, normalizedValue),
+            "COUNTRY" => ContainsNormalized(Country, normalizedValue),
+            "NAME" => ContainsNormalized(OperatorName, normalizedValue),
+            "GRID" => ContainsNormalized(Grid, normalizedValue),
+            "EXCH" or "EXCHANGE" => ContainsNormalized(Exchange, normalizedValue),
+            "CONTEST" => ContainsNormalized(Contest, normalizedValue),
+            "STATION" => ContainsNormalized(Station, normalizedValue),
+            "NOTE" or "COMMENT" => ContainsNormalized(Note, normalizedValue),
+            "CQ" => ContainsNormalized(CqZone, normalizedValue),
+            "ITU" => ContainsNormalized(ItuZone, normalizedValue),
+            "QTH" => ContainsNormalized(Qth, normalizedValue),
+            "SYNC" => ContainsNormalized(SyncStatus, normalizedValue),
+            _ => false
         };
     }
 
-    private static string BuildComment(QsoRecord qso)
+    internal bool TryBuildUpdatedQso(out QsoRecord? qso, out string? error)
+    {
+        error = null;
+        qso = null;
+
+        var updated = _sourceQso.Clone();
+        var sourceState = EditableQsoState.FromQso(_sourceQso);
+
+        if (!TryParseTimestamp(UtcDisplay, required: true, out var utcTimestamp))
+        {
+            error = "Invalid UTC value. Use yy-MM-dd HH:mm or an ISO-8601 timestamp.";
+            return false;
+        }
+
+        updated.UtcTimestamp = Timestamp.FromDateTimeOffset(utcTimestamp);
+
+        var workedCallsign = NormalizeToken(WorkedCallsign, uppercase: true);
+        if (workedCallsign.Length == 0)
+        {
+            error = "Call is required.";
+            return false;
+        }
+
+        updated.WorkedCallsign = workedCallsign;
+
+        if (!ProtoEnumDisplay.TryParseBand(Band, out var band))
+        {
+            error = $"Invalid band: {Band}.";
+            return false;
+        }
+
+        if (!ProtoEnumDisplay.TryParseMode(Mode, out var mode))
+        {
+            error = $"Invalid mode: {Mode}.";
+            return false;
+        }
+
+        updated.Band = band;
+        updated.Mode = mode;
+
+        if (!TryApplyFrequency(updated, out error)
+            || (!StringComparer.Ordinal.Equals(Rst, sourceState.Rst) && !TryApplyRst(updated, out error))
+            || !TryApplyOptionalUInt(Dxcc, "DXCC", value => updated.WorkedDxcc = value, updated.ClearWorkedDxcc, out error)
+            || !TryApplyOptionalUInt(CqZone, "CQ zone", value => updated.WorkedCqZone = value, updated.ClearWorkedCqZone, out error)
+            || !TryApplyOptionalUInt(ItuZone, "ITU zone", value => updated.WorkedItuZone = value, updated.ClearWorkedItuZone, out error)
+            || !TryApplyUtcEnd(updated, out error))
+        {
+            return false;
+        }
+
+        if (!StringComparer.Ordinal.Equals(Country, sourceState.Country))
+        {
+            ApplyOptionalString(Country, value => updated.WorkedCountry = value, updated.ClearWorkedCountry);
+        }
+
+        if (!StringComparer.Ordinal.Equals(OperatorName, sourceState.OperatorName))
+        {
+            ApplyOptionalString(
+                OperatorName,
+                value => updated.WorkedOperatorName = value,
+                () =>
+                {
+                    updated.ClearWorkedOperatorName();
+                    updated.ClearWorkedOperatorCallsign();
+                });
+        }
+
+        ApplyOptionalString(Grid, value => updated.WorkedGrid = value, updated.ClearWorkedGrid, uppercase: true);
+        ApplyOptionalString(Contest, value => updated.ContestId = value, updated.ClearContestId);
+        ApplyOptionalString(Station, value => updated.StationCallsign = value, () => updated.StationCallsign = string.Empty, uppercase: true);
+
+        if (!StringComparer.Ordinal.Equals(Exchange, sourceState.Exchange))
+        {
+            ApplyExchange(updated);
+        }
+
+        if (!StringComparer.Ordinal.Equals(Note, sourceState.Note))
+        {
+            ApplyNote(updated);
+        }
+
+        qso = updated;
+        return true;
+    }
+
+    private void LoadSourceQso(QsoRecord qso)
+    {
+        _sourceQso = qso.Clone();
+        _editSnapshot = null;
+        ApplyState(EditableQsoState.FromQso(_sourceQso));
+        Qth = BuildQth(_sourceQso);
+        SyncStatus = BuildSyncStatus(_sourceQso.SyncStatus);
+        RecomputeDirty();
+    }
+
+    private EditableQsoState CaptureState() => new(
+        UtcDisplay,
+        WorkedCallsign,
+        Band,
+        Mode,
+        Frequency,
+        Rst,
+        Dxcc,
+        Country,
+        OperatorName,
+        Grid,
+        Exchange,
+        Contest,
+        Station,
+        Note,
+        UtcEndDisplay,
+        CqZone,
+        ItuZone);
+
+    private void ApplyState(EditableQsoState state)
+    {
+        UtcDisplay = state.UtcDisplay;
+        WorkedCallsign = state.WorkedCallsign;
+        Band = state.Band;
+        Mode = state.Mode;
+        Frequency = state.Frequency;
+        Rst = state.Rst;
+        Dxcc = state.Dxcc;
+        Country = state.Country;
+        OperatorName = state.OperatorName;
+        Grid = state.Grid;
+        Exchange = state.Exchange;
+        Contest = state.Contest;
+        Station = state.Station;
+        Note = state.Note;
+        UtcEndDisplay = state.UtcEndDisplay;
+        CqZone = state.CqZone;
+        ItuZone = state.ItuZone;
+    }
+
+    private void RecomputeDirty()
+    {
+        IsDirty = CaptureState() != EditableQsoState.FromQso(_sourceQso);
+    }
+
+    private bool TryApplyFrequency(QsoRecord updated, out string? error)
+    {
+        error = null;
+
+        if (TryParseFrequency(Frequency, out var frequency))
+        {
+            updated.FrequencyKhz = frequency;
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(Frequency) || Frequency == "-")
+        {
+            updated.ClearFrequencyKhz();
+            return true;
+        }
+
+        error = $"Invalid frequency: {Frequency}.";
+        return false;
+    }
+
+    private bool TryApplyRst(QsoRecord updated, out string? error)
+    {
+        error = null;
+
+        var value = NoteOrNull(Rst);
+        if (value is null)
+        {
+            updated.RstSent = null;
+            updated.RstReceived = null;
+            return true;
+        }
+
+        var parts = value.Split(['/', ' '], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length is < 1 or > 2)
+        {
+            error = $"Invalid RST: {Rst}. Use 59 or 59/59.";
+            return false;
+        }
+
+        if (!TryParseRstToken(parts[0], out var sent))
+        {
+            error = $"Invalid RST: {Rst}.";
+            return false;
+        }
+
+        var received = sent.Clone();
+        if (parts.Length == 2 && !TryParseRstToken(parts[1], out received))
+        {
+            error = $"Invalid RST: {Rst}.";
+            return false;
+        }
+
+        updated.RstSent = sent;
+        updated.RstReceived = received;
+        return true;
+    }
+
+    private static bool TryApplyOptionalUInt(
+        string value,
+        string fieldName,
+        Action<uint> setter,
+        Action clearer,
+        out string? error)
+    {
+        error = null;
+
+        if (TryParseOptionalUInt(value, out var parsed))
+        {
+            if (parsed == 0)
+            {
+                clearer();
+            }
+            else
+            {
+                setter(parsed);
+            }
+
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(value) || value == "-")
+        {
+            clearer();
+            return true;
+        }
+
+        error = $"Invalid {fieldName}: {value}.";
+        return false;
+    }
+
+    private bool TryApplyUtcEnd(QsoRecord updated, out string? error)
+    {
+        error = null;
+
+        if (TryParseTimestamp(UtcEndDisplay, required: false, out var utcEnd))
+        {
+            if (utcEnd == DateTimeOffset.MinValue)
+            {
+                updated.UtcEndTimestamp = null;
+            }
+            else
+            {
+                updated.UtcEndTimestamp = Timestamp.FromDateTimeOffset(utcEnd);
+            }
+
+            return true;
+        }
+
+        error = "Invalid end time. Use yy-MM-dd HH:mm or an ISO-8601 timestamp.";
+        return false;
+    }
+
+    private void ApplyExchange(QsoRecord updated)
+    {
+        var exchange = NoteOrNull(Exchange);
+        if (exchange is null)
+        {
+            updated.ClearExchangeReceived();
+            updated.ClearExchangeSent();
+            updated.ClearSerialReceived();
+            updated.ClearSerialSent();
+            return;
+        }
+
+        updated.ExchangeReceived = exchange;
+        updated.ClearExchangeSent();
+        updated.ClearSerialReceived();
+        updated.ClearSerialSent();
+    }
+
+    private void ApplyNote(QsoRecord updated)
+    {
+        var note = NoteOrNull(Note);
+        if (note is null)
+        {
+            updated.ClearComment();
+            updated.ClearNotes();
+            return;
+        }
+
+        updated.Comment = note;
+        updated.ClearNotes();
+    }
+
+    private static EditableQsoState EditableQsoStateFromQso(QsoRecord qso) => new(
+        FormatTimestamp(qso.UtcTimestamp),
+        DisplayOrDash(qso.WorkedCallsign),
+        ProtoEnumDisplay.ForBand(qso.Band),
+        ProtoEnumDisplay.ForMode(qso.Mode),
+        qso.HasFrequencyKhz ? qso.FrequencyKhz.ToString("N0", CultureInfo.InvariantCulture) : "-",
+        BuildCombinedReport(DisplayOrDash(qso.RstSent?.Raw), DisplayOrDash(qso.RstReceived?.Raw)),
+        BuildDxcc(qso),
+        BuildCountry(qso),
+        BuildOperatorName(qso),
+        DisplayOrDash(qso.WorkedGrid),
+        BuildExchange(qso),
+        DisplayOrDash(qso.ContestId),
+        DisplayOrDash(qso.StationCallsign),
+        BuildNote(qso),
+        FormatTimestamp(qso.UtcEndTimestamp),
+        BuildOptionalNumber(qso.WorkedCqZone),
+        BuildOptionalNumber(qso.WorkedItuZone));
+
+    private static string BuildNote(QsoRecord qso)
     {
         var parts = new[]
             {
-                TrimOrNull(qso.Comment),
-                TrimOrNull(qso.Notes),
-                TrimOrNull(qso.ContestId)
+                NoteOrNull(qso.Comment),
+                NoteOrNull(qso.Notes)
             }
             .Where(static value => value is not null)
             .Distinct(StringComparer.Ordinal)
@@ -174,6 +631,74 @@ internal sealed class RecentQsoItemViewModel
 
     private static string BuildOperatorName(QsoRecord qso) =>
         FirstNonBlank(qso.WorkedOperatorName, qso.WorkedOperatorCallsign) ?? "-";
+
+    private static string BuildExchange(QsoRecord qso)
+    {
+        return FirstNonBlank(
+                   qso.ExchangeReceived,
+                   qso.SerialReceived,
+                   qso.ExchangeSent,
+                   qso.SerialSent)
+               ?? "-";
+    }
+
+    private static string BuildQth(QsoRecord qso)
+    {
+        var parts = new[]
+            {
+                NoteOrNull(qso.WorkedState),
+                NoteOrNull(qso.WorkedCounty),
+                NoteOrNull(qso.WorkedContinent)
+            }
+            .Where(static value => value is not null)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
+        return parts.Length == 0 ? "-" : string.Join(" / ", parts!);
+    }
+
+    private static string BuildDxcc(QsoRecord qso) =>
+        qso.WorkedDxcc == 0 ? "-" : qso.WorkedDxcc.ToString(CultureInfo.InvariantCulture);
+
+    private static string BuildOptionalNumber(uint value) =>
+        value == 0 ? "-" : value.ToString(CultureInfo.InvariantCulture);
+
+    private static string BuildCombinedReport(string rstSent, string rstReceived)
+    {
+        if (rstSent == "-" && rstReceived == "-")
+        {
+            return "-";
+        }
+
+        if (rstSent == "-")
+        {
+            return rstReceived;
+        }
+
+        if (rstReceived == "-")
+        {
+            return rstSent;
+        }
+
+        return $"{rstSent}/{rstReceived}";
+    }
+
+    private static (string Sent, string Received) SplitCombinedReport(string value)
+    {
+        var normalized = NoteOrNull(value);
+        if (normalized is null)
+        {
+            return ("-", "-");
+        }
+
+        var parts = normalized.Split(['/', ' '], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        return parts.Length switch
+        {
+            0 => ("-", "-"),
+            1 => (parts[0], parts[0]),
+            _ => (parts[0], parts[1])
+        };
+    }
 
     private static string BuildSearchDocument(params string?[] values)
     {
@@ -197,14 +722,126 @@ internal sealed class RecentQsoItemViewModel
         };
     }
 
+    private static bool TryParseTimestamp(string? value, bool required, out DateTimeOffset timestamp)
+    {
+        timestamp = DateTimeOffset.MinValue;
+        var normalized = NoteOrNull(value);
+        if (normalized is null || normalized == "-")
+        {
+            return !required;
+        }
+
+        return DateTimeOffset.TryParseExact(
+                   normalized,
+                   TimestampFormats,
+                   CultureInfo.InvariantCulture,
+                   DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                   out timestamp)
+               || DateTimeOffset.TryParse(
+                   normalized,
+                   CultureInfo.InvariantCulture,
+                   DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                   out timestamp);
+    }
+
+    private static bool TryParseFrequency(string? value, out ulong frequency)
+    {
+        frequency = 0;
+        var normalized = NoteOrNull(value);
+        if (normalized is null || normalized == "-")
+        {
+            return false;
+        }
+
+        return ulong.TryParse(
+            normalized.Replace(",", string.Empty, StringComparison.Ordinal),
+            NumberStyles.None,
+            CultureInfo.InvariantCulture,
+            out frequency);
+    }
+
+    private static bool TryParseOptionalUInt(string? value, out uint parsed)
+    {
+        parsed = 0;
+        var normalized = NoteOrNull(value);
+        if (normalized is null || normalized == "-")
+        {
+            return true;
+        }
+
+        return uint.TryParse(
+            normalized.Replace(",", string.Empty, StringComparison.Ordinal),
+            NumberStyles.None,
+            CultureInfo.InvariantCulture,
+            out parsed);
+    }
+
+    private static bool TryParseRstToken(string value, out RstReport report)
+    {
+        report = new RstReport();
+
+        if (value.Length is not (2 or 3) || value.Any(static c => !char.IsAsciiDigit(c)))
+        {
+            return false;
+        }
+
+        report.Readability = (uint)(value[0] - '0');
+        report.Strength = (uint)(value[1] - '0');
+
+        if (value.Length == 3)
+        {
+            report.Tone = (uint)(value[2] - '0');
+        }
+
+        return true;
+    }
+
+    private static void ApplyOptionalString(
+        string value,
+        Action<string> setter,
+        Action clearer,
+        bool uppercase = false)
+    {
+        var normalized = NormalizeToken(value, uppercase);
+        if (normalized.Length == 0)
+        {
+            clearer();
+            return;
+        }
+
+        setter(normalized);
+    }
+
     private static string DisplayOrDash(string? value) =>
         string.IsNullOrWhiteSpace(value) ? "-" : value.Trim();
+
+    private static bool ContainsNormalized(string? candidate, string normalizedValue) =>
+        NormalizeSearchValue(candidate).Contains(normalizedValue, StringComparison.Ordinal);
+
+    private static string NormalizeSearchValue(string? value) =>
+        string.IsNullOrWhiteSpace(value) || value == "-"
+            ? string.Empty
+            : value.Trim().ToUpperInvariant();
+
+    private static string NormalizeToken(string? value, bool uppercase = false)
+    {
+        if (string.IsNullOrWhiteSpace(value) || value == "-")
+        {
+            return string.Empty;
+        }
+
+        var normalized = value.Trim();
+        return uppercase ? normalized.ToUpperInvariant() : normalized;
+    }
+
+    private static string? NoteOrNull(string? value) =>
+        string.IsNullOrWhiteSpace(value) || value == "-" ? null : value.Trim();
 
     private static string? FirstNonBlank(params string?[] values)
     {
         foreach (var value in values)
         {
-            var trimmed = TrimOrNull(value);
+            var trimmed = NoteOrNull(value);
             if (trimmed is not null)
             {
                 return trimmed;
@@ -221,11 +858,25 @@ internal sealed class RecentQsoItemViewModel
             : timestamp.ToDateTimeOffset().ToUniversalTime().ToString("yy-MM-dd HH:mm", CultureInfo.InvariantCulture);
     }
 
-    private static string NormalizeSortValue(string? value) =>
-        string.IsNullOrWhiteSpace(value) || value == "-"
-            ? string.Empty
-            : value.Trim().ToUpperInvariant();
-
-    private static string? TrimOrNull(string? value) =>
-        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    private readonly record struct EditableQsoState(
+        string UtcDisplay,
+        string WorkedCallsign,
+        string Band,
+        string Mode,
+        string Frequency,
+        string Rst,
+        string Dxcc,
+        string Country,
+        string OperatorName,
+        string Grid,
+        string Exchange,
+        string Contest,
+        string Station,
+        string Note,
+        string UtcEndDisplay,
+        string CqZone,
+        string ItuZone)
+    {
+        public static EditableQsoState FromQso(QsoRecord qso) => EditableQsoStateFromQso(qso);
+    }
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -1,5 +1,8 @@
+using System.Collections;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
+using Avalonia.Collections;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Grpc.Core;
@@ -10,18 +13,40 @@ namespace QsoRipper.Gui.ViewModels;
 internal sealed partial class RecentQsoListViewModel : ObservableObject
 {
     private const int DefaultLimit = 500;
+    private const double DefaultGridFontSize = 12;
+    private const double MinGridFontSize = 10;
+    private const double MaxGridFontSize = 18;
+    private const double GridFontSizeStep = 1;
 
     private readonly IEngineClient _engine;
     private readonly List<RecentQsoItemViewModel> _allItems = [];
+    private readonly ObservableCollection<RecentQsoItemViewModel> _viewItems = [];
+    private ParsedSearchQuery _parsedSearchQuery = ParsedSearchQuery.Empty;
+    private bool _suppressSortStateSync;
 
     public RecentQsoListViewModel(IEngineClient engine)
     {
         _engine = engine;
+        View = new DataGridCollectionView(_viewItems);
+        View.Filter = FilterVisibleItem;
+        View.SortDescriptions.CollectionChanged += OnSortDescriptionsChanged;
+        ColumnOptions = new ObservableCollection<RecentQsoColumnOptionViewModel>(CreateColumnOptions());
+        ApplyPersistedSort(RecentQsoSortColumn.Utc, ascending: false);
     }
 
-    public ObservableCollection<RecentQsoItemViewModel> VisibleItems { get; } = [];
+    public DataGridCollectionView View { get; }
 
-    public bool HasVisibleItems => VisibleItems.Count > 0;
+    public ObservableCollection<RecentQsoColumnOptionViewModel> ColumnOptions { get; }
+
+    public ObservableCollection<string> ActiveFilterTokens { get; } = [];
+
+    public IReadOnlyList<RecentQsoItemViewModel> VisibleItems => View.Cast<RecentQsoItemViewModel>().ToArray();
+
+    public bool HasVisibleItems => VisibleItemCount > 0;
+
+    public bool HasActiveFilterTokens => ActiveFilterTokens.Count > 0;
+
+    public bool HasPendingEdits => PendingEditCount > 0;
 
     public string EmptyStateMessage
     {
@@ -37,7 +62,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
                 return ErrorMessage;
             }
 
-            if (!string.IsNullOrWhiteSpace(SearchText))
+            if (_parsedSearchQuery.HasTokens)
             {
                 return "No recent QSOs match the current search.";
             }
@@ -46,42 +71,50 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         }
     }
 
-    public string LastLoadedText => LastLoadedAtUtc is null
-        ? "Not loaded yet"
-        : $"Updated {LastLoadedAtUtc.Value:HH:mm:ss} UTC";
+    public string RefreshIndicatorText => IsSaving
+        ? "Saving"
+        : IsLoading
+            ? "Refreshing"
+        : LastLoadedAtUtc is null
+            ? "Not loaded"
+            : $"Loaded {LastLoadedAtUtc.Value:HH:mm:ss}";
 
-    public string SortStatusText => $"Sorted by {GetSortLabel(CurrentSortColumn)} ({(SortAscending ? "ascending" : "descending")})";
+    public string CountStatusText => $"{_allItems.Count:N0} QSOs";
 
-    public string UtcHeaderText => BuildHeaderText("UTC", RecentQsoSortColumn.Utc);
+    public string FilterStatusText => _parsedSearchQuery.HasTokens
+        ? $"{VisibleItemCount:N0} filtered"
+        : "No filter";
 
-    public string CallsignHeaderText => BuildHeaderText("Call", RecentQsoSortColumn.Callsign);
+    public string SortStatusText => $"Sort: {GetSortLabel(CurrentSortColumn)} {(SortAscending ? "asc" : "desc")}";
 
-    public string BandHeaderText => BuildHeaderText("Band", RecentQsoSortColumn.Band);
+    public string EditStatusText => IsSaving
+        ? "Saving edits"
+        : HasPendingEdits
+            ? $"{PendingEditCount:N0} unsaved"
+            : "No pending edits";
 
-    public string ModeHeaderText => BuildHeaderText("Mode", RecentQsoSortColumn.Mode);
+    public string GridZoomStatusText => $"Zoom {Math.Round((GridFontSize / DefaultGridFontSize) * 100):0}%";
 
-    public string CountryHeaderText => BuildHeaderText("Country", RecentQsoSortColumn.Country);
+    public double GridRowHeight => Math.Round(21 * (GridFontSize / DefaultGridFontSize));
 
-    public string NameHeaderText => BuildHeaderText("Name", RecentQsoSortColumn.Name);
+    public double GridHeaderHeight => Math.Round(23 * (GridFontSize / DefaultGridFontSize));
 
-    public string FrequencyHeaderText => BuildHeaderText("Freq", RecentQsoSortColumn.Frequency);
+    public string SyncSummaryText => BuildSyncSummaryText();
 
-    public string RstSentHeaderText => BuildHeaderText("S", RecentQsoSortColumn.RstSent);
-
-    public string RstReceivedHeaderText => BuildHeaderText("R", RecentQsoSortColumn.RstReceived);
-
-    public string GridHeaderText => BuildHeaderText("Grid", RecentQsoSortColumn.Grid);
-
-    public string CommentHeaderText => BuildHeaderText("Comment", RecentQsoSortColumn.Comment);
-
-    public string UtcEndHeaderText => BuildHeaderText("End", RecentQsoSortColumn.UtcEnd);
-
-    public string SyncHeaderText => BuildHeaderText("Sync", RecentQsoSortColumn.Sync);
+    public string TopSyncIndicatorText => BuildTopSyncIndicatorText();
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(RefreshCommand))]
     [NotifyPropertyChangedFor(nameof(EmptyStateMessage))]
+    [NotifyPropertyChangedFor(nameof(RefreshIndicatorText))]
     private bool _isLoading;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RefreshCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveEditsCommand))]
+    [NotifyPropertyChangedFor(nameof(EditStatusText))]
+    [NotifyPropertyChangedFor(nameof(RefreshIndicatorText))]
+    private bool _isSaving;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(EmptyStateMessage))]
@@ -92,55 +125,47 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
     private bool _hasLoaded;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(LastLoadedText))]
+    [NotifyPropertyChangedFor(nameof(RefreshIndicatorText))]
     private DateTimeOffset? _lastLoadedAtUtc;
 
     [ObservableProperty]
     private string _searchText = string.Empty;
 
     [ObservableProperty]
-    private string _summaryText = "Recent QSOs will appear here after setup completes.";
+    [NotifyPropertyChangedFor(nameof(HasVisibleItems))]
+    [NotifyPropertyChangedFor(nameof(EmptyStateMessage))]
+    [NotifyPropertyChangedFor(nameof(FilterStatusText))]
+    private int _visibleItemCount;
+
+    [ObservableProperty]
+    [NotifyCanExecuteChangedFor(nameof(RefreshCommand))]
+    [NotifyCanExecuteChangedFor(nameof(SaveEditsCommand))]
+    [NotifyPropertyChangedFor(nameof(HasPendingEdits))]
+    [NotifyPropertyChangedFor(nameof(EditStatusText))]
+    private int _pendingEditCount;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(GridZoomStatusText))]
+    [NotifyPropertyChangedFor(nameof(GridRowHeight))]
+    [NotifyPropertyChangedFor(nameof(GridHeaderHeight))]
+    private double _gridFontSize = DefaultGridFontSize;
 
     [ObservableProperty]
     private RecentQsoItemViewModel? _selectedQso;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(SortStatusText))]
-    [NotifyPropertyChangedFor(nameof(UtcHeaderText))]
-    [NotifyPropertyChangedFor(nameof(CallsignHeaderText))]
-    [NotifyPropertyChangedFor(nameof(BandHeaderText))]
-    [NotifyPropertyChangedFor(nameof(ModeHeaderText))]
-    [NotifyPropertyChangedFor(nameof(CountryHeaderText))]
-    [NotifyPropertyChangedFor(nameof(NameHeaderText))]
-    [NotifyPropertyChangedFor(nameof(FrequencyHeaderText))]
-    [NotifyPropertyChangedFor(nameof(RstSentHeaderText))]
-    [NotifyPropertyChangedFor(nameof(RstReceivedHeaderText))]
-    [NotifyPropertyChangedFor(nameof(GridHeaderText))]
-    [NotifyPropertyChangedFor(nameof(CommentHeaderText))]
-    [NotifyPropertyChangedFor(nameof(UtcEndHeaderText))]
-    [NotifyPropertyChangedFor(nameof(SyncHeaderText))]
     private RecentQsoSortColumn _currentSortColumn = RecentQsoSortColumn.Utc;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(SortStatusText))]
-    [NotifyPropertyChangedFor(nameof(UtcHeaderText))]
-    [NotifyPropertyChangedFor(nameof(CallsignHeaderText))]
-    [NotifyPropertyChangedFor(nameof(BandHeaderText))]
-    [NotifyPropertyChangedFor(nameof(ModeHeaderText))]
-    [NotifyPropertyChangedFor(nameof(CountryHeaderText))]
-    [NotifyPropertyChangedFor(nameof(NameHeaderText))]
-    [NotifyPropertyChangedFor(nameof(FrequencyHeaderText))]
-    [NotifyPropertyChangedFor(nameof(RstSentHeaderText))]
-    [NotifyPropertyChangedFor(nameof(RstReceivedHeaderText))]
-    [NotifyPropertyChangedFor(nameof(GridHeaderText))]
-    [NotifyPropertyChangedFor(nameof(CommentHeaderText))]
-    [NotifyPropertyChangedFor(nameof(UtcEndHeaderText))]
-    [NotifyPropertyChangedFor(nameof(SyncHeaderText))]
     private bool _sortAscending;
 
     partial void OnSearchTextChanged(string value)
     {
-        ApplyFilter();
+        _parsedSearchQuery = ParseSearchQuery(value);
+        UpdateFilterTokens();
+        RefreshView();
     }
 
     [RelayCommand(CanExecute = nameof(CanRefresh))]
@@ -154,12 +179,11 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
             var selectedLocalId = SelectedQso?.LocalId;
             var qsos = await _engine.ListRecentQsosAsync(DefaultLimit);
 
-            _allItems.Clear();
-            _allItems.AddRange(qsos.Select(RecentQsoItemViewModel.FromQso));
+            ReplaceItems(qsos.Select(RecentQsoItemViewModel.FromQso));
 
             HasLoaded = true;
             LastLoadedAtUtc = DateTimeOffset.UtcNow;
-            ApplyFilter(selectedLocalId);
+            RefreshView(selectedLocalId);
         }
         catch (RpcException ex)
         {
@@ -167,11 +191,12 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
             ErrorMessage = string.IsNullOrWhiteSpace(ex.Status.Detail)
                 ? $"Recent QSOs could not be loaded ({ex.StatusCode})."
                 : ex.Status.Detail;
-            ApplyFilter();
+            RefreshView();
         }
         finally
         {
             IsLoading = false;
+            NotifyStatusPropertiesChanged();
         }
     }
 
@@ -179,17 +204,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
     {
         ArgumentNullException.ThrowIfNull(item);
 
-        if (string.IsNullOrWhiteSpace(searchText))
-        {
-            return true;
-        }
-
-        var searchTokens = searchText
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(static token => token.ToUpperInvariant())
-            .ToArray();
-
-        return searchTokens.All(token => item.SearchDocument.Contains(token, StringComparison.Ordinal));
+        return MatchesSearch(item, ParseSearchQuery(searchText));
     }
 
     [RelayCommand]
@@ -204,6 +219,93 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         ApplySort(column);
     }
 
+    [RelayCommand(CanExecute = nameof(CanSaveEdits))]
+    internal async Task SaveEditsAsync()
+    {
+        if (!HasPendingEdits)
+        {
+            return;
+        }
+
+        IsSaving = true;
+        ErrorMessage = null;
+
+        try
+        {
+            var dirtyItems = _allItems.Where(item => item.IsDirty).ToArray();
+            foreach (var item in dirtyItems)
+            {
+                if (!item.TryBuildUpdatedQso(out var qso, out var validationError))
+                {
+                    SelectedQso = item;
+                    ErrorMessage = validationError;
+                    return;
+                }
+
+                var response = await _engine.UpdateQsoAsync(qso!);
+                if (!response.Success)
+                {
+                    SelectedQso = item;
+                    ErrorMessage = string.IsNullOrWhiteSpace(response.Error)
+                        ? $"Update failed for {item.WorkedCallsign}."
+                        : response.Error;
+                    return;
+                }
+
+                item.AcceptSavedChanges(qso!);
+            }
+
+            await RefreshAsync();
+        }
+        catch (RpcException ex)
+        {
+            ErrorMessage = string.IsNullOrWhiteSpace(ex.Status.Detail)
+                ? $"QSO edits could not be saved ({ex.StatusCode})."
+                : ex.Status.Detail;
+        }
+        finally
+        {
+            IsSaving = false;
+            UpdatePendingEditCount();
+            NotifyStatusPropertiesChanged();
+        }
+    }
+
+    [RelayCommand]
+    private void ZoomIn()
+    {
+        ZoomInGrid();
+    }
+
+    [RelayCommand]
+    private void ZoomOut()
+    {
+        ZoomOutGrid();
+    }
+
+    [RelayCommand]
+    private void ResetZoom()
+    {
+        ResetGridZoom();
+    }
+
+    internal void ApplyPersistedSort(RecentQsoSortColumn column, bool ascending)
+    {
+        CurrentSortColumn = column;
+        SortAscending = ascending;
+        ApplySortDescriptions(column, ascending);
+    }
+
+    internal void ApplyPersistedGridFontSize(double fontSize)
+    {
+        if (fontSize <= 0)
+        {
+            return;
+        }
+
+        GridFontSize = Math.Clamp(fontSize, MinGridFontSize, MaxGridFontSize);
+    }
+
     internal void ApplySort(RecentQsoSortColumn column)
     {
         if (CurrentSortColumn == column)
@@ -216,63 +318,80 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
             SortAscending = GetDefaultSortAscending(column);
         }
 
-        ApplyFilter();
+        ApplySortDescriptions(CurrentSortColumn, SortAscending);
+        RefreshView();
     }
 
     internal void ReverseCurrentSortDirection()
     {
         SortAscending = !SortAscending;
-        ApplyFilter();
+        ApplySortDescriptions(CurrentSortColumn, SortAscending);
+        RefreshView();
     }
 
-    private bool CanRefresh() => !IsLoading;
-
-    private void ApplyFilter(string? preferredLocalId = null)
+    internal void ZoomInGrid()
     {
-        var selectedLocalId = preferredLocalId ?? SelectedQso?.LocalId;
-        var filteredItems = SortItems(_allItems.Where(item => MatchesSearch(item, SearchText))).ToArray();
-
-        VisibleItems.Clear();
-        foreach (var item in filteredItems)
-        {
-            VisibleItems.Add(item);
-        }
-
-        SelectedQso = filteredItems.FirstOrDefault(item => string.Equals(item.LocalId, selectedLocalId, StringComparison.Ordinal))
-            ?? filteredItems.FirstOrDefault();
-
-        SummaryText = BuildSummaryText(filteredItems.Length);
-        OnPropertyChanged(nameof(HasVisibleItems));
-        OnPropertyChanged(nameof(EmptyStateMessage));
+        AdjustZoom(1);
     }
 
-    private string BuildHeaderText(string label, RecentQsoSortColumn column)
+    internal void ZoomOutGrid()
     {
-        return CurrentSortColumn == column
-            ? $"{label} {(SortAscending ? '\u2191' : '\u2193')}"
-            : label;
+        AdjustZoom(-1);
     }
 
-    private string BuildSummaryText(int filteredCount)
+    internal void ResetGridZoom()
     {
-        if (!HasLoaded)
+        GridFontSize = DefaultGridFontSize;
+    }
+
+    internal bool AdjustZoom(int direction)
+    {
+        var nextFontSize = Math.Clamp(
+            GridFontSize + (direction * GridFontSizeStep),
+            MinGridFontSize,
+            MaxGridFontSize);
+
+        if (Math.Abs(nextFontSize - GridFontSize) < 0.01)
         {
-            return "Recent QSOs will appear here after setup completes.";
+            return false;
         }
 
-        if (!string.IsNullOrWhiteSpace(ErrorMessage) && _allItems.Count == 0)
+        GridFontSize = nextFontSize;
+        return true;
+    }
+
+    internal void SetColumnVisibility(RecentQsoGridColumn column, bool isVisible)
+    {
+        var option = ColumnOptions.FirstOrDefault(item => item.Column == column);
+        if (option is not null)
         {
-            return "Recent QSOs unavailable";
+            option.IsVisible = isVisible;
+        }
+    }
+
+    private static bool MatchesSearch(RecentQsoItemViewModel item, ParsedSearchQuery query)
+    {
+        if (!query.HasTokens)
+        {
+            return true;
         }
 
-        if (_allItems.Count == 0)
-        {
-            return "No QSOs logged yet";
-        }
+        return query.FreeTextTokens.All(token => item.SearchDocument.Contains(token, StringComparison.Ordinal))
+            && query.FieldTokens.All(token => item.MatchesFieldToken(token.Key, token.Value));
+    }
 
-        return filteredCount == _allItems.Count
-            ? $"Showing {_allItems.Count} recent QSOs"
-            : $"Showing {filteredCount} of {_allItems.Count} recent QSOs";
+    private bool CanRefresh() => !IsLoading && !IsSaving && !HasPendingEdits;
+
+    private bool CanSaveEdits() => !IsLoading && !IsSaving && HasPendingEdits;
+
+    private bool FilterVisibleItem(object item) =>
+        item is RecentQsoItemViewModel recentQso && MatchesSearch(recentQso, _parsedSearchQuery);
+
+    private void RefreshView(string? preferredLocalId = null)
+    {
+        View.Refresh();
+        UpdateVisibleSelectionAndCounts(preferredLocalId);
+        NotifyStatusPropertiesChanged();
     }
 
     private static bool GetDefaultSortAscending(RecentQsoSortColumn column) => column switch
@@ -288,66 +407,357 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         RecentQsoSortColumn.Callsign => "callsign",
         RecentQsoSortColumn.Band => "band",
         RecentQsoSortColumn.Mode => "mode",
+        RecentQsoSortColumn.Frequency => "frequency",
+        RecentQsoSortColumn.Rst => "RST",
+        RecentQsoSortColumn.Dxcc => "DXCC",
         RecentQsoSortColumn.Country => "country",
         RecentQsoSortColumn.Name => "name",
-        RecentQsoSortColumn.Frequency => "frequency",
-        RecentQsoSortColumn.RstSent => "RST sent",
-        RecentQsoSortColumn.RstReceived => "RST received",
         RecentQsoSortColumn.Grid => "grid",
-        RecentQsoSortColumn.Comment => "comment",
+        RecentQsoSortColumn.Exchange => "exchange",
+        RecentQsoSortColumn.Contest => "contest",
+        RecentQsoSortColumn.Station => "station",
+        RecentQsoSortColumn.Note => "note",
         RecentQsoSortColumn.UtcEnd => "end time",
+        RecentQsoSortColumn.CqZone => "CQ zone",
+        RecentQsoSortColumn.ItuZone => "ITU zone",
+        RecentQsoSortColumn.Qth => "QTH",
         RecentQsoSortColumn.Sync => "sync",
         _ => "recent QSOs"
     };
 
-    private IEnumerable<RecentQsoItemViewModel> SortItems(IEnumerable<RecentQsoItemViewModel> items)
+    private void ApplySortDescriptions(RecentQsoSortColumn column, bool ascending)
     {
-        var ordered = CurrentSortColumn switch
+        var primaryDirection = ascending ? ListSortDirection.Ascending : ListSortDirection.Descending;
+        _suppressSortStateSync = true;
+        try
         {
-            RecentQsoSortColumn.Utc => SortAscending
-                ? items.OrderBy(item => item.UtcSortKey)
-                : items.OrderByDescending(item => item.UtcSortKey),
-            RecentQsoSortColumn.Callsign => SortAscending
-                ? items.OrderBy(item => item.CallsignSortKey, StringComparer.Ordinal)
-                : items.OrderByDescending(item => item.CallsignSortKey, StringComparer.Ordinal),
-            RecentQsoSortColumn.Band => SortAscending
-                ? items.OrderBy(item => item.BandSortKey, StringComparer.Ordinal)
-                : items.OrderByDescending(item => item.BandSortKey, StringComparer.Ordinal),
-            RecentQsoSortColumn.Mode => SortAscending
-                ? items.OrderBy(item => item.ModeSortKey, StringComparer.Ordinal)
-                : items.OrderByDescending(item => item.ModeSortKey, StringComparer.Ordinal),
-            RecentQsoSortColumn.Country => SortAscending
-                ? items.OrderBy(item => item.CountrySortKey, StringComparer.Ordinal)
-                : items.OrderByDescending(item => item.CountrySortKey, StringComparer.Ordinal),
-            RecentQsoSortColumn.Name => SortAscending
-                ? items.OrderBy(item => item.NameSortKey, StringComparer.Ordinal)
-                : items.OrderByDescending(item => item.NameSortKey, StringComparer.Ordinal),
-            RecentQsoSortColumn.Frequency => SortAscending
-                ? items.OrderBy(item => item.FrequencySortKey)
-                : items.OrderByDescending(item => item.FrequencySortKey),
-            RecentQsoSortColumn.RstSent => SortAscending
-                ? items.OrderBy(item => item.RstSentSortKey, StringComparer.Ordinal)
-                : items.OrderByDescending(item => item.RstSentSortKey, StringComparer.Ordinal),
-            RecentQsoSortColumn.RstReceived => SortAscending
-                ? items.OrderBy(item => item.RstReceivedSortKey, StringComparer.Ordinal)
-                : items.OrderByDescending(item => item.RstReceivedSortKey, StringComparer.Ordinal),
-            RecentQsoSortColumn.Grid => SortAscending
-                ? items.OrderBy(item => item.GridSortKey, StringComparer.Ordinal)
-                : items.OrderByDescending(item => item.GridSortKey, StringComparer.Ordinal),
-            RecentQsoSortColumn.Comment => SortAscending
-                ? items.OrderBy(item => item.CommentSortKey, StringComparer.Ordinal)
-                : items.OrderByDescending(item => item.CommentSortKey, StringComparer.Ordinal),
-            RecentQsoSortColumn.UtcEnd => SortAscending
-                ? items.OrderBy(item => item.UtcEndSortKey)
-                : items.OrderByDescending(item => item.UtcEndSortKey),
-            RecentQsoSortColumn.Sync => SortAscending
-                ? items.OrderBy(item => item.SyncStatusSortKey, StringComparer.Ordinal)
-                : items.OrderByDescending(item => item.SyncStatusSortKey, StringComparer.Ordinal),
-            _ => items.OrderByDescending(item => item.UtcSortKey)
-        };
+            View.SortDescriptions.Clear();
+            View.SortDescriptions.Add(
+                new DataGridComparerSortDescription(
+                    new PropertyPathComparer(GetSortMemberPath(column)),
+                    primaryDirection));
 
-        return ordered
-            .ThenByDescending(item => item.UtcSortKey)
-            .ThenBy(item => item.CallsignSortKey, StringComparer.Ordinal);
+            if (column != RecentQsoSortColumn.Utc)
+            {
+                View.SortDescriptions.Add(
+                    new DataGridComparerSortDescription(
+                        new PropertyPathComparer(nameof(RecentQsoItemViewModel.UtcSortKey)),
+                        ListSortDirection.Descending));
+            }
+        }
+        finally
+        {
+            _suppressSortStateSync = false;
+        }
+    }
+
+    private void UpdateVisibleSelectionAndCounts(string? preferredLocalId = null)
+    {
+        var selectedLocalId = preferredLocalId ?? SelectedQso?.LocalId;
+        var visibleItems = VisibleItems;
+        VisibleItemCount = visibleItems.Count;
+        SelectedQso = visibleItems.FirstOrDefault(item => string.Equals(item.LocalId, selectedLocalId, StringComparison.Ordinal))
+            ?? (visibleItems.Count > 0 ? visibleItems[0] : null);
+    }
+
+    private void NotifyStatusPropertiesChanged()
+    {
+        OnPropertyChanged(nameof(CountStatusText));
+        OnPropertyChanged(nameof(FilterStatusText));
+        OnPropertyChanged(nameof(SortStatusText));
+        OnPropertyChanged(nameof(EditStatusText));
+        OnPropertyChanged(nameof(SyncSummaryText));
+        OnPropertyChanged(nameof(TopSyncIndicatorText));
+        OnPropertyChanged(nameof(RefreshIndicatorText));
+        OnPropertyChanged(nameof(HasActiveFilterTokens));
+    }
+
+    private void UpdateFilterTokens()
+    {
+        ActiveFilterTokens.Clear();
+        foreach (var token in _parsedSearchQuery.DisplayTokens)
+        {
+            ActiveFilterTokens.Add(token);
+        }
+
+        OnPropertyChanged(nameof(HasActiveFilterTokens));
+    }
+
+    private void OnSortDescriptionsChanged(object? sender, EventArgs e)
+    {
+        if (_suppressSortStateSync)
+        {
+            return;
+        }
+
+        SyncSortStateFromView();
+        NotifyStatusPropertiesChanged();
+    }
+
+    private void ReplaceItems(IEnumerable<RecentQsoItemViewModel> items)
+    {
+        foreach (var item in _allItems)
+        {
+            item.PropertyChanged -= OnItemPropertyChanged;
+        }
+
+        _allItems.Clear();
+        _allItems.AddRange(items);
+
+        _viewItems.Clear();
+        foreach (var item in _allItems)
+        {
+            item.PropertyChanged += OnItemPropertyChanged;
+            _viewItems.Add(item);
+        }
+
+        UpdatePendingEditCount();
+    }
+
+    private void OnItemPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(RecentQsoItemViewModel.IsDirty))
+        {
+            return;
+        }
+
+        UpdatePendingEditCount();
+        NotifyStatusPropertiesChanged();
+    }
+
+    private void UpdatePendingEditCount()
+    {
+        PendingEditCount = _allItems.Count(item => item.IsDirty);
+    }
+
+    private void SyncSortStateFromView()
+    {
+        if (View.SortDescriptions.Count == 0)
+        {
+            CurrentSortColumn = RecentQsoSortColumn.Utc;
+            SortAscending = false;
+            return;
+        }
+
+        var primarySort = View.SortDescriptions[0];
+        CurrentSortColumn = GetSortColumn(primarySort.PropertyPath);
+        SortAscending = primarySort.Direction == ListSortDirection.Ascending;
+    }
+
+    private string BuildSyncSummaryText()
+    {
+        if (_allItems.Count == 0)
+        {
+            return "Sync: idle";
+        }
+
+        var localOnly = _allItems.Count(item => string.Equals(item.SyncStatus, "Local", StringComparison.Ordinal));
+        var modified = _allItems.Count(item => string.Equals(item.SyncStatus, "Modified", StringComparison.Ordinal));
+        var conflict = _allItems.Count(item => string.Equals(item.SyncStatus, "Conflict", StringComparison.Ordinal));
+        var synced = _allItems.Count(item => string.Equals(item.SyncStatus, "Synced", StringComparison.Ordinal));
+
+        return $"Sync: {localOnly} local | {modified} modified | {conflict} conflict | {synced} synced";
+    }
+
+    private string BuildTopSyncIndicatorText()
+    {
+        if (_allItems.Count == 0)
+        {
+            return "Sync idle";
+        }
+
+        if (_allItems.Any(item => string.Equals(item.SyncStatus, "Conflict", StringComparison.Ordinal)))
+        {
+            return "Sync conflict";
+        }
+
+        if (_allItems.Any(item => string.Equals(item.SyncStatus, "Modified", StringComparison.Ordinal)))
+        {
+            return "Sync modified";
+        }
+
+        if (_allItems.Any(item => string.Equals(item.SyncStatus, "Local", StringComparison.Ordinal)))
+        {
+            return "Sync local";
+        }
+
+        return "Sync ready";
+    }
+
+    private static string GetSortMemberPath(RecentQsoSortColumn column) => column switch
+    {
+        RecentQsoSortColumn.Utc => nameof(RecentQsoItemViewModel.UtcSortKey),
+        RecentQsoSortColumn.Callsign => nameof(RecentQsoItemViewModel.WorkedCallsign),
+        RecentQsoSortColumn.Band => nameof(RecentQsoItemViewModel.Band),
+        RecentQsoSortColumn.Mode => nameof(RecentQsoItemViewModel.Mode),
+        RecentQsoSortColumn.Frequency => nameof(RecentQsoItemViewModel.FrequencySortKey),
+        RecentQsoSortColumn.Rst => nameof(RecentQsoItemViewModel.Rst),
+        RecentQsoSortColumn.Dxcc => nameof(RecentQsoItemViewModel.DxccSortKey),
+        RecentQsoSortColumn.Country => nameof(RecentQsoItemViewModel.Country),
+        RecentQsoSortColumn.Name => nameof(RecentQsoItemViewModel.OperatorName),
+        RecentQsoSortColumn.Grid => nameof(RecentQsoItemViewModel.Grid),
+        RecentQsoSortColumn.Exchange => nameof(RecentQsoItemViewModel.Exchange),
+        RecentQsoSortColumn.Contest => nameof(RecentQsoItemViewModel.Contest),
+        RecentQsoSortColumn.Station => nameof(RecentQsoItemViewModel.Station),
+        RecentQsoSortColumn.Note => nameof(RecentQsoItemViewModel.Note),
+        RecentQsoSortColumn.UtcEnd => nameof(RecentQsoItemViewModel.UtcEndSortKey),
+        RecentQsoSortColumn.CqZone => nameof(RecentQsoItemViewModel.CqZone),
+        RecentQsoSortColumn.ItuZone => nameof(RecentQsoItemViewModel.ItuZone),
+        RecentQsoSortColumn.Qth => nameof(RecentQsoItemViewModel.Qth),
+        RecentQsoSortColumn.Sync => nameof(RecentQsoItemViewModel.SyncStatus),
+        _ => nameof(RecentQsoItemViewModel.UtcSortKey)
+    };
+
+    private static RecentQsoSortColumn GetSortColumn(string memberPath) => memberPath switch
+    {
+        nameof(RecentQsoItemViewModel.UtcSortKey) => RecentQsoSortColumn.Utc,
+        nameof(RecentQsoItemViewModel.WorkedCallsign) => RecentQsoSortColumn.Callsign,
+        nameof(RecentQsoItemViewModel.Band) => RecentQsoSortColumn.Band,
+        nameof(RecentQsoItemViewModel.Mode) => RecentQsoSortColumn.Mode,
+        nameof(RecentQsoItemViewModel.FrequencySortKey) => RecentQsoSortColumn.Frequency,
+        nameof(RecentQsoItemViewModel.Rst) => RecentQsoSortColumn.Rst,
+        nameof(RecentQsoItemViewModel.DxccSortKey) => RecentQsoSortColumn.Dxcc,
+        nameof(RecentQsoItemViewModel.Country) => RecentQsoSortColumn.Country,
+        nameof(RecentQsoItemViewModel.OperatorName) => RecentQsoSortColumn.Name,
+        nameof(RecentQsoItemViewModel.Grid) => RecentQsoSortColumn.Grid,
+        nameof(RecentQsoItemViewModel.Exchange) => RecentQsoSortColumn.Exchange,
+        nameof(RecentQsoItemViewModel.Contest) => RecentQsoSortColumn.Contest,
+        nameof(RecentQsoItemViewModel.Station) => RecentQsoSortColumn.Station,
+        nameof(RecentQsoItemViewModel.Note) => RecentQsoSortColumn.Note,
+        nameof(RecentQsoItemViewModel.UtcEndSortKey) => RecentQsoSortColumn.UtcEnd,
+        nameof(RecentQsoItemViewModel.CqZone) => RecentQsoSortColumn.CqZone,
+        nameof(RecentQsoItemViewModel.ItuZone) => RecentQsoSortColumn.ItuZone,
+        nameof(RecentQsoItemViewModel.Qth) => RecentQsoSortColumn.Qth,
+        nameof(RecentQsoItemViewModel.SyncStatus) => RecentQsoSortColumn.Sync,
+        _ => RecentQsoSortColumn.Utc
+    };
+
+    private static ParsedSearchQuery ParseSearchQuery(string? searchText)
+    {
+        if (string.IsNullOrWhiteSpace(searchText))
+        {
+            return ParsedSearchQuery.Empty;
+        }
+
+        var freeTextTokens = new List<string>();
+        var fieldTokens = new List<SearchToken>();
+        var displayTokens = new List<string>();
+
+        foreach (var rawToken in searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var separatorIndex = rawToken.IndexOf(':', StringComparison.Ordinal);
+            if (separatorIndex > 0 && separatorIndex < rawToken.Length - 1)
+            {
+                var key = rawToken[..separatorIndex].Trim().ToUpperInvariant();
+                var value = rawToken[(separatorIndex + 1)..].Trim().ToUpperInvariant();
+                fieldTokens.Add(new SearchToken(key, value));
+                displayTokens.Add(rawToken.Trim());
+            }
+            else
+            {
+                freeTextTokens.Add(rawToken.ToUpperInvariant());
+                displayTokens.Add(rawToken.Trim());
+            }
+        }
+
+        return new ParsedSearchQuery(
+            freeTextTokens.ToArray(),
+            fieldTokens.ToArray(),
+            displayTokens.ToArray());
+    }
+
+    private static IEnumerable<RecentQsoColumnOptionViewModel> CreateColumnOptions()
+    {
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Utc, "UTC", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Callsign, "Call", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Band, "Band", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Mode, "Mode", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Frequency, "Freq", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Rst, "RST", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Dxcc, "DXCC", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Country, "Country", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Name, "Name", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Grid, "Grid", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Exchange, "Exch", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Contest, "Contest", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Station, "Station", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Note, "Note", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.UtcEnd, "End", false);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.CqZone, "CQ", false);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.ItuZone, "ITU", false);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Qth, "QTH", false);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Sync, "Sync", false);
+    }
+
+    private readonly record struct SearchToken(string Key, string Value);
+
+    private sealed record ParsedSearchQuery(
+        string[] FreeTextTokens,
+        SearchToken[] FieldTokens,
+        string[] DisplayTokens)
+    {
+        public static readonly ParsedSearchQuery Empty = new([], [], []);
+
+        public bool HasTokens => FreeTextTokens.Length > 0 || FieldTokens.Length > 0;
+    }
+
+    private sealed class PropertyPathComparer(string propertyPath) : IComparer
+    {
+        public int Compare(object? x, object? y)
+        {
+            var left = GetComparableValue(x);
+            var right = GetComparableValue(y);
+
+            if (left is null && right is null)
+            {
+                return 0;
+            }
+
+            if (left is null)
+            {
+                return -1;
+            }
+
+            if (right is null)
+            {
+                return 1;
+            }
+
+            return left switch
+            {
+                string leftString when right is string rightString => StringComparer.OrdinalIgnoreCase.Compare(leftString, rightString),
+                IComparable comparable => comparable.CompareTo(right),
+                _ => StringComparer.OrdinalIgnoreCase.Compare(left.ToString(), right.ToString())
+            };
+        }
+
+        private object? GetComparableValue(object? candidate)
+        {
+            var item = candidate as RecentQsoItemViewModel;
+            return item switch
+            {
+                null => null,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.UtcSortKey) => item.UtcSortKey,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.WorkedCallsign) => item.WorkedCallsign,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.Band) => item.Band,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.Mode) => item.Mode,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.FrequencySortKey) => item.FrequencySortKey,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.Rst) => item.Rst,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.DxccSortKey) => item.DxccSortKey,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.Country) => item.Country,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.OperatorName) => item.OperatorName,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.Grid) => item.Grid,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.Exchange) => item.Exchange,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.Contest) => item.Contest,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.Station) => item.Station,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.Note) => item.Note,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.UtcEndSortKey) => item.UtcEndSortKey,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.CqZone) => item.CqZone,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.ItuZone) => item.ItuZone,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.Qth) => item.Qth,
+                _ when propertyPath == nameof(RecentQsoItemViewModel.SyncStatus) => item.SyncStatus,
+                _ => null
+            };
+        }
     }
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/ReviewStepViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/ReviewStepViewModel.cs
@@ -47,7 +47,9 @@ internal sealed partial class ReviewStepViewModel : WizardStepViewModel
 
     private static string MaskIfSensitive(string key, string value)
     {
-        if (key.Contains("password", StringComparison.OrdinalIgnoreCase) && value.Length > 0)
+        if ((key.Contains("password", StringComparison.OrdinalIgnoreCase)
+            || key.Contains("api_key", StringComparison.OrdinalIgnoreCase))
+            && value.Length > 0)
         {
             return new string('•', value.Length);
         }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,376 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QsoRipper.Domain;
+using QsoRipper.Gui.Services;
+using QsoRipper.Services;
+
+namespace QsoRipper.Gui.ViewModels;
+
+internal sealed partial class SettingsViewModel : ObservableObject
+{
+    private readonly IEngineClient _engine;
+
+    // Station Profile
+    [ObservableProperty]
+    private string _callsign = string.Empty;
+
+    [ObservableProperty]
+    private string _gridSquare = string.Empty;
+
+    [ObservableProperty]
+    private string _operatorName = string.Empty;
+
+    [ObservableProperty]
+    private string _operatorCallsign = string.Empty;
+
+    [ObservableProperty]
+    private string _profileName = string.Empty;
+
+    [ObservableProperty]
+    private string _county = string.Empty;
+
+    [ObservableProperty]
+    private string _state = string.Empty;
+
+    [ObservableProperty]
+    private string _country = string.Empty;
+
+    [ObservableProperty]
+    private string _dxcc = string.Empty;
+
+    [ObservableProperty]
+    private string _cqZone = string.Empty;
+
+    [ObservableProperty]
+    private string _ituZone = string.Empty;
+
+    [ObservableProperty]
+    private string _latitude = string.Empty;
+
+    [ObservableProperty]
+    private string _longitude = string.Empty;
+
+    [ObservableProperty]
+    private string _arrlSection = string.Empty;
+
+    // QRZ XML
+    [ObservableProperty]
+    private string _qrzXmlUsername = string.Empty;
+
+    [ObservableProperty]
+    private string _qrzXmlPassword = string.Empty;
+
+    [ObservableProperty]
+    private bool _isTestingQrzXml;
+
+    [ObservableProperty]
+    private string? _qrzXmlTestResult;
+
+    [ObservableProperty]
+    private bool _qrzXmlTestSucceeded;
+
+    // QRZ Logbook
+    [ObservableProperty]
+    private string _qrzLogbookApiKey = string.Empty;
+
+    [ObservableProperty]
+    private bool _isTestingLogbook;
+
+    [ObservableProperty]
+    private string? _logbookTestResult;
+
+    [ObservableProperty]
+    private bool _logbookTestSucceeded;
+
+    // Sync Settings
+    [ObservableProperty]
+    private bool _autoSyncEnabled;
+
+    [ObservableProperty]
+    private int _syncIntervalSeconds = 300;
+
+    [ObservableProperty]
+    private ConflictPolicy _conflictPolicy = ConflictPolicy.LastWriteWins;
+
+    // Log file (read-only display)
+    [ObservableProperty]
+    private string _logFilePath = string.Empty;
+
+    // UI state
+    [ObservableProperty]
+    private bool _isLoading;
+
+    [ObservableProperty]
+    private bool _isSaving;
+
+    [ObservableProperty]
+    private string? _errorMessage;
+
+    /// <summary>
+    /// True after a successful save. Checked by the caller after the dialog closes.
+    /// </summary>
+    [ObservableProperty]
+    private bool _didSave;
+
+    /// <summary>
+    /// Raised when the dialog should close. The bool parameter is true for save, false for cancel.
+    /// </summary>
+    internal event EventHandler<bool>? CloseRequested;
+
+    public SettingsViewModel(IEngineClient engine)
+    {
+        _engine = engine;
+    }
+
+    /// <summary>
+    /// Loads current settings from the engine. Call after construction.
+    /// </summary>
+    internal async Task LoadAsync()
+    {
+        IsLoading = true;
+        ErrorMessage = null;
+        try
+        {
+            var state = await _engine.GetWizardStateAsync();
+            ApplyStatus(state.Status);
+
+            var activeProfile = state.StationProfiles
+                .FirstOrDefault(p => p.IsActive)?.Profile
+                ?? state.Status.StationProfile;
+
+            if (activeProfile is not null)
+            {
+                ApplyStationProfile(activeProfile);
+            }
+        }
+        catch (Grpc.Core.RpcException ex)
+        {
+            ErrorMessage = $"Failed to load settings: {ex.Status.Detail}";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task SaveAsync()
+    {
+        IsSaving = true;
+        ErrorMessage = null;
+        try
+        {
+            var request = BuildSaveRequest();
+            await _engine.SaveSetupAsync(request);
+            DidSave = true;
+            CloseRequested?.Invoke(this, true);
+        }
+        catch (Grpc.Core.RpcException ex)
+        {
+            ErrorMessage = $"Save failed: {ex.Status.Detail}";
+        }
+        finally
+        {
+            IsSaving = false;
+        }
+    }
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        CloseRequested?.Invoke(this, false);
+    }
+
+    [RelayCommand]
+    private async Task TestQrzXmlAsync()
+    {
+        if (string.IsNullOrWhiteSpace(QrzXmlUsername) || string.IsNullOrWhiteSpace(QrzXmlPassword))
+        {
+            QrzXmlTestResult = "Username and password are required.";
+            QrzXmlTestSucceeded = false;
+            return;
+        }
+
+        IsTestingQrzXml = true;
+        QrzXmlTestResult = null;
+        try
+        {
+            var result = await _engine.TestQrzCredentialsAsync(QrzXmlUsername, QrzXmlPassword);
+            QrzXmlTestSucceeded = result.Success;
+            QrzXmlTestResult = result.Success
+                ? "✓ Connected to QRZ XML successfully!"
+                : $"✗ {result.ErrorMessage}";
+        }
+        catch (Grpc.Core.RpcException ex)
+        {
+            QrzXmlTestSucceeded = false;
+            QrzXmlTestResult = $"✗ Connection failed: {ex.Status.Detail}";
+        }
+        finally
+        {
+            IsTestingQrzXml = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task TestQrzLogbookAsync()
+    {
+        if (string.IsNullOrWhiteSpace(QrzLogbookApiKey))
+        {
+            LogbookTestResult = "API key is required.";
+            LogbookTestSucceeded = false;
+            return;
+        }
+
+        IsTestingLogbook = true;
+        LogbookTestResult = null;
+        try
+        {
+            var result = await _engine.TestQrzLogbookCredentialsAsync(QrzLogbookApiKey);
+            LogbookTestSucceeded = result.Success;
+            if (result.Success)
+            {
+                var owner = string.IsNullOrWhiteSpace(result.LogbookOwner)
+                    ? string.Empty
+                    : $" ({result.LogbookOwner})";
+                var count = result.HasQsoCount
+                    ? $" — {result.QsoCount} QSOs"
+                    : string.Empty;
+                LogbookTestResult = $"✓ Logbook connected{owner}{count}";
+            }
+            else
+            {
+                LogbookTestResult = $"✗ {result.ErrorMessage}";
+            }
+        }
+        catch (Grpc.Core.RpcException ex)
+        {
+            LogbookTestSucceeded = false;
+            LogbookTestResult = $"✗ Connection failed: {ex.Status.Detail}";
+        }
+        finally
+        {
+            IsTestingLogbook = false;
+        }
+    }
+
+    private void ApplyStatus(SetupStatus status)
+    {
+        QrzXmlUsername = status.QrzXmlUsername ?? string.Empty;
+        LogFilePath = status.LogFilePath ?? string.Empty;
+
+        if (status.SyncConfig is not null)
+        {
+            AutoSyncEnabled = status.SyncConfig.AutoSyncEnabled;
+            SyncIntervalSeconds = status.SyncConfig.SyncIntervalSeconds > 0
+                ? (int)status.SyncConfig.SyncIntervalSeconds
+                : 300;
+            ConflictPolicy = status.SyncConfig.ConflictPolicy;
+        }
+
+        // Password and API key are never returned by the engine for security;
+        // leave them empty so the user can re-enter if they want to change them.
+    }
+
+    private void ApplyStationProfile(StationProfile profile)
+    {
+        ProfileName = profile.ProfileName ?? string.Empty;
+        Callsign = profile.StationCallsign ?? string.Empty;
+        OperatorCallsign = profile.OperatorCallsign ?? string.Empty;
+        OperatorName = profile.OperatorName ?? string.Empty;
+        GridSquare = profile.Grid ?? string.Empty;
+        County = profile.County ?? string.Empty;
+        State = profile.State ?? string.Empty;
+        Country = profile.Country ?? string.Empty;
+        ArrlSection = profile.ArrlSection ?? string.Empty;
+        Dxcc = profile.Dxcc != 0
+            ? profile.Dxcc.ToString(CultureInfo.InvariantCulture) : string.Empty;
+        CqZone = profile.CqZone != 0
+            ? profile.CqZone.ToString(CultureInfo.InvariantCulture) : string.Empty;
+        ItuZone = profile.ItuZone != 0
+            ? profile.ItuZone.ToString(CultureInfo.InvariantCulture) : string.Empty;
+        Latitude = profile.Latitude != 0
+            ? profile.Latitude.ToString(CultureInfo.InvariantCulture) : string.Empty;
+        Longitude = profile.Longitude != 0
+            ? profile.Longitude.ToString(CultureInfo.InvariantCulture) : string.Empty;
+    }
+
+    private SaveSetupRequest BuildSaveRequest()
+    {
+        var profile = new StationProfile
+        {
+            StationCallsign = Callsign.Trim(),
+            Grid = GridSquare.Trim(),
+            OperatorName = OperatorName.Trim(),
+        };
+
+        SetOptionalString(ProfileName, v => profile.ProfileName = v);
+        SetOptionalString(OperatorCallsign, v => profile.OperatorCallsign = v);
+        SetOptionalString(County, v => profile.County = v);
+        SetOptionalString(State, v => profile.State = v);
+        SetOptionalString(Country, v => profile.Country = v);
+        SetOptionalString(ArrlSection, v => profile.ArrlSection = v);
+        SetUintField(Dxcc, v => profile.Dxcc = v);
+        SetUintField(CqZone, v => profile.CqZone = v);
+        SetUintField(ItuZone, v => profile.ItuZone = v);
+        SetDoubleField(Latitude, v => profile.Latitude = v);
+        SetDoubleField(Longitude, v => profile.Longitude = v);
+
+        var request = new SaveSetupRequest
+        {
+            StationProfile = profile,
+            LogFilePath = LogFilePath.Trim(),
+            SyncConfig = new SyncConfig
+            {
+                AutoSyncEnabled = AutoSyncEnabled,
+                SyncIntervalSeconds = SyncIntervalSeconds > 0
+                    ? (uint)SyncIntervalSeconds : 300,
+                ConflictPolicy = ConflictPolicy,
+            },
+        };
+
+        if (!string.IsNullOrWhiteSpace(QrzXmlUsername))
+        {
+            request.QrzXmlUsername = QrzXmlUsername.Trim();
+            if (!string.IsNullOrEmpty(QrzXmlPassword))
+            {
+                request.QrzXmlPassword = QrzXmlPassword;
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(QrzLogbookApiKey))
+        {
+            request.QrzLogbookApiKey = QrzLogbookApiKey.Trim();
+        }
+
+        return request;
+    }
+
+    private static void SetOptionalString(string input, Action<string> setter)
+    {
+        if (!string.IsNullOrWhiteSpace(input))
+        {
+            setter(input.Trim());
+        }
+    }
+
+    private static void SetUintField(string? input, Action<uint> setter)
+    {
+        if (uint.TryParse(input, CultureInfo.InvariantCulture, out var value))
+        {
+            setter(value);
+        }
+    }
+
+    private static void SetDoubleField(string? input, Action<double> setter)
+    {
+        if (double.TryParse(input, CultureInfo.InvariantCulture, out var value))
+        {
+            setter(value);
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/SetupWizardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/SetupWizardViewModel.cs
@@ -47,6 +47,7 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
         Steps.Add(new LogFileStepViewModel());
         Steps.Add(new StationProfileStepViewModel());
         Steps.Add(new QrzStepViewModel(engine));
+        Steps.Add(new QrzLogbookStepViewModel());
         Steps.Add(new ReviewStepViewModel());
     }
 
@@ -120,6 +121,19 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
                 }
             }
 
+            if (Steps[3] is QrzLogbookStepViewModel logbookStep)
+            {
+                logbookStep.HasExistingKey = state.Status.HasQrzLogbookApiKey;
+                if (state.Status.SyncConfig is { } syncConfig)
+                {
+                    logbookStep.AutoSyncEnabled = syncConfig.AutoSyncEnabled;
+                    if (syncConfig.SyncIntervalSeconds > 0)
+                    {
+                        logbookStep.SyncIntervalSeconds = (int)syncConfig.SyncIntervalSeconds;
+                    }
+                }
+            }
+
             foreach (var ss in state.Steps)
             {
                 var idx = StepIndex(ss.Step);
@@ -158,14 +172,26 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
         ErrorMessage = null;
         try
         {
-            var request = BuildValidationRequest(CurrentStepIndex);
-            var result = await _engine.ValidateStepAsync(request);
-
-            if (!result.Valid)
+            // QRZ Logbook step uses client-side validation only (no server round-trip).
+            if (CurrentStep is QrzLogbookStepViewModel logbookStep)
             {
-                CurrentStep.ApplyValidationErrors(result.Fields);
-                ErrorMessage = "Please fix the errors above before continuing.";
-                return;
+                if (!logbookStep.ValidateLocally())
+                {
+                    ErrorMessage = "Please fix the errors above before continuing.";
+                    return;
+                }
+            }
+            else
+            {
+                var request = BuildValidationRequest(CurrentStepIndex);
+                var result = await _engine.ValidateStepAsync(request);
+
+                if (!result.Valid)
+                {
+                    CurrentStep.ApplyValidationErrors(result.Fields);
+                    ErrorMessage = "Please fix the errors above before continuing.";
+                    return;
+                }
             }
 
             CurrentStep.IsComplete = true;
@@ -202,8 +228,7 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
     [RelayCommand]
     private void Skip()
     {
-        // Only QRZ step is skippable
-        if (CurrentStep is QrzStepViewModel)
+        if (CurrentStep is QrzStepViewModel or QrzLogbookStepViewModel)
         {
             CurrentStep.IsComplete = true;
             CurrentStep.ClearErrors();
@@ -244,6 +269,7 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
             var logStep = Steps.OfType<LogFileStepViewModel>().First();
             var stationStep = Steps.OfType<StationProfileStepViewModel>().First();
             var qrzStep = Steps.OfType<QrzStepViewModel>().First();
+            var logbookStep = Steps.OfType<QrzLogbookStepViewModel>().First();
 
             var request = new SaveSetupRequest
             {
@@ -255,6 +281,21 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
             {
                 request.QrzXmlUsername = qrzStep.Username;
                 request.QrzXmlPassword = qrzStep.Password ?? string.Empty;
+            }
+
+            if (!string.IsNullOrWhiteSpace(logbookStep.ApiKey))
+            {
+                request.QrzLogbookApiKey = logbookStep.ApiKey;
+            }
+
+            // Include sync config when the logbook feature is in use.
+            if (!string.IsNullOrWhiteSpace(logbookStep.ApiKey) || logbookStep.HasExistingKey)
+            {
+                request.SyncConfig = new QsoRipper.Domain.SyncConfig
+                {
+                    AutoSyncEnabled = logbookStep.AutoSyncEnabled,
+                    SyncIntervalSeconds = (uint)logbookStep.SyncIntervalSeconds,
+                };
             }
 
             var response = await _engine.SaveSetupAsync(request);
@@ -296,7 +337,8 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
         SetupWizardStep.LogFile => 0,
         SetupWizardStep.StationProfiles => 1,
         SetupWizardStep.QrzIntegration => 2,
-        SetupWizardStep.Review => 3,
+        // Index 3 (QrzLogbook) has no server-side wizard step.
+        SetupWizardStep.Review => 4,
         _ => -1,
     };
 
@@ -305,7 +347,8 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
         0 => SetupWizardStep.LogFile,
         1 => SetupWizardStep.StationProfiles,
         2 => SetupWizardStep.QrzIntegration,
-        3 => SetupWizardStep.Review,
+        // Index 3 (QrzLogbook) is client-validated only.
+        4 => SetupWizardStep.Review,
         _ => SetupWizardStep.Unspecified,
     };
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -4,8 +4,8 @@
         xmlns:v="using:QsoRipper.Gui.Views"
         x:Class="QsoRipper.Gui.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
-        Title="QsoRipper" Width="1500" Height="820"
-        MinWidth="1380" MinHeight="700"
+        Title="QsoRipper" Width="1280" Height="760"
+        MinWidth="1024" MinHeight="640"
         WindowStartupLocation="CenterScreen"
         Icon="avares://QsoRipper.Gui/Assets/qsoripper.ico">
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -97,8 +97,8 @@
       <Grid RowDefinitions="Auto,* ,Auto"
             IsEnabled="{Binding !IsWizardOpen}">
         <Grid Grid.Row="0"
-              Height="34"
-              Margin="10,4,10,6"
+              MinHeight="40"
+              Margin="10,6,10,8"
               ColumnDefinitions="Auto,*,Auto"
               ColumnSpacing="12">
           <StackPanel Grid.Column="0"
@@ -124,12 +124,12 @@
                 ColumnDefinitions="Auto,*"
                 ColumnSpacing="8"
                 VerticalAlignment="Center">
-            <TextBox x:Name="RecentQsoSearchBox"
-                     Grid.Column="0"
-                     Height="28"
-                     MinWidth="200"
-                     MaxWidth="400"
-                     VerticalAlignment="Center"
+             <TextBox x:Name="RecentQsoSearchBox"
+                      Grid.Column="0"
+                      Height="30"
+                      MinWidth="200"
+                      MaxWidth="400"
+                      VerticalAlignment="Center"
                      PlaceholderText="Search callsign, grid, name, contest, note..."
                      Text="{Binding RecentQsos.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
@@ -162,13 +162,13 @@
                     Command="{Binding OpenWizardCommand}"
                     Classes="accent"
                     MinWidth="62"
-                    Height="26"
+                    Height="28"
                     IsVisible="{Binding IsSetupIncomplete}" />
             <TextBlock Classes="commandCaption"
                        Text="{Binding RecentQsos.RefreshIndicatorText}" />
             <Button Content="⟳ Sync"
                     Command="{Binding SyncNowCommand}"
-                    Height="26"
+                    Height="28"
                     MinWidth="54"
                     ToolTip.Tip="Sync with QRZ (F6)" />
             <TextBlock Classes="commandCaption"
@@ -182,11 +182,11 @@
                        Text="{Binding CurrentUtcDate}" />
             <Button Content="Sort"
                     Command="{Binding ToggleSortChooserCommand}"
-                    Height="26"
+                    Height="28"
                     MinWidth="54" />
             <Button Content="Cols"
                     Command="{Binding ToggleColumnChooserCommand}"
-                    Height="26"
+                    Height="28"
                     MinWidth="54" />
           </StackPanel>
         </Grid>
@@ -195,7 +195,7 @@
           <Grid ColumnDefinitions="*,Auto">
             <Grid Grid.Column="0">
               <DataGrid x:Name="RecentQsoGrid"
-                         Margin="8,0,8,0"
+                         Margin="8,2,8,0"
                          RowHeight="{Binding RecentQsos.GridRowHeight}"
                          ColumnHeaderHeight="{Binding RecentQsos.GridHeaderHeight}"
                          FontSize="{Binding RecentQsos.GridFontSize}"
@@ -205,34 +205,42 @@
                 <DataGrid.Columns>
                   <DataGridTextColumn Header="UTC"
                                       Width="104"
+                                      MinWidth="96"
                                       Binding="{ReflectionBinding UtcDisplay, Mode=TwoWay}"
                                       SortMemberPath="UtcSortKey" />
                   <DataGridTextColumn Header="Call"
                                       Width="92"
+                                      MinWidth="88"
                                       Binding="{ReflectionBinding WorkedCallsign, Mode=TwoWay}"
                                       SortMemberPath="WorkedCallsign" />
                   <DataGridTextColumn Header="Band"
                                       Width="56"
+                                      MinWidth="64"
                                       Binding="{ReflectionBinding Band, Mode=TwoWay}"
                                       SortMemberPath="Band" />
                   <DataGridTextColumn Header="Mode"
                                       Width="64"
+                                      MinWidth="64"
                                       Binding="{ReflectionBinding Mode, Mode=TwoWay}"
                                       SortMemberPath="Mode" />
                   <DataGridTextColumn Header="Freq"
                                       Width="82"
+                                      MinWidth="80"
                                       Binding="{ReflectionBinding Frequency, Mode=TwoWay}"
                                       SortMemberPath="FrequencySortKey" />
                   <DataGridTextColumn Header="RST"
                                       Width="70"
+                                      MinWidth="64"
                                       Binding="{ReflectionBinding Rst, Mode=TwoWay}"
                                       SortMemberPath="Rst" />
                   <DataGridTextColumn Header="DXCC"
                                       Width="58"
+                                      MinWidth="64"
                                       Binding="{ReflectionBinding Dxcc, Mode=TwoWay}"
                                       SortMemberPath="DxccSortKey" />
                   <DataGridTemplateColumn Header="Country"
                                           Width="120"
+                                          MinWidth="96"
                                           SortMemberPath="Country">
                     <DataGridTemplateColumn.CellTemplate>
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
@@ -253,6 +261,7 @@
                   </DataGridTemplateColumn>
                   <DataGridTemplateColumn Header="Name"
                                           Width="122"
+                                          MinWidth="96"
                                           SortMemberPath="OperatorName">
                     <DataGridTemplateColumn.CellTemplate>
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
@@ -273,14 +282,17 @@
                   </DataGridTemplateColumn>
                   <DataGridTextColumn Header="Grid"
                                       Width="72"
+                                      MinWidth="64"
                                       Binding="{ReflectionBinding Grid, Mode=TwoWay}"
                                       SortMemberPath="Grid" />
                   <DataGridTextColumn Header="Exch"
                                       Width="76"
+                                      MinWidth="72"
                                       Binding="{ReflectionBinding Exchange, Mode=TwoWay}"
                                       SortMemberPath="Exchange" />
                   <DataGridTemplateColumn Header="Contest"
                                           Width="92"
+                                          MinWidth="80"
                                           SortMemberPath="Contest">
                     <DataGridTemplateColumn.CellTemplate>
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
@@ -301,10 +313,12 @@
                   </DataGridTemplateColumn>
                   <DataGridTextColumn Header="Station"
                                       Width="92"
+                                      MinWidth="80"
                                       Binding="{ReflectionBinding Station, Mode=TwoWay}"
                                       SortMemberPath="Station" />
                   <DataGridTemplateColumn Header="Note"
                                           Width="2*"
+                                          MinWidth="120"
                                           MaxWidth="240"
                                           SortMemberPath="Note">
                     <DataGridTemplateColumn.CellTemplate>
@@ -326,21 +340,25 @@
                   </DataGridTemplateColumn>
                   <DataGridTextColumn Header="End"
                                       Width="104"
+                                      MinWidth="96"
                                       Binding="{ReflectionBinding UtcEndDisplay, Mode=TwoWay}"
                                       SortMemberPath="UtcEndSortKey"
                                       IsVisible="False" />
                   <DataGridTextColumn Header="CQ"
                                       Width="50"
+                                      MinWidth="64"
                                       Binding="{ReflectionBinding CqZone, Mode=TwoWay}"
                                       SortMemberPath="CqZone"
                                       IsVisible="False" />
                   <DataGridTextColumn Header="ITU"
                                       Width="50"
+                                      MinWidth="64"
                                       Binding="{ReflectionBinding ItuZone, Mode=TwoWay}"
                                       SortMemberPath="ItuZone"
                                       IsVisible="False" />
                   <DataGridTemplateColumn Header="QTH"
                                           Width="120"
+                                          MinWidth="96"
                                           SortMemberPath="Qth"
                                           IsVisible="False"
                                           IsReadOnly="True">
@@ -355,6 +373,7 @@
                   </DataGridTemplateColumn>
                   <DataGridTextColumn Header="Sync"
                                       Width="78"
+                                      MinWidth="72"
                                       Binding="{ReflectionBinding SyncStatus}"
                                       SortMemberPath="SyncStatus"
                                       IsReadOnly="True"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -121,12 +121,14 @@
           </StackPanel>
 
           <Grid Grid.Column="1"
-                ColumnDefinitions="360,*"
+                ColumnDefinitions="Auto,*"
                 ColumnSpacing="8"
                 VerticalAlignment="Center">
             <TextBox x:Name="RecentQsoSearchBox"
                      Grid.Column="0"
                      Height="28"
+                     MinWidth="200"
+                     MaxWidth="400"
                      VerticalAlignment="Center"
                      PlaceholderText="Search callsign, grid, name, contest, note..."
                      Text="{Binding RecentQsos.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
@@ -163,11 +165,8 @@
                     Height="26"
                     IsVisible="{Binding IsSetupIncomplete}" />
             <TextBlock Classes="commandCaption"
-                       Text="{Binding RecentQsos.TopSyncIndicatorText}"
-                       ToolTip.Tip="{Binding RecentQsos.SyncSummaryText}" />
-            <TextBlock Classes="commandCaption"
                        Text="{Binding RecentQsos.RefreshIndicatorText}" />
-            <Button Content="{Binding SyncStatusText}"
+            <Button Content="⟳ Sync"
                     Command="{Binding SyncNowCommand}"
                     Height="26"
                     MinWidth="54"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -10,7 +10,7 @@
         Icon="avares://QsoRipper.Gui/Assets/qsoripper.ico">
 
   <Window.KeyBindings>
-    <KeyBinding Gesture="Ctrl+OemComma" Command="{Binding OpenWizardCommand}" />
+    <KeyBinding Gesture="Ctrl+OemComma" Command="{Binding OpenSettingsCommand}" />
     <KeyBinding Gesture="Alt+X" Command="{Binding ExitCommand}" />
     <KeyBinding Gesture="Ctrl+F" Command="{Binding FocusSearchCommand}" />
     <KeyBinding Gesture="Ctrl+S" Command="{Binding RecentQsos.SaveEditsCommand}" />
@@ -18,6 +18,7 @@
     <KeyBinding Gesture="Ctrl+Shift+S" Command="{Binding ToggleSortChooserCommand}" />
     <KeyBinding Gesture="Ctrl+H" Command="{Binding ToggleColumnChooserCommand}" />
     <KeyBinding Gesture="Alt+Enter" Command="{Binding ToggleInspectorCommand}" />
+    <KeyBinding Gesture="F6" Command="{Binding SyncNowCommand}" />
   </Window.KeyBindings>
 
   <Window.Styles>
@@ -61,7 +62,7 @@
     <Menu DockPanel.Dock="Top">
       <MenuItem x:Name="FileMenuItem" Header="_File">
         <MenuItem Header="_Settings" InputGesture="Ctrl+OemComma"
-                  Command="{Binding OpenWizardCommand}" />
+                  Command="{Binding OpenSettingsCommand}" />
         <MenuItem Header="_Save Edits" InputGesture="Ctrl+S"
                   Command="{Binding RecentQsos.SaveEditsCommand}" />
         <Separator />
@@ -85,6 +86,10 @@
                   Command="{Binding ToggleColumnChooserCommand}" />
         <MenuItem Header="_Inspector" InputGesture="Alt+Enter"
                   Command="{Binding ToggleInspectorCommand}" />
+      </MenuItem>
+      <MenuItem Header="_Tools">
+        <MenuItem Header="Sync _Now" InputGesture="F6"
+                  Command="{Binding SyncNowCommand}" />
       </MenuItem>
     </Menu>
 
@@ -162,6 +167,11 @@
                        ToolTip.Tip="{Binding RecentQsos.SyncSummaryText}" />
             <TextBlock Classes="commandCaption"
                        Text="{Binding RecentQsos.RefreshIndicatorText}" />
+            <Button Content="{Binding SyncStatusText}"
+                    Command="{Binding SyncNowCommand}"
+                    Height="26"
+                    MinWidth="54"
+                    ToolTip.Tip="Sync with QRZ (F6)" />
             <TextBlock Classes="commandCaption"
                        Text="UTC" />
             <TextBlock Text="{Binding CurrentUtcTime}"
@@ -537,10 +547,15 @@
                          FontSize="11.5"
                          TextTrimming="CharacterEllipsis"
                          MaxWidth="420" />
+              <TextBlock Text="|" Opacity="0.45" />
+              <TextBlock Text="{Binding SyncStatusText}"
+                         FontSize="11.5"
+                         TextTrimming="CharacterEllipsis"
+                         MaxWidth="200" />
             </StackPanel>
 
             <TextBlock Grid.Column="1"
-                       Text="F2 Edit • Ctrl+S Save • Ctrl+A Select • Ctrl+Wheel Zoom • Alt+Enter Details"
+                       Text="F2 Edit • Ctrl+S Save • F5 Refresh • F6 Sync • Alt+Enter Details"
                        FontSize="11.5"
                        Opacity="0.68"
                        VerticalAlignment="Center"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -13,511 +13,345 @@
     <KeyBinding Gesture="Ctrl+OemComma" Command="{Binding OpenWizardCommand}" />
     <KeyBinding Gesture="Alt+X" Command="{Binding ExitCommand}" />
     <KeyBinding Gesture="Ctrl+F" Command="{Binding FocusSearchCommand}" />
+    <KeyBinding Gesture="Ctrl+S" Command="{Binding RecentQsos.SaveEditsCommand}" />
     <KeyBinding Gesture="F5" Command="{Binding RecentQsos.RefreshCommand}" />
-    <KeyBinding Gesture="Ctrl+Shift+T"
-                Command="{Binding RecentQsos.SortByColumnCommand}"
-                CommandParameter="{x:Static vm:RecentQsoSortColumn.Utc}" />
-    <KeyBinding Gesture="Ctrl+Shift+C"
-                Command="{Binding RecentQsos.SortByColumnCommand}"
-                CommandParameter="{x:Static vm:RecentQsoSortColumn.Callsign}" />
-    <KeyBinding Gesture="Ctrl+Shift+B"
-                Command="{Binding RecentQsos.SortByColumnCommand}"
-                CommandParameter="{x:Static vm:RecentQsoSortColumn.Band}" />
-    <KeyBinding Gesture="Ctrl+Shift+M"
-                Command="{Binding RecentQsos.SortByColumnCommand}"
-                CommandParameter="{x:Static vm:RecentQsoSortColumn.Mode}" />
-    <KeyBinding Gesture="Ctrl+Shift+L"
-                Command="{Binding RecentQsos.SortByColumnCommand}"
-                CommandParameter="{x:Static vm:RecentQsoSortColumn.Country}" />
-    <KeyBinding Gesture="Ctrl+Shift+N"
-                Command="{Binding RecentQsos.SortByColumnCommand}"
-                CommandParameter="{x:Static vm:RecentQsoSortColumn.Name}" />
-    <KeyBinding Gesture="Ctrl+Shift+F"
-                Command="{Binding RecentQsos.SortByColumnCommand}"
-                CommandParameter="{x:Static vm:RecentQsoSortColumn.Frequency}" />
-    <KeyBinding Gesture="Ctrl+Shift+G"
-                Command="{Binding RecentQsos.SortByColumnCommand}"
-                CommandParameter="{x:Static vm:RecentQsoSortColumn.Grid}" />
-    <KeyBinding Gesture="Ctrl+Shift+E"
-                Command="{Binding RecentQsos.SortByColumnCommand}"
-                CommandParameter="{x:Static vm:RecentQsoSortColumn.UtcEnd}" />
-    <KeyBinding Gesture="Ctrl+Shift+S"
-                Command="{Binding RecentQsos.SortByColumnCommand}"
-                CommandParameter="{x:Static vm:RecentQsoSortColumn.Sync}" />
-    <KeyBinding Gesture="Ctrl+Shift+O"
-                Command="{Binding RecentQsos.SortByColumnCommand}"
-                CommandParameter="{x:Static vm:RecentQsoSortColumn.Comment}" />
-    <KeyBinding Gesture="Ctrl+Shift+D"
-                Command="{Binding RecentQsos.ReverseSortDirectionCommand}" />
+    <KeyBinding Gesture="Ctrl+Shift+S" Command="{Binding ToggleSortChooserCommand}" />
+    <KeyBinding Gesture="Ctrl+H" Command="{Binding ToggleColumnChooserCommand}" />
+    <KeyBinding Gesture="Alt+Enter" Command="{Binding ToggleInspectorCommand}" />
   </Window.KeyBindings>
 
   <Window.Styles>
-    <Style Selector="Border.qsoCell">
-      <Setter Property="BorderBrush"
-              Value="{DynamicResource SystemControlForegroundBaseLowBrush}" />
-      <Setter Property="BorderThickness"
-              Value="0,0,1,0" />
-      <Setter Property="Padding"
-              Value="0,0,5,0" />
+    <Style Selector="TextBlock.commandCaption">
+      <Setter Property="FontSize" Value="12" />
+      <Setter Property="TextTrimming" Value="CharacterEllipsis" />
+      <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
 
-    <Style Selector="Border.qsoCellLast">
-      <Setter Property="Padding"
-              Value="0" />
+    <Style Selector="Border.filterToken">
+      <Setter Property="Padding" Value="6,1" />
+      <Setter Property="CornerRadius" Value="4" />
+      <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundAltMediumLowBrush}" />
     </Style>
+
+    <Style Selector="DataGrid#RecentQsoGrid">
+      <Setter Property="CanUserReorderColumns" Value="True" />
+      <Setter Property="CanUserResizeColumns" Value="True" />
+      <Setter Property="CanUserSortColumns" Value="True" />
+      <Setter Property="HeadersVisibility" Value="Column" />
+      <Setter Property="GridLinesVisibility" Value="Horizontal" />
+      <Setter Property="FrozenColumnCount" Value="5" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="SelectionMode" Value="Extended" />
+      <Setter Property="IsReadOnly" Value="False" />
+    </Style>
+
+    <Style Selector="DataGrid#RecentQsoGrid DataGridColumnHeader">
+      <Setter Property="Padding" Value="4,1" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+
+    <Style Selector="DataGrid#RecentQsoGrid DataGridCell">
+      <Setter Property="Padding" Value="4,1" />
+      <Setter Property="BorderThickness" Value="0" />
+    </Style>
+
   </Window.Styles>
 
   <DockPanel>
-    <!-- Menu bar — always on top, never covered by overlay -->
     <Menu DockPanel.Dock="Top">
       <MenuItem x:Name="FileMenuItem" Header="_File">
         <MenuItem Header="_Settings" InputGesture="Ctrl+OemComma"
                   Command="{Binding OpenWizardCommand}" />
+        <MenuItem Header="_Save Edits" InputGesture="Ctrl+S"
+                  Command="{Binding RecentQsos.SaveEditsCommand}" />
         <Separator />
         <MenuItem Header="E_xit" InputGesture="Alt+X" Command="{Binding ExitCommand}" />
       </MenuItem>
       <MenuItem Header="_View">
-        <MenuItem Header="_Find Recent QSOs" InputGesture="Ctrl+F"
+        <MenuItem Header="_Find" InputGesture="Ctrl+F"
                   Command="{Binding FocusSearchCommand}" />
         <MenuItem Header="_Refresh Recent QSOs" InputGesture="F5"
                   Command="{Binding RecentQsos.RefreshCommand}" />
+        <MenuItem Header="Zoom _In" InputGesture="Ctrl++"
+                  Command="{Binding RecentQsos.ZoomInCommand}" />
+        <MenuItem Header="Zoom _Out" InputGesture="Ctrl+-"
+                  Command="{Binding RecentQsos.ZoomOutCommand}" />
+        <MenuItem Header="_Reset Zoom" InputGesture="Ctrl+0"
+                  Command="{Binding RecentQsos.ResetZoomCommand}" />
         <Separator />
-        <MenuItem Header="_Sort Recent QSOs">
-          <MenuItem Header="_Time" InputGesture="Ctrl+Shift+T"
-                    Command="{Binding RecentQsos.SortByColumnCommand}"
-                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Utc}" />
-          <MenuItem Header="_Call" InputGesture="Ctrl+Shift+C"
-                    Command="{Binding RecentQsos.SortByColumnCommand}"
-                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Callsign}" />
-          <MenuItem Header="_Band" InputGesture="Ctrl+Shift+B"
-                    Command="{Binding RecentQsos.SortByColumnCommand}"
-                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Band}" />
-          <MenuItem Header="_Mode" InputGesture="Ctrl+Shift+M"
-                    Command="{Binding RecentQsos.SortByColumnCommand}"
-                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Mode}" />
-          <MenuItem Header="_Country" InputGesture="Ctrl+Shift+L"
-                    Command="{Binding RecentQsos.SortByColumnCommand}"
-                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Country}" />
-          <MenuItem Header="_Name" InputGesture="Ctrl+Shift+N"
-                    Command="{Binding RecentQsos.SortByColumnCommand}"
-                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Name}" />
-          <MenuItem Header="_Frequency" InputGesture="Ctrl+Shift+F"
-                    Command="{Binding RecentQsos.SortByColumnCommand}"
-                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Frequency}" />
-          <MenuItem Header="_Grid" InputGesture="Ctrl+Shift+G"
-                    Command="{Binding RecentQsos.SortByColumnCommand}"
-                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Grid}" />
-          <MenuItem Header="_End Time" InputGesture="Ctrl+Shift+E"
-                    Command="{Binding RecentQsos.SortByColumnCommand}"
-                    CommandParameter="{x:Static vm:RecentQsoSortColumn.UtcEnd}" />
-          <MenuItem Header="_Sync" InputGesture="Ctrl+Shift+S"
-                    Command="{Binding RecentQsos.SortByColumnCommand}"
-                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Sync}" />
-          <MenuItem Header="C_omment" InputGesture="Ctrl+Shift+O"
-                    Command="{Binding RecentQsos.SortByColumnCommand}"
-                    CommandParameter="{x:Static vm:RecentQsoSortColumn.Comment}" />
-          <Separator />
-          <MenuItem Header="_Reverse Direction" InputGesture="Ctrl+Shift+D"
-                    Command="{Binding RecentQsos.ReverseSortDirectionCommand}" />
-        </MenuItem>
+        <MenuItem Header="_Sort Columns..." InputGesture="Ctrl+Shift+S"
+                  Command="{Binding ToggleSortChooserCommand}" />
+        <MenuItem Header="_Choose Columns..." InputGesture="Ctrl+H"
+                  Command="{Binding ToggleColumnChooserCommand}" />
+        <MenuItem Header="_Inspector" InputGesture="Alt+Enter"
+                  Command="{Binding ToggleInspectorCommand}" />
       </MenuItem>
     </Menu>
 
-    <!-- Content area with optional wizard overlay -->
     <Panel>
-      <Grid Margin="24"
-            RowDefinitions="Auto,Auto,Auto,*"
-            RowSpacing="16"
+      <Grid RowDefinitions="Auto,* ,Auto"
             IsEnabled="{Binding !IsWizardOpen}">
-        <Grid Grid.Row="0" ColumnDefinitions="*,Auto" ColumnSpacing="16">
-          <Border Padding="20,18"
-                  CornerRadius="12"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                  BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
-                  BorderThickness="1">
-            <StackPanel Spacing="6">
-              <TextBlock Text="QsoRipper"
-                         FontSize="28"
-                         FontWeight="SemiBold" />
-              <TextBlock Text="{Binding StatusMessage}"
-                         FontSize="15"
-                         Opacity="0.72"
-                         TextWrapping="Wrap" />
-            </StackPanel>
-          </Border>
+        <Grid Grid.Row="0"
+              Height="34"
+              Margin="10,4,10,6"
+              ColumnDefinitions="Auto,*,Auto"
+              ColumnSpacing="12">
+          <StackPanel Grid.Column="0"
+                      Orientation="Horizontal"
+                      Spacing="10"
+                      VerticalAlignment="Center">
+            <TextBlock Text="QsoRipper"
+                       FontSize="13"
+                       FontWeight="SemiBold"
+                       VerticalAlignment="Center" />
+            <TextBlock Classes="commandCaption"
+                       Text="{Binding ActiveLogText}"
+                       ToolTip.Tip="{Binding ActiveLogText}" />
+            <TextBlock Classes="commandCaption"
+                       Text="{Binding ActiveProfileText}"
+                       ToolTip.Tip="{Binding ActiveProfileText}" />
+            <TextBlock Classes="commandCaption"
+                       Text="{Binding ActiveStationText}"
+                       ToolTip.Tip="{Binding ActiveStationText}" />
+          </StackPanel>
 
-          <Border Grid.Column="1"
-                  Padding="20,16"
-                  CornerRadius="12"
-                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                  BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
-                  BorderThickness="1">
-            <StackPanel Spacing="2"
-                        HorizontalAlignment="Right">
-              <TextBlock Text="CURRENT UTC"
-                         FontSize="11"
-                         FontWeight="SemiBold"
-                         Opacity="0.62"
-                         HorizontalAlignment="Right" />
-              <TextBlock Text="{Binding CurrentUtcTime}"
-                         FontSize="30"
-                         FontWeight="Bold"
-                         FontFamily="Cascadia Mono, Consolas, monospace"
-                         HorizontalAlignment="Right" />
-              <TextBlock Text="{Binding CurrentUtcDate}"
-                         Opacity="0.72"
-                         HorizontalAlignment="Right" />
-            </StackPanel>
-          </Border>
-        </Grid>
-
-        <Border Grid.Row="1"
-                Padding="16,12"
-                CornerRadius="12"
-                Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
-                BorderThickness="1"
-                IsVisible="{Binding IsSetupIncomplete}">
-          <DockPanel LastChildFill="False">
-            <TextBlock Text="Setup incomplete - finish settings before you start logging."
-                       VerticalAlignment="Center"
-                       TextWrapping="Wrap" />
-            <Button DockPanel.Dock="Right"
-                    Content="Open Settings (Ctrl+,)"
-                    Command="{Binding OpenWizardCommand}"
-                    Classes="accent"
-                    Margin="12,0,0,0" />
-          </DockPanel>
-        </Border>
-
-        <Border Grid.Row="2"
-                Padding="16"
-                CornerRadius="12"
-                Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
-                BorderThickness="1">
-          <Grid ColumnDefinitions="*,Auto"
-                RowDefinitions="Auto,Auto,Auto"
-                ColumnSpacing="12"
-                RowSpacing="12">
-            <StackPanel Spacing="4">
-              <TextBlock Text="Recent QSOs"
-                         FontSize="18"
-                         FontWeight="SemiBold" />
-              <TextBlock Text="{Binding RecentQsos.SummaryText}"
-                          Opacity="0.68" />
-              <TextBlock Text="{Binding RecentQsos.SortStatusText}"
-                         FontSize="12"
-                         Opacity="0.62" />
-              <TextBlock Text="Sort: T time, C call, B band, M mode, L country, N name, F freq, G grid, E end, S sync, O comment, D reverse"
-                         FontSize="11"
-                         Opacity="0.52"
-                         TextWrapping="Wrap" />
-            </StackPanel>
-
-            <TextBlock Grid.Column="1"
-                       Text="{Binding RecentQsos.LastLoadedText}"
-                       VerticalAlignment="Center"
-                       Opacity="0.68"
-                       HorizontalAlignment="Right" />
-
+          <Grid Grid.Column="1"
+                ColumnDefinitions="360,*"
+                ColumnSpacing="8"
+                VerticalAlignment="Center">
             <TextBox x:Name="RecentQsoSearchBox"
-                     Grid.Row="1"
-                     PlaceholderText="Search callsign, band, mode, country, name, grid, reports, comment, contest, and sync"
-                     Text="{Binding RecentQsos.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                     MinWidth="420" />
+                     Grid.Column="0"
+                     Height="28"
+                     VerticalAlignment="Center"
+                     PlaceholderText="Search callsign, grid, name, contest, note..."
+                     Text="{Binding RecentQsos.SearchText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
 
-            <Button Grid.Row="1"
-                    Grid.Column="1"
-                    Content="Refresh (F5)"
-                    Command="{Binding RecentQsos.RefreshCommand}"
-                    Classes="accent"
-                    MinWidth="130" />
-
-            <TextBlock Grid.Row="2"
-                       Grid.ColumnSpan="2"
-                       Text="{Binding RecentQsos.ErrorMessage}"
-                       Foreground="IndianRed"
-                       TextWrapping="Wrap"
-                       IsVisible="{Binding RecentQsos.ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-          </Grid>
-        </Border>
-
-        <Border Grid.Row="3"
-                CornerRadius="12"
-                Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
-                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
-                BorderThickness="1"
-                ClipToBounds="True">
-          <Grid RowDefinitions="Auto,*">
-            <Border Padding="12,10"
-                    BorderThickness="0,0,0,1"
-                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}">
-              <Grid ColumnDefinitions="112,82,52,52,110,130,82,50,50,72,*,112,70"
-                    ColumnSpacing="0">
-                <Border Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.UtcHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Utc}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by UTC (Ctrl+Shift+T)" />
-                </Border>
-                <Border Grid.Column="1" Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.CallsignHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Callsign}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by call (Ctrl+Shift+C)" />
-                </Border>
-                <Border Grid.Column="2" Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.BandHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Band}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by band (Ctrl+Shift+B)" />
-                </Border>
-                <Border Grid.Column="3" Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.ModeHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Mode}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by mode (Ctrl+Shift+M)" />
-                </Border>
-                <Border Grid.Column="4" Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.CountryHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Country}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by country (Ctrl+Shift+L)" />
-                </Border>
-                <Border Grid.Column="5" Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.NameHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Name}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by name (Ctrl+Shift+N)" />
-                </Border>
-                <Border Grid.Column="6" Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.FrequencyHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Frequency}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by frequency (Ctrl+Shift+F)" />
-                </Border>
-                <Border Grid.Column="7" Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.RstSentHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.RstSent}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by sent report" />
-                </Border>
-                <Border Grid.Column="8" Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.RstReceivedHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.RstReceived}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by received report" />
-                </Border>
-                <Border Grid.Column="9" Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.GridHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Grid}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by grid (Ctrl+Shift+G)" />
-                </Border>
-                <Border Grid.Column="10" Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.CommentHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Comment}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by comment (Ctrl+Shift+O)" />
-                </Border>
-                <Border Grid.Column="11" Classes="qsoCell">
-                  <Button Content="{Binding RecentQsos.UtcEndHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.UtcEnd}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by end time (Ctrl+Shift+E)" />
-                </Border>
-                <Border Grid.Column="12" Classes="qsoCellLast">
-                  <Button Content="{Binding RecentQsos.SyncHeaderText}"
-                          Command="{Binding RecentQsos.SortByColumnCommand}"
-                          CommandParameter="{x:Static vm:RecentQsoSortColumn.Sync}"
-                          Background="Transparent"
-                          BorderBrush="Transparent"
-                          BorderThickness="0"
-                          Padding="0"
-                          HorizontalContentAlignment="Left"
-                          FontWeight="SemiBold"
-                          ToolTip.Tip="Sort by sync (Ctrl+Shift+S)" />
-                </Border>
-              </Grid>
-            </Border>
-
-            <Grid Grid.Row="1">
-              <ListBox ItemsSource="{Binding RecentQsos.VisibleItems}"
-                       SelectedItem="{Binding RecentQsos.SelectedQso, Mode=TwoWay}"
-                       Classes="qsoList"
-                       BorderThickness="0"
-                       Background="Transparent"
-                       IsVisible="{Binding RecentQsos.HasVisibleItems}">
-                <ListBox.Styles>
-                  <Style Selector="ListBoxItem">
-                    <Setter Property="Padding" Value="0" />
-                    <Setter Property="Margin" Value="0" />
-                    <Setter Property="MinHeight" Value="0" />
-                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                  </Style>
-                </ListBox.Styles>
-                <ListBox.ItemTemplate>
-                  <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
-                    <Border Padding="6,1"
-                            BorderThickness="0,0,0,1"
-                            BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}">
-                      <Grid ColumnDefinitions="112,82,52,52,110,130,82,50,50,72,*,112,70"
-                            ColumnSpacing="0">
-                        <Border Classes="qsoCell">
-                          <TextBlock Text="{Binding UtcDisplay}"
-                                     FontFamily="Cascadia Mono, Consolas, monospace"
-                                     VerticalAlignment="Center"
-                                     FontSize="12" />
-                        </Border>
-                        <Border Grid.Column="1" Classes="qsoCell">
-                          <TextBlock Text="{Binding WorkedCallsign}"
-                                     FontWeight="SemiBold"
-                                     VerticalAlignment="Center"
-                                     FontSize="12"
-                                     TextTrimming="CharacterEllipsis" />
-                        </Border>
-                        <Border Grid.Column="2" Classes="qsoCell">
-                          <TextBlock Text="{Binding Band}"
-                                     VerticalAlignment="Center"
-                                     FontSize="12"
-                                     TextTrimming="CharacterEllipsis" />
-                        </Border>
-                        <Border Grid.Column="3" Classes="qsoCell">
-                          <TextBlock Text="{Binding Mode}"
-                                     VerticalAlignment="Center"
-                                     FontSize="12"
-                                     TextTrimming="CharacterEllipsis" />
-                        </Border>
-                        <Border Grid.Column="4" Classes="qsoCell">
-                          <TextBlock Text="{Binding Country}"
-                                     VerticalAlignment="Center"
-                                     FontSize="12"
-                                     TextTrimming="CharacterEllipsis" />
-                        </Border>
-                        <Border Grid.Column="5" Classes="qsoCell">
-                          <TextBlock Text="{Binding OperatorName}"
-                                     VerticalAlignment="Center"
-                                     FontSize="12"
-                                     TextTrimming="CharacterEllipsis" />
-                        </Border>
-                        <Border Grid.Column="6" Classes="qsoCell">
-                          <TextBlock Text="{Binding Frequency}"
-                                     VerticalAlignment="Center"
-                                     FontSize="12" />
-                        </Border>
-                        <Border Grid.Column="7" Classes="qsoCell">
-                          <TextBlock Text="{Binding RstSent}"
-                                     VerticalAlignment="Center"
-                                     FontSize="12" />
-                        </Border>
-                        <Border Grid.Column="8" Classes="qsoCell">
-                          <TextBlock Text="{Binding RstReceived}"
-                                     VerticalAlignment="Center"
-                                     FontSize="12" />
-                        </Border>
-                        <Border Grid.Column="9" Classes="qsoCell">
-                          <TextBlock Text="{Binding Grid}"
-                                     VerticalAlignment="Center"
-                                     FontSize="12"
-                                     TextTrimming="CharacterEllipsis" />
-                        </Border>
-                        <Border Grid.Column="10" Classes="qsoCell">
-                          <TextBlock Text="{Binding Comment}"
-                                     VerticalAlignment="Center"
-                                     FontSize="12"
-                                     TextWrapping="NoWrap"
-                                     TextTrimming="CharacterEllipsis" />
-                        </Border>
-                        <Border Grid.Column="11" Classes="qsoCell">
-                          <TextBlock Text="{Binding UtcEndDisplay}"
-                                     VerticalAlignment="Center"
-                                     FontSize="12"
-                                     FontFamily="Cascadia Mono, Consolas, monospace" />
-                        </Border>
-                        <Border Grid.Column="12" Classes="qsoCellLast">
-                          <TextBlock Text="{Binding SyncStatus}"
-                                     VerticalAlignment="Center"
-                                     FontSize="12"
-                                     TextTrimming="CharacterEllipsis" />
-                        </Border>
-                      </Grid>
+            <ScrollViewer Grid.Column="1"
+                          HorizontalScrollBarVisibility="Hidden"
+                          VerticalScrollBarVisibility="Disabled"
+                          IsVisible="{Binding RecentQsos.HasActiveFilterTokens}">
+              <ItemsControl ItemsSource="{Binding RecentQsos.ActiveFilterTokens}">
+                <ItemsControl.ItemsPanel>
+                  <ItemsPanelTemplate>
+                    <StackPanel Orientation="Horizontal" Spacing="6" />
+                  </ItemsPanelTemplate>
+                </ItemsControl.ItemsPanel>
+                <ItemsControl.ItemTemplate>
+                  <DataTemplate x:DataType="x:String">
+                    <Border Classes="filterToken">
+                      <TextBlock Text="{Binding .}" FontSize="11.5" />
                     </Border>
                   </DataTemplate>
-                </ListBox.ItemTemplate>
-              </ListBox>
+                </ItemsControl.ItemTemplate>
+              </ItemsControl>
+            </ScrollViewer>
+          </Grid>
+
+          <StackPanel Grid.Column="2"
+                      Orientation="Horizontal"
+                      Spacing="10"
+                      VerticalAlignment="Center">
+            <Button Content="Setup"
+                    Command="{Binding OpenWizardCommand}"
+                    Classes="accent"
+                    MinWidth="62"
+                    Height="26"
+                    IsVisible="{Binding IsSetupIncomplete}" />
+            <TextBlock Classes="commandCaption"
+                       Text="{Binding RecentQsos.TopSyncIndicatorText}"
+                       ToolTip.Tip="{Binding RecentQsos.SyncSummaryText}" />
+            <TextBlock Classes="commandCaption"
+                       Text="{Binding RecentQsos.RefreshIndicatorText}" />
+            <TextBlock Classes="commandCaption"
+                       Text="UTC" />
+            <TextBlock Text="{Binding CurrentUtcTime}"
+                       FontFamily="Cascadia Mono, Consolas, monospace"
+                       FontSize="12.5"
+                       FontWeight="SemiBold"
+                       VerticalAlignment="Center" />
+            <TextBlock Classes="commandCaption"
+                       Text="{Binding CurrentUtcDate}" />
+            <Button Content="Sort"
+                    Command="{Binding ToggleSortChooserCommand}"
+                    Height="26"
+                    MinWidth="54" />
+            <Button Content="Cols"
+                    Command="{Binding ToggleColumnChooserCommand}"
+                    Height="26"
+                    MinWidth="54" />
+          </StackPanel>
+        </Grid>
+
+        <Panel Grid.Row="1">
+          <Grid ColumnDefinitions="*,Auto">
+            <Grid Grid.Column="0">
+              <DataGrid x:Name="RecentQsoGrid"
+                         Margin="8,0,8,0"
+                         RowHeight="{Binding RecentQsos.GridRowHeight}"
+                         ColumnHeaderHeight="{Binding RecentQsos.GridHeaderHeight}"
+                         FontSize="{Binding RecentQsos.GridFontSize}"
+                         ItemsSource="{Binding RecentQsos.View}"
+                         PointerWheelChanged="OnRecentQsoGridPointerWheelChanged"
+                         SelectedItem="{Binding RecentQsos.SelectedQso, Mode=TwoWay}">
+                <DataGrid.Columns>
+                  <DataGridTextColumn Header="UTC"
+                                      Width="104"
+                                      Binding="{ReflectionBinding UtcDisplay, Mode=TwoWay}"
+                                      SortMemberPath="UtcSortKey" />
+                  <DataGridTextColumn Header="Call"
+                                      Width="92"
+                                      Binding="{ReflectionBinding WorkedCallsign, Mode=TwoWay}"
+                                      SortMemberPath="WorkedCallsign" />
+                  <DataGridTextColumn Header="Band"
+                                      Width="56"
+                                      Binding="{ReflectionBinding Band, Mode=TwoWay}"
+                                      SortMemberPath="Band" />
+                  <DataGridTextColumn Header="Mode"
+                                      Width="64"
+                                      Binding="{ReflectionBinding Mode, Mode=TwoWay}"
+                                      SortMemberPath="Mode" />
+                  <DataGridTextColumn Header="Freq"
+                                      Width="82"
+                                      Binding="{ReflectionBinding Frequency, Mode=TwoWay}"
+                                      SortMemberPath="FrequencySortKey" />
+                  <DataGridTextColumn Header="RST"
+                                      Width="70"
+                                      Binding="{ReflectionBinding Rst, Mode=TwoWay}"
+                                      SortMemberPath="Rst" />
+                  <DataGridTextColumn Header="DXCC"
+                                      Width="58"
+                                      Binding="{ReflectionBinding Dxcc, Mode=TwoWay}"
+                                      SortMemberPath="DxccSortKey" />
+                  <DataGridTemplateColumn Header="Country"
+                                          Width="120"
+                                          SortMemberPath="Country">
+                    <DataGridTemplateColumn.CellTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBlock Text="{Binding Country}"
+                                   TextWrapping="NoWrap"
+                                   TextTrimming="CharacterEllipsis"
+                                   ToolTip.Tip="{Binding Country}" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBox Text="{Binding Country, Mode=TwoWay}"
+                                 BorderThickness="0"
+                                 Padding="0"
+                                 Background="Transparent" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                  </DataGridTemplateColumn>
+                  <DataGridTemplateColumn Header="Name"
+                                          Width="122"
+                                          SortMemberPath="OperatorName">
+                    <DataGridTemplateColumn.CellTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBlock Text="{Binding OperatorName}"
+                                   TextWrapping="NoWrap"
+                                   TextTrimming="CharacterEllipsis"
+                                   ToolTip.Tip="{Binding OperatorName}" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBox Text="{Binding OperatorName, Mode=TwoWay}"
+                                 BorderThickness="0"
+                                 Padding="0"
+                                 Background="Transparent" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                  </DataGridTemplateColumn>
+                  <DataGridTextColumn Header="Grid"
+                                      Width="72"
+                                      Binding="{ReflectionBinding Grid, Mode=TwoWay}"
+                                      SortMemberPath="Grid" />
+                  <DataGridTextColumn Header="Exch"
+                                      Width="76"
+                                      Binding="{ReflectionBinding Exchange, Mode=TwoWay}"
+                                      SortMemberPath="Exchange" />
+                  <DataGridTemplateColumn Header="Contest"
+                                          Width="92"
+                                          SortMemberPath="Contest">
+                    <DataGridTemplateColumn.CellTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBlock Text="{Binding Contest}"
+                                   TextWrapping="NoWrap"
+                                   TextTrimming="CharacterEllipsis"
+                                   ToolTip.Tip="{Binding Contest}" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBox Text="{Binding Contest, Mode=TwoWay}"
+                                 BorderThickness="0"
+                                 Padding="0"
+                                 Background="Transparent" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                  </DataGridTemplateColumn>
+                  <DataGridTextColumn Header="Station"
+                                      Width="92"
+                                      Binding="{ReflectionBinding Station, Mode=TwoWay}"
+                                      SortMemberPath="Station" />
+                  <DataGridTemplateColumn Header="Note"
+                                          Width="2*"
+                                          MaxWidth="240"
+                                          SortMemberPath="Note">
+                    <DataGridTemplateColumn.CellTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBlock Text="{Binding Note}"
+                                   TextWrapping="NoWrap"
+                                   TextTrimming="CharacterEllipsis"
+                                   ToolTip.Tip="{Binding Note}" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBox Text="{Binding Note, Mode=TwoWay}"
+                                 BorderThickness="0"
+                                 Padding="0"
+                                 Background="Transparent" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                  </DataGridTemplateColumn>
+                  <DataGridTextColumn Header="End"
+                                      Width="104"
+                                      Binding="{ReflectionBinding UtcEndDisplay, Mode=TwoWay}"
+                                      SortMemberPath="UtcEndSortKey"
+                                      IsVisible="False" />
+                  <DataGridTextColumn Header="CQ"
+                                      Width="50"
+                                      Binding="{ReflectionBinding CqZone, Mode=TwoWay}"
+                                      SortMemberPath="CqZone"
+                                      IsVisible="False" />
+                  <DataGridTextColumn Header="ITU"
+                                      Width="50"
+                                      Binding="{ReflectionBinding ItuZone, Mode=TwoWay}"
+                                      SortMemberPath="ItuZone"
+                                      IsVisible="False" />
+                  <DataGridTemplateColumn Header="QTH"
+                                          Width="120"
+                                          SortMemberPath="Qth"
+                                          IsVisible="False"
+                                          IsReadOnly="True">
+                    <DataGridTemplateColumn.CellTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBlock Text="{Binding Qth}"
+                                   TextWrapping="NoWrap"
+                                   TextTrimming="CharacterEllipsis"
+                                   ToolTip.Tip="{Binding Qth}" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                  </DataGridTemplateColumn>
+                  <DataGridTextColumn Header="Sync"
+                                      Width="78"
+                                      Binding="{ReflectionBinding SyncStatus}"
+                                      SortMemberPath="SyncStatus"
+                                      IsReadOnly="True"
+                                      IsVisible="False" />
+                </DataGrid.Columns>
+              </DataGrid>
 
               <StackPanel HorizontalAlignment="Center"
                           VerticalAlignment="Center"
@@ -531,15 +365,190 @@
                            Opacity="0.72" />
               </StackPanel>
 
-              <ProgressBar IsIndeterminate="True"
-                           IsVisible="{Binding RecentQsos.IsLoading}"
-                           VerticalAlignment="Top" />
+              <Border HorizontalAlignment="Right"
+                      VerticalAlignment="Top"
+                      Background="{DynamicResource SystemControlBackgroundAltMediumLowBrush}"
+                      CornerRadius="4"
+                      Margin="0,8,12,0"
+                      Padding="8,4"
+                      IsVisible="{Binding RecentQsos.ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                <TextBlock Text="{Binding RecentQsos.ErrorMessage}"
+                           Foreground="IndianRed"
+                           FontSize="11.5"
+                           TextTrimming="CharacterEllipsis"
+                           MaxWidth="360" />
+              </Border>
             </Grid>
+
+            <Border Grid.Column="1"
+                    Width="320"
+                    Padding="12,10"
+                    BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                    BorderThickness="1,0,0,0"
+                    Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                    IsVisible="{Binding IsInspectorOpen}">
+              <ScrollViewer>
+                <StackPanel Spacing="10"
+                            DataContext="{Binding RecentQsos.SelectedQso}">
+                  <TextBlock Text="Inspector"
+                             FontSize="13"
+                             FontWeight="SemiBold" />
+
+                  <StackPanel Spacing="6"
+                              IsVisible="{Binding .}">
+                    <Grid ColumnDefinitions="Auto,*"
+                          ColumnSpacing="10"
+                          RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                      <TextBlock Text="Call" Grid.Row="0" Opacity="0.68" />
+                      <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding WorkedCallsign}" />
+                      <TextBlock Text="UTC" Grid.Row="1" Opacity="0.68" />
+                      <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding UtcDisplay}" />
+                      <TextBlock Text="Band / Mode" Grid.Row="2" Opacity="0.68" />
+                      <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding Band}" />
+                      <TextBlock Grid.Row="2" Grid.Column="1" Margin="44,0,0,0" Text="{Binding Mode}" />
+                      <TextBlock Text="Freq / RST" Grid.Row="3" Opacity="0.68" />
+                      <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Frequency}" />
+                      <TextBlock Grid.Row="3" Grid.Column="1" Margin="74,0,0,0" Text="{Binding Rst}" />
+                      <TextBlock Text="DXCC / Country" Grid.Row="4" Opacity="0.68" />
+                      <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding Dxcc}" />
+                      <TextBlock Grid.Row="4" Grid.Column="1" Margin="42,0,0,0" Text="{Binding Country}" />
+                      <TextBlock Text="Name" Grid.Row="5" Opacity="0.68" />
+                      <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding OperatorName}" TextWrapping="Wrap" />
+                      <TextBlock Text="Grid / QTH" Grid.Row="6" Opacity="0.68" />
+                      <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding Grid}" />
+                      <TextBlock Grid.Row="6" Grid.Column="1" Margin="52,0,0,0" Text="{Binding Qth}" TextWrapping="Wrap" />
+                      <TextBlock Text="Contest / Exch" Grid.Row="7" Opacity="0.68" />
+                      <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding Contest}" />
+                      <TextBlock Grid.Row="7" Grid.Column="1" Margin="92,0,0,0" Text="{Binding Exchange}" />
+                      <TextBlock Text="Station" Grid.Row="8" Opacity="0.68" />
+                      <TextBlock Grid.Row="8" Grid.Column="1" Text="{Binding Station}" />
+                      <TextBlock Text="Zones" Grid.Row="9" Opacity="0.68" />
+                      <TextBlock Grid.Row="9" Grid.Column="1" Text="{Binding CqZone}" />
+                      <TextBlock Grid.Row="9" Grid.Column="1" Margin="34,0,0,0" Text="{Binding ItuZone}" />
+                      <TextBlock Text="End" Grid.Row="10" Opacity="0.68" />
+                      <TextBlock Grid.Row="10" Grid.Column="1" Text="{Binding UtcEndDisplay}" />
+                      <TextBlock Text="Sync" Grid.Row="11" Opacity="0.68" />
+                      <TextBlock Grid.Row="11" Grid.Column="1" Text="{Binding SyncStatus}" />
+                      <TextBlock Text="Note" Grid.Row="12" Opacity="0.68" />
+                      <TextBlock Grid.Row="12" Grid.Column="1" Text="{Binding Note}" TextWrapping="Wrap" />
+                    </Grid>
+                  </StackPanel>
+
+                  <TextBlock Text="No QSO selected."
+                             Opacity="0.68"
+                             IsVisible="{Binding !.}" />
+                </StackPanel>
+              </ScrollViewer>
+            </Border>
+          </Grid>
+
+          <Border HorizontalAlignment="Right"
+                  VerticalAlignment="Top"
+                  Margin="0,8,14,0"
+                  Padding="10,8"
+                  CornerRadius="6"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                  BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                  BorderThickness="1"
+                  IsVisible="{Binding IsSortChooserOpen}">
+            <StackPanel Spacing="6">
+              <TextBlock Text="Sort recent QSOs"
+                         FontSize="12.5"
+                         FontWeight="SemiBold" />
+              <Button Content="UTC"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Utc}" />
+              <Button Content="Call"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Callsign}" />
+              <Button Content="Band"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Band}" />
+              <Button Content="Mode"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Mode}" />
+              <Button Content="Freq"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Frequency}" />
+              <Button Content="DXCC"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Dxcc}" />
+              <Button Content="Country"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Country}" />
+              <Button Content="Contest"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Contest}" />
+              <Button Content="Note"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Note}" />
+              <Button Content="Reverse direction"
+                      Command="{Binding RecentQsos.ReverseSortDirectionCommand}" />
+            </StackPanel>
+          </Border>
+
+          <Border HorizontalAlignment="Right"
+                  VerticalAlignment="Top"
+                  Margin="0,8,150,0"
+                  Padding="10,8"
+                  CornerRadius="6"
+                  Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                  BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                  BorderThickness="1"
+                  IsVisible="{Binding IsColumnChooserOpen}">
+            <StackPanel Spacing="4">
+              <TextBlock Text="Visible columns"
+                         FontSize="12.5"
+                         FontWeight="SemiBold" />
+              <ItemsControl ItemsSource="{Binding RecentQsos.ColumnOptions}">
+                <ItemsControl.ItemTemplate>
+                  <DataTemplate x:DataType="vm:RecentQsoColumnOptionViewModel">
+                    <CheckBox Content="{Binding Label}"
+                              IsChecked="{Binding IsVisible, Mode=TwoWay}" />
+                  </DataTemplate>
+                </ItemsControl.ItemTemplate>
+              </ItemsControl>
+            </StackPanel>
+          </Border>
+        </Panel>
+
+        <Border Grid.Row="2"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
+                BorderThickness="1,0,0,0"
+                Padding="10,4">
+          <Grid ColumnDefinitions="*,Auto"
+                ColumnSpacing="12">
+            <StackPanel Orientation="Horizontal"
+                        Spacing="10"
+                        VerticalAlignment="Center">
+              <TextBlock Text="{Binding RecentQsos.CountStatusText}" FontSize="11.5" />
+              <TextBlock Text="|" Opacity="0.45" />
+              <TextBlock Text="{Binding RecentQsos.FilterStatusText}" FontSize="11.5" />
+              <TextBlock Text="|" Opacity="0.45" />
+              <TextBlock Text="{Binding RecentQsos.SortStatusText}" FontSize="11.5" />
+              <TextBlock Text="|" Opacity="0.45" />
+              <TextBlock Text="{Binding RecentQsos.EditStatusText}" FontSize="11.5" />
+              <TextBlock Text="|" Opacity="0.45" />
+              <TextBlock Text="{Binding RecentQsos.GridZoomStatusText}" FontSize="11.5" />
+              <TextBlock Text="|" Opacity="0.45" />
+              <TextBlock Text="{Binding ActiveStationText}" FontSize="11.5" />
+              <TextBlock Text="|" Opacity="0.45" />
+              <TextBlock Text="{Binding RecentQsos.SyncSummaryText}"
+                         FontSize="11.5"
+                         TextTrimming="CharacterEllipsis"
+                         MaxWidth="420" />
+            </StackPanel>
+
+            <TextBlock Grid.Column="1"
+                       Text="F2 Edit • Ctrl+S Save • Ctrl+A Select • Ctrl+Wheel Zoom • Alt+Enter Details"
+                       FontSize="11.5"
+                       Opacity="0.68"
+                       VerticalAlignment="Center"
+                       HorizontalAlignment="Right" />
           </Grid>
         </Border>
       </Grid>
 
-      <!-- Wizard overlay — covers content area only, not the menu bar -->
       <Border IsVisible="{Binding IsWizardOpen}"
               Background="#80000000">
         <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -1,5 +1,7 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
+using QsoRipper.Gui.Utilities;
 
 namespace QsoRipper.Gui.Views;
 
@@ -7,12 +9,20 @@ internal sealed partial class MainWindow : Window
 {
     private readonly MenuItem? _fileMenuItem;
     private readonly TextBox? _recentQsoSearchBox;
+    private readonly double _preferredWidth;
+    private readonly double _preferredHeight;
+    private readonly double _preferredMinWidth;
+    private readonly double _preferredMinHeight;
     private ViewModels.MainWindowViewModel? _viewModel;
     private bool _menuAccessKeysPrimed;
 
     public MainWindow()
     {
         InitializeComponent();
+        _preferredWidth = Width;
+        _preferredHeight = Height;
+        _preferredMinWidth = MinWidth;
+        _preferredMinHeight = MinHeight;
         _fileMenuItem = this.FindControl<MenuItem>("FileMenuItem");
         _recentQsoSearchBox = this.FindControl<TextBox>("RecentQsoSearchBox");
         DataContextChanged += OnDataContextChanged;
@@ -21,6 +31,7 @@ internal sealed partial class MainWindow : Window
     protected override async void OnOpened(System.EventArgs e)
     {
         base.OnOpened(e);
+        ClampToCurrentScreen();
         PrimeMenuAccessKeys();
         if (DataContext is ViewModels.MainWindowViewModel vm)
         {
@@ -98,5 +109,28 @@ internal sealed partial class MainWindow : Window
                 _recentQsoSearchBox.SelectAll();
             },
             DispatcherPriority.Input);
+    }
+
+    private void ClampToCurrentScreen()
+    {
+        var screen = Screens.ScreenFromWindow(this) ?? Screens.Primary;
+        if (screen is null)
+        {
+            return;
+        }
+
+        var layout = ResponsiveWindowLayout.ClampToWorkingArea(
+            _preferredWidth,
+            _preferredHeight,
+            _preferredMinWidth,
+            _preferredMinHeight,
+            screen.WorkingArea,
+            screen.Scaling);
+
+        MinWidth = layout.MinWidth;
+        MinHeight = layout.MinHeight;
+        Width = layout.Width;
+        Height = layout.Height;
+        Position = layout.Position;
     }
 }

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -1,20 +1,29 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Threading;
 using QsoRipper.Gui.Utilities;
+using QsoRipper.Gui.ViewModels;
 
 namespace QsoRipper.Gui.Views;
 
 internal sealed partial class MainWindow : Window
 {
+    private readonly RecentQsoGridLayoutStore _gridLayoutStore = new();
     private readonly MenuItem? _fileMenuItem;
     private readonly TextBox? _recentQsoSearchBox;
+    private readonly DataGrid? _recentQsoGrid;
     private readonly double _preferredWidth;
     private readonly double _preferredHeight;
     private readonly double _preferredMinWidth;
     private readonly double _preferredMinHeight;
-    private ViewModels.MainWindowViewModel? _viewModel;
+    private MainWindowViewModel? _viewModel;
+    private bool _gridLayoutApplied;
     private bool _menuAccessKeysPrimed;
+    private Dictionary<RecentQsoGridColumn, DataGridColumn> _columnMap = [];
 
     public MainWindow()
     {
@@ -25,15 +34,18 @@ internal sealed partial class MainWindow : Window
         _preferredMinHeight = MinHeight;
         _fileMenuItem = this.FindControl<MenuItem>("FileMenuItem");
         _recentQsoSearchBox = this.FindControl<TextBox>("RecentQsoSearchBox");
+        _recentQsoGrid = this.FindControl<DataGrid>("RecentQsoGrid");
         DataContextChanged += OnDataContextChanged;
+        BuildColumnMap();
     }
 
-    protected override async void OnOpened(System.EventArgs e)
+    protected override async void OnOpened(EventArgs e)
     {
         base.OnOpened(e);
         ClampToCurrentScreen();
         PrimeMenuAccessKeys();
-        if (DataContext is ViewModels.MainWindowViewModel vm)
+        ApplyPersistedGridLayout();
+        if (DataContext is MainWindowViewModel vm)
         {
             await vm.CheckFirstRunAsync();
         }
@@ -41,9 +53,12 @@ internal sealed partial class MainWindow : Window
 
     protected override void OnClosed(EventArgs e)
     {
+        SaveGridLayout();
+
         if (_viewModel is not null)
         {
             _viewModel.SearchFocusRequested -= OnSearchFocusRequested;
+            UnsubscribeColumnOptions(_viewModel.RecentQsos);
             _viewModel = null;
         }
 
@@ -53,6 +68,141 @@ internal sealed partial class MainWindow : Window
         }
 
         base.OnClosed(e);
+    }
+
+    protected override void OnKeyDown(KeyEventArgs e)
+    {
+        if (_viewModel is null || _viewModel.IsWizardOpen)
+        {
+            base.OnKeyDown(e);
+            return;
+        }
+
+        if (TryHandleRecentQsoZoomKey(e))
+        {
+            return;
+        }
+
+        if (HandleRecentQsoGridKeyDown(e))
+        {
+            return;
+        }
+
+        base.OnKeyDown(e);
+
+        if (e.Handled || _viewModel is null || _viewModel.IsWizardOpen)
+        {
+            return;
+        }
+
+        if (string.Equals(e.KeySymbol, "/", StringComparison.Ordinal)
+            && e.Source is not TextBox
+            && !(_recentQsoSearchBox?.IsFocused ?? false))
+        {
+            FocusRecentQsoSearchBox();
+            e.Handled = true;
+            return;
+        }
+
+        if (e.Key == Key.Escape)
+        {
+            if (_viewModel.IsColumnChooserOpen || _viewModel.IsSortChooserOpen)
+            {
+                _viewModel.CloseTransientPanelsCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
+            if (_viewModel.IsInspectorOpen)
+            {
+                _viewModel.ToggleInspectorCommand.Execute(null);
+                e.Handled = true;
+            }
+        }
+    }
+
+    private bool HandleRecentQsoGridKeyDown(KeyEventArgs e)
+    {
+        if (_recentQsoGrid is null || _viewModel is null || !_recentQsoGrid.IsKeyboardFocusWithin)
+        {
+            return false;
+        }
+
+        var isEditingTextBox = e.Source is TextBox;
+        var modifiers = e.KeyModifiers;
+
+        if (!isEditingTextBox && modifiers.HasFlag(KeyModifiers.Control) && e.Key == Key.A)
+        {
+            _recentQsoGrid.SelectAll();
+            e.Handled = true;
+            return true;
+        }
+
+        if (modifiers.HasFlag(KeyModifiers.Control) && e.Key == Key.S)
+        {
+            CommitAndSaveGridEdits();
+            e.Handled = true;
+            return true;
+        }
+
+        if (!isEditingTextBox && e.Key == Key.F2)
+        {
+            EnsureGridHasEditableCell();
+            if (_recentQsoGrid.BeginEdit())
+            {
+                e.Handled = true;
+                return true;
+            }
+        }
+
+        if (e.Key == Key.Enter && _recentQsoGrid.CommitEdit())
+        {
+            e.Handled = true;
+            return true;
+        }
+
+        if (e.Key == Key.Escape && _recentQsoGrid.CancelEdit())
+        {
+            e.Handled = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool TryHandleRecentQsoZoomKey(KeyEventArgs e)
+    {
+        if (_viewModel is null || !e.KeyModifiers.HasFlag(KeyModifiers.Control))
+        {
+            return false;
+        }
+
+        switch (e.Key)
+        {
+            case Key.Add:
+            case Key.OemPlus:
+                _viewModel.RecentQsos.ZoomInGrid();
+                e.Handled = true;
+                return true;
+            case Key.Subtract:
+            case Key.OemMinus:
+                _viewModel.RecentQsos.ZoomOutGrid();
+                e.Handled = true;
+                return true;
+            case Key.D0:
+            case Key.NumPad0:
+                _viewModel.RecentQsos.ResetGridZoom();
+                e.Handled = true;
+                return true;
+        }
+
+        return e.KeySymbol switch
+        {
+            "+" or "=" => HandleZoomAction(_viewModel.RecentQsos.ZoomInGrid, e),
+            "-" or "_" => HandleZoomAction(_viewModel.RecentQsos.ZoomOutGrid, e),
+            "0" => HandleZoomAction(_viewModel.RecentQsos.ResetGridZoom, e),
+            _ => false
+        };
     }
 
     private void PrimeMenuAccessKeys()
@@ -81,12 +231,16 @@ internal sealed partial class MainWindow : Window
         if (_viewModel is not null)
         {
             _viewModel.SearchFocusRequested -= OnSearchFocusRequested;
+            UnsubscribeColumnOptions(_viewModel.RecentQsos);
         }
 
-        _viewModel = DataContext as ViewModels.MainWindowViewModel;
+        _viewModel = DataContext as MainWindowViewModel;
         if (_viewModel is not null)
         {
             _viewModel.SearchFocusRequested += OnSearchFocusRequested;
+            SubscribeColumnOptions(_viewModel.RecentQsos);
+            ApplyDefaultColumnVisibility();
+            ApplyPersistedGridLayout();
         }
     }
 
@@ -111,6 +265,56 @@ internal sealed partial class MainWindow : Window
             DispatcherPriority.Input);
     }
 
+    private void CommitAndSaveGridEdits()
+    {
+        if (_recentQsoGrid is null || _viewModel is null)
+        {
+            return;
+        }
+
+        _recentQsoGrid.CommitEdit();
+        if (_viewModel.RecentQsos.SaveEditsCommand.CanExecute(null))
+        {
+            _ = _viewModel.RecentQsos.SaveEditsCommand.ExecuteAsync(null);
+        }
+    }
+
+    private void EnsureGridHasEditableCell()
+    {
+        if (_recentQsoGrid is null || _viewModel is null)
+        {
+            return;
+        }
+
+        if (_recentQsoGrid.SelectedItem is null && _viewModel.RecentQsos.VisibleItems.Count > 0)
+        {
+            _recentQsoGrid.SelectedItem = _viewModel.RecentQsos.VisibleItems[0];
+        }
+
+        if (_recentQsoGrid.CurrentColumn is { IsVisible: true, IsReadOnly: false })
+        {
+            return;
+        }
+
+        _recentQsoGrid.CurrentColumn = _recentQsoGrid.Columns
+            .Where(column => column.IsVisible && !column.IsReadOnly)
+            .OrderBy(column => column.DisplayIndex)
+            .FirstOrDefault();
+    }
+
+    private void OnRecentQsoGridPointerWheelChanged(object? sender, PointerWheelEventArgs e)
+    {
+        if (_viewModel?.IsWizardOpen != false || !e.KeyModifiers.HasFlag(KeyModifiers.Control))
+        {
+            return;
+        }
+
+        if (_viewModel.RecentQsos.AdjustZoom(Math.Sign(e.Delta.Y)))
+        {
+            e.Handled = true;
+        }
+    }
+
     private void ClampToCurrentScreen()
     {
         var screen = Screens.ScreenFromWindow(this) ?? Screens.Primary;
@@ -132,5 +336,157 @@ internal sealed partial class MainWindow : Window
         Width = layout.Width;
         Height = layout.Height;
         Position = layout.Position;
+    }
+
+    private void BuildColumnMap()
+    {
+        if (_recentQsoGrid is null || _recentQsoGrid.Columns.Count < 19)
+        {
+            return;
+        }
+
+        _columnMap = new Dictionary<RecentQsoGridColumn, DataGridColumn>
+        {
+            [RecentQsoGridColumn.Utc] = _recentQsoGrid.Columns[0],
+            [RecentQsoGridColumn.Callsign] = _recentQsoGrid.Columns[1],
+            [RecentQsoGridColumn.Band] = _recentQsoGrid.Columns[2],
+            [RecentQsoGridColumn.Mode] = _recentQsoGrid.Columns[3],
+            [RecentQsoGridColumn.Frequency] = _recentQsoGrid.Columns[4],
+            [RecentQsoGridColumn.Rst] = _recentQsoGrid.Columns[5],
+            [RecentQsoGridColumn.Dxcc] = _recentQsoGrid.Columns[6],
+            [RecentQsoGridColumn.Country] = _recentQsoGrid.Columns[7],
+            [RecentQsoGridColumn.Name] = _recentQsoGrid.Columns[8],
+            [RecentQsoGridColumn.Grid] = _recentQsoGrid.Columns[9],
+            [RecentQsoGridColumn.Exchange] = _recentQsoGrid.Columns[10],
+            [RecentQsoGridColumn.Contest] = _recentQsoGrid.Columns[11],
+            [RecentQsoGridColumn.Station] = _recentQsoGrid.Columns[12],
+            [RecentQsoGridColumn.Note] = _recentQsoGrid.Columns[13],
+            [RecentQsoGridColumn.UtcEnd] = _recentQsoGrid.Columns[14],
+            [RecentQsoGridColumn.CqZone] = _recentQsoGrid.Columns[15],
+            [RecentQsoGridColumn.ItuZone] = _recentQsoGrid.Columns[16],
+            [RecentQsoGridColumn.Qth] = _recentQsoGrid.Columns[17],
+            [RecentQsoGridColumn.Sync] = _recentQsoGrid.Columns[18]
+        };
+    }
+
+    private void SubscribeColumnOptions(RecentQsoListViewModel viewModel)
+    {
+        foreach (var option in viewModel.ColumnOptions)
+        {
+            option.PropertyChanged += OnColumnOptionPropertyChanged;
+        }
+    }
+
+    private void UnsubscribeColumnOptions(RecentQsoListViewModel viewModel)
+    {
+        foreach (var option in viewModel.ColumnOptions)
+        {
+            option.PropertyChanged -= OnColumnOptionPropertyChanged;
+        }
+    }
+
+    private void OnColumnOptionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(RecentQsoColumnOptionViewModel.IsVisible)
+            || sender is not RecentQsoColumnOptionViewModel option)
+        {
+            return;
+        }
+
+        ApplyColumnVisibility(option.Column, option.IsVisible);
+    }
+
+    private void ApplyDefaultColumnVisibility()
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        foreach (var option in _viewModel.RecentQsos.ColumnOptions)
+        {
+            ApplyColumnVisibility(option.Column, option.IsVisible);
+        }
+    }
+
+    private void ApplyPersistedGridLayout()
+    {
+        if (_gridLayoutApplied || _viewModel is null || _recentQsoGrid is null || _columnMap.Count == 0)
+        {
+            return;
+        }
+
+        ApplyDefaultColumnVisibility();
+
+        var layout = _gridLayoutStore.Load();
+        if (layout is null)
+        {
+            _gridLayoutApplied = true;
+            return;
+        }
+
+        _viewModel.RecentQsos.ApplyPersistedGridFontSize(layout.GridFontSize);
+
+        foreach (var columnState in layout.Columns.OrderBy(state => state.DisplayIndex))
+        {
+            if (!_columnMap.TryGetValue(columnState.Column, out var column))
+            {
+                continue;
+            }
+
+            _viewModel.RecentQsos.SetColumnVisibility(columnState.Column, columnState.IsVisible);
+            column.DisplayIndex = columnState.DisplayIndex;
+            if (columnState.Width > 0)
+            {
+                column.Width = new DataGridLength(columnState.Width);
+            }
+        }
+
+        _viewModel.RecentQsos.ApplyPersistedSort(layout.SortColumn, layout.SortAscending);
+        _gridLayoutApplied = true;
+    }
+
+    private void ApplyColumnVisibility(RecentQsoGridColumn column, bool isVisible)
+    {
+        if (_columnMap.TryGetValue(column, out var dataGridColumn))
+        {
+            dataGridColumn.IsVisible = isVisible;
+        }
+    }
+
+    private void SaveGridLayout()
+    {
+        if (_viewModel is null || _columnMap.Count == 0)
+        {
+            return;
+        }
+
+        var state = new RecentQsoGridLayoutState
+        {
+            SortColumn = _viewModel.RecentQsos.CurrentSortColumn,
+            SortAscending = _viewModel.RecentQsos.SortAscending,
+            GridFontSize = _viewModel.RecentQsos.GridFontSize
+        };
+
+        foreach (var pair in _columnMap.OrderBy(item => item.Value.DisplayIndex))
+        {
+            state.Columns.Add(
+                new RecentQsoGridColumnState
+                {
+                    Column = pair.Key,
+                    IsVisible = pair.Value.IsVisible,
+                    DisplayIndex = pair.Value.DisplayIndex,
+                    Width = pair.Value.ActualWidth
+                });
+        }
+
+        _gridLayoutStore.Save(state);
+    }
+
+    private static bool HandleZoomAction(Action handler, KeyEventArgs e)
+    {
+        handler();
+        e.Handled = true;
+        return true;
     }
 }

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -58,6 +58,7 @@ internal sealed partial class MainWindow : Window
         if (_viewModel is not null)
         {
             _viewModel.SearchFocusRequested -= OnSearchFocusRequested;
+            _viewModel.SettingsRequested -= OnSettingsRequested;
             UnsubscribeColumnOptions(_viewModel.RecentQsos);
             _viewModel = null;
         }
@@ -231,6 +232,7 @@ internal sealed partial class MainWindow : Window
         if (_viewModel is not null)
         {
             _viewModel.SearchFocusRequested -= OnSearchFocusRequested;
+            _viewModel.SettingsRequested -= OnSettingsRequested;
             UnsubscribeColumnOptions(_viewModel.RecentQsos);
         }
 
@@ -238,6 +240,7 @@ internal sealed partial class MainWindow : Window
         if (_viewModel is not null)
         {
             _viewModel.SearchFocusRequested += OnSearchFocusRequested;
+            _viewModel.SettingsRequested += OnSettingsRequested;
             SubscribeColumnOptions(_viewModel.RecentQsos);
             ApplyDefaultColumnVisibility();
             ApplyPersistedGridLayout();
@@ -247,6 +250,23 @@ internal sealed partial class MainWindow : Window
     private void OnSearchFocusRequested(object? sender, EventArgs e)
     {
         FocusRecentQsoSearchBox();
+    }
+
+    private async void OnSettingsRequested(object? sender, EventArgs e)
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        _viewModel.IsSettingsOpen = true;
+        var settingsVm = _viewModel.CreateSettingsViewModel();
+        await settingsVm.LoadAsync();
+
+        var dialog = new SettingsView { DataContext = settingsVm };
+        await dialog.ShowDialog(this);
+
+        await _viewModel.OnSettingsClosedAsync(settingsVm.DidSave);
     }
 
     private void FocusRecentQsoSearchBox()

--- a/src/dotnet/QsoRipper.Gui/Views/QrzLogbookStepView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/QrzLogbookStepView.axaml
@@ -1,0 +1,36 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:QsoRipper.Gui.ViewModels"
+             x:Class="QsoRipper.Gui.Views.QrzLogbookStepView"
+             x:DataType="vm:QrzLogbookStepViewModel">
+
+  <StackPanel Spacing="12">
+    <TextBlock TextWrapping="Wrap" Opacity="0.7"
+               Text="Enter your QRZ.com Logbook API key. You can find this at qrz.com → Logbook → Settings → API Key." />
+
+    <TextBlock Text="QRZ Logbook API Key:" FontWeight="SemiBold" />
+    <TextBox Text="{Binding ApiKey, Mode=TwoWay}"
+             PasswordChar="•"
+             PlaceholderText="Paste your API key here" />
+
+    <TextBlock Text="A key is already configured. Leave blank to keep it."
+               IsVisible="{Binding HasExistingKey}"
+               Opacity="0.6" FontSize="12" />
+
+    <CheckBox Content="Enable automatic sync"
+              IsChecked="{Binding AutoSyncEnabled, Mode=TwoWay}"
+              Margin="0,8,0,0" />
+
+    <StackPanel Spacing="4" IsEnabled="{Binding IsSyncIntervalEnabled}">
+      <TextBlock Text="Sync interval (seconds):" FontWeight="SemiBold" />
+      <NumericUpDown Value="{Binding SyncIntervalSeconds, Mode=TwoWay}"
+                     Minimum="60" Maximum="3600" Increment="60"
+                     FormatString="0" />
+      <TextBlock Text="How often to sync with QRZ logbook (60–3600 seconds)."
+                 Opacity="0.6" FontSize="12" />
+    </StackPanel>
+
+    <TextBlock Text="If you don't have a QRZ Logbook API key, skip this step — local logging works without it."
+               Opacity="0.5" TextWrapping="Wrap" FontSize="12" Margin="0,8,0,0" />
+  </StackPanel>
+</UserControl>

--- a/src/dotnet/QsoRipper.Gui/Views/QrzLogbookStepView.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/QrzLogbookStepView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace QsoRipper.Gui.Views;
+
+internal sealed partial class QrzLogbookStepView : UserControl
+{
+    public QrzLogbookStepView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
@@ -5,8 +5,9 @@
         x:Class="QsoRipper.Gui.Views.SettingsView"
         x:DataType="vm:SettingsViewModel"
         Title="Settings"
-        Width="560" Height="640"
+        Width="560" Height="780"
         MinWidth="480" MinHeight="520"
+        MaxHeight="900"
         WindowStartupLocation="CenterOwner"
         CanResize="True">
 

--- a/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
@@ -1,0 +1,282 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:QsoRipper.Gui.ViewModels"
+        xmlns:v="using:QsoRipper.Gui.Views"
+        x:Class="QsoRipper.Gui.Views.SettingsView"
+        x:DataType="vm:SettingsViewModel"
+        Title="Settings"
+        Width="560" Height="640"
+        MinWidth="480" MinHeight="520"
+        WindowStartupLocation="CenterOwner"
+        CanResize="True">
+
+  <Window.KeyBindings>
+    <KeyBinding Gesture="Escape" Command="{Binding CancelCommand}" />
+  </Window.KeyBindings>
+
+  <DockPanel>
+    <!-- Footer: Save / Cancel -->
+    <Border DockPanel.Dock="Bottom"
+            Padding="16,10"
+            BorderThickness="0,1,0,0"
+            BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}">
+      <DockPanel>
+        <TextBlock DockPanel.Dock="Left"
+                   Text="{Binding ErrorMessage}"
+                   Foreground="IndianRed"
+                   FontWeight="SemiBold"
+                   TextWrapping="Wrap"
+                   VerticalAlignment="Center"
+                   IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+
+        <StackPanel DockPanel.Dock="Right"
+                    Orientation="Horizontal"
+                    Spacing="8"
+                    HorizontalAlignment="Right">
+          <Button Content="Cancel"
+                  Command="{Binding CancelCommand}"
+                  IsEnabled="{Binding !IsSaving}" />
+          <Button Content="Save"
+                  Command="{Binding SaveCommand}"
+                  Classes="accent"
+                  IsDefault="True"
+                  IsEnabled="{Binding !IsSaving}" />
+        </StackPanel>
+      </DockPanel>
+    </Border>
+
+    <!-- Loading indicator -->
+    <ProgressBar DockPanel.Dock="Top"
+                 IsIndeterminate="True"
+                 IsVisible="{Binding IsLoading}"
+                 Margin="0,0,0,4" />
+
+    <!-- Scrollable settings form -->
+    <ScrollViewer VerticalScrollBarVisibility="Auto"
+                  HorizontalScrollBarVisibility="Disabled"
+                  Padding="24,16">
+      <StackPanel Spacing="20">
+
+        <!-- Station Profile -->
+        <StackPanel Spacing="8">
+          <TextBlock Text="Station Profile"
+                     FontSize="16" FontWeight="SemiBold" />
+
+          <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto"
+                ColumnSpacing="12" RowSpacing="6">
+            <TextBlock Grid.Row="0" Grid.Column="0"
+                       Text="Callsign:" VerticalAlignment="Center" />
+            <TextBox Grid.Row="0" Grid.Column="1"
+                     Text="{Binding Callsign, Mode=TwoWay}"
+                     PlaceholderText="e.g. W1AW" />
+
+            <TextBlock Grid.Row="1" Grid.Column="0"
+                       Text="Grid Square:" VerticalAlignment="Center" />
+            <TextBox Grid.Row="1" Grid.Column="1"
+                     Text="{Binding GridSquare, Mode=TwoWay}"
+                     PlaceholderText="e.g. FN31" />
+
+            <TextBlock Grid.Row="2" Grid.Column="0"
+                       Text="Operator Name:" VerticalAlignment="Center" />
+            <TextBox Grid.Row="2" Grid.Column="1"
+                     Text="{Binding OperatorName, Mode=TwoWay}" />
+
+            <TextBlock Grid.Row="3" Grid.Column="0"
+                       Text="Operator Call:" VerticalAlignment="Center" />
+            <TextBox Grid.Row="3" Grid.Column="1"
+                     Text="{Binding OperatorCallsign, Mode=TwoWay}" />
+
+            <TextBlock Grid.Row="4" Grid.Column="0"
+                       Text="Profile Name:" VerticalAlignment="Center" />
+            <TextBox Grid.Row="4" Grid.Column="1"
+                     Text="{Binding ProfileName, Mode=TwoWay}"
+                     PlaceholderText="Default" />
+          </Grid>
+
+          <!-- Expander for extended station fields -->
+          <Expander Header="More Station Fields" Padding="0,4">
+            <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                  ColumnSpacing="12" RowSpacing="6" Margin="0,4,0,0">
+              <TextBlock Grid.Row="0" Grid.Column="0"
+                         Text="County:" VerticalAlignment="Center" />
+              <TextBox Grid.Row="0" Grid.Column="1"
+                       Text="{Binding County, Mode=TwoWay}" />
+
+              <TextBlock Grid.Row="1" Grid.Column="0"
+                         Text="State:" VerticalAlignment="Center" />
+              <TextBox Grid.Row="1" Grid.Column="1"
+                       Text="{Binding State, Mode=TwoWay}" />
+
+              <TextBlock Grid.Row="2" Grid.Column="0"
+                         Text="Country:" VerticalAlignment="Center" />
+              <TextBox Grid.Row="2" Grid.Column="1"
+                       Text="{Binding Country, Mode=TwoWay}" />
+
+              <TextBlock Grid.Row="3" Grid.Column="0"
+                         Text="DXCC:" VerticalAlignment="Center" />
+              <TextBox Grid.Row="3" Grid.Column="1"
+                       Text="{Binding Dxcc, Mode=TwoWay}"
+                       PlaceholderText="e.g. 291" />
+
+              <TextBlock Grid.Row="4" Grid.Column="0"
+                         Text="CQ Zone:" VerticalAlignment="Center" />
+              <TextBox Grid.Row="4" Grid.Column="1"
+                       Text="{Binding CqZone, Mode=TwoWay}" />
+
+              <TextBlock Grid.Row="5" Grid.Column="0"
+                         Text="ITU Zone:" VerticalAlignment="Center" />
+              <TextBox Grid.Row="5" Grid.Column="1"
+                       Text="{Binding ItuZone, Mode=TwoWay}" />
+
+              <TextBlock Grid.Row="6" Grid.Column="0"
+                         Text="Latitude:" VerticalAlignment="Center" />
+              <TextBox Grid.Row="6" Grid.Column="1"
+                       Text="{Binding Latitude, Mode=TwoWay}"
+                       PlaceholderText="Decimal degrees" />
+
+              <TextBlock Grid.Row="7" Grid.Column="0"
+                         Text="Longitude:" VerticalAlignment="Center" />
+              <TextBox Grid.Row="7" Grid.Column="1"
+                       Text="{Binding Longitude, Mode=TwoWay}"
+                       PlaceholderText="Decimal degrees" />
+
+              <TextBlock Grid.Row="8" Grid.Column="0"
+                         Text="ARRL Section:" VerticalAlignment="Center" />
+              <TextBox Grid.Row="8" Grid.Column="1"
+                       Text="{Binding ArrlSection, Mode=TwoWay}" />
+            </Grid>
+          </Expander>
+        </StackPanel>
+
+        <Separator />
+
+        <!-- QRZ XML Credentials -->
+        <StackPanel Spacing="8">
+          <TextBlock Text="QRZ XML Lookup"
+                     FontSize="16" FontWeight="SemiBold" />
+          <TextBlock Text="Used for callsign lookups. Leave blank to disable."
+                     Opacity="0.6" TextWrapping="Wrap" />
+
+          <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto"
+                ColumnSpacing="12" RowSpacing="6">
+            <TextBlock Grid.Row="0" Grid.Column="0"
+                       Text="Username:" VerticalAlignment="Center" />
+            <TextBox Grid.Row="0" Grid.Column="1"
+                     Text="{Binding QrzXmlUsername, Mode=TwoWay}" />
+
+            <TextBlock Grid.Row="1" Grid.Column="0"
+                       Text="Password:" VerticalAlignment="Center" />
+            <TextBox Grid.Row="1" Grid.Column="1"
+                     Text="{Binding QrzXmlPassword, Mode=TwoWay}"
+                     PasswordChar="•"
+                     PlaceholderText="Enter to update" />
+          </Grid>
+
+          <StackPanel Orientation="Horizontal" Spacing="12">
+            <Button Content="Test XML Connection"
+                    Command="{Binding TestQrzXmlCommand}"
+                    IsEnabled="{Binding !IsTestingQrzXml}" />
+            <ProgressBar IsIndeterminate="True"
+                         IsVisible="{Binding IsTestingQrzXml}"
+                         Width="100" VerticalAlignment="Center" />
+          </StackPanel>
+
+          <TextBlock Text="{Binding QrzXmlTestResult}"
+                     TextWrapping="Wrap"
+                     IsVisible="{Binding QrzXmlTestResult, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                     Foreground="{Binding QrzXmlTestSucceeded, Converter={x:Static v:SettingsView.TestResultColor}}" />
+        </StackPanel>
+
+        <Separator />
+
+        <!-- QRZ Logbook -->
+        <StackPanel Spacing="8">
+          <TextBlock Text="QRZ Logbook Sync"
+                     FontSize="16" FontWeight="SemiBold" />
+          <TextBlock Text="API key for bidirectional sync with logbook.qrz.com."
+                     Opacity="0.6" TextWrapping="Wrap" />
+
+          <Grid ColumnDefinitions="140,*" RowDefinitions="Auto"
+                ColumnSpacing="12" RowSpacing="6">
+            <TextBlock Grid.Row="0" Grid.Column="0"
+                       Text="API Key:" VerticalAlignment="Center" />
+            <TextBox Grid.Row="0" Grid.Column="1"
+                     Text="{Binding QrzLogbookApiKey, Mode=TwoWay}"
+                     PasswordChar="•"
+                     PlaceholderText="Enter to update" />
+          </Grid>
+
+          <StackPanel Orientation="Horizontal" Spacing="12">
+            <Button Content="Test Logbook"
+                    Command="{Binding TestQrzLogbookCommand}"
+                    IsEnabled="{Binding !IsTestingLogbook}" />
+            <ProgressBar IsIndeterminate="True"
+                         IsVisible="{Binding IsTestingLogbook}"
+                         Width="100" VerticalAlignment="Center" />
+          </StackPanel>
+
+          <TextBlock Text="{Binding LogbookTestResult}"
+                     TextWrapping="Wrap"
+                     IsVisible="{Binding LogbookTestResult, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                     Foreground="{Binding LogbookTestSucceeded, Converter={x:Static v:SettingsView.TestResultColor}}" />
+        </StackPanel>
+
+        <Separator />
+
+        <!-- Sync Settings -->
+        <StackPanel Spacing="8">
+          <TextBlock Text="Sync Settings"
+                     FontSize="16" FontWeight="SemiBold" />
+
+          <CheckBox Content="Enable automatic sync"
+                    IsChecked="{Binding AutoSyncEnabled, Mode=TwoWay}" />
+
+          <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto"
+                ColumnSpacing="12" RowSpacing="6">
+            <TextBlock Grid.Row="0" Grid.Column="0"
+                       Text="Interval (sec):" VerticalAlignment="Center" />
+            <NumericUpDown Grid.Row="0" Grid.Column="1"
+                          Value="{Binding SyncIntervalSeconds, Mode=TwoWay}"
+                          Minimum="30" Maximum="86400"
+                          Increment="30"
+                          FormatString="F0"
+                          HorizontalAlignment="Left"
+                          Width="140" />
+
+            <TextBlock Grid.Row="1" Grid.Column="0"
+                       Text="Conflict Policy:" VerticalAlignment="Center" />
+            <ComboBox Grid.Row="1" Grid.Column="1"
+                      SelectedIndex="{Binding ConflictPolicy, Mode=TwoWay, Converter={x:Static v:SettingsView.ConflictPolicyIndex}}"
+                      HorizontalAlignment="Left"
+                      Width="220">
+              <ComboBoxItem Content="Last Write Wins" />
+              <ComboBoxItem Content="Flag for Review" />
+            </ComboBox>
+          </Grid>
+        </StackPanel>
+
+        <Separator />
+
+        <!-- Log File Path (informational) -->
+        <StackPanel Spacing="8">
+          <TextBlock Text="Log File"
+                     FontSize="16" FontWeight="SemiBold" />
+
+          <Grid ColumnDefinitions="140,*"
+                ColumnSpacing="12">
+            <TextBlock Grid.Column="0"
+                       Text="Path:" VerticalAlignment="Center" />
+            <TextBox Grid.Column="1"
+                     Text="{Binding LogFilePath, Mode=TwoWay}" />
+          </Grid>
+        </StackPanel>
+
+        <!-- Saving indicator -->
+        <ProgressBar IsIndeterminate="True"
+                     IsVisible="{Binding IsSaving}"
+                     Margin="0,8,0,0" />
+
+      </StackPanel>
+    </ScrollViewer>
+  </DockPanel>
+</Window>

--- a/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Globalization;
+using Avalonia.Controls;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using QsoRipper.Domain;
+using QsoRipper.Gui.ViewModels;
+
+namespace QsoRipper.Gui.Views;
+
+internal sealed partial class SettingsView : Window
+{
+    public SettingsView()
+    {
+        InitializeComponent();
+        DataContextChanged += OnDataContextChanged;
+    }
+
+    /// <summary>
+    /// Converts a bool (success/failure) to a green or red brush for test result text.
+    /// </summary>
+    public static readonly FuncValueConverter<bool, IBrush> TestResultColor =
+        new(success => success ? Brushes.ForestGreen : Brushes.IndianRed);
+
+    /// <summary>
+    /// Two-way converter between <see cref="ConflictPolicy"/> enum and ComboBox selected index.
+    /// </summary>
+    public static readonly IValueConverter ConflictPolicyIndex = new ConflictPolicyIndexConverter();
+
+    private void OnDataContextChanged(object? sender, EventArgs e)
+    {
+        if (DataContext is SettingsViewModel vm)
+        {
+            vm.CloseRequested += OnCloseRequested;
+        }
+    }
+
+    private void OnCloseRequested(object? sender, bool didSave)
+    {
+        if (sender is SettingsViewModel vm)
+        {
+            vm.CloseRequested -= OnCloseRequested;
+        }
+
+        Close(didSave);
+    }
+
+    protected override void OnClosed(EventArgs e)
+    {
+        if (DataContext is SettingsViewModel vm)
+        {
+            vm.CloseRequested -= OnCloseRequested;
+        }
+
+        base.OnClosed(e);
+    }
+
+    private sealed class ConflictPolicyIndexConverter : IValueConverter
+    {
+        public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            return value is ConflictPolicy policy ? (int)policy : 0;
+        }
+
+        public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            return value is int index && Enum.IsDefined(typeof(ConflictPolicy), index)
+                ? (ConflictPolicy)index
+                : ConflictPolicy.LastWriteWins;
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Views/SetupWizardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/SetupWizardView.axaml
@@ -85,6 +85,9 @@
               <DataTemplate DataType="vm:QrzStepViewModel">
                 <v:QrzStepView />
               </DataTemplate>
+              <DataTemplate DataType="vm:QrzLogbookStepViewModel">
+                <v:QrzLogbookStepView />
+              </DataTemplate>
               <DataTemplate DataType="vm:ReviewStepViewModel">
                 <v:ReviewStepView />
               </DataTemplate>

--- a/src/rust/qsoripper-core/src/adif/mod.rs
+++ b/src/rust/qsoripper-core/src/adif/mod.rs
@@ -17,12 +17,33 @@ use std::fmt::Write as _;
 ///
 /// Returns an error when the ADIF payload is malformed and cannot be parsed.
 pub async fn parse_adi_qsos(data: &[u8]) -> Result<Vec<QsoRecord>, String> {
-    let mut stream = RecordStream::new(data, true);
+    parse_adi_qsos_internal(data, true).await
+}
+
+/// Parse an ADI payload while treating all records as QSO records.
+///
+/// This variant disables header detection, which is useful for provider payloads
+/// that omit `<EOH>` or otherwise confuse header classification.
+///
+/// # Errors
+///
+/// Returns an error when the ADIF payload is malformed and cannot be parsed.
+pub async fn parse_adi_qsos_without_header_detection(
+    data: &[u8],
+) -> Result<Vec<QsoRecord>, String> {
+    parse_adi_qsos_internal(data, false).await
+}
+
+async fn parse_adi_qsos_internal(
+    data: &[u8],
+    detect_headers: bool,
+) -> Result<Vec<QsoRecord>, String> {
+    let mut stream = RecordStream::new(data, detect_headers);
     let mut qsos = Vec::new();
 
     while let Some(result) = stream.next().await {
         let record = result.map_err(|error| error.to_string())?;
-        if record.is_header() {
+        if detect_headers && record.is_header() {
             continue;
         }
 
@@ -64,7 +85,7 @@ fn adif_header() -> String {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
-    use super::{parse_adi_qsos, serialize_adi_qsos};
+    use super::{parse_adi_qsos, parse_adi_qsos_without_header_detection, serialize_adi_qsos};
 
     #[tokio::test]
     async fn parse_adi_qsos_skips_header_records() {
@@ -83,5 +104,14 @@ mod tests {
         assert!(text.contains("<ADIF_VER:5>3.1.7"));
         assert!(text.contains("<PROGRAMID:9>QsoRipper"));
         assert!(text.contains("<EOH>"));
+    }
+
+    #[tokio::test]
+    async fn parse_adi_qsos_without_header_detection_parses_basic_payload() {
+        let data = b"<CALL:4>W1AW <QSO_DATE:8>20250101 <TIME_ON:4>1200 <EOR>\n";
+        let qsos = parse_adi_qsos_without_header_detection(data)
+            .await
+            .expect("parsed qsos");
+        assert_eq!(qsos.len(), 1);
     }
 }

--- a/src/rust/qsoripper-core/src/application/logbook.rs
+++ b/src/rust/qsoripper-core/src/application/logbook.rs
@@ -31,6 +31,16 @@ impl LogbookEngine {
         self.storage.backend_name()
     }
 
+    /// Return the logbook-oriented storage surface for direct store access.
+    ///
+    /// Used by the sync workflow which needs fine-grained control over
+    /// individual QSO reads and writes without the validation/normalization
+    /// pipeline applied by the higher-level CRUD methods on this engine.
+    #[must_use]
+    pub fn logbook_store(&self) -> &dyn crate::storage::LogbookStore {
+        self.storage.logbook()
+    }
+
     /// Persist a new QSO and return the normalized stored record.
     ///
     /// # Errors

--- a/src/rust/qsoripper-core/src/lib.rs
+++ b/src/rust/qsoripper-core/src/lib.rs
@@ -13,5 +13,7 @@ pub mod ffi;
 pub mod lookup;
 /// Generated protobuf and gRPC bindings.
 pub mod proto;
+/// QRZ Logbook API client for bidirectional QSO sync.
+pub mod qrz_logbook;
 /// Storage ports, errors, and query types for engine-owned persistence.
 pub mod storage;

--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -226,6 +226,25 @@ fn is_auth_error(reason: &str) -> bool {
         || lower.contains("access denied")
 }
 
+/// Extract the ADIF payload from a QRZ FETCH response body.
+///
+/// QRZ FETCH responses use the format:
+///   `RESULT=OK&COUNT=773&ADIF=<time_off:4>2328\n<qso_date_off:8>...`
+///
+/// The ADIF data starts immediately after `ADIF=` and runs to the end of
+/// the body. We cannot use `parse_kv_response` to extract it because the
+/// ADIF content contains `&` and `=` characters inside angle-bracket fields.
+fn extract_adif_from_fetch_body(body: &str) -> Option<String> {
+    // Case-insensitive search for the ADIF= marker.
+    let upper = body.to_ascii_uppercase();
+    let marker_pos = upper.find("ADIF=")?;
+    let start = marker_pos + "ADIF=".len();
+    if start >= body.len() {
+        return None;
+    }
+    Some(body[start..].to_string())
+}
+
 // ---------------------------------------------------------------------------
 // Client
 // ---------------------------------------------------------------------------
@@ -297,12 +316,33 @@ impl QrzLogbookClient {
             .post_form(&[("ACTION", "FETCH"), ("OPTION", &option_value)])
             .await?;
 
-        // The FETCH response body is ADIF data.  If QRZ returned a kv error
-        // instead (e.g. RESULT=FAIL), detect that first.
+        // QRZ FETCH responses use the format:
+        //   RESULT=OK&COUNT=N&ADIF=<adif data here...>
+        // The ADIF key's value contains newlines and the full record set.
+        // If RESULT=FAIL, detect and report the error.
         if body.trim_start().starts_with("RESULT=") {
-            let map = parse_kv_response(&body);
+            // Extract the ADIF portion before parsing the kv header.
+            // The ADIF data starts after "ADIF=" and may contain '&' chars
+            // inside field values, so we locate the marker directly.
+            let adif_data = extract_adif_from_fetch_body(&body);
+
+            // Parse only the header portion (before the ADIF data) for
+            // RESULT/COUNT/REASON etc.
+            let header = match body.find("ADIF=") {
+                Some(pos) => &body[..pos],
+                None => &body,
+            };
+            let map = parse_kv_response(header);
             check_result(map)?;
-            // If RESULT=OK but no ADIF data, return empty.
+
+            // Parse whatever ADIF data was present.
+            if let Some(adif) = adif_data {
+                if !adif.trim().is_empty() {
+                    return adif::parse_adi_qsos(adif.as_bytes())
+                        .await
+                        .map_err(QrzLogbookError::ParseError);
+                }
+            }
             return Ok(Vec::new());
         }
 
@@ -832,6 +872,44 @@ mod tests {
         let qsos = client.fetch_qsos(None).await.expect("fetch");
 
         assert!(qsos.is_empty());
+    }
+
+    #[tokio::test]
+    async fn fetch_qsos_parses_result_ok_with_inline_adif() {
+        // Real QRZ FETCH format: RESULT=OK&COUNT=N&ADIF=<adif records...>
+        let body = "RESULT=OK&COUNT=2&ADIF=<CALL:4>W1AW <BAND:3>20M <MODE:3>SSB \
+                    <QSO_DATE:8>20250101 <TIME_ON:4>1200 <EOR>\n\
+                    <CALL:6>N0CALL <BAND:3>40M <MODE:2>CW \
+                    <QSO_DATE:8>20250102 <TIME_ON:4>1300 <EOR>\n";
+        let (base_url, _) = spawn_logbook_server(&[("text/plain", body)]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qsos = client.fetch_qsos(None).await.expect("fetch");
+
+        assert_eq!(qsos.len(), 2, "expected 2 QSOs from inline ADIF");
+        assert_eq!(qsos[0].worked_callsign, "W1AW");
+        assert_eq!(qsos[1].worked_callsign, "N0CALL");
+    }
+
+    #[test]
+    fn extract_adif_from_fetch_body_extracts_content() {
+        let body = "RESULT=OK&COUNT=1&ADIF=<CALL:4>W1AW <EOR>\n";
+        let adif = extract_adif_from_fetch_body(body);
+        assert_eq!(adif.as_deref(), Some("<CALL:4>W1AW <EOR>\n"));
+    }
+
+    #[test]
+    fn extract_adif_from_fetch_body_returns_none_when_missing() {
+        let body = "RESULT=OK&COUNT=0";
+        let adif = extract_adif_from_fetch_body(body);
+        assert!(adif.is_none());
+    }
+
+    #[test]
+    fn extract_adif_from_fetch_body_case_insensitive() {
+        let body = "RESULT=OK&COUNT=1&adif=<CALL:4>W1AW <EOR>\n";
+        let adif = extract_adif_from_fetch_body(body);
+        assert_eq!(adif.as_deref(), Some("<CALL:4>W1AW <EOR>\n"));
     }
 
     // -- upload_qso integration ---------------------------------------------

--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -226,6 +226,16 @@ fn is_auth_error(reason: &str) -> bool {
         || lower.contains("access denied")
 }
 
+fn find_adif_marker_index(body: &str) -> Option<usize> {
+    body.to_ascii_uppercase().find("ADIF=")
+}
+
+fn starts_with_result_header(body: &str) -> bool {
+    body.trim_start()
+        .get(..7)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("RESULT="))
+}
+
 /// Extract the ADIF payload from a QRZ FETCH response body.
 ///
 /// QRZ FETCH responses use the format:
@@ -235,14 +245,97 @@ fn is_auth_error(reason: &str) -> bool {
 /// the body. We cannot use `parse_kv_response` to extract it because the
 /// ADIF content contains `&` and `=` characters inside angle-bracket fields.
 fn extract_adif_from_fetch_body(body: &str) -> Option<String> {
-    // Case-insensitive search for the ADIF= marker.
-    let upper = body.to_ascii_uppercase();
-    let marker_pos = upper.find("ADIF=")?;
+    let marker_pos = find_adif_marker_index(body)?;
     let start = marker_pos + "ADIF=".len();
     if start >= body.len() {
         return None;
     }
     Some(body[start..].to_string())
+}
+
+/// Decode HTML entities that QRZ may return for FETCH ADIF payloads.
+fn decode_fetch_adif_payload(payload: &str) -> String {
+    if !payload.contains('&') {
+        return payload.to_string();
+    }
+
+    payload
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+        .replace("&#39;", "'")
+        // Decode ampersands last to avoid re-encoding other entities.
+        .replace("&amp;", "&")
+}
+
+/// Ensure ADIF has an explicit `<EOH>` marker so the parser treats entries as
+/// QSO records even when the payload starts with arbitrary field order.
+fn ensure_adif_has_eoh(payload: &str) -> String {
+    if payload.to_ascii_uppercase().contains("<EOH>") {
+        payload.to_string()
+    } else {
+        format!("<EOH>\n{payload}")
+    }
+}
+
+fn normalize_adif_record_markers(payload: &str) -> String {
+    payload.replace("<eor>", "<EOR>").replace("<eoh>", "<EOH>")
+}
+
+async fn parse_adif_records_tolerantly(payload: &str) -> Vec<QsoRecord> {
+    if !payload.to_ascii_uppercase().contains("<EOR>") {
+        return Vec::new();
+    }
+
+    let mut parsed = Vec::new();
+    for record_fragment in payload.split("<EOR>") {
+        let record = record_fragment.trim();
+        if record.is_empty() {
+            continue;
+        }
+
+        let candidate = format!("<EOH>\n{record}<EOR>\n");
+        if let Ok(mut qsos) =
+            adif::parse_adi_qsos_without_header_detection(candidate.as_bytes()).await
+        {
+            parsed.append(&mut qsos);
+        }
+    }
+
+    parsed
+}
+
+async fn parse_fetch_adif_payload(
+    adif_payload: &str,
+    expected_count: Option<usize>,
+) -> Result<Vec<QsoRecord>, QrzLogbookError> {
+    let decoded_adif = decode_fetch_adif_payload(adif_payload);
+    let normalized_markers = normalize_adif_record_markers(&decoded_adif);
+    let normalized_adif = ensure_adif_has_eoh(&normalized_markers);
+
+    let strict_result = adif::parse_adi_qsos(normalized_adif.as_bytes()).await;
+    let strict_parse_error = match strict_result {
+        Ok(qsos) if !qsos.is_empty() => {
+            let over_parsed =
+                expected_count.is_some_and(|expected| expected > 0 && qsos.len() > expected);
+            if !over_parsed {
+                return Ok(qsos);
+            }
+            None
+        }
+        Ok(_) => None,
+        Err(err) => Some(err),
+    };
+
+    let tolerant = parse_adif_records_tolerantly(&normalized_adif).await;
+    if !tolerant.is_empty() {
+        return Ok(tolerant);
+    }
+
+    if let Some(err) = strict_parse_error {
+        return Err(QrzLogbookError::ParseError(err));
+    }
+    Ok(Vec::new())
 }
 
 // ---------------------------------------------------------------------------
@@ -316,34 +409,31 @@ impl QrzLogbookClient {
             .post_form(&[("ACTION", "FETCH"), ("OPTION", &option_value)])
             .await?;
 
-        // QRZ FETCH responses use the format:
-        //   RESULT=OK&COUNT=N&ADIF=<adif data here...>
-        // The ADIF key's value contains newlines and the full record set.
-        // If RESULT=FAIL, detect and report the error.
-        if body.trim_start().starts_with("RESULT=") {
-            // Extract the ADIF portion before parsing the kv header.
-            // The ADIF data starts after "ADIF=" and may contain '&' chars
-            // inside field values, so we locate the marker directly.
-            let adif_data = extract_adif_from_fetch_body(&body);
-
-            // Parse only the header portion (before the ADIF data) for
-            // RESULT/COUNT/REASON etc.
-            let header = match body.find("ADIF=") {
-                Some(pos) => &body[..pos],
-                None => &body,
-            };
-            let map = parse_kv_response(header);
+        // Some error/empty FETCH responses are key-value only (no ADIF field).
+        if starts_with_result_header(&body) && find_adif_marker_index(&body).is_none() {
+            let map = parse_kv_response(&body);
             check_result(map)?;
-
-            // Parse whatever ADIF data was present.
-            if let Some(adif) = adif_data {
-                if !adif.trim().is_empty() {
-                    return adif::parse_adi_qsos(adif.as_bytes())
-                        .await
-                        .map_err(QrzLogbookError::ParseError);
-                }
-            }
             return Ok(Vec::new());
+        }
+
+        // QRZ FETCH responses commonly use:
+        //   RESULT=OK&COUNT=N&ADIF=<adif data...>
+        // Detect that shape by splitting at ADIF= and checking for RESULT in
+        // the prefix.
+        if let Some(marker_pos) = find_adif_marker_index(&body) {
+            let header = &body[..marker_pos];
+            let map = parse_kv_response(header);
+            if map.contains_key("RESULT") {
+                let map = check_result(map)?;
+                let expected_count = map
+                    .get("COUNT")
+                    .and_then(|value| value.parse::<usize>().ok());
+                let adif = extract_adif_from_fetch_body(&body).unwrap_or_default();
+                if !adif.trim().is_empty() {
+                    return parse_fetch_adif_payload(&adif, expected_count).await;
+                }
+                return Ok(Vec::new());
+            }
         }
 
         adif::parse_adi_qsos(body.as_bytes())
@@ -891,6 +981,48 @@ mod tests {
         assert_eq!(qsos[1].worked_callsign, "N0CALL");
     }
 
+    #[tokio::test]
+    async fn fetch_qsos_decodes_html_encoded_inline_adif() {
+        let body = "RESULT=OK&COUNT=1&ADIF=&lt;CALL:4&gt;W1AW &lt;BAND:3&gt;20M \
+                    &lt;MODE:3&gt;SSB &lt;QSO_DATE:8&gt;20250101 &lt;TIME_ON:4&gt;1200 \
+                    &lt;EOR&gt;\n";
+        let (base_url, _) = spawn_logbook_server(&[("text/plain", body)]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qsos = client.fetch_qsos(None).await.expect("fetch");
+
+        assert_eq!(qsos.len(), 1, "expected one decoded QSO");
+        assert_eq!(qsos[0].worked_callsign, "W1AW");
+    }
+
+    #[tokio::test]
+    async fn fetch_qsos_decodes_html_encoded_lowercase_eor_markers() {
+        let body = "RESULT=OK&COUNT=1&ADIF=&lt;CALL:4&gt;W1AW &lt;BAND:3&gt;20M \
+                    &lt;MODE:3&gt;SSB &lt;QSO_DATE:8&gt;20250101 &lt;TIME_ON:4&gt;1200 \
+                    &lt;eor&gt;\n";
+        let (base_url, _) = spawn_logbook_server(&[("text/plain", body)]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qsos = client.fetch_qsos(None).await.expect("fetch");
+
+        assert_eq!(qsos.len(), 1, "expected one decoded QSO");
+        assert_eq!(qsos[0].worked_callsign, "W1AW");
+    }
+
+    #[tokio::test]
+    async fn fetch_qsos_parses_inline_adif_without_eoh_and_non_call_first_field() {
+        // QRZ often starts each record with fields like DXCC/FREQ before CALL.
+        let body = "RESULT=OK&COUNT=1&ADIF=<DXCC:3>339 <FREQ:6>28.405 <CALL:4>W1AW \
+                    <BAND:3>10M <MODE:3>SSB <QSO_DATE:8>20250101 <TIME_ON:4>1200 <EOR>\n";
+        let (base_url, _) = spawn_logbook_server(&[("text/plain", body)]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qsos = client.fetch_qsos(None).await.expect("fetch");
+
+        assert_eq!(qsos.len(), 1, "expected one QSO from non-CALL-first record");
+        assert_eq!(qsos[0].worked_callsign, "W1AW");
+    }
+
     #[test]
     fn extract_adif_from_fetch_body_extracts_content() {
         let body = "RESULT=OK&COUNT=1&ADIF=<CALL:4>W1AW <EOR>\n";
@@ -910,6 +1042,34 @@ mod tests {
         let body = "RESULT=OK&COUNT=1&adif=<CALL:4>W1AW <EOR>\n";
         let adif = extract_adif_from_fetch_body(body);
         assert_eq!(adif.as_deref(), Some("<CALL:4>W1AW <EOR>\n"));
+    }
+
+    #[test]
+    fn decode_fetch_adif_payload_decodes_entities() {
+        let encoded = "&lt;CALL:4&gt;W1AW &lt;EOR&gt; &amp; &quot;OK&quot; &#39;QSO&#39;";
+        let decoded = decode_fetch_adif_payload(encoded);
+        assert_eq!(decoded, "<CALL:4>W1AW <EOR> & \"OK\" 'QSO'");
+    }
+
+    #[test]
+    fn ensure_adif_has_eoh_adds_header_marker_when_missing() {
+        let payload = "<CALL:4>W1AW <EOR>\n";
+        let normalized = ensure_adif_has_eoh(payload);
+        assert!(normalized.starts_with("<EOH>\n"));
+    }
+
+    #[test]
+    fn ensure_adif_has_eoh_preserves_existing_marker() {
+        let payload = "<ADIF_VER:5>3.1.0\n<EOH>\n<CALL:4>W1AW <EOR>\n";
+        let normalized = ensure_adif_has_eoh(payload);
+        assert_eq!(normalized, payload);
+    }
+
+    #[test]
+    fn normalize_adif_record_markers_converts_lowercase_markers() {
+        let payload = "<CALL:4>W1AW <eor>\n<eoh>\n";
+        let normalized = normalize_adif_record_markers(payload);
+        assert_eq!(normalized, "<CALL:4>W1AW <EOR>\n<EOH>\n");
     }
 
     // -- upload_qso integration ---------------------------------------------

--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -1,0 +1,957 @@
+//! QRZ Logbook API client for bidirectional QSO sync.
+//!
+//! This module talks to the QRZ Logbook HTTP API (`https://logbook.qrz.com/api`)
+//! to fetch, upload, and delete QSO records. Authentication uses a
+//! per-user API key (distinct from the QRZ XML session key used for callsign
+//! enrichment in [`crate::lookup::qrz_xml`]).
+//!
+//! Responses from the QRZ Logbook API come in two forms:
+//! - **Key-value** pairs (`KEY=VALUE&KEY=VALUE`) for status, insert, and delete.
+//! - **ADIF** payload for the FETCH action.
+//!
+//! The client reuses the existing [`crate::adif`] module for ADIF
+//! parsing and serialization.
+
+use std::{collections::HashMap, env, fmt, time::Duration};
+
+use reqwest::Client;
+
+use crate::{
+    adif::{self, mapper::AdifMapper},
+    proto::qsoripper::domain::QsoRecord,
+};
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Default QRZ Logbook API endpoint.
+pub const DEFAULT_QRZ_LOGBOOK_BASE_URL: &str = "https://logbook.qrz.com/api";
+
+/// Default user-agent string sent with requests.
+const DEFAULT_USER_AGENT: &str = "QsoRipper/0.1";
+
+/// Environment variable that provides the QRZ Logbook API key.
+pub const QRZ_LOGBOOK_API_KEY_ENV_VAR: &str = "QSORIPPER_QRZ_LOGBOOK_API_KEY";
+
+/// Environment variable that overrides the QRZ Logbook base URL.
+pub const QRZ_LOGBOOK_BASE_URL_ENV_VAR: &str = "QSORIPPER_QRZ_LOGBOOK_BASE_URL";
+
+/// Environment variable that overrides the user-agent string.
+pub const QRZ_LOGBOOK_USER_AGENT_ENV_VAR: &str = "QSORIPPER_QRZ_LOGBOOK_USER_AGENT";
+
+/// Default HTTP timeout in seconds for logbook requests.
+const DEFAULT_HTTP_TIMEOUT_SECONDS: u64 = 30;
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for the QRZ Logbook API client.
+#[derive(Clone)]
+pub struct QrzLogbookConfig {
+    /// QRZ Logbook API key.
+    api_key: String,
+    /// Base URL for the logbook API endpoint.
+    base_url: String,
+    /// User-agent header sent with every request.
+    user_agent: String,
+    /// HTTP timeout per request.
+    http_timeout: Duration,
+}
+
+impl fmt::Debug for QrzLogbookConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("QrzLogbookConfig")
+            .field("api_key", &"<redacted>")
+            .field("base_url", &self.base_url)
+            .field("user_agent", &self.user_agent)
+            .field("http_timeout", &self.http_timeout)
+            .finish()
+    }
+}
+
+impl QrzLogbookConfig {
+    /// Create a configuration with explicit values.
+    #[must_use]
+    pub fn new(api_key: String, base_url: String, user_agent: String) -> Self {
+        Self {
+            api_key,
+            base_url,
+            user_agent,
+            http_timeout: Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECONDS),
+        }
+    }
+
+    /// Load configuration from environment variables.
+    ///
+    /// Required: `QSORIPPER_QRZ_LOGBOOK_API_KEY`
+    /// Optional: `QSORIPPER_QRZ_LOGBOOK_BASE_URL`, `QSORIPPER_QRZ_LOGBOOK_USER_AGENT`
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QrzLogbookError::AuthenticationFailed`] when the API key
+    /// environment variable is missing or blank.
+    pub fn from_env() -> Result<Self, QrzLogbookError> {
+        let api_key = env::var(QRZ_LOGBOOK_API_KEY_ENV_VAR)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                QrzLogbookError::AuthenticationFailed(format!(
+                    "Required environment variable '{QRZ_LOGBOOK_API_KEY_ENV_VAR}' is missing or blank"
+                ))
+            })?;
+
+        let base_url = env::var(QRZ_LOGBOOK_BASE_URL_ENV_VAR)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_QRZ_LOGBOOK_BASE_URL.to_string());
+
+        let user_agent = env::var(QRZ_LOGBOOK_USER_AGENT_ENV_VAR)
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_USER_AGENT.to_string());
+
+        Ok(Self::new(api_key, base_url, user_agent))
+    }
+
+    /// Return the configured base URL for diagnostics.
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
+
+/// Errors produced by the QRZ Logbook client.
+#[derive(Debug, thiserror::Error)]
+pub enum QrzLogbookError {
+    /// The API key was rejected or is missing.
+    #[error("QRZ Logbook authentication failed: {0}")]
+    AuthenticationFailed(String),
+
+    /// QRZ Logbook returned `RESULT=FAIL` with a reason.
+    #[error("QRZ Logbook API error: {0}")]
+    ApiError(String),
+
+    /// HTTP transport failure.
+    #[error("QRZ Logbook network error: {0}")]
+    NetworkError(#[from] reqwest::Error),
+
+    /// Response body could not be parsed as expected.
+    #[error("QRZ Logbook parse error: {0}")]
+    ParseError(String),
+
+    /// The server returned HTTP 429 Too Many Requests.
+    #[error("QRZ Logbook rate limited")]
+    RateLimited,
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+/// Result of a successful STATUS call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QrzLogbookStatus {
+    /// Owner callsign of the logbook.
+    pub owner: String,
+    /// Number of QSOs in the logbook.
+    pub qso_count: u32,
+}
+
+/// Result of a successful INSERT call.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QrzUploadResult {
+    /// QRZ-assigned logbook record identifier.
+    pub logid: String,
+}
+
+// ---------------------------------------------------------------------------
+// Response parsing helpers (pure functions, easily testable)
+// ---------------------------------------------------------------------------
+
+/// Parse a QRZ key-value response body (`KEY=VALUE&KEY=VALUE`) into a map.
+///
+/// QRZ sometimes returns values that contain `&` inside angle-bracket
+/// delimiters, so we do a simple split on `&` and `=`. Fields whose values
+/// are empty are still inserted.
+fn parse_kv_response(body: &str) -> HashMap<String, String> {
+    let trimmed = body.trim();
+    let mut map = HashMap::new();
+    for pair in trimmed.split('&') {
+        if let Some((key, value)) = pair.split_once('=') {
+            map.insert(key.to_uppercase(), value.to_string());
+        }
+    }
+    map
+}
+
+/// Check a parsed key-value response for `RESULT=OK`.
+///
+/// Returns `Ok(map)` when the result is OK, or an appropriate
+/// [`QrzLogbookError`] variant when it is not.
+fn check_result(map: HashMap<String, String>) -> Result<HashMap<String, String>, QrzLogbookError> {
+    match map.get("RESULT").map(String::as_str) {
+        Some("OK") => Ok(map),
+        Some("FAIL") => {
+            let reason = map
+                .get("REASON")
+                .cloned()
+                .unwrap_or_else(|| "unknown error".to_string());
+            if is_auth_error(&reason) {
+                Err(QrzLogbookError::AuthenticationFailed(reason))
+            } else {
+                Err(QrzLogbookError::ApiError(reason))
+            }
+        }
+        Some(other) => Err(QrzLogbookError::ParseError(format!(
+            "unexpected RESULT value: {other}"
+        ))),
+        None => Err(QrzLogbookError::ParseError(
+            "response missing RESULT field".to_string(),
+        )),
+    }
+}
+
+/// Determine whether a QRZ error reason indicates an authentication problem.
+fn is_auth_error(reason: &str) -> bool {
+    let lower = reason.to_ascii_lowercase();
+    lower.contains("invalid api key")
+        || lower.contains("api key required")
+        || lower.contains("access denied")
+}
+
+// ---------------------------------------------------------------------------
+// Client
+// ---------------------------------------------------------------------------
+
+/// HTTP client for the QRZ Logbook API.
+#[derive(Debug)]
+pub struct QrzLogbookClient {
+    config: QrzLogbookConfig,
+    client: Client,
+}
+
+impl QrzLogbookClient {
+    /// Create a new client from validated configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QrzLogbookError::NetworkError`] if the underlying HTTP client
+    /// cannot be built.
+    pub fn new(config: QrzLogbookConfig) -> Result<Self, QrzLogbookError> {
+        let client = Client::builder()
+            .user_agent(config.user_agent.clone())
+            .timeout(config.http_timeout)
+            .build()?;
+        Ok(Self { config, client })
+    }
+
+    /// Test the connection and return logbook status.
+    ///
+    /// Calls the QRZ Logbook `STATUS` action.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when authentication fails, the API returns an error,
+    /// or the response cannot be parsed.
+    pub async fn test_connection(&self) -> Result<QrzLogbookStatus, QrzLogbookError> {
+        let body = self.post_form(&[("ACTION", "STATUS")]).await?;
+        let map = parse_kv_response(&body);
+        let map = check_result(map)?;
+
+        let owner = map
+            .get("CALLSIGN")
+            .or_else(|| map.get("OWNER"))
+            .cloned()
+            .unwrap_or_default();
+        let qso_count = map
+            .get("COUNT")
+            .and_then(|value| value.parse::<u32>().ok())
+            .unwrap_or(0);
+
+        Ok(QrzLogbookStatus { owner, qso_count })
+    }
+
+    /// Fetch QSO records from the QRZ Logbook.
+    ///
+    /// When `since` is `Some("YYYY-MM-DD")`, only QSOs modified after that
+    /// date are returned. Otherwise all QSOs are fetched.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on network failure, authentication failure, or ADIF
+    /// parse failure.
+    pub async fn fetch_qsos(&self, since: Option<&str>) -> Result<Vec<QsoRecord>, QrzLogbookError> {
+        let option_value = match since {
+            Some(date) => format!("MODSINCE:{date}"),
+            None => "ALL".to_string(),
+        };
+
+        let body = self
+            .post_form(&[("ACTION", "FETCH"), ("OPTION", &option_value)])
+            .await?;
+
+        // The FETCH response body is ADIF data.  If QRZ returned a kv error
+        // instead (e.g. RESULT=FAIL), detect that first.
+        if body.trim_start().starts_with("RESULT=") {
+            let map = parse_kv_response(&body);
+            check_result(map)?;
+            // If RESULT=OK but no ADIF data, return empty.
+            return Ok(Vec::new());
+        }
+
+        adif::parse_adi_qsos(body.as_bytes())
+            .await
+            .map_err(QrzLogbookError::ParseError)
+    }
+
+    /// Upload a single QSO to the QRZ Logbook.
+    ///
+    /// The QSO is serialized to an ADIF record string and sent via the
+    /// `INSERT` action.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on network failure, authentication failure, or if
+    /// the QRZ API rejects the record.
+    pub async fn upload_qso(&self, qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError> {
+        let adif_record = AdifMapper::qso_to_adi(qso);
+
+        let body = self
+            .post_form(&[("ACTION", "INSERT"), ("ADIF", &adif_record)])
+            .await?;
+        let map = parse_kv_response(&body);
+        let map = check_result(map)?;
+
+        let logid = map.get("LOGID").cloned().unwrap_or_default();
+        if logid.is_empty() {
+            return Err(QrzLogbookError::ParseError(
+                "INSERT response missing LOGID".to_string(),
+            ));
+        }
+
+        Ok(QrzUploadResult { logid })
+    }
+
+    /// Delete a QSO from the QRZ Logbook by its logbook record ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on network failure, authentication failure, or if
+    /// the QRZ API rejects the deletion.
+    pub async fn delete_qso(&self, logid: &str) -> Result<(), QrzLogbookError> {
+        let body = self
+            .post_form(&[("ACTION", "DELETE"), ("LOGID", logid)])
+            .await?;
+        let map = parse_kv_response(&body);
+        check_result(map)?;
+        Ok(())
+    }
+
+    /// Send a form-encoded POST to the QRZ Logbook API.
+    ///
+    /// Every request includes the API key. Returns the response body as text,
+    /// or an appropriate error for HTTP-level failures.
+    async fn post_form(&self, params: &[(&str, &str)]) -> Result<String, QrzLogbookError> {
+        let mut form: Vec<(&str, &str)> = vec![("KEY", &self.config.api_key)];
+        form.extend_from_slice(params);
+
+        let response = self
+            .client
+            .post(&self.config.base_url)
+            .form(&form)
+            .send()
+            .await?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(QrzLogbookError::RateLimited);
+        }
+
+        if !status.is_success() {
+            return Err(QrzLogbookError::ApiError(format!("HTTP {status}")));
+        }
+
+        response.text().await.map_err(QrzLogbookError::NetworkError)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use super::*;
+
+    // -- Response parsing helpers -------------------------------------------
+
+    #[test]
+    fn parse_kv_response_extracts_fields() {
+        let body = "RESULT=OK&COUNT=42&CALLSIGN=W1AW";
+        let map = parse_kv_response(body);
+        assert_eq!(map.get("RESULT").unwrap(), "OK");
+        assert_eq!(map.get("COUNT").unwrap(), "42");
+        assert_eq!(map.get("CALLSIGN").unwrap(), "W1AW");
+    }
+
+    #[test]
+    fn parse_kv_response_uppercases_keys() {
+        let body = "result=OK&count=7";
+        let map = parse_kv_response(body);
+        assert_eq!(map.get("RESULT").unwrap(), "OK");
+        assert_eq!(map.get("COUNT").unwrap(), "7");
+    }
+
+    #[test]
+    fn parse_kv_response_handles_empty_body() {
+        let map = parse_kv_response("");
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn parse_kv_response_trims_whitespace() {
+        let body = "  RESULT=OK&COUNT=1  \n";
+        let map = parse_kv_response(body);
+        assert_eq!(map.get("RESULT").unwrap(), "OK");
+    }
+
+    #[test]
+    fn check_result_ok_returns_map() {
+        let map = parse_kv_response("RESULT=OK&LOGID=12345");
+        let result = check_result(map).unwrap();
+        assert_eq!(result.get("LOGID").unwrap(), "12345");
+    }
+
+    #[test]
+    fn check_result_fail_returns_api_error() {
+        let map = parse_kv_response("RESULT=FAIL&REASON=bad record format");
+        let err = check_result(map).unwrap_err();
+        match err {
+            QrzLogbookError::ApiError(reason) => assert_eq!(reason, "bad record format"),
+            other => panic!("expected ApiError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn check_result_fail_auth_error() {
+        let map = parse_kv_response("RESULT=FAIL&REASON=invalid api key");
+        let err = check_result(map).unwrap_err();
+        assert!(matches!(err, QrzLogbookError::AuthenticationFailed(_)));
+    }
+
+    #[test]
+    fn check_result_missing_result_field() {
+        let map = parse_kv_response("LOGID=12345");
+        let err = check_result(map).unwrap_err();
+        assert!(matches!(err, QrzLogbookError::ParseError(_)));
+    }
+
+    #[test]
+    fn check_result_unexpected_result_value() {
+        let map = parse_kv_response("RESULT=MAYBE");
+        let err = check_result(map).unwrap_err();
+        assert!(matches!(err, QrzLogbookError::ParseError(_)));
+    }
+
+    #[test]
+    fn check_result_fail_without_reason_uses_default() {
+        let map = parse_kv_response("RESULT=FAIL");
+        let err = check_result(map).unwrap_err();
+        match err {
+            QrzLogbookError::ApiError(reason) => assert_eq!(reason, "unknown error"),
+            other => panic!("expected ApiError, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn is_auth_error_detects_common_messages() {
+        assert!(is_auth_error("invalid api key"));
+        assert!(is_auth_error("Invalid API Key"));
+        assert!(is_auth_error("API key required"));
+        assert!(is_auth_error("Access Denied"));
+        assert!(!is_auth_error("bad record format"));
+        assert!(!is_auth_error("duplicate QSO"));
+    }
+
+    // -- Status parsing -----------------------------------------------------
+
+    #[test]
+    fn status_parsing_extracts_owner_and_count() {
+        let body = "RESULT=OK&CALLSIGN=KC7AVA&COUNT=1234";
+        let map = parse_kv_response(body);
+        let map = check_result(map).unwrap();
+
+        let owner = map
+            .get("CALLSIGN")
+            .or_else(|| map.get("OWNER"))
+            .cloned()
+            .unwrap_or_default();
+        let qso_count = map
+            .get("COUNT")
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(0);
+
+        assert_eq!(owner, "KC7AVA");
+        assert_eq!(qso_count, 1234);
+    }
+
+    #[test]
+    fn status_parsing_uses_owner_field_as_fallback() {
+        let body = "RESULT=OK&OWNER=N0CALL&COUNT=0";
+        let map = parse_kv_response(body);
+        let map = check_result(map).unwrap();
+
+        let owner = map
+            .get("CALLSIGN")
+            .or_else(|| map.get("OWNER"))
+            .cloned()
+            .unwrap_or_default();
+
+        assert_eq!(owner, "N0CALL");
+    }
+
+    #[test]
+    fn status_parsing_defaults_count_when_missing() {
+        let body = "RESULT=OK&CALLSIGN=W1AW";
+        let map = parse_kv_response(body);
+        let map = check_result(map).unwrap();
+
+        let qso_count = map
+            .get("COUNT")
+            .and_then(|v| v.parse::<u32>().ok())
+            .unwrap_or(0);
+
+        assert_eq!(qso_count, 0);
+    }
+
+    // -- Insert response parsing --------------------------------------------
+
+    #[test]
+    fn insert_response_extracts_logid() {
+        let body = "RESULT=OK&LOGID=987654&LOGIDS=987654";
+        let map = parse_kv_response(body);
+        let map = check_result(map).unwrap();
+        let logid = map.get("LOGID").cloned().unwrap_or_default();
+        assert_eq!(logid, "987654");
+    }
+
+    #[test]
+    fn insert_response_missing_logid_is_error() {
+        let body = "RESULT=OK";
+        let map = parse_kv_response(body);
+        let map = check_result(map).unwrap();
+        let logid = map.get("LOGID").cloned().unwrap_or_default();
+        assert!(logid.is_empty(), "expected empty logid");
+    }
+
+    // -- ADIF pipeline tests ------------------------------------------------
+
+    #[test]
+    fn qso_serializes_to_adif_record_for_upload() {
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            ..Default::default()
+        };
+        let adif = AdifMapper::qso_to_adi(&qso);
+        assert!(adif.contains("<CALL:4>W1AW"));
+        assert!(adif.contains("<eor>"));
+    }
+
+    #[tokio::test]
+    async fn adif_round_trip_through_parse() {
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            ..Default::default()
+        };
+        let adif_bytes = adif::serialize_adi_qsos(&[qso], false);
+        let parsed = adif::parse_adi_qsos(&adif_bytes)
+            .await
+            .expect("round-trip parse");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].worked_callsign, "W1AW");
+    }
+
+    // -- Config tests -------------------------------------------------------
+
+    #[test]
+    fn config_debug_redacts_api_key() {
+        let config = QrzLogbookConfig::new(
+            "secret-key".to_string(),
+            DEFAULT_QRZ_LOGBOOK_BASE_URL.to_string(),
+            DEFAULT_USER_AGENT.to_string(),
+        );
+        let debug = format!("{config:?}");
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("secret-key"));
+    }
+
+    #[test]
+    fn config_new_sets_defaults() {
+        let config = QrzLogbookConfig::new(
+            "key".to_string(),
+            "http://localhost".to_string(),
+            "Agent/1.0".to_string(),
+        );
+        assert_eq!(config.base_url(), "http://localhost");
+        assert_eq!(
+            config.http_timeout,
+            Duration::from_secs(DEFAULT_HTTP_TIMEOUT_SECONDS)
+        );
+    }
+
+    // -- Integration-level tests using a local TCP server -------------------
+
+    use std::sync::{Arc, Mutex as StdMutex};
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::{TcpListener, TcpStream},
+    };
+
+    fn test_config(base_url: String) -> QrzLogbookConfig {
+        QrzLogbookConfig {
+            api_key: "test-api-key".to_string(),
+            base_url,
+            user_agent: "QsoRipper/test".to_string(),
+            http_timeout: Duration::from_secs(2),
+        }
+    }
+
+    /// Spawn a minimal HTTP server that serves pre-canned responses in order.
+    async fn spawn_logbook_server(
+        responses: &[(&str, &str)],
+    ) -> (String, Arc<StdMutex<Vec<String>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("local addr");
+        let recorded_requests = Arc::new(StdMutex::new(Vec::new()));
+        let recorded_clone = Arc::clone(&recorded_requests);
+        let responses: Vec<(String, String)> = responses
+            .iter()
+            .map(|(ct, body)| ((*ct).to_string(), (*body).to_string()))
+            .collect();
+
+        tokio::spawn(async move {
+            for (content_type, response_body) in responses {
+                let (mut socket, _) = listener.accept().await.expect("accept");
+                let request = read_http_request(&mut socket).await;
+                recorded_clone
+                    .lock()
+                    .expect("recorded requests")
+                    .push(request);
+                write_http_response(&mut socket, &content_type, &response_body).await;
+            }
+        });
+
+        (format!("http://{address}/api"), recorded_requests)
+    }
+
+    async fn read_http_request(socket: &mut TcpStream) -> String {
+        let mut bytes = Vec::new();
+        let mut buffer = [0_u8; 4096];
+        let mut content_length: Option<usize> = None;
+
+        loop {
+            let read = socket.read(&mut buffer).await.expect("read request");
+            if read == 0 {
+                break;
+            }
+            bytes.extend_from_slice(buffer.get(..read).expect("buffer slice"));
+
+            // Check if we've received all headers.
+            if let Some(pos) = bytes.windows(4).position(|w| w == b"\r\n\r\n") {
+                let header_end = pos + 4;
+                // Extract Content-Length from headers.
+                let header_str =
+                    String::from_utf8_lossy(bytes.get(..header_end).unwrap_or_default());
+                for line in header_str.lines() {
+                    if let Some(value) = line.strip_prefix("Content-Length: ") {
+                        content_length = value.trim().parse().ok();
+                    }
+                    // Also handle lowercase
+                    if let Some(value) = line.strip_prefix("content-length: ") {
+                        content_length = value.trim().parse().ok();
+                    }
+                }
+
+                let expected_total = header_end + content_length.unwrap_or(0);
+                if bytes.len() >= expected_total {
+                    break;
+                }
+            }
+        }
+
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    async fn write_http_response(socket: &mut TcpStream, content_type: &str, body: &str) {
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response");
+    }
+
+    async fn write_http_response_with_status(
+        socket: &mut TcpStream,
+        status_code: u16,
+        status_text: &str,
+        body: &str,
+    ) {
+        let response = format!(
+            "HTTP/1.1 {status_code} {status_text}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        );
+        socket
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response");
+    }
+
+    // -- test_connection integration ----------------------------------------
+
+    #[tokio::test]
+    async fn test_connection_success() {
+        let (base_url, requests) =
+            spawn_logbook_server(&[("text/plain", "RESULT=OK&CALLSIGN=KC7AVA&COUNT=500")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let status = client.test_connection().await.expect("status");
+
+        assert_eq!(status.owner, "KC7AVA");
+        assert_eq!(status.qso_count, 500);
+
+        let reqs = requests.lock().expect("requests");
+        assert_eq!(reqs.len(), 1);
+        assert!(reqs[0].contains("ACTION=STATUS"));
+        assert!(reqs[0].contains("KEY=test-api-key"));
+    }
+
+    #[tokio::test]
+    async fn test_connection_auth_failure() {
+        let (base_url, _) =
+            spawn_logbook_server(&[("text/plain", "RESULT=FAIL&REASON=invalid api key")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let err = client.test_connection().await.unwrap_err();
+
+        assert!(
+            matches!(err, QrzLogbookError::AuthenticationFailed(_)),
+            "expected AuthenticationFailed, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_connection_api_error() {
+        let (base_url, _) =
+            spawn_logbook_server(&[("text/plain", "RESULT=FAIL&REASON=service unavailable")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let err = client.test_connection().await.unwrap_err();
+
+        match err {
+            QrzLogbookError::ApiError(reason) => {
+                assert_eq!(reason, "service unavailable");
+            }
+            other => panic!("expected ApiError, got: {other:?}"),
+        }
+    }
+
+    // -- fetch_qsos integration ---------------------------------------------
+
+    #[tokio::test]
+    async fn fetch_qsos_parses_adif_response() {
+        let adif_body = "<CALL:4>W1AW <BAND:3>20M <FREQ:6>14.250 <MODE:3>SSB <QSO_DATE:8>20250101 <TIME_ON:4>1200 <EOR>\n\
+                         <CALL:6>N0CALL <BAND:3>40M <FREQ:5>7.200 <MODE:2>CW <QSO_DATE:8>20250102 <TIME_ON:4>1300 <EOR>\n";
+        let (base_url, requests) = spawn_logbook_server(&[("text/plain", adif_body)]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qsos = client.fetch_qsos(None).await.expect("fetch");
+
+        assert_eq!(qsos.len(), 2);
+        assert_eq!(qsos[0].worked_callsign, "W1AW");
+        assert_eq!(qsos[1].worked_callsign, "N0CALL");
+
+        let reqs = requests.lock().expect("requests");
+        assert!(reqs[0].contains("ACTION=FETCH"));
+        assert!(reqs[0].contains("OPTION=ALL"));
+    }
+
+    #[tokio::test]
+    async fn fetch_qsos_sends_modsince_option() {
+        let adif_body = "<CALL:4>W1AW <EOR>\n";
+        let (base_url, requests) = spawn_logbook_server(&[("text/plain", adif_body)]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qsos = client.fetch_qsos(Some("2025-06-01")).await.expect("fetch");
+
+        assert_eq!(qsos.len(), 1);
+        let reqs = requests.lock().expect("requests");
+        // URL-encoded colon: %3A
+        assert!(
+            reqs[0].contains("MODSINCE") && reqs[0].contains("2025-06-01"),
+            "expected MODSINCE with date in request: {}",
+            reqs[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_qsos_handles_kv_error_response() {
+        let (base_url, _) =
+            spawn_logbook_server(&[("text/plain", "RESULT=FAIL&REASON=invalid api key")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let err = client.fetch_qsos(None).await.unwrap_err();
+
+        assert!(
+            matches!(err, QrzLogbookError::AuthenticationFailed(_)),
+            "expected AuthenticationFailed, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_qsos_returns_empty_for_ok_with_no_adif() {
+        let (base_url, _) = spawn_logbook_server(&[("text/plain", "RESULT=OK")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qsos = client.fetch_qsos(None).await.expect("fetch");
+
+        assert!(qsos.is_empty());
+    }
+
+    // -- upload_qso integration ---------------------------------------------
+
+    #[tokio::test]
+    async fn upload_qso_sends_adif_and_returns_logid() {
+        let (base_url, requests) =
+            spawn_logbook_server(&[("text/plain", "RESULT=OK&LOGID=999888&LOGIDS=999888")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            ..Default::default()
+        };
+        let result = client.upload_qso(&qso).await.expect("upload");
+
+        assert_eq!(result.logid, "999888");
+
+        let reqs = requests.lock().expect("requests");
+        assert!(reqs[0].contains("ACTION=INSERT"));
+        // The ADIF record should be in the form body (URL-encoded)
+        assert!(reqs[0].contains("ADIF="));
+    }
+
+    #[tokio::test]
+    async fn upload_qso_returns_error_on_missing_logid() {
+        let (base_url, _) = spawn_logbook_server(&[("text/plain", "RESULT=OK")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            ..Default::default()
+        };
+        let err = client.upload_qso(&qso).await.unwrap_err();
+
+        assert!(
+            matches!(err, QrzLogbookError::ParseError(_)),
+            "expected ParseError, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_qso_surfaces_api_failure() {
+        let (base_url, _) =
+            spawn_logbook_server(&[("text/plain", "RESULT=FAIL&REASON=duplicate QSO")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qso = QsoRecord::default();
+        let err = client.upload_qso(&qso).await.unwrap_err();
+
+        match err {
+            QrzLogbookError::ApiError(reason) => assert_eq!(reason, "duplicate QSO"),
+            other => panic!("expected ApiError, got: {other:?}"),
+        }
+    }
+
+    // -- delete_qso integration ---------------------------------------------
+
+    #[tokio::test]
+    async fn delete_qso_success() {
+        let (base_url, requests) = spawn_logbook_server(&[("text/plain", "RESULT=OK")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        client.delete_qso("123456").await.expect("delete");
+
+        let reqs = requests.lock().expect("requests");
+        assert!(reqs[0].contains("ACTION=DELETE"));
+        assert!(reqs[0].contains("LOGID=123456"));
+    }
+
+    #[tokio::test]
+    async fn delete_qso_api_failure() {
+        let (base_url, _) =
+            spawn_logbook_server(&[("text/plain", "RESULT=FAIL&REASON=record not found")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let err = client.delete_qso("000000").await.unwrap_err();
+
+        match err {
+            QrzLogbookError::ApiError(reason) => assert_eq!(reason, "record not found"),
+            other => panic!("expected ApiError, got: {other:?}"),
+        }
+    }
+
+    // -- Rate limiting ------------------------------------------------------
+
+    #[tokio::test]
+    async fn rate_limited_response_returns_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("local addr");
+
+        tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.expect("accept");
+            let mut buffer = [0_u8; 4096];
+            // Read the full request.
+            loop {
+                let n = socket.read(&mut buffer).await.expect("read");
+                if n == 0 {
+                    break;
+                }
+                if buffer
+                    .get(..n)
+                    .unwrap_or_default()
+                    .windows(4)
+                    .any(|w| w == b"\r\n\r\n")
+                {
+                    break;
+                }
+            }
+            write_http_response_with_status(&mut socket, 429, "Too Many Requests", "").await;
+        });
+
+        let config = test_config(format!("http://{address}/api"));
+        let client = QrzLogbookClient::new(config).expect("client");
+
+        let err = client.test_connection().await.unwrap_err();
+
+        assert!(
+            matches!(err, QrzLogbookError::RateLimited),
+            "expected RateLimited, got: {err:?}"
+        );
+    }
+}

--- a/src/rust/qsoripper-server/Cargo.toml
+++ b/src/rust/qsoripper-server/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+chrono = "0.4"
 dotenvy = "0.15"
 qsoripper-core = { path = "../qsoripper-core", version = "0.1.0" }
 qsoripper-storage-memory = { path = "../qsoripper-storage-memory", version = "0.1.0" }

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -387,6 +387,10 @@ impl LogbookService for DeveloperLogbookService {
             pending_upload: sync_status.pending_upload,
             last_sync: sync_status.last_sync,
             qrz_logbook_owner: sync_status.qrz_logbook_owner,
+            is_syncing: false,        // TODO: wire to sync scheduler state
+            next_sync: None,          // TODO: wire to sync scheduler state
+            auto_sync_enabled: false, // TODO: wire to runtime config
+            last_sync_error: None,    // TODO: wire to sync scheduler state
         }))
     }
 

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -3,6 +3,8 @@
 mod runtime_config;
 mod setup;
 mod station_profile_support;
+mod sync;
+mod sync_scheduler;
 
 use std::{fs, future::Future, io, net::SocketAddr, path::PathBuf, sync::Arc};
 
@@ -16,7 +18,7 @@ use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 
-use qsoripper_core::proto::qsoripper::domain::{Band, Mode};
+use qsoripper_core::proto::qsoripper::domain::{Band, ConflictPolicy, Mode};
 use qsoripper_core::proto::qsoripper::services::{
     developer_control_service_server::{DeveloperControlService, DeveloperControlServiceServer},
     logbook_service_server::{LogbookService, LogbookServiceServer},
@@ -62,7 +64,10 @@ where
             &options.runtime_config_cli_storage_overrides(),
         )?,
     );
-    let logbook_service = DeveloperLogbookService::new(runtime_config.clone());
+    let sync_scheduler = Arc::new(sync_scheduler::SyncScheduler::new());
+    sync_scheduler.start(runtime_config.clone());
+    let logbook_service =
+        DeveloperLogbookService::new(runtime_config.clone(), sync_scheduler.clone());
     let lookup_service = DeveloperLookupService::new(runtime_config.clone());
     let developer_control_service = DeveloperControlSurface::new(runtime_config.clone());
     let setup_service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
@@ -118,6 +123,7 @@ where
         signal_result = &mut shutdown_signal => {
             signal_result?;
             println!("Shutting down.");
+            sync_scheduler.stop();
             let _ = shutdown_sender.send(());
             server.await?;
         }
@@ -247,11 +253,18 @@ fn find_dotenv_path() -> io::Result<Option<PathBuf>> {
 #[derive(Clone)]
 struct DeveloperLogbookService {
     runtime_config: Arc<RuntimeConfigManager>,
+    sync_scheduler: Arc<sync_scheduler::SyncScheduler>,
 }
 
 impl DeveloperLogbookService {
-    fn new(runtime_config: Arc<RuntimeConfigManager>) -> Self {
-        Self { runtime_config }
+    fn new(
+        runtime_config: Arc<RuntimeConfigManager>,
+        sync_scheduler: Arc<sync_scheduler::SyncScheduler>,
+    ) -> Self {
+        Self {
+            runtime_config,
+            sync_scheduler,
+        }
     }
 }
 
@@ -364,9 +377,53 @@ impl LogbookService for DeveloperLogbookService {
 
     async fn sync_with_qrz(
         &self,
-        _request: Request<SyncWithQrzRequest>,
+        request: Request<SyncWithQrzRequest>,
     ) -> Result<Response<Self::SyncWithQrzStream>, Status> {
-        Err(Status::unimplemented("SyncWithQrz is not implemented yet."))
+        let request = request.into_inner();
+        let effective = self.runtime_config.effective_values().await;
+
+        let api_key = effective
+            .get(runtime_config::QRZ_LOGBOOK_API_KEY_ENV_VAR)
+            .cloned()
+            .unwrap_or_default();
+        if api_key.trim().is_empty() {
+            return Err(Status::failed_precondition(
+                "QRZ Logbook API key is not configured. Set it via setup or runtime config.",
+            ));
+        }
+
+        let base_url = effective
+            .get(runtime_config::QRZ_LOGBOOK_BASE_URL_ENV_VAR)
+            .cloned()
+            .unwrap_or_else(|| runtime_config::DEFAULT_QRZ_LOGBOOK_BASE_URL.to_string());
+
+        let config = qsoripper_core::qrz_logbook::QrzLogbookConfig::new(
+            api_key,
+            base_url,
+            "QsoRipper/1.0".to_string(),
+        );
+
+        let client = qsoripper_core::qrz_logbook::QrzLogbookClient::new(config).map_err(|err| {
+            Status::internal(format!("Failed to create QRZ logbook client: {err}"))
+        })?;
+
+        let conflict_policy = match effective
+            .get(runtime_config::SYNC_CONFLICT_POLICY_ENV_VAR)
+            .map(String::as_str)
+        {
+            Some("flag_for_review") => ConflictPolicy::FlagForReview,
+            _ => ConflictPolicy::LastWriteWins,
+        };
+
+        let engine = self.runtime_config.logbook_engine().await;
+        let (tx, rx) = tokio::sync::mpsc::channel(16);
+
+        tokio::spawn(async move {
+            let store = engine.logbook_store();
+            sync::execute_sync(&client, store, request.full_sync, conflict_policy, &tx).await;
+        });
+
+        Ok(Response::new(ReceiverStream::new(rx)))
     }
 
     async fn get_sync_status(
@@ -381,16 +438,21 @@ impl LogbookService for DeveloperLogbookService {
             .await
             .map_err(map_logbook_error)?;
 
+        let effective = self.runtime_config.effective_values().await;
+        let auto_sync_enabled = effective
+            .get(runtime_config::SYNC_AUTO_ENABLED_ENV_VAR)
+            .is_some_and(|v| v == "true");
+
         Ok(Response::new(GetSyncStatusResponse {
             local_qso_count: sync_status.local_qso_count,
             qrz_qso_count: sync_status.qrz_qso_count,
             pending_upload: sync_status.pending_upload,
             last_sync: sync_status.last_sync,
             qrz_logbook_owner: sync_status.qrz_logbook_owner,
-            is_syncing: false,        // TODO: wire to sync scheduler state
-            next_sync: None,          // TODO: wire to sync scheduler state
-            auto_sync_enabled: false, // TODO: wire to runtime config
-            last_sync_error: None,    // TODO: wire to sync scheduler state
+            is_syncing: self.sync_scheduler.is_syncing().await,
+            next_sync: self.sync_scheduler.next_sync().await,
+            auto_sync_enabled,
+            last_sync_error: self.sync_scheduler.last_error().await,
         }))
     }
 
@@ -820,7 +882,7 @@ mod tests {
     use super::{
         build_storage, legacy_qrz_user_agent_line_compatibility, load_dotenv_if_present,
         parse_storage_backend, run_server, sanitize_legacy_qrz_user_agent_contents,
-        server_ready_message, server_starting_message, DeveloperLogbookService,
+        server_ready_message, server_starting_message, sync_scheduler, DeveloperLogbookService,
         DeveloperLookupService, Server, ServerOptions, StorageBackendKind, StorageOptions,
     };
     use crate::runtime_config::{
@@ -903,6 +965,14 @@ mod tests {
 
     fn test_lookup_service() -> DeveloperLookupService {
         DeveloperLookupService::new(test_runtime_config())
+    }
+
+    fn test_sync_scheduler() -> Arc<sync_scheduler::SyncScheduler> {
+        Arc::new(sync_scheduler::SyncScheduler::new())
+    }
+
+    fn test_logbook_service(config: Arc<RuntimeConfigManager>) -> DeveloperLogbookService {
+        DeveloperLogbookService::new(config, test_sync_scheduler())
     }
 
     fn test_runtime_config() -> Arc<RuntimeConfigManager> {
@@ -1535,7 +1605,7 @@ mod tests {
 
     #[tokio::test]
     async fn logbook_crud_flow_works_through_memory_grpc_surface() {
-        let service = DeveloperLogbookService::new(test_runtime_config_with_logbook(
+        let service = test_logbook_service(test_runtime_config_with_logbook(
             StorageBackendKind::Memory,
             None,
             true,
@@ -1547,7 +1617,7 @@ mod tests {
     #[tokio::test]
     async fn logbook_crud_flow_works_through_sqlite_grpc_surface() {
         let sqlite_path = unique_sqlite_test_path("logbook-grpc");
-        let service = DeveloperLogbookService::new(test_runtime_config_with_logbook(
+        let service = test_logbook_service(test_runtime_config_with_logbook(
             StorageBackendKind::Sqlite,
             Some(&sqlite_path),
             true,
@@ -1563,7 +1633,7 @@ mod tests {
 
     #[tokio::test]
     async fn logbook_sync_status_reports_live_local_counts() {
-        let service = DeveloperLogbookService::new(test_runtime_config());
+        let service = test_logbook_service(test_runtime_config());
 
         let logged = LogbookService::log_qso(
             &service,
@@ -1634,7 +1704,7 @@ mod tests {
 
     #[tokio::test]
     async fn adif_import_preserves_station_history_and_reports_duplicates() {
-        let service = DeveloperLogbookService::new(test_runtime_config_with_logbook(
+        let service = test_logbook_service(test_runtime_config_with_logbook(
             StorageBackendKind::Memory,
             None,
             true,
@@ -1695,7 +1765,7 @@ mod tests {
 
     #[tokio::test]
     async fn adif_import_uses_active_station_profile_only_as_explicit_fallback() {
-        let service = DeveloperLogbookService::new(test_runtime_config_with_logbook(
+        let service = test_logbook_service(test_runtime_config_with_logbook(
             StorageBackendKind::Memory,
             None,
             true,
@@ -1743,7 +1813,7 @@ mod tests {
 
     #[tokio::test]
     async fn adif_import_reports_invalid_records_without_active_station_fallback() {
-        let service = DeveloperLogbookService::new(test_runtime_config());
+        let service = test_logbook_service(test_runtime_config());
         let (mut client, server_handle) = grpc_logbook_client(service).await;
         let payload = b"<CALL:5>DL1AA<STATION_CALLSIGN:5>K1ABC<QSO_DATE:8>20250103<TIME_ON:6>030405<BAND:3>11M<MODE:2>CW<EOR>\n";
 
@@ -1761,7 +1831,7 @@ mod tests {
 
     #[tokio::test]
     async fn adif_import_refresh_updates_existing_records() {
-        let service = DeveloperLogbookService::new(test_runtime_config_with_logbook(
+        let service = test_logbook_service(test_runtime_config_with_logbook(
             StorageBackendKind::Memory,
             None,
             true,
@@ -1831,7 +1901,7 @@ mod tests {
 
     #[tokio::test]
     async fn adif_import_refresh_preserves_fields_absent_from_import() {
-        let service = DeveloperLogbookService::new(test_runtime_config_with_logbook(
+        let service = test_logbook_service(test_runtime_config_with_logbook(
             StorageBackendKind::Memory,
             None,
             true,
@@ -1881,7 +1951,7 @@ mod tests {
 
     #[tokio::test]
     async fn adif_import_refresh_handles_mixed_new_and_existing() {
-        let service = DeveloperLogbookService::new(test_runtime_config_with_logbook(
+        let service = test_logbook_service(test_runtime_config_with_logbook(
             StorageBackendKind::Memory,
             None,
             true,
@@ -1916,7 +1986,7 @@ mod tests {
 
     #[tokio::test]
     async fn adif_export_streams_filtered_qsos_in_adif_order() {
-        let service = DeveloperLogbookService::new(test_runtime_config_with_logbook(
+        let service = test_logbook_service(test_runtime_config_with_logbook(
             StorageBackendKind::Memory,
             None,
             true,
@@ -1992,7 +2062,7 @@ mod tests {
 
     #[tokio::test]
     async fn logbook_requires_station_context_when_station_callsign_is_missing() {
-        let service = DeveloperLogbookService::new(test_runtime_config());
+        let service = test_logbook_service(test_runtime_config());
 
         let error = LogbookService::log_qso(
             &service,
@@ -2010,7 +2080,7 @@ mod tests {
 
     #[tokio::test]
     async fn logbook_requires_timestamp_band_and_mode() {
-        let service = DeveloperLogbookService::new(test_runtime_config_with_logbook(
+        let service = test_logbook_service(test_runtime_config_with_logbook(
             StorageBackendKind::Memory,
             None,
             true,

--- a/src/rust/qsoripper-server/src/runtime_config.rs
+++ b/src/rust/qsoripper-server/src/runtime_config.rs
@@ -39,9 +39,22 @@ pub(crate) const STATION_CQ_ZONE_ENV_VAR: &str = "QSORIPPER_STATION_CQ_ZONE";
 pub(crate) const STATION_ITU_ZONE_ENV_VAR: &str = "QSORIPPER_STATION_ITU_ZONE";
 pub(crate) const STATION_LATITUDE_ENV_VAR: &str = "QSORIPPER_STATION_LATITUDE";
 pub(crate) const STATION_LONGITUDE_ENV_VAR: &str = "QSORIPPER_STATION_LONGITUDE";
+pub(crate) const QRZ_LOGBOOK_API_KEY_ENV_VAR: &str = "QSORIPPER_QRZ_LOGBOOK_API_KEY";
+pub(crate) const QRZ_LOGBOOK_BASE_URL_ENV_VAR: &str = "QSORIPPER_QRZ_LOGBOOK_BASE_URL";
+pub(crate) const SYNC_AUTO_ENABLED_ENV_VAR: &str = "QSORIPPER_SYNC_AUTO_ENABLED";
+pub(crate) const SYNC_INTERVAL_SECONDS_ENV_VAR: &str = "QSORIPPER_SYNC_INTERVAL_SECONDS";
+pub(crate) const SYNC_CONFLICT_POLICY_ENV_VAR: &str = "QSORIPPER_SYNC_CONFLICT_POLICY";
+
+pub(crate) const DEFAULT_QRZ_LOGBOOK_BASE_URL: &str = "https://logbook.qrz.com/api";
+const DEFAULT_SYNC_AUTO_ENABLED: &str = "false";
+const DEFAULT_SYNC_INTERVAL_SECONDS: &str = "300";
+const DEFAULT_SYNC_CONFLICT_POLICY: &str = "last_write_wins";
+
 const DEFAULT_STORAGE_BACKEND: &str = "memory";
 const DEFAULT_SQLITE_PATH: &str = "qsoripper.db";
 const REDACTED_VALUE: &str = "<redacted>";
+
+const CONFLICT_POLICY_ALLOWED_VALUES: &[&str] = &["last_write_wins", "flag_for_review"];
 
 #[derive(Clone)]
 struct RuntimeBindings {
@@ -501,6 +514,51 @@ const SUPPORTED_FIELDS: &[ConfigFieldSpec] = &[
         allowed_values: BOOLEAN_ALLOWED_VALUES,
         default_value: Some("false"),
     },
+    ConfigFieldSpec {
+        key: QRZ_LOGBOOK_API_KEY_ENV_VAR,
+        label: "QRZ logbook API key",
+        description: "API key for bidirectional sync with the QRZ logbook.",
+        kind: RuntimeConfigValueKind::String,
+        secret: true,
+        allowed_values: &[],
+        default_value: None,
+    },
+    ConfigFieldSpec {
+        key: QRZ_LOGBOOK_BASE_URL_ENV_VAR,
+        label: "QRZ logbook base URL",
+        description: "QRZ logbook API endpoint URL.",
+        kind: RuntimeConfigValueKind::String,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some(DEFAULT_QRZ_LOGBOOK_BASE_URL),
+    },
+    ConfigFieldSpec {
+        key: SYNC_AUTO_ENABLED_ENV_VAR,
+        label: "Sync auto-enabled",
+        description: "Whether the engine should automatically sync with the QRZ logbook on a periodic schedule.",
+        kind: RuntimeConfigValueKind::Boolean,
+        secret: false,
+        allowed_values: BOOLEAN_ALLOWED_VALUES,
+        default_value: Some(DEFAULT_SYNC_AUTO_ENABLED),
+    },
+    ConfigFieldSpec {
+        key: SYNC_INTERVAL_SECONDS_ENV_VAR,
+        label: "Sync interval seconds",
+        description: "Interval between automatic QRZ logbook syncs, in seconds.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some(DEFAULT_SYNC_INTERVAL_SECONDS),
+    },
+    ConfigFieldSpec {
+        key: SYNC_CONFLICT_POLICY_ENV_VAR,
+        label: "Sync conflict policy",
+        description: "How to handle conflicting records during QRZ logbook sync.",
+        kind: RuntimeConfigValueKind::String,
+        secret: false,
+        allowed_values: CONFLICT_POLICY_ALLOWED_VALUES,
+        default_value: Some(DEFAULT_SYNC_CONFLICT_POLICY),
+    },
 ];
 
 fn capture_supported_env() -> BTreeMap<String, String> {
@@ -588,6 +646,29 @@ fn normalize_value(key: &'static str, raw_value: &str) -> Result<String, String>
         parse_bounded_f64(key, trimmed, -90.0, 90.0).map(|value| value.to_string())
     } else if key == STATION_LONGITUDE_ENV_VAR {
         parse_bounded_f64(key, trimmed, -180.0, 180.0).map(|value| value.to_string())
+    } else if key == SYNC_AUTO_ENABLED_ENV_VAR {
+        parse_bool(trimmed).map(|value| {
+            if value {
+                "true".to_string()
+            } else {
+                "false".to_string()
+            }
+        })
+    } else if key == SYNC_INTERVAL_SECONDS_ENV_VAR {
+        trimmed
+            .parse::<u32>()
+            .map(|value| value.to_string())
+            .map_err(|_| format!("'{key}' expects an integer value."))
+    } else if key == SYNC_CONFLICT_POLICY_ENV_VAR {
+        let lower = trimmed.to_ascii_lowercase();
+        if CONFLICT_POLICY_ALLOWED_VALUES.contains(&lower.as_str()) {
+            Ok(lower)
+        } else {
+            Err(format!(
+                "'{key}' must be one of: {}.",
+                CONFLICT_POLICY_ALLOWED_VALUES.join(", ")
+            ))
+        }
     } else {
         Ok(trimmed.to_string())
     }

--- a/src/rust/qsoripper-server/src/setup.rs
+++ b/src/rust/qsoripper-server/src/setup.rs
@@ -22,7 +22,8 @@ use qsoripper_core::proto::qsoripper::services::{
     SetActiveStationProfileResponse, SetSessionStationProfileOverrideRequest,
     SetSessionStationProfileOverrideResponse, SetupFieldValidation, SetupStatus, SetupWizardStep,
     SetupWizardStepStatus, StationProfileRecord, StorageBackend, TestQrzCredentialsRequest,
-    TestQrzCredentialsResponse, ValidateSetupStepRequest, ValidateSetupStepResponse,
+    TestQrzCredentialsResponse, TestQrzLogbookCredentialsRequest,
+    TestQrzLogbookCredentialsResponse, ValidateSetupStepRequest, ValidateSetupStepResponse,
 };
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
@@ -121,6 +122,16 @@ impl SetupService for SetupControlSurface {
         )
         .await;
         Ok(Response::new(result))
+    }
+
+    async fn test_qrz_logbook_credentials(
+        &self,
+        _request: Request<TestQrzLogbookCredentialsRequest>,
+    ) -> Result<Response<TestQrzLogbookCredentialsResponse>, Status> {
+        // TODO: implement when QRZ logbook HTTP client is built
+        Err(Status::unimplemented(
+            "TestQrzLogbookCredentials is not implemented yet.",
+        ))
     }
 }
 
@@ -1087,6 +1098,8 @@ fn build_status(
         log_file_path,
         suggested_log_file_path: suggested_log_file_path.display().to_string(),
         is_first_run: persisted_config.is_none(),
+        has_qrz_logbook_api_key: false, // TODO: populate from persisted config
+        sync_config: None,              // TODO: populate from persisted config
     }
 }
 
@@ -1663,6 +1676,7 @@ station_callsign = "K7RND"
                 }),
                 qrz_xml_username: Some("k7rnd".to_string()),
                 qrz_xml_password: Some("secret".to_string()),
+                ..Default::default()
             }),
         )
         .await
@@ -1741,6 +1755,7 @@ station_callsign = "K7RND"
                 }),
                 qrz_xml_username: None,
                 qrz_xml_password: None,
+                ..Default::default()
             }),
         )
         .await
@@ -1776,6 +1791,7 @@ station_callsign = "K7RND"
                 }),
                 qrz_xml_username: Some("k7rnd".to_string()),
                 qrz_xml_password: Some("secret".to_string()),
+                ..Default::default()
             }),
         )
         .await
@@ -1859,6 +1875,7 @@ station_callsign = "K7RND"
                 }),
                 qrz_xml_username: Some("k7rnd".to_string()),
                 qrz_xml_password: None,
+                ..Default::default()
             }),
         )
         .await
@@ -1893,6 +1910,7 @@ station_callsign = "K7RND"
                 }),
                 qrz_xml_username: None,
                 qrz_xml_password: None,
+                ..Default::default()
             }),
         )
         .await

--- a/src/rust/qsoripper-server/src/setup.rs
+++ b/src/rust/qsoripper-server/src/setup.rs
@@ -9,7 +9,7 @@ use qsoripper_core::lookup::{
     QrzXmlConfig, QrzXmlProvider, QRZ_USER_AGENT_ENV_VAR, QRZ_XML_PASSWORD_ENV_VAR,
     QRZ_XML_USERNAME_ENV_VAR,
 };
-use qsoripper_core::proto::qsoripper::domain::StationProfile;
+use qsoripper_core::proto::qsoripper::domain::{ConflictPolicy, StationProfile, SyncConfig};
 use qsoripper_core::proto::qsoripper::services::{
     setup_service_server::SetupService, station_profile_service_server::StationProfileService,
     ActiveStationContext, ClearSessionStationProfileOverrideRequest,
@@ -25,11 +25,16 @@ use qsoripper_core::proto::qsoripper::services::{
     TestQrzCredentialsResponse, TestQrzLogbookCredentialsRequest,
     TestQrzLogbookCredentialsResponse, ValidateSetupStepRequest, ValidateSetupStepResponse,
 };
+use qsoripper_core::qrz_logbook::{QrzLogbookClient, QrzLogbookConfig};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
 
-use crate::runtime_config::{RuntimeConfigManager, SQLITE_PATH_ENV_VAR, STORAGE_BACKEND_ENV_VAR};
+use crate::runtime_config::{
+    RuntimeConfigManager, DEFAULT_QRZ_LOGBOOK_BASE_URL, QRZ_LOGBOOK_API_KEY_ENV_VAR,
+    QRZ_LOGBOOK_BASE_URL_ENV_VAR, SQLITE_PATH_ENV_VAR, STORAGE_BACKEND_ENV_VAR,
+    SYNC_AUTO_ENABLED_ENV_VAR, SYNC_CONFLICT_POLICY_ENV_VAR, SYNC_INTERVAL_SECONDS_ENV_VAR,
+};
 use crate::station_profile_support::{
     insert_station_profile_runtime_values, normalize_station_profile as normalize_profile_payload,
     DEFAULT_PROFILE_NAME,
@@ -126,12 +131,11 @@ impl SetupService for SetupControlSurface {
 
     async fn test_qrz_logbook_credentials(
         &self,
-        _request: Request<TestQrzLogbookCredentialsRequest>,
+        request: Request<TestQrzLogbookCredentialsRequest>,
     ) -> Result<Response<TestQrzLogbookCredentialsResponse>, Status> {
-        // TODO: implement when QRZ logbook HTTP client is built
-        Err(Status::unimplemented(
-            "TestQrzLogbookCredentials is not implemented yet.",
-        ))
+        let inner = request.into_inner();
+        let result = test_qrz_logbook_api_key(&inner.api_key, &self.runtime_config).await;
+        Ok(Response::new(result))
     }
 }
 
@@ -511,6 +515,10 @@ struct PersistedSetupConfig {
     station_profiles: PersistedStationProfileCatalog,
     #[serde(default)]
     qrz_xml: PersistedQrzXmlConfig,
+    #[serde(default, skip_serializing_if = "PersistedQrzLogbookConfig::is_empty")]
+    qrz_logbook: PersistedQrzLogbookConfig,
+    #[serde(default, skip_serializing_if = "PersistedSyncConfig::is_empty")]
+    sync: PersistedSyncConfig,
 }
 
 impl PersistedSetupConfig {
@@ -597,6 +605,18 @@ impl PersistedSetupConfig {
             username: qrz_xml_username,
             password: qrz_xml_password,
         };
+
+        // QRZ logbook API key: update when explicitly provided, otherwise keep existing.
+        let qrz_logbook_api_key = normalize_optional_string(request.qrz_logbook_api_key.as_deref());
+        if qrz_logbook_api_key.is_some() {
+            config.qrz_logbook.api_key = qrz_logbook_api_key;
+        }
+
+        // Sync config: update when explicitly provided, otherwise keep existing.
+        if let Some(ref sync_config) = request.sync_config {
+            config.sync = PersistedSyncConfig::from_proto(sync_config);
+        }
+
         config.sync_active_station_profile();
 
         Ok(config)
@@ -628,6 +648,33 @@ impl PersistedSetupConfig {
         }
         if let Some(password) = self.qrz_xml.password.as_deref() {
             values.insert(QRZ_XML_PASSWORD_ENV_VAR.to_string(), password.to_string());
+        }
+
+        // QRZ logbook config
+        if let Some(api_key) = self.qrz_logbook.api_key.as_deref() {
+            values.insert(QRZ_LOGBOOK_API_KEY_ENV_VAR.to_string(), api_key.to_string());
+        }
+        if let Some(base_url) = self.qrz_logbook.base_url.as_deref() {
+            values.insert(
+                QRZ_LOGBOOK_BASE_URL_ENV_VAR.to_string(),
+                base_url.to_string(),
+            );
+        }
+
+        // Sync config
+        values.insert(
+            SYNC_AUTO_ENABLED_ENV_VAR.to_string(),
+            self.sync.auto_sync_enabled.to_string(),
+        );
+        values.insert(
+            SYNC_INTERVAL_SECONDS_ENV_VAR.to_string(),
+            self.sync.sync_interval_seconds.to_string(),
+        );
+        if !self.sync.conflict_policy.is_empty() {
+            values.insert(
+                SYNC_CONFLICT_POLICY_ENV_VAR.to_string(),
+                self.sync.conflict_policy.clone(),
+            );
         }
 
         values
@@ -981,6 +1028,73 @@ struct PersistedQrzXmlConfig {
     password: Option<String>,
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct PersistedQrzLogbookConfig {
+    api_key: Option<String>,
+    base_url: Option<String>,
+}
+
+impl PersistedQrzLogbookConfig {
+    fn is_empty(config: &Self) -> bool {
+        normalize_optional_string(config.api_key.as_deref()).is_none()
+            && normalize_optional_string(config.base_url.as_deref()).is_none()
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct PersistedSyncConfig {
+    #[serde(default)]
+    auto_sync_enabled: bool,
+    #[serde(default = "default_sync_interval_seconds")]
+    sync_interval_seconds: u32,
+    #[serde(default)]
+    conflict_policy: String,
+}
+
+fn default_sync_interval_seconds() -> u32 {
+    300
+}
+
+impl PersistedSyncConfig {
+    fn is_empty(config: &Self) -> bool {
+        !config.auto_sync_enabled
+            && config.sync_interval_seconds == default_sync_interval_seconds()
+            && (config.conflict_policy.is_empty() || config.conflict_policy == "last_write_wins")
+    }
+
+    fn from_proto(sync_config: &SyncConfig) -> Self {
+        let conflict_policy = match ConflictPolicy::try_from(sync_config.conflict_policy) {
+            Ok(ConflictPolicy::FlagForReview) => "flag_for_review".to_string(),
+            _ => "last_write_wins".to_string(),
+        };
+        Self {
+            auto_sync_enabled: sync_config.auto_sync_enabled,
+            sync_interval_seconds: if sync_config.sync_interval_seconds == 0 {
+                default_sync_interval_seconds()
+            } else {
+                sync_config.sync_interval_seconds
+            },
+            conflict_policy,
+        }
+    }
+
+    fn to_proto(&self) -> SyncConfig {
+        let conflict_policy = match self.conflict_policy.as_str() {
+            "flag_for_review" => ConflictPolicy::FlagForReview,
+            _ => ConflictPolicy::LastWriteWins,
+        };
+        SyncConfig {
+            auto_sync_enabled: self.auto_sync_enabled,
+            sync_interval_seconds: if self.sync_interval_seconds == 0 {
+                default_sync_interval_seconds()
+            } else {
+                self.sync_interval_seconds
+            },
+            conflict_policy: conflict_policy as i32,
+        }
+    }
+}
+
 pub(crate) fn default_config_path() -> Result<PathBuf, String> {
     #[cfg(target_os = "windows")]
     {
@@ -1098,8 +1212,10 @@ fn build_status(
         log_file_path,
         suggested_log_file_path: suggested_log_file_path.display().to_string(),
         is_first_run: persisted_config.is_none(),
-        has_qrz_logbook_api_key: false, // TODO: populate from persisted config
-        sync_config: None,              // TODO: populate from persisted config
+        has_qrz_logbook_api_key: persisted_config
+            .and_then(|config| config.qrz_logbook.api_key.as_ref())
+            .is_some(),
+        sync_config: persisted_config.map(|config| config.sync.to_proto()),
     }
 }
 
@@ -1425,6 +1541,56 @@ async fn test_qrz_login(
     }
 }
 
+async fn test_qrz_logbook_api_key(
+    api_key: &str,
+    runtime_config: &RuntimeConfigManager,
+) -> TestQrzLogbookCredentialsResponse {
+    let api_key = api_key.trim();
+    if api_key.is_empty() {
+        return TestQrzLogbookCredentialsResponse {
+            success: false,
+            error_message: "API key is required.".to_string(),
+            qso_count: None,
+            logbook_owner: None,
+        };
+    }
+
+    let effective = runtime_config.effective_values().await;
+    let base_url = effective
+        .get(QRZ_LOGBOOK_BASE_URL_ENV_VAR)
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_QRZ_LOGBOOK_BASE_URL.to_string());
+
+    let config = QrzLogbookConfig::new(api_key.to_string(), base_url, "QsoRipper/1.0".to_string());
+
+    let client = match QrzLogbookClient::new(config) {
+        Ok(c) => c,
+        Err(error) => {
+            return TestQrzLogbookCredentialsResponse {
+                success: false,
+                error_message: format!("Failed to create logbook client: {error}"),
+                qso_count: None,
+                logbook_owner: None,
+            };
+        }
+    };
+
+    match client.test_connection().await {
+        Ok(status) => TestQrzLogbookCredentialsResponse {
+            success: true,
+            error_message: String::new(),
+            qso_count: Some(status.qso_count),
+            logbook_owner: Some(status.owner),
+        },
+        Err(error) => TestQrzLogbookCredentialsResponse {
+            success: false,
+            error_message: format!("{error}"),
+            qso_count: None,
+            logbook_owner: None,
+        },
+    }
+}
+
 fn normalize_optional_string(value: Option<&str>) -> Option<String> {
     let trimmed = value?.trim();
     if trimmed.is_empty() {
@@ -1516,7 +1682,7 @@ mod tests {
         StationProfileControlSurface, DEFAULT_CONFIG_FILE_NAME,
     };
     use crate::runtime_config::RuntimeConfigManager;
-    use qsoripper_core::proto::qsoripper::domain::StationProfile;
+    use qsoripper_core::proto::qsoripper::domain::{ConflictPolicy, StationProfile, SyncConfig};
     use qsoripper_core::proto::qsoripper::services::{
         setup_service_server::SetupService, station_profile_service_server::StationProfileService,
         GetActiveStationContextRequest, GetSetupStatusRequest, GetSetupWizardStateRequest,
@@ -2372,5 +2538,255 @@ station_callsign = "K7RND"
 
         assert!(!response.success);
         assert!(!response.error_message.is_empty());
+    }
+
+    // ── QRZ logbook API key and sync config tests ───────────────────────────
+
+    #[tokio::test]
+    async fn save_setup_persists_logbook_api_key_and_reports_in_status() {
+        let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "logbook-key.db");
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
+
+        // Save with logbook API key
+        let response = SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file_path),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                qrz_logbook_api_key: Some("abc-123-logbook-key".to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("save setup")
+        .into_inner();
+
+        let status = response.status.expect("status payload");
+        assert!(status.has_qrz_logbook_api_key);
+
+        // Verify it round-trips through persisted config on disk
+        let saved_toml = fs::read_to_string(&config_path).expect("read config");
+        let parsed =
+            toml::from_str::<PersistedSetupConfig>(&saved_toml).expect("parse saved config");
+        assert_eq!(
+            Some("abc-123-logbook-key"),
+            parsed.qrz_logbook.api_key.as_deref()
+        );
+
+        // Verify runtime values include the key
+        let runtime_values = setup_state.runtime_config_values().await;
+        assert_eq!(
+            Some("abc-123-logbook-key"),
+            runtime_values
+                .get(crate::runtime_config::QRZ_LOGBOOK_API_KEY_ENV_VAR)
+                .map(String::as_str)
+        );
+
+        drop(service);
+        drop(runtime_config);
+        drop(setup_state);
+
+        let config_directory = config_path.parent().expect("config directory");
+        let _ = fs::remove_dir_all(config_directory);
+    }
+
+    #[tokio::test]
+    async fn save_setup_without_logbook_key_reports_false() {
+        let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "no-logbook-key.db");
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state, runtime_config);
+
+        let response = SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file_path),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("save setup")
+        .into_inner();
+
+        let status = response.status.expect("status payload");
+        assert!(!status.has_qrz_logbook_api_key);
+        // Default sync config should be present
+        let sync = status.sync_config.expect("sync_config should be present");
+        assert!(!sync.auto_sync_enabled);
+        assert_eq!(300, sync.sync_interval_seconds);
+        assert_eq!(ConflictPolicy::LastWriteWins as i32, sync.conflict_policy);
+
+        drop(service);
+        let config_directory = config_path.parent().expect("config directory");
+        let _ = fs::remove_dir_all(config_directory);
+    }
+
+    #[tokio::test]
+    async fn save_setup_persists_sync_config_and_round_trips() {
+        let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "sync-config.db");
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
+
+        let response = SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file_path),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                sync_config: Some(SyncConfig {
+                    auto_sync_enabled: true,
+                    sync_interval_seconds: 600,
+                    conflict_policy: ConflictPolicy::FlagForReview as i32,
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("save setup")
+        .into_inner();
+
+        let status = response.status.expect("status payload");
+        let sync = status.sync_config.expect("sync_config");
+        assert!(sync.auto_sync_enabled);
+        assert_eq!(600, sync.sync_interval_seconds);
+        assert_eq!(ConflictPolicy::FlagForReview as i32, sync.conflict_policy);
+
+        // Verify persisted TOML
+        let saved_toml = fs::read_to_string(&config_path).expect("read config");
+        let parsed =
+            toml::from_str::<PersistedSetupConfig>(&saved_toml).expect("parse saved config");
+        assert!(parsed.sync.auto_sync_enabled);
+        assert_eq!(600, parsed.sync.sync_interval_seconds);
+        assert_eq!("flag_for_review", parsed.sync.conflict_policy);
+
+        // Verify runtime values
+        let runtime_values = setup_state.runtime_config_values().await;
+        assert_eq!(
+            Some("true"),
+            runtime_values
+                .get(crate::runtime_config::SYNC_AUTO_ENABLED_ENV_VAR)
+                .map(String::as_str)
+        );
+        assert_eq!(
+            Some("600"),
+            runtime_values
+                .get(crate::runtime_config::SYNC_INTERVAL_SECONDS_ENV_VAR)
+                .map(String::as_str)
+        );
+        assert_eq!(
+            Some("flag_for_review"),
+            runtime_values
+                .get(crate::runtime_config::SYNC_CONFLICT_POLICY_ENV_VAR)
+                .map(String::as_str)
+        );
+
+        drop(service);
+        drop(runtime_config);
+        drop(setup_state);
+
+        let config_directory = config_path.parent().expect("config directory");
+        let _ = fs::remove_dir_all(config_directory);
+    }
+
+    #[tokio::test]
+    async fn save_setup_preserves_logbook_key_when_omitted_in_subsequent_save() {
+        let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "preserve-key.db");
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
+
+        // First save: set the key
+        SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file_path.clone()),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                qrz_logbook_api_key: Some("original-key".to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("first save");
+
+        // Second save: omit the key
+        let response = SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file_path),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                // qrz_logbook_api_key omitted
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("second save")
+        .into_inner();
+
+        let status = response.status.expect("status payload");
+        assert!(
+            status.has_qrz_logbook_api_key,
+            "logbook key should be preserved across saves when omitted"
+        );
+
+        drop(service);
+        drop(runtime_config);
+        drop(setup_state);
+
+        let config_directory = config_path.parent().expect("config directory");
+        let _ = fs::remove_dir_all(config_directory);
+    }
+
+    #[test]
+    fn persisted_sync_config_round_trips_through_proto() {
+        let proto = SyncConfig {
+            auto_sync_enabled: true,
+            sync_interval_seconds: 120,
+            conflict_policy: ConflictPolicy::FlagForReview as i32,
+        };
+        let persisted = super::PersistedSyncConfig::from_proto(&proto);
+        assert!(persisted.auto_sync_enabled);
+        assert_eq!(120, persisted.sync_interval_seconds);
+        assert_eq!("flag_for_review", persisted.conflict_policy);
+
+        let back = persisted.to_proto();
+        assert!(back.auto_sync_enabled);
+        assert_eq!(120, back.sync_interval_seconds);
+        assert_eq!(ConflictPolicy::FlagForReview as i32, back.conflict_policy);
+    }
+
+    #[test]
+    fn persisted_sync_config_defaults_interval_when_zero() {
+        let proto = SyncConfig {
+            auto_sync_enabled: false,
+            sync_interval_seconds: 0,
+            conflict_policy: ConflictPolicy::LastWriteWins as i32,
+        };
+        let persisted = super::PersistedSyncConfig::from_proto(&proto);
+        assert_eq!(300, persisted.sync_interval_seconds);
+
+        let back = persisted.to_proto();
+        assert_eq!(300, back.sync_interval_seconds);
     }
 }

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -1,0 +1,1304 @@
+//! Bidirectional QRZ logbook sync workflow.
+//!
+//! **Phase 1** — Download QSOs from QRZ and merge into local storage.
+//! **Phase 2** — Upload local-only and modified QSOs to QRZ.
+//! **Phase 3** — Update sync metadata with the current timestamp.
+
+use std::collections::HashMap;
+
+use qsoripper_core::domain::qso::new_local_id;
+use qsoripper_core::proto::qsoripper::domain::{ConflictPolicy, QsoRecord, SyncStatus};
+use qsoripper_core::proto::qsoripper::services::SyncWithQrzResponse;
+use qsoripper_core::qrz_logbook::{QrzLogbookClient, QrzLogbookError, QrzUploadResult};
+use qsoripper_core::storage::{LogbookStore, QsoListQuery, SyncMetadata};
+use tokio::sync::mpsc;
+use tonic::Status;
+
+// ---------------------------------------------------------------------------
+// Type aliases (avoids clippy::type_complexity)
+// ---------------------------------------------------------------------------
+
+/// Index from QRZ logbook-record-id → local QSO.
+type LogidIndex = HashMap<String, QsoRecord>;
+
+/// Index from (callsign, band, mode) → local QSOs with that key.
+type FuzzyIndex = HashMap<(String, i32, i32), Vec<QsoRecord>>;
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/// Extra-field key that QRZ ADIF responses use for the logbook record ID.
+const QRZ_LOGID_EXTRA_FIELD: &str = "APP_QRZ_LOGID";
+
+/// Maximum time difference (seconds) for fuzzy timestamp matching.
+const TIMESTAMP_TOLERANCE_SECONDS: i64 = 60;
+
+// ---------------------------------------------------------------------------
+// Trait — testable abstraction over the real QRZ HTTP client
+// ---------------------------------------------------------------------------
+
+/// QRZ logbook HTTP operations required by the sync workflow.
+///
+/// Extracted into a trait so unit tests can substitute a mock without hitting
+/// the network.
+#[tonic::async_trait]
+pub(crate) trait QrzLogbookApi: Send + Sync {
+    /// Fetch QSOs from the remote logbook, optionally since a date.
+    async fn fetch_qsos(&self, since: Option<&str>) -> Result<Vec<QsoRecord>, QrzLogbookError>;
+
+    /// Upload a single QSO and return its QRZ-assigned log ID.
+    async fn upload_qso(&self, qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError>;
+}
+
+#[tonic::async_trait]
+impl QrzLogbookApi for QrzLogbookClient {
+    async fn fetch_qsos(&self, since: Option<&str>) -> Result<Vec<QsoRecord>, QrzLogbookError> {
+        QrzLogbookClient::fetch_qsos(self, since).await
+    }
+
+    async fn upload_qso(&self, qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError> {
+        QrzLogbookClient::upload_qso(self, qso).await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Accumulated sync counters
+// ---------------------------------------------------------------------------
+
+struct SyncCounters {
+    downloaded: u32,
+    uploaded: u32,
+    conflicts: u32,
+    errors: Vec<String>,
+}
+
+impl SyncCounters {
+    fn new() -> Self {
+        Self {
+            downloaded: 0,
+            uploaded: 0,
+            conflicts: 0,
+            errors: Vec::new(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Core sync orchestrator
+// ---------------------------------------------------------------------------
+
+/// Execute a bidirectional sync between the local logbook and QRZ.
+///
+/// Sends streaming progress updates through `progress_tx`. The final message
+/// will have `complete = true`.
+pub(crate) async fn execute_sync(
+    client: &dyn QrzLogbookApi,
+    store: &dyn LogbookStore,
+    full_sync: bool,
+    conflict_policy: ConflictPolicy,
+    progress_tx: &mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
+) {
+    let mut counters = SyncCounters::new();
+
+    let metadata = download_phase(
+        client,
+        store,
+        full_sync,
+        conflict_policy,
+        progress_tx,
+        &mut counters,
+    )
+    .await;
+
+    upload_phase(client, store, progress_tx, &mut counters).await;
+
+    update_metadata(store, &metadata, &mut counters).await;
+
+    let error_summary = if counters.errors.is_empty() {
+        None
+    } else {
+        Some(counters.errors.join("; "))
+    };
+
+    eprintln!(
+        "[sync] Sync completed: downloaded={} uploaded={} conflicts={} errors={}",
+        counters.downloaded,
+        counters.uploaded,
+        counters.conflicts,
+        counters.errors.len(),
+    );
+
+    send_complete(
+        progress_tx,
+        counters.downloaded,
+        counters.uploaded,
+        counters.conflicts,
+        error_summary,
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — Download from QRZ
+// ---------------------------------------------------------------------------
+
+async fn download_phase(
+    client: &dyn QrzLogbookApi,
+    store: &dyn LogbookStore,
+    full_sync: bool,
+    conflict_policy: ConflictPolicy,
+    progress_tx: &mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
+    counters: &mut SyncCounters,
+) -> SyncMetadata {
+    send_progress(progress_tx, "Fetching QSOs from QRZ…", 0, 0, 0).await;
+
+    let metadata = match store.get_sync_metadata().await {
+        Ok(m) => m,
+        Err(err) => {
+            eprintln!("[sync] Failed to read sync metadata: {err}");
+            SyncMetadata::default()
+        }
+    };
+
+    let since_date = if full_sync {
+        None
+    } else {
+        metadata
+            .last_sync
+            .as_ref()
+            .and_then(|ts| chrono::DateTime::from_timestamp(ts.seconds, 0))
+            .map(|dt| dt.format("%Y-%m-%d").to_string())
+    };
+
+    let remote_qsos = match client.fetch_qsos(since_date.as_deref()).await {
+        Ok(qsos) => qsos,
+        Err(err) => {
+            send_complete(
+                progress_tx,
+                0,
+                0,
+                0,
+                Some(format!("Failed to fetch QSOs from QRZ: {err}")),
+            )
+            .await;
+            return metadata;
+        }
+    };
+
+    eprintln!(
+        "[sync] Fetched {} QSOs from QRZ (full_sync={full_sync})",
+        remote_qsos.len()
+    );
+
+    send_progress(
+        progress_tx,
+        &format!("Processing {} downloaded QSOs…", remote_qsos.len()),
+        counters.downloaded,
+        counters.uploaded,
+        counters.conflicts,
+    )
+    .await;
+
+    // Load all local QSOs for matching.
+    let local_qsos = match store.list_qsos(&QsoListQuery::default()).await {
+        Ok(qsos) => qsos,
+        Err(err) => {
+            send_complete(
+                progress_tx,
+                0,
+                0,
+                0,
+                Some(format!("Failed to load local QSOs: {err}")),
+            )
+            .await;
+            return metadata;
+        }
+    };
+
+    // Build lookup indexes.
+    let (mut by_qrz_logid, mut by_key) = build_local_indexes(&local_qsos);
+
+    // Process each remote QSO.
+    for remote in &remote_qsos {
+        let remote_logid = extract_qrz_logid(remote);
+
+        let local_match = remote_logid
+            .as_deref()
+            .and_then(|logid| by_qrz_logid.get(logid).cloned())
+            .or_else(|| fuzzy_match(remote, &by_key));
+
+        match local_match {
+            None => {
+                insert_new_remote_qso(
+                    remote,
+                    remote_logid.as_deref(),
+                    store,
+                    &mut by_qrz_logid,
+                    &mut by_key,
+                    counters,
+                )
+                .await;
+            }
+            Some(local) => {
+                merge_with_local(
+                    &local,
+                    remote_logid.as_deref(),
+                    remote,
+                    store,
+                    conflict_policy,
+                    counters,
+                )
+                .await;
+            }
+        }
+    }
+
+    metadata
+}
+
+/// Insert a QSO downloaded from QRZ that has no local match.
+async fn insert_new_remote_qso(
+    remote: &QsoRecord,
+    remote_logid: Option<&str>,
+    store: &dyn LogbookStore,
+    by_qrz_logid: &mut LogidIndex,
+    by_key: &mut FuzzyIndex,
+    counters: &mut SyncCounters,
+) {
+    let mut new_qso = remote.clone();
+    if new_qso.local_id.is_empty() {
+        new_qso.local_id = new_local_id();
+    }
+    new_qso.sync_status = SyncStatus::Synced as i32;
+    if let Some(logid) = remote_logid {
+        new_qso.qrz_logid = Some(logid.to_string());
+    }
+    match store.insert_qso(&new_qso).await {
+        Ok(()) => {
+            counters.downloaded += 1;
+            // Keep indexes up to date for subsequent matches.
+            if let Some(logid) = remote_logid {
+                by_qrz_logid.insert(logid.to_string(), new_qso.clone());
+            }
+            let key = (
+                new_qso.worked_callsign.to_ascii_uppercase(),
+                new_qso.band,
+                new_qso.mode,
+            );
+            by_key.entry(key).or_default().push(new_qso);
+        }
+        Err(err) => {
+            eprintln!(
+                "[sync] Failed to insert downloaded QSO for {}: {err}",
+                remote.worked_callsign
+            );
+            counters.errors.push(format!(
+                "Insert failed for {}: {err}",
+                remote.worked_callsign
+            ));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2 — Upload pending local QSOs to QRZ
+// ---------------------------------------------------------------------------
+
+async fn upload_phase(
+    client: &dyn QrzLogbookApi,
+    store: &dyn LogbookStore,
+    progress_tx: &mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
+    counters: &mut SyncCounters,
+) {
+    send_progress(
+        progress_tx,
+        "Uploading local QSOs to QRZ…",
+        counters.downloaded,
+        counters.uploaded,
+        counters.conflicts,
+    )
+    .await;
+
+    let pending_qsos: Vec<QsoRecord> = match store.list_qsos(&QsoListQuery::default()).await {
+        Ok(qsos) => qsos
+            .into_iter()
+            .filter(|q| {
+                q.sync_status == SyncStatus::LocalOnly as i32
+                    || q.sync_status == SyncStatus::Modified as i32
+            })
+            .collect(),
+        Err(err) => {
+            eprintln!("[sync] Failed to list pending QSOs for upload: {err}");
+            counters
+                .errors
+                .push(format!("Failed to list pending QSOs: {err}"));
+            Vec::new()
+        }
+    };
+
+    eprintln!(
+        "[sync] Uploading {} pending QSOs to QRZ",
+        pending_qsos.len()
+    );
+
+    for qso in &pending_qsos {
+        match client.upload_qso(qso).await {
+            Ok(result) => {
+                let mut synced = qso.clone();
+                synced.qrz_logid = Some(result.logid);
+                synced.sync_status = SyncStatus::Synced as i32;
+                match store.update_qso(&synced).await {
+                    Ok(_) => counters.uploaded += 1,
+                    Err(err) => {
+                        eprintln!(
+                            "[sync] Uploaded but failed to update local record {}: {err}",
+                            qso.local_id
+                        );
+                        counters.errors.push(format!(
+                            "Upload succeeded for {} but local update failed: {err}",
+                            qso.worked_callsign,
+                        ));
+                    }
+                }
+            }
+            Err(err) => {
+                eprintln!(
+                    "[sync] Failed to upload QSO {} ({}): {err}",
+                    qso.local_id, qso.worked_callsign
+                );
+                counters
+                    .errors
+                    .push(format!("Upload failed for {}: {err}", qso.worked_callsign));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 3 — Persist updated metadata
+// ---------------------------------------------------------------------------
+
+async fn update_metadata(
+    store: &dyn LogbookStore,
+    prev_metadata: &SyncMetadata,
+    counters: &mut SyncCounters,
+) {
+    let now = chrono::Utc::now();
+    let updated = SyncMetadata {
+        qrz_qso_count: prev_metadata.qrz_qso_count,
+        last_sync: Some(prost_types::Timestamp {
+            seconds: now.timestamp(),
+            nanos: 0,
+        }),
+        qrz_logbook_owner: prev_metadata.qrz_logbook_owner.clone(),
+    };
+
+    if let Err(err) = store.upsert_sync_metadata(&updated).await {
+        eprintln!("[sync] Failed to update sync metadata: {err}");
+        counters
+            .errors
+            .push(format!("Failed to update sync metadata: {err}"));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Download merge helpers
+// ---------------------------------------------------------------------------
+
+/// Merge a remote QSO with a matched local QSO based on sync status.
+async fn merge_with_local(
+    local: &QsoRecord,
+    remote_logid: Option<&str>,
+    remote: &QsoRecord,
+    store: &dyn LogbookStore,
+    conflict_policy: ConflictPolicy,
+    counters: &mut SyncCounters,
+) {
+    match SyncStatus::try_from(local.sync_status) {
+        Ok(SyncStatus::Synced) => {
+            // Remote wins — update local with remote data.
+            let mut updated = remote.clone();
+            updated.local_id.clone_from(&local.local_id);
+            updated.sync_status = SyncStatus::Synced as i32;
+            updated.qrz_logid = remote_logid
+                .map(String::from)
+                .or_else(|| local.qrz_logid.clone());
+
+            match store.update_qso(&updated).await {
+                Ok(_) => counters.downloaded += 1,
+                Err(err) => {
+                    eprintln!(
+                        "[sync] Failed to update QSO {} from remote: {err}",
+                        local.local_id
+                    );
+                    counters.errors.push(format!(
+                        "Update failed for {}: {err}",
+                        local.worked_callsign
+                    ));
+                }
+            }
+        }
+        Ok(SyncStatus::LocalOnly) => {
+            // The QSO was already on QRZ (e.g. uploaded outside QsoRipper).
+            // Link it and mark synced to avoid a duplicate upload in Phase 2.
+            let mut linked = local.clone();
+            linked.sync_status = SyncStatus::Synced as i32;
+            if let Some(logid) = remote_logid {
+                linked.qrz_logid = Some(logid.to_string());
+            }
+            match store.update_qso(&linked).await {
+                Ok(_) => counters.downloaded += 1,
+                Err(err) => {
+                    eprintln!(
+                        "[sync] Failed to link local-only QSO {} to remote: {err}",
+                        local.local_id
+                    );
+                    counters
+                        .errors
+                        .push(format!("Link failed for {}: {err}", local.worked_callsign));
+                }
+            }
+        }
+        Ok(SyncStatus::Modified) => {
+            resolve_modified_conflict(local, remote, store, conflict_policy, counters).await;
+        }
+        _ => {
+            // Conflict or unknown — leave untouched.
+        }
+    }
+}
+
+/// Resolve a modified-vs-remote conflict according to the configured policy.
+///
+/// - **`LastWriteWins`**: compare `updated_at` timestamps. If remote is newer
+///   (or timestamps tie), overwrite local and set `SYNCED`. If local is newer,
+///   leave it as `MODIFIED` so the upload phase pushes it.
+/// - **`FlagForReview`**: set local to `CONFLICT` without overwriting.
+async fn resolve_modified_conflict(
+    local: &QsoRecord,
+    remote: &QsoRecord,
+    store: &dyn LogbookStore,
+    policy: ConflictPolicy,
+    counters: &mut SyncCounters,
+) {
+    match policy {
+        ConflictPolicy::LastWriteWins => {
+            let local_ts = local.updated_at.as_ref().map_or(0, |ts| ts.seconds);
+            let remote_ts = remote.updated_at.as_ref().map_or(0, |ts| ts.seconds);
+
+            if remote_ts >= local_ts {
+                // Remote is newer (or equal) — overwrite local.
+                let mut updated = remote.clone();
+                updated.local_id.clone_from(&local.local_id);
+                updated.sync_status = SyncStatus::Synced as i32;
+                updated.qrz_logid.clone_from(&local.qrz_logid);
+                match store.update_qso(&updated).await {
+                    Ok(_) => counters.downloaded += 1,
+                    Err(err) => {
+                        eprintln!(
+                            "[sync] Failed to overwrite QSO {} with newer remote: {err}",
+                            local.local_id
+                        );
+                        counters.errors.push(format!(
+                            "Overwrite failed for {}: {err}",
+                            local.worked_callsign,
+                        ));
+                    }
+                }
+            } else {
+                // Local is newer — keep MODIFIED; upload phase will push it.
+                eprintln!(
+                    "[sync] Local QSO {} is newer than remote; keeping MODIFIED for upload",
+                    local.local_id
+                );
+            }
+        }
+        ConflictPolicy::FlagForReview => {
+            let mut conflicted = local.clone();
+            conflicted.sync_status = SyncStatus::Conflict as i32;
+            match store.update_qso(&conflicted).await {
+                Ok(_) => counters.conflicts += 1,
+                Err(err) => {
+                    eprintln!(
+                        "[sync] Failed to mark QSO {} as conflict: {err}",
+                        local.local_id
+                    );
+                    counters.errors.push(format!(
+                        "Conflict mark failed for {}: {err}",
+                        local.worked_callsign
+                    ));
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Matching helpers
+// ---------------------------------------------------------------------------
+
+fn build_local_indexes(local_qsos: &[QsoRecord]) -> (LogidIndex, FuzzyIndex) {
+    let mut by_qrz_logid: LogidIndex = HashMap::new();
+    let mut by_key: FuzzyIndex = HashMap::new();
+
+    for qso in local_qsos {
+        if let Some(logid) = qso.qrz_logid.as_deref() {
+            if !logid.is_empty() {
+                by_qrz_logid.insert(logid.to_string(), qso.clone());
+            }
+        }
+        let key = (qso.worked_callsign.to_ascii_uppercase(), qso.band, qso.mode);
+        by_key.entry(key).or_default().push(qso.clone());
+    }
+
+    (by_qrz_logid, by_key)
+}
+
+/// Extract the QRZ logbook record ID from a QSO.
+///
+/// Checks the dedicated `qrz_logid` field first, then falls back to
+/// `extra_fields["APP_QRZ_LOGID"]`.
+fn extract_qrz_logid(qso: &QsoRecord) -> Option<String> {
+    if let Some(logid) = qso.qrz_logid.as_deref() {
+        if !logid.is_empty() {
+            return Some(logid.to_string());
+        }
+    }
+    qso.extra_fields
+        .get(QRZ_LOGID_EXTRA_FIELD)
+        .filter(|v| !v.is_empty())
+        .cloned()
+}
+
+/// Find a local QSO matching by worked callsign, band, mode, and timestamp
+/// (within [`TIMESTAMP_TOLERANCE_SECONDS`]).
+fn fuzzy_match(remote: &QsoRecord, by_key: &FuzzyIndex) -> Option<QsoRecord> {
+    let key = (
+        remote.worked_callsign.to_ascii_uppercase(),
+        remote.band,
+        remote.mode,
+    );
+    let candidates = by_key.get(&key)?;
+    let remote_ts = remote.utc_timestamp.as_ref()?.seconds;
+
+    candidates
+        .iter()
+        .find(|local| {
+            local
+                .utc_timestamp
+                .as_ref()
+                .is_some_and(|ts| (ts.seconds - remote_ts).abs() <= TIMESTAMP_TOLERANCE_SECONDS)
+        })
+        .cloned()
+}
+
+// ---------------------------------------------------------------------------
+// Progress reporting helpers
+// ---------------------------------------------------------------------------
+
+async fn send_progress(
+    tx: &mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
+    action: &str,
+    downloaded: u32,
+    uploaded: u32,
+    conflicts: u32,
+) {
+    drop(
+        tx.send(Ok(SyncWithQrzResponse {
+            total_records: downloaded + uploaded,
+            processed_records: downloaded + uploaded,
+            uploaded_records: uploaded,
+            downloaded_records: downloaded,
+            conflict_records: conflicts,
+            current_action: Some(action.to_string()),
+            complete: false,
+            error: None,
+        }))
+        .await,
+    );
+}
+
+async fn send_complete(
+    tx: &mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
+    downloaded: u32,
+    uploaded: u32,
+    conflicts: u32,
+    error: Option<String>,
+) {
+    drop(
+        tx.send(Ok(SyncWithQrzResponse {
+            total_records: downloaded + uploaded,
+            processed_records: downloaded + uploaded,
+            uploaded_records: uploaded,
+            downloaded_records: downloaded,
+            conflict_records: conflicts,
+            current_action: Some("Sync complete".to_string()),
+            complete: true,
+            error,
+        }))
+        .await,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(
+    clippy::unwrap_used,
+    clippy::panic,
+    clippy::expect_used,
+    clippy::indexing_slicing
+)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use prost_types::Timestamp;
+    use qsoripper_core::domain::qso::QsoRecordBuilder;
+    use qsoripper_core::proto::qsoripper::domain::{
+        Band, ConflictPolicy, Mode, QsoRecord, SyncStatus,
+    };
+    use qsoripper_core::qrz_logbook::{QrzLogbookError, QrzUploadResult};
+    use qsoripper_core::storage::{LogbookStore, QsoListQuery, SyncMetadata};
+    use qsoripper_storage_memory::MemoryStorage;
+    use tokio::sync::mpsc;
+
+    use super::{execute_sync, QrzLogbookApi};
+
+    // -- Mock API -----------------------------------------------------------
+
+    struct MockQrzApi {
+        fetch_result: Mutex<Option<Result<Vec<QsoRecord>, QrzLogbookError>>>,
+        upload_results: Mutex<Vec<Result<QrzUploadResult, QrzLogbookError>>>,
+    }
+
+    impl MockQrzApi {
+        fn new(
+            fetch: Result<Vec<QsoRecord>, QrzLogbookError>,
+            uploads: Vec<Result<QrzUploadResult, QrzLogbookError>>,
+        ) -> Self {
+            Self {
+                fetch_result: Mutex::new(Some(fetch)),
+                upload_results: Mutex::new(uploads),
+            }
+        }
+    }
+
+    #[tonic::async_trait]
+    impl QrzLogbookApi for MockQrzApi {
+        async fn fetch_qsos(
+            &self,
+            _since: Option<&str>,
+        ) -> Result<Vec<QsoRecord>, QrzLogbookError> {
+            self.fetch_result
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or_else(|| Ok(Vec::new()))
+        }
+
+        async fn upload_qso(&self, _qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError> {
+            let mut results = self.upload_results.lock().unwrap();
+            if results.is_empty() {
+                Err(QrzLogbookError::ApiError(
+                    "no more mock upload results".into(),
+                ))
+            } else {
+                results.remove(0)
+            }
+        }
+    }
+
+    /// Capturing mock that records what `since` value was passed to `fetch_qsos`.
+    struct CapturingApi {
+        since: Arc<Mutex<Option<String>>>,
+    }
+
+    #[tonic::async_trait]
+    impl QrzLogbookApi for CapturingApi {
+        async fn fetch_qsos(&self, since: Option<&str>) -> Result<Vec<QsoRecord>, QrzLogbookError> {
+            *self.since.lock().unwrap() = since.map(String::from);
+            Ok(vec![])
+        }
+
+        async fn upload_qso(&self, _qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError> {
+            Ok(QrzUploadResult {
+                logid: "ignored".into(),
+            })
+        }
+    }
+
+    // -- Helpers ------------------------------------------------------------
+
+    fn make_qso(station: &str, worked: &str, band: Band, mode: Mode, ts_seconds: i64) -> QsoRecord {
+        QsoRecordBuilder::new(station, worked)
+            .band(band)
+            .mode(mode)
+            .timestamp(Timestamp {
+                seconds: ts_seconds,
+                nanos: 0,
+            })
+            .build()
+    }
+
+    /// Collect the final streamed response.
+    async fn collect_final(
+        mut rx: mpsc::Receiver<Result<super::SyncWithQrzResponse, tonic::Status>>,
+    ) -> super::SyncWithQrzResponse {
+        let mut last = None;
+        while let Some(Ok(msg)) = rx.recv().await {
+            last = Some(msg);
+        }
+        last.expect("expected at least one streamed response")
+    }
+
+    // -- Test cases ---------------------------------------------------------
+
+    #[tokio::test]
+    async fn download_inserts_new_qsos_from_remote() {
+        let store = MemoryStorage::new();
+
+        let remote1 = {
+            let mut q = make_qso("W1AW", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+            q.qrz_logid = Some("QRZ001".into());
+            q
+        };
+        let remote2 = {
+            let mut q = make_qso("W1AW", "JA1ZZZ", Band::Band40m, Mode::Cw, 1_700_000_100);
+            q.qrz_logid = Some("QRZ002".into());
+            q
+        };
+        let api = MockQrzApi::new(Ok(vec![remote1, remote2]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.downloaded_records, 2);
+        assert_eq!(final_msg.uploaded_records, 0);
+        assert!(final_msg.error.is_none());
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 2);
+        for qso in &all {
+            assert_eq!(qso.sync_status, SyncStatus::Synced as i32);
+            assert!(qso.qrz_logid.is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn upload_sends_local_only_qsos() {
+        let store = MemoryStorage::new();
+
+        let local1 = make_qso("W1AW", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        let local2 = make_qso("W1AW", "DL1ABC", Band::Band40m, Mode::Ssb, 1_700_000_100);
+        store.insert_qso(&local1).await.unwrap();
+        store.insert_qso(&local2).await.unwrap();
+
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![
+                Ok(QrzUploadResult {
+                    logid: "QRZ100".into(),
+                }),
+                Ok(QrzUploadResult {
+                    logid: "QRZ101".into(),
+                }),
+            ],
+        );
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.uploaded_records, 2);
+        assert_eq!(final_msg.downloaded_records, 0);
+        assert!(final_msg.error.is_none());
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        for qso in &all {
+            assert_eq!(qso.sync_status, SyncStatus::Synced as i32);
+            assert!(qso.qrz_logid.is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn mixed_sync_downloads_and_uploads() {
+        let store = MemoryStorage::new();
+
+        // One local QSO pending upload.
+        let local = make_qso("W1AW", "K7LOCAL", Band::Band10m, Mode::Ft8, 1_700_000_500);
+        store.insert_qso(&local).await.unwrap();
+
+        // One remote QSO not yet in local store.
+        let remote = {
+            let mut q = make_qso("W1AW", "VK3REMOTE", Band::Band20m, Mode::Cw, 1_700_000_600);
+            q.qrz_logid = Some("QRZ200".into());
+            q
+        };
+
+        let api = MockQrzApi::new(
+            Ok(vec![remote]),
+            vec![Ok(QrzUploadResult {
+                logid: "QRZ201".into(),
+            })],
+        );
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.downloaded_records, 1);
+        assert_eq!(final_msg.uploaded_records, 1);
+        assert!(final_msg.error.is_none());
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn upload_errors_do_not_abort_sync() {
+        let store = MemoryStorage::new();
+
+        let local1 = make_qso("W1AW", "K7FAIL", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        let local2 = make_qso("W1AW", "K7PASS", Band::Band40m, Mode::Ssb, 1_700_000_100);
+        store.insert_qso(&local1).await.unwrap();
+        store.insert_qso(&local2).await.unwrap();
+
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![
+                Err(QrzLogbookError::ApiError("rejected".into())),
+                Ok(QrzUploadResult {
+                    logid: "QRZ300".into(),
+                }),
+            ],
+        );
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        // One upload succeeded, one failed.
+        assert_eq!(final_msg.uploaded_records, 1);
+        assert!(final_msg.error.is_some());
+    }
+
+    #[tokio::test]
+    async fn metadata_persisted_after_sync() {
+        let store = MemoryStorage::new();
+
+        let api = MockQrzApi::new(Ok(vec![]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        drop(collect_final(rx).await);
+
+        let metadata = store.get_sync_metadata().await.unwrap();
+        assert!(
+            metadata.last_sync.is_some(),
+            "last_sync should be set after sync"
+        );
+    }
+
+    #[tokio::test]
+    async fn fuzzy_match_links_by_callsign_time_band_mode() {
+        let store = MemoryStorage::new();
+
+        // Insert a local QSO.
+        let local = make_qso("W1AW", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        store.insert_qso(&local).await.unwrap();
+
+        // Remote QSO: same callsign+band+mode, timestamp differs by 30 seconds.
+        // No qrz_logid on local, so the match must be fuzzy.
+        let remote = {
+            let mut q = make_qso("W1AW", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_030);
+            q.qrz_logid = Some("QRZ400".into());
+            // Give it a fresh local_id to make it clearly different from the local one.
+            q.local_id = "remote-temp-id".into();
+            q
+        };
+
+        let api = MockQrzApi::new(Ok(vec![remote]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        // The remote matched the local, so it counts as a download update,
+        // not a new insert. No new QSOs created.
+        assert_eq!(final_msg.downloaded_records, 1);
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1, "fuzzy match should not insert a duplicate");
+        assert_eq!(all[0].sync_status, SyncStatus::Synced as i32);
+    }
+
+    #[tokio::test]
+    async fn modified_local_marked_as_conflict_on_remote_match() {
+        let store = MemoryStorage::new();
+
+        // Local QSO with MODIFIED status.
+        let mut local = make_qso("W1AW", "K7MOD", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        local.sync_status = SyncStatus::Modified as i32;
+        local.qrz_logid = Some("QRZ500".into());
+        store.insert_qso(&local).await.unwrap();
+
+        // Remote QSO with same logid.
+        let remote = {
+            let mut q = make_qso("W1AW", "K7MOD", Band::Band20m, Mode::Ft8, 1_700_000_000);
+            q.qrz_logid = Some("QRZ500".into());
+            q
+        };
+
+        let api = MockQrzApi::new(Ok(vec![remote]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::FlagForReview, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.conflict_records, 1);
+        assert_eq!(final_msg.uploaded_records, 0);
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].sync_status, SyncStatus::Conflict as i32);
+    }
+
+    #[tokio::test]
+    async fn local_only_linked_to_remote_not_reuploaded() {
+        let store = MemoryStorage::new();
+
+        // Local QSO with LOCAL_ONLY status that happens to match a remote QSO.
+        let local = make_qso("W1AW", "K7LINK", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        assert_eq!(local.sync_status, SyncStatus::LocalOnly as i32);
+        store.insert_qso(&local).await.unwrap();
+
+        // Remote QSO matches by callsign+band+mode+timestamp.
+        let remote = {
+            let mut q = make_qso("W1AW", "K7LINK", Band::Band20m, Mode::Ft8, 1_700_000_010);
+            q.qrz_logid = Some("QRZ600".into());
+            q.local_id = "remote-temp".into();
+            q
+        };
+
+        // No upload results needed — the QSO should be linked, not uploaded.
+        let api = MockQrzApi::new(Ok(vec![remote]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.downloaded_records, 1);
+        assert_eq!(
+            final_msg.uploaded_records, 0,
+            "linked QSO should not be re-uploaded"
+        );
+        assert!(final_msg.error.is_none());
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].sync_status, SyncStatus::Synced as i32);
+        assert_eq!(all[0].qrz_logid.as_deref(), Some("QRZ600"));
+    }
+
+    #[tokio::test]
+    async fn incremental_sync_uses_last_sync_date() {
+        let store = MemoryStorage::new();
+
+        // Seed metadata with a previous sync timestamp.
+        let metadata = SyncMetadata {
+            last_sync: Some(Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            }),
+            ..SyncMetadata::default()
+        };
+        store.upsert_sync_metadata(&metadata).await.unwrap();
+
+        let since_capture: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let api = CapturingApi {
+            since: since_capture.clone(),
+        };
+
+        let (tx, rx) = mpsc::channel(16);
+        // full_sync = false → should use last_sync date.
+        execute_sync(&api, &store, false, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        drop(collect_final(rx).await);
+
+        let captured = since_capture.lock().unwrap().clone();
+        assert_eq!(captured.as_deref(), Some("2023-11-14"));
+    }
+
+    #[tokio::test]
+    async fn full_sync_ignores_last_sync_date() {
+        let store = MemoryStorage::new();
+
+        let metadata = SyncMetadata {
+            last_sync: Some(Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            }),
+            ..SyncMetadata::default()
+        };
+        store.upsert_sync_metadata(&metadata).await.unwrap();
+
+        let since_capture: Arc<Mutex<Option<String>>> =
+            Arc::new(Mutex::new(Some("should-be-cleared".into())));
+        let api = CapturingApi {
+            since: since_capture.clone(),
+        };
+
+        let (tx, rx) = mpsc::channel(16);
+        // full_sync = true → should NOT pass a since date.
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        drop(collect_final(rx).await);
+
+        let captured = since_capture.lock().unwrap().clone();
+        assert!(
+            captured.is_none(),
+            "full_sync should not pass a since parameter"
+        );
+    }
+
+    #[tokio::test]
+    async fn extract_logid_from_extra_fields() {
+        let qso = QsoRecord {
+            extra_fields: [(super::QRZ_LOGID_EXTRA_FIELD.into(), "EX123".into())]
+                .into_iter()
+                .collect(),
+            ..QsoRecord::default()
+        };
+
+        let logid = super::extract_qrz_logid(&qso);
+        assert_eq!(logid.as_deref(), Some("EX123"));
+    }
+
+    #[tokio::test]
+    async fn extract_logid_prefers_dedicated_field() {
+        let qso = QsoRecord {
+            qrz_logid: Some("DIRECT".into()),
+            extra_fields: [(super::QRZ_LOGID_EXTRA_FIELD.into(), "EXTRA".into())]
+                .into_iter()
+                .collect(),
+            ..QsoRecord::default()
+        };
+
+        let logid = super::extract_qrz_logid(&qso);
+        assert_eq!(logid.as_deref(), Some("DIRECT"));
+    }
+
+    // -- Conflict-policy tests -----------------------------------------------
+
+    #[tokio::test]
+    async fn last_write_wins_remote_newer_overwrites_local() {
+        let store = MemoryStorage::new();
+
+        // Local QSO: MODIFIED, updated_at = 1000.
+        let mut local = make_qso("W1AW", "K7LWW", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        local.sync_status = SyncStatus::Modified as i32;
+        local.qrz_logid = Some("QRZ700".into());
+        local.updated_at = Some(Timestamp {
+            seconds: 1000,
+            nanos: 0,
+        });
+        local.notes = Some("local edit".into());
+        store.insert_qso(&local).await.unwrap();
+
+        // Remote QSO: same logid, updated_at = 2000 (newer).
+        let remote = {
+            let mut q = make_qso("W1AW", "K7LWW", Band::Band20m, Mode::Ft8, 1_700_000_000);
+            q.qrz_logid = Some("QRZ700".into());
+            q.updated_at = Some(Timestamp {
+                seconds: 2000,
+                nanos: 0,
+            });
+            q.notes = Some("remote edit".into());
+            q
+        };
+
+        let api = MockQrzApi::new(Ok(vec![remote]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.downloaded_records, 1, "remote should overwrite");
+        assert_eq!(final_msg.conflict_records, 0);
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].sync_status, SyncStatus::Synced as i32);
+        assert_eq!(all[0].notes.as_deref(), Some("remote edit"));
+    }
+
+    #[tokio::test]
+    async fn last_write_wins_local_newer_keeps_modified() {
+        let store = MemoryStorage::new();
+
+        // Local QSO: MODIFIED, updated_at = 3000 (newer).
+        let mut local = make_qso("W1AW", "K7LWW2", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        local.sync_status = SyncStatus::Modified as i32;
+        local.qrz_logid = Some("QRZ701".into());
+        local.updated_at = Some(Timestamp {
+            seconds: 3000,
+            nanos: 0,
+        });
+        local.notes = Some("local newer".into());
+        store.insert_qso(&local).await.unwrap();
+
+        // Remote QSO: updated_at = 1000 (older).
+        let remote = {
+            let mut q = make_qso("W1AW", "K7LWW2", Band::Band20m, Mode::Ft8, 1_700_000_000);
+            q.qrz_logid = Some("QRZ701".into());
+            q.updated_at = Some(Timestamp {
+                seconds: 1000,
+                nanos: 0,
+            });
+            q.notes = Some("remote older".into());
+            q
+        };
+
+        // Provide an upload result because the upload phase will push the local QSO.
+        let api = MockQrzApi::new(
+            Ok(vec![remote]),
+            vec![Ok(QrzUploadResult {
+                logid: "QRZ701".into(),
+            })],
+        );
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(
+            final_msg.downloaded_records, 0,
+            "local is newer, no download"
+        );
+        assert_eq!(final_msg.conflict_records, 0);
+        // Upload phase should push the locally modified QSO.
+        assert_eq!(final_msg.uploaded_records, 1);
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1);
+        // After upload, status is SYNCED.
+        assert_eq!(all[0].sync_status, SyncStatus::Synced as i32);
+    }
+
+    #[tokio::test]
+    async fn flag_for_review_does_not_overwrite_and_skips_upload() {
+        let store = MemoryStorage::new();
+
+        // Local QSO: MODIFIED.
+        let mut local = make_qso("W1AW", "K7FFR", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        local.sync_status = SyncStatus::Modified as i32;
+        local.qrz_logid = Some("QRZ800".into());
+        local.updated_at = Some(Timestamp {
+            seconds: 1000,
+            nanos: 0,
+        });
+        local.notes = Some("local version".into());
+        store.insert_qso(&local).await.unwrap();
+
+        // Remote QSO: newer updated_at but with FLAG_FOR_REVIEW we don't compare timestamps.
+        let remote = {
+            let mut q = make_qso("W1AW", "K7FFR", Band::Band20m, Mode::Ft8, 1_700_000_000);
+            q.qrz_logid = Some("QRZ800".into());
+            q.updated_at = Some(Timestamp {
+                seconds: 5000,
+                nanos: 0,
+            });
+            q.notes = Some("remote version".into());
+            q
+        };
+
+        // No upload results — CONFLICT QSOs should not be uploaded.
+        let api = MockQrzApi::new(Ok(vec![remote]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::FlagForReview, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.conflict_records, 1);
+        assert_eq!(final_msg.downloaded_records, 0);
+        assert_eq!(final_msg.uploaded_records, 0);
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].sync_status, SyncStatus::Conflict as i32);
+        // Local data preserved, not overwritten by remote.
+        assert_eq!(all[0].notes.as_deref(), Some("local version"));
+    }
+
+    #[tokio::test]
+    async fn last_write_wins_equal_timestamps_remote_wins() {
+        let store = MemoryStorage::new();
+
+        // Local QSO: MODIFIED, updated_at = 2000.
+        let mut local = make_qso("W1AW", "K7EQ", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        local.sync_status = SyncStatus::Modified as i32;
+        local.qrz_logid = Some("QRZ900".into());
+        local.updated_at = Some(Timestamp {
+            seconds: 2000,
+            nanos: 0,
+        });
+        local.notes = Some("local tie".into());
+        store.insert_qso(&local).await.unwrap();
+
+        // Remote QSO: same updated_at → tie, remote wins.
+        let remote = {
+            let mut q = make_qso("W1AW", "K7EQ", Band::Band20m, Mode::Ft8, 1_700_000_000);
+            q.qrz_logid = Some("QRZ900".into());
+            q.updated_at = Some(Timestamp {
+                seconds: 2000,
+                nanos: 0,
+            });
+            q.notes = Some("remote tie".into());
+            q
+        };
+
+        let api = MockQrzApi::new(Ok(vec![remote]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.downloaded_records, 1, "tie goes to remote");
+        assert_eq!(final_msg.conflict_records, 0);
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].sync_status, SyncStatus::Synced as i32);
+        assert_eq!(all[0].notes.as_deref(), Some("remote tie"));
+    }
+}

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -161,7 +161,26 @@ async fn download_phase(
         }
     };
 
-    let since_date = if full_sync {
+    // Load all local QSOs for matching and sync-policy decisions.
+    let local_qsos = match store.list_qsos(&QsoListQuery::default()).await {
+        Ok(qsos) => qsos,
+        Err(err) => {
+            send_complete(
+                progress_tx,
+                0,
+                0,
+                0,
+                Some(format!("Failed to load local QSOs: {err}")),
+            )
+            .await;
+            return metadata;
+        }
+    };
+
+    // If the local logbook is empty, force a full remote fetch even for
+    // incremental sync requests. This recovers from stale metadata and gives
+    // first-time users the expected "download everything" behavior.
+    let since_date = if full_sync || local_qsos.is_empty() {
         None
     } else {
         metadata
@@ -199,22 +218,6 @@ async fn download_phase(
         counters.conflicts,
     )
     .await;
-
-    // Load all local QSOs for matching.
-    let local_qsos = match store.list_qsos(&QsoListQuery::default()).await {
-        Ok(qsos) => qsos,
-        Err(err) => {
-            send_complete(
-                progress_tx,
-                0,
-                0,
-                0,
-                Some(format!("Failed to load local QSOs: {err}")),
-            )
-            .await;
-            return metadata;
-        }
-    };
 
     // Build lookup indexes.
     let (mut by_qrz_logid, mut by_key) = build_local_indexes(&local_qsos);
@@ -1024,6 +1027,10 @@ mod tests {
     async fn incremental_sync_uses_last_sync_date() {
         let store = MemoryStorage::new();
 
+        // Add at least one local record so incremental sync uses last_sync.
+        let local = make_qso("W1AW", "K7LOCAL", Band::Band20m, Mode::Cw, 1_700_000_050);
+        store.insert_qso(&local).await.unwrap();
+
         // Seed metadata with a previous sync timestamp.
         let metadata = SyncMetadata {
             last_sync: Some(Timestamp {
@@ -1048,6 +1055,38 @@ mod tests {
 
         let captured = since_capture.lock().unwrap().clone();
         assert_eq!(captured.as_deref(), Some("2023-11-14"));
+    }
+
+    #[tokio::test]
+    async fn incremental_sync_with_empty_local_log_uses_full_fetch() {
+        let store = MemoryStorage::new();
+
+        // Metadata exists, but there are no local QSOs yet.
+        let metadata = SyncMetadata {
+            last_sync: Some(Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            }),
+            ..SyncMetadata::default()
+        };
+        store.upsert_sync_metadata(&metadata).await.unwrap();
+
+        let since_capture: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+        let api = CapturingApi {
+            since: since_capture.clone(),
+        };
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, false, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        drop(collect_final(rx).await);
+
+        let captured = since_capture.lock().unwrap().clone();
+        assert!(
+            captured.is_none(),
+            "empty local log should force a full remote fetch"
+        );
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-server/src/sync_scheduler.rs
+++ b/src/rust/qsoripper-server/src/sync_scheduler.rs
@@ -1,0 +1,286 @@
+//! Periodic background sync scheduler.
+//!
+//! Spawns a cancellable Tokio task that reads runtime configuration each cycle,
+//! builds a [`QrzLogbookClient`], and runs [`execute_sync`] at the configured
+//! interval.  The scheduler exposes read-only accessors so the gRPC handler can
+//! report live sync state in [`GetSyncStatusResponse`].
+
+use std::sync::Arc;
+
+use prost_types::Timestamp;
+use tokio::sync::{watch, Mutex};
+use tokio::time::Duration;
+
+use qsoripper_core::proto::qsoripper::domain::ConflictPolicy;
+use qsoripper_core::qrz_logbook::{QrzLogbookClient, QrzLogbookConfig};
+
+use crate::runtime_config::{
+    RuntimeConfigManager, DEFAULT_QRZ_LOGBOOK_BASE_URL, QRZ_LOGBOOK_API_KEY_ENV_VAR,
+    QRZ_LOGBOOK_BASE_URL_ENV_VAR, SYNC_AUTO_ENABLED_ENV_VAR, SYNC_CONFLICT_POLICY_ENV_VAR,
+    SYNC_INTERVAL_SECONDS_ENV_VAR,
+};
+use crate::sync;
+
+// ---------------------------------------------------------------------------
+// Public state
+// ---------------------------------------------------------------------------
+
+/// Live state produced by the background sync loop and consumed by the gRPC
+/// handler to populate `GetSyncStatusResponse`.
+pub(crate) struct SyncScheduler {
+    is_syncing: Arc<Mutex<bool>>,
+    last_error: Arc<Mutex<Option<String>>>,
+    next_sync: Arc<Mutex<Option<Timestamp>>>,
+    cancel_tx: watch::Sender<bool>,
+}
+
+impl SyncScheduler {
+    /// Create a new scheduler.  Call [`start`](Self::start) to spawn the
+    /// background loop.
+    pub(crate) fn new() -> Self {
+        let (cancel_tx, _) = watch::channel(false);
+        Self {
+            is_syncing: Arc::new(Mutex::new(false)),
+            last_error: Arc::new(Mutex::new(None)),
+            next_sync: Arc::new(Mutex::new(None)),
+            cancel_tx,
+        }
+    }
+
+    /// Spawn the periodic sync loop.
+    ///
+    /// The task re-reads runtime configuration every cycle so that changes to
+    /// the sync interval, auto-sync toggle, or API key take effect without a
+    /// server restart.
+    pub(crate) fn start(&self, runtime_config: Arc<RuntimeConfigManager>) {
+        let is_syncing = self.is_syncing.clone();
+        let last_error = self.last_error.clone();
+        let next_sync = self.next_sync.clone();
+        let mut cancel_rx = self.cancel_tx.subscribe();
+
+        tokio::spawn(async move {
+            loop {
+                // ── Read effective config ────────────────────────────
+                let values = runtime_config.effective_values().await;
+
+                let auto_enabled = values
+                    .get(SYNC_AUTO_ENABLED_ENV_VAR)
+                    .is_some_and(|v| v == "true");
+
+                let interval_secs: u64 = values
+                    .get(SYNC_INTERVAL_SECONDS_ENV_VAR)
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(300);
+
+                // Clear next_sync when auto-sync is disabled.
+                if !auto_enabled {
+                    *next_sync.lock().await = None;
+                    if wait_or_cancel(&mut cancel_rx, Duration::from_secs(30)).await {
+                        break;
+                    }
+                    continue;
+                }
+
+                let api_key = values
+                    .get(QRZ_LOGBOOK_API_KEY_ENV_VAR)
+                    .cloned()
+                    .unwrap_or_default();
+
+                if api_key.trim().is_empty() {
+                    *next_sync.lock().await = None;
+                    if wait_or_cancel(&mut cancel_rx, Duration::from_secs(30)).await {
+                        break;
+                    }
+                    continue;
+                }
+
+                // ── Compute and publish the next sync time ───────────
+                let wake_at = chrono::Utc::now()
+                    + chrono::Duration::seconds(i64::try_from(interval_secs).unwrap_or(300));
+                *next_sync.lock().await = Some(Timestamp {
+                    seconds: wake_at.timestamp(),
+                    nanos: 0,
+                });
+
+                // ── Wait for the interval (or cancellation) ──────────
+                if wait_or_cancel(&mut cancel_rx, Duration::from_secs(interval_secs)).await {
+                    break;
+                }
+
+                // ── Build client and execute sync ────────────────────
+                // Re-read values since we slept for the full interval.
+                let values = runtime_config.effective_values().await;
+
+                let base_url = values
+                    .get(QRZ_LOGBOOK_BASE_URL_ENV_VAR)
+                    .cloned()
+                    .unwrap_or_else(|| DEFAULT_QRZ_LOGBOOK_BASE_URL.to_string());
+
+                // Re-read the API key in case it changed during the wait.
+                let api_key = values
+                    .get(QRZ_LOGBOOK_API_KEY_ENV_VAR)
+                    .cloned()
+                    .unwrap_or_default();
+                if api_key.trim().is_empty() {
+                    continue;
+                }
+
+                let conflict_policy =
+                    match values.get(SYNC_CONFLICT_POLICY_ENV_VAR).map(String::as_str) {
+                        Some("flag_for_review") => ConflictPolicy::FlagForReview,
+                        _ => ConflictPolicy::LastWriteWins,
+                    };
+
+                let config = QrzLogbookConfig::new(api_key, base_url, "QsoRipper/1.0".to_string());
+
+                let client = match QrzLogbookClient::new(config) {
+                    Ok(c) => c,
+                    Err(err) => {
+                        eprintln!("[sync-scheduler] Failed to create QRZ client: {err}");
+                        *last_error.lock().await =
+                            Some(format!("Failed to create QRZ client: {err}"));
+                        continue;
+                    }
+                };
+
+                let store = runtime_config.logbook_engine().await;
+                let logbook_store = store.logbook_store();
+
+                *is_syncing.lock().await = true;
+                // Use a channel that we drain immediately — the scheduler does
+                // not stream progress anywhere, it just needs the final result.
+                let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+                sync::execute_sync(&client, logbook_store, false, conflict_policy, &tx).await;
+                drop(tx);
+
+                // Drain to find the final (complete) message.
+                let mut sync_error: Option<String> = None;
+                while let Some(Ok(msg)) = rx.recv().await {
+                    if msg.complete {
+                        sync_error.clone_from(&msg.error);
+                    }
+                }
+
+                *is_syncing.lock().await = false;
+                (*last_error.lock().await).clone_from(&sync_error);
+
+                if let Some(ref err) = sync_error {
+                    eprintln!("[sync-scheduler] Sync completed with error: {err}");
+                } else {
+                    eprintln!("[sync-scheduler] Sync completed successfully.");
+                }
+            }
+
+            // Cleanup on exit.
+            *next_sync.lock().await = None;
+            eprintln!("[sync-scheduler] Stopped.");
+        });
+    }
+
+    // ── Read-only accessors for gRPC handler ─────────────────────────────
+
+    pub(crate) async fn is_syncing(&self) -> bool {
+        *self.is_syncing.lock().await
+    }
+
+    pub(crate) async fn last_error(&self) -> Option<String> {
+        self.last_error.lock().await.clone()
+    }
+
+    pub(crate) async fn next_sync(&self) -> Option<Timestamp> {
+        *self.next_sync.lock().await
+    }
+
+    /// Signal the background loop to stop.
+    pub(crate) fn stop(&self) {
+        let _ = self.cancel_tx.send(true);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Sleep for `duration`, but return early if `cancel_rx` fires.
+/// Returns `true` when cancellation was received.
+async fn wait_or_cancel(cancel_rx: &mut watch::Receiver<bool>, duration: Duration) -> bool {
+    tokio::select! {
+        () = tokio::time::sleep(duration) => false,
+        _ = cancel_rx.changed() => true,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use tokio::time::Duration;
+
+    /// Helper: build a `RuntimeConfigManager` with custom overrides.
+    fn make_config(overrides: &[(&str, &str)]) -> Arc<RuntimeConfigManager> {
+        let config_file_values: BTreeMap<String, String> = overrides
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect();
+        let cli_overrides = BTreeMap::new();
+        Arc::new(
+            RuntimeConfigManager::new_with_config_file_values_and_cli_storage_overrides(
+                config_file_values,
+                &cli_overrides,
+            )
+            .expect("failed to build RuntimeConfigManager"),
+        )
+    }
+
+    #[tokio::test]
+    async fn scheduler_does_not_sync_when_auto_disabled() {
+        let scheduler = SyncScheduler::new();
+        let config = make_config(&[("QSORIPPER_SYNC_AUTO_ENABLED", "false")]);
+        scheduler.start(config);
+
+        // Give the loop one iteration (the 30-second idle sleep is real time,
+        // but we only need to verify initial state).
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(!scheduler.is_syncing().await);
+        assert!(scheduler.next_sync().await.is_none());
+
+        scheduler.stop();
+    }
+
+    #[tokio::test]
+    async fn scheduler_stops_on_cancel() {
+        let scheduler = SyncScheduler::new();
+        let config = make_config(&[("QSORIPPER_SYNC_AUTO_ENABLED", "false")]);
+        scheduler.start(config);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        scheduler.stop();
+        // The task should exit quickly after cancel; if it deadlocks this test
+        // will time out.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(!scheduler.is_syncing().await);
+        assert!(scheduler.next_sync().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn scheduler_clears_next_sync_when_no_api_key() {
+        let scheduler = SyncScheduler::new();
+        // Auto-sync enabled but no API key.
+        let config = make_config(&[("QSORIPPER_SYNC_AUTO_ENABLED", "true")]);
+        scheduler.start(config);
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        assert!(scheduler.next_sync().await.is_none());
+        assert!(!scheduler.is_syncing().await);
+
+        scheduler.stop();
+    }
+}

--- a/start-qsoripper.ps1
+++ b/start-qsoripper.ps1
@@ -138,22 +138,22 @@ function Get-LogTail([string]$Path) {
     return Get-Content -LiteralPath $Path -Tail 20
 }
 
-function Stop-TrackedProcess([int]$Pid) {
-    $process = Get-Process -Id $Pid -ErrorAction SilentlyContinue
+function Stop-TrackedProcess([int]$ProcessId) {
+    $process = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
     if ($null -eq $process) {
         return
     }
 
-    Stop-Process -Id $Pid
+    Stop-Process -Id $ProcessId
 
     for ($attempt = 0; $attempt -lt 50; $attempt++) {
         Start-Sleep -Milliseconds 200
-        if ($null -eq (Get-Process -Id $Pid -ErrorAction SilentlyContinue)) {
+        if ($null -eq (Get-Process -Id $ProcessId -ErrorAction SilentlyContinue)) {
             return
         }
     }
 
-    throw "Timed out waiting for process $Pid to stop."
+    throw "Timed out waiting for process $ProcessId to stop."
 }
 
 New-Item -ItemType Directory -Path $runtimeDirectory -Force | Out-Null
@@ -168,7 +168,7 @@ if ($null -ne $existing) {
     }
 
     Write-Info "Stopping existing QsoRipper process $($existing.Process.Id)."
-    Stop-TrackedProcess -Pid $existing.Process.Id
+    Stop-TrackedProcess -ProcessId $existing.Process.Id
     Remove-Item -LiteralPath $statePath -Force -ErrorAction SilentlyContinue
 }
 


### PR DESCRIPTION
## Summary

Adds full bidirectional QRZ logbook synchronization across the Rust engine, proto contracts, Avalonia GUI, and CLI.

### Rust Engine
- **QRZ logbook HTTP client** — fetch, upload, delete, test_connection (33 tests)
- **Bidirectional sync engine** — download from QRZ + upload local changes (14 tests)
- **Conflict policies** — LastWriteWins (timestamp comparison) and FlagForReview (marks CONFLICT)
- **Background sync scheduler** — configurable interval, cancellable, re-reads config each cycle
- **Runtime config** — 5 new env vars (API key, base URL, auto-sync, interval, conflict policy)
- **Persisted TOML config** — `[qrz_logbook]` and `[sync]` sections with proto round-trip

### Proto Contracts
- `ConflictPolicy` enum, `SyncConfig` message
- `TestQrzLogbookCredentials` request/response
- Extended `SaveSetupRequest`, `SetupStatus`, `GetSyncStatusResponse`

### GUI
- **F6** sync button in toolbar + Tools menu
- **Ctrl+,** Settings dialog for post-wizard config changes
- Wizard logbook API key step
- Status bar sync indicator with elapsed time
- Auto-refresh QSO grid after sync

### CLI
- `sync [--force]` — triggers bidirectional sync with streaming progress
- `sync-status [--json]` — displays sync state
- `test-logbook [--api-key]` — validates QRZ logbook credentials

### Validation
- 239 Rust tests passing
- 180 .NET tests passing
- Clippy clean (`-D warnings`)
- .NET build clean (0 warnings, 0 errors)

### New files (12)

| File | Purpose |
|---|---|
| `src/rust/qsoripper-core/src/qrz_logbook/mod.rs` | QRZ logbook HTTP client |
| `src/rust/qsoripper-server/src/sync.rs` | Bidirectional sync engine |
| `src/rust/qsoripper-server/src/sync_scheduler.rs` | Background periodic sync |
| `src/dotnet/QsoRipper.Cli/Commands/SyncCommand.cs` | CLI sync command |
| `src/dotnet/QsoRipper.Cli/Commands/SyncStatusCommand.cs` | CLI sync-status command |
| `src/dotnet/QsoRipper.Cli/Commands/TestLogbookCommand.cs` | CLI test-logbook command |
| `src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs` | Settings dialog VM |
| `src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml` | Settings dialog view |
| `src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml.cs` | Settings dialog code-behind |
| `src/dotnet/QsoRipper.Gui/ViewModels/QrzLogbookStepViewModel.cs` | Wizard logbook step VM |
| `src/dotnet/QsoRipper.Gui/Views/QrzLogbookStepView.axaml` | Wizard logbook step view |
| `src/dotnet/QsoRipper.Gui/Views/QrzLogbookStepView.axaml.cs` | Wizard logbook step code-behind |
