### PR TITLE
Add TUI automation lane for ui-reviewer

### DIFF
--- a/.github/skills/ux-inspection/SKILL.md
+++ b/.github/skills/ux-inspection/SKILL.md
@@ -34,8 +34,9 @@ description: >-
 ### Terminal / TUI workflows
 
 - Script: `scripts/capture-tui.ps1` (Windows-only today)
+- Interactive script: `scripts/drive-tui.ts`
 - Today this targets scripted CLI/terminal workflows honestly; point it at a future TUI binary later
-- Best for terminal review artifacts, transcripts, and GIF capture through Terminalizer
+- Best for terminal review artifacts, rendered PNG snapshots, transcripts, GIF capture through Terminalizer, and PTY-driven screen-state automation
 
 ## Required Workflow
 

--- a/.github/skills/ux-inspection/refs/tui-capture.md
+++ b/.github/skills/ux-inspection/refs/tui-capture.md
@@ -10,10 +10,12 @@
 ## QsoRipper rules
 
 - Use `scripts\capture-tui.ps1` as the entry point; it is currently Windows-only and can bootstrap a compatible repo-local Terminalizer runtime when needed.
+- Use `scripts\drive-tui.ts` when you need a live PTY session with JSON action scripts, wait/assert steps, and rendered screen snapshots under `artifacts\ux\current\<scenario>\`.
 - Be honest about scope: today this path targets terminal workflows and the CLI, not a full ratatui UI.
 - Keep terminal size and theme fixed so the rendered artifact is repeatable.
 - Always save the raw transcript as well as the rendered artifact.
 - Structure scenarios so they can later point at a dedicated TUI binary without changing the artifact contract.
+- Keep `capture-tui.ps1` for rendered GIFs; the PTY driver complements it rather than replacing it.
 
 ## Default scenario posture
 
@@ -28,6 +30,14 @@
 4. Render the YAML to GIF.
 5. Save the transcript and JSON summary beside the artifact.
 
+## Live PTY automation flow
+
+1. Resolve a JSON action script to a PTY command or built-in fixture.
+2. Launch the terminal with fixed rows/columns.
+3. Send scripted key/text input.
+4. Wait for expected screen or transcript text.
+5. Save visible screen snapshots (`*.screen.png`, `*.screen.txt`, `*.screen.json`, `*.ansi.txt`) plus `transcript.txt` and `report.json`.
+
 ## Check this first
 
 - Did the script finish bootstrapping the local Terminalizer runtime successfully on this machine?
@@ -35,10 +45,12 @@
 - Is the scenario deterministic enough for visual review?
 - Does the transcript capture the same command/output the GIF shows?
 - Would a plain transcript be more useful than a GIF for this defect?
+- Is Playwright Chromium installed so the PTY driver can render PNG snapshots?
 
 ## Minimal command
 
 ```powershell
 .\scripts\capture-tui.ps1 -Scenario cli-help
 .\scripts\capture-tui.ps1 -Scenario custom -Command "dotnet run --project src\dotnet\QsoRipper.Cli -- --help"
+npm run ux:drive:tui -- --action-script .\scripts\automation\tui-sample-smoke.json
 ```

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The repo now includes three developer-facing UX inspection lanes:
 - **Web** screenshots and diffs with Playwright
 - **Avalonia desktop** deterministic capture plus Windows UI automation
 - **Terminal** workflow capture to GIF/transcript via a repo-local Terminalizer runtime (**Windows-only** today)
+- **Terminal/TUI live automation** through a repo-local PTY harness with JSON action scripts and screen snapshots
 
 One-time setup after cloning:
 
@@ -169,6 +170,7 @@ npx playwright install chromium
 ```
 
 - `npm install` restores the root TypeScript and Playwright tooling used by `scripts\capture-web.ts` and `scripts\capture-web-diff.ts`.
+- The same repo-local Node toolchain now also drives `scripts\drive-tui.ts`, browser-rendered terminal snapshots, and the sample terminal fixture used for TUI automation smoke coverage.
 - `npx playwright install chromium` installs the browser binary used for web captures.
 - `scripts\capture-tui.ps1` is currently **Windows-only**. It does **not** require a global Terminalizer install; on first run it bootstraps a repo-local Node 22 + Terminalizer runtime under `tools\terminalizer-bootstrap\` and `tools\terminalizer-runtime\`.
 - `scripts\drive-avalonia.ps1` is **Windows-only** and needs an interactive desktop session because it uses Windows UI Automation APIs. It does not require WinAppDriver.
@@ -185,6 +187,9 @@ npm run ux:diff:web -- --scenario debughost-home --launch-debughost
 
 # Windows UI automation against the live Avalonia window
 .\scripts\drive-avalonia.ps1 -ActionScript .\scripts\automation\avalonia-main-window-smoke.json
+
+# Cross-platform terminal/TUI automation against the sample fixture
+npm run ux:drive:tui -- --action-script .\scripts\automation\tui-sample-smoke.json
 
 # Terminal workflow capture (Windows-only today)
 .\scripts\capture-tui.ps1 -Scenario cli-help
@@ -249,6 +254,27 @@ The inspection harness supports `MainWindow`, `Settings`, and `Wizard` surfaces.
 ```
 
 Use `-KeepOpen` when you want the fixture-backed window to stay open after the scripted steps finish.
+
+### Terminal / TUI automation
+
+The repo also includes a first-class PTY-backed terminal automation lane for interactive text UIs. It complements `capture-tui.ps1`:
+
+- `scripts\drive-tui.ts` drives a live terminal session from a JSON action script.
+- It writes artifacts under `artifacts\ux\current\<scenario>\`.
+- Snapshot actions save:
+  - `*.screen.png` — rendered terminal image for the visible viewport
+  - `*.screen.txt` — visible viewport text
+  - `*.screen.json` — viewport metadata and lines
+  - `*.ansi.txt` — serialized ANSI screen content
+- Every run also writes `transcript.txt` plus `report.json`.
+
+Today's built-in fixture is `sample-tui`, a deterministic menu/filter/list/details demo used to validate the harness before a production TUI exists.
+
+```powershell
+npm run ux:drive:tui -- --action-script .\scripts\automation\tui-sample-smoke.json
+```
+
+Use `scripts\capture-tui.ps1` when you specifically want a rendered GIF. Use `scripts\drive-tui.ts` when you need repeatable interactive input, screen-state assertions, and step-by-step screen artifacts with rendered PNG snapshots.
 
 ### Local engine configuration
 

--- a/docs/development/ui-inspection.md
+++ b/docs/development/ui-inspection.md
@@ -7,6 +7,7 @@ QsoRipper now has three repo-local UI inspection lanes:
 - **Web** capture and visual diff with Playwright
 - **Avalonia desktop** deterministic screenshot export plus Windows UI automation
 - **Terminal** workflow capture to GIF/transcript with a repo-local Terminalizer runtime (Windows-only today)
+- **Terminal/TUI live automation** with a PTY-backed TypeScript harness and JSON action scripts
 
 All three write artifacts under:
 
@@ -37,6 +38,7 @@ npx playwright install chromium
 Notes:
 
 - `npm install` restores the root TypeScript/Playwright toolchain from `package.json`.
+- The same install also restores the PTY and xterm packages used by `scripts\drive-tui.ts`.
 - `npx playwright install chromium` installs the browser binary used by the web capture scripts.
 - You do **not** need to install Terminalizer globally. `scripts\capture-tui.ps1` is currently Windows-only and bootstraps a repo-local Node 22 + Terminalizer runtime under `tools\terminalizer-bootstrap\` and `tools\terminalizer-runtime\` on first use.
 - `drive-avalonia.ps1` does **not** require WinAppDriver. It uses built-in Windows UI Automation assemblies plus native user32 calls.
@@ -125,14 +127,38 @@ Notes:
 - The current terminal lane targets scripted CLI workflows honestly; it can point at a future TUI binary later without changing the artifact contract.
 - Output includes a GIF, transcript, YAML recording, and JSON summary.
 
+### Terminal / TUI live automation
+
+Entry point:
+
+```powershell
+npm run ux:drive:tui -- --action-script .\scripts\automation\tui-sample-smoke.json
+```
+
+Requirements:
+
+- `npm install` completed successfully
+- A terminal that supports PTY execution on the current platform
+- Playwright Chromium installed (`npx playwright install chromium`)
+
+Notes:
+
+- This lane is intended for interactive terminal flows, not GIF rendering.
+- It is cross-platform in principle because it uses `node-pty` plus a repo-local TypeScript harness.
+- Action scripts are JSON and conceptually mirror `drive-avalonia.ps1`: scenario in, artifacts plus `report.json` out.
+- The harness can drive either a structured command or the built-in deterministic `sample-tui` fixture.
+- Snapshot actions write rendered `*.screen.png` files plus `*.screen.txt`, `*.screen.json`, and `*.ansi.txt` artifacts under `artifacts\ux\current\<scenario>\`.
+- Keep `scripts\capture-tui.ps1` for rendered GIF review; the two paths are complementary.
+
 ## Recommended quick verification
 
 ```powershell
 npm run ux:capture:web -- --scenario debughost-home --launch-debughost
 .\scripts\capture-avalonia.ps1 -Scenario main-window
+npm run ux:drive:tui -- --action-script .\scripts\automation\tui-sample-smoke.json
 .\scripts\capture-tui.ps1 -Scenario cli-help
 ```
 
-If all three commands succeed, the local UI inspection toolchain is ready.
+If all four commands succeed, the local UI inspection toolchain is ready.
 
-The terminal verification command currently requires Windows.
+The Terminalizer GIF capture verification command currently requires Windows.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,10 @@
       "devDependencies": {
         "@types/node": "^24.6.0",
         "@types/pngjs": "^6.0.5",
+        "@xterm/addon-serialize": "^0.14.0",
+        "@xterm/headless": "^6.0.0",
+        "@xterm/xterm": "^6.0.0",
+        "node-pty": "^1.1.0",
         "pixelmatch": "^7.1.0",
         "playwright": "^1.55.0",
         "pngjs": "^7.0.0",
@@ -477,6 +481,33 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@xterm/addon-serialize": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.14.0.tgz",
+      "integrity": "sha512-uteyTU1EkrQa2Ux6P/uFl2fzmXI46jy5uoQMKEOM0fKTyiW7cSn0WrFenHm5vO5uEXX/GpwW/FgILvv3r0WbkA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@xterm/headless": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-6.0.0.tgz",
+      "integrity": "sha512-5Yj1QINYCyzrZtf8OFIHi47iQtI+0qYFPHmouEfG8dHNxbZ9Tb9YGSuLcsEwj9Z+OL75GJqPyJbyoFer80a2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
+      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "addons/*"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
@@ -545,6 +576,24 @@
       },
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-pty": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0.tgz",
+      "integrity": "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^7.1.0"
       }
     },
     "node_modules/pixelmatch": {

--- a/package.json
+++ b/package.json
@@ -4,11 +4,16 @@
   "type": "module",
   "scripts": {
     "ux:capture:web": "tsx scripts/capture-web.ts",
-    "ux:diff:web": "tsx scripts/capture-web-diff.ts"
+    "ux:diff:web": "tsx scripts/capture-web-diff.ts",
+    "ux:drive:tui": "tsx scripts/drive-tui.ts"
   },
   "devDependencies": {
     "@types/node": "^24.6.0",
     "@types/pngjs": "^6.0.5",
+    "@xterm/addon-serialize": "^0.14.0",
+    "@xterm/headless": "^6.0.0",
+    "@xterm/xterm": "^6.0.0",
+    "node-pty": "^1.1.0",
     "pixelmatch": "^7.1.0",
     "playwright": "^1.55.0",
     "pngjs": "^7.0.0",

--- a/scripts/automation/tui-sample-smoke.json
+++ b/scripts/automation/tui-sample-smoke.json
@@ -1,0 +1,77 @@
+{
+  "fixture": "sample-tui",
+  "terminal": {
+    "columns": 100,
+    "rows": 30
+  },
+  "actions": [
+    {
+      "type": "wait-for-text",
+      "text": "QsoRipper Sample TUI",
+      "source": "screen",
+      "timeoutMs": 5000
+    },
+    {
+      "type": "snapshot",
+      "path": "sample-start"
+    },
+    {
+      "type": "send-keys",
+      "keys": "{right}{tab}",
+      "settleMs": 150
+    },
+    {
+      "type": "send-text",
+      "text": "cw",
+      "settleMs": 150
+    },
+    {
+      "type": "wait-for-text",
+      "text": "Filter: cw",
+      "source": "screen",
+      "timeoutMs": 5000
+    },
+    {
+      "type": "snapshot",
+      "path": "sample-filtered"
+    },
+    {
+      "type": "send-keys",
+      "keys": "{tab}{down}{enter}",
+      "settleMs": 150
+    },
+    {
+      "type": "wait-for-text",
+      "text": "Details: Low-noise path after sunset.",
+      "source": "screen",
+      "timeoutMs": 5000
+    },
+    {
+      "type": "snapshot",
+      "path": "sample-details"
+    },
+    {
+      "type": "send-keys",
+      "keys": "{escape}{tab}{left}",
+      "settleMs": 150
+    },
+    {
+      "type": "wait-for-text",
+      "text": "[Recent]",
+      "source": "screen",
+      "timeoutMs": 5000
+    },
+    {
+      "type": "snapshot",
+      "path": "sample-returned"
+    },
+    {
+      "type": "send-keys",
+      "keys": "{ctrl+c}"
+    },
+    {
+      "type": "wait-for-exit",
+      "timeoutMs": 5000
+    }
+  ]
+}

--- a/scripts/drive-tui.ts
+++ b/scripts/drive-tui.ts
@@ -1,0 +1,990 @@
+import path from 'node:path';
+import process from 'node:process';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { setTimeout as delay } from 'node:timers/promises';
+import * as nodePty from 'node-pty';
+import { chromium, type Browser, type Page } from 'playwright';
+import xtermHeadless from '@xterm/headless';
+import addonSerialize from '@xterm/addon-serialize';
+
+type MatchSource = 'screen' | 'transcript' | 'ansi' | 'any';
+
+const { Terminal } = xtermHeadless as typeof import('@xterm/headless');
+const { SerializeAddon } = addonSerialize as typeof import('@xterm/addon-serialize');
+type HeadlessTerminal = InstanceType<typeof Terminal>;
+type XtermSerializeAddon = InstanceType<typeof SerializeAddon>;
+
+interface ActionScript {
+  scenario?: string;
+  fixture?: string;
+  command?: string | CommandSpec;
+  cwd?: string;
+  env?: Record<string, string>;
+  terminal?: TerminalSpec;
+  actions: Action[];
+}
+
+interface CommandSpec {
+  program?: string;
+  args?: string[];
+  commandLine?: string;
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+interface TerminalSpec {
+  columns?: number;
+  rows?: number;
+  scrollback?: number;
+}
+
+type Action =
+  | WaitAction
+  | WaitForTextAction
+  | WaitForIdleAction
+  | SendKeysAction
+  | SendTextAction
+  | SnapshotAction
+  | ResizeAction
+  | WaitForExitAction;
+
+interface BaseAction {
+  type:
+    | 'wait'
+    | 'wait-for-text'
+    | 'wait-for-idle'
+    | 'send-keys'
+    | 'send-text'
+    | 'snapshot'
+    | 'resize'
+    | 'wait-for-exit';
+  label?: string;
+}
+
+interface WaitAction extends BaseAction {
+  type: 'wait';
+  milliseconds: number;
+}
+
+interface WaitForTextAction extends BaseAction {
+  type: 'wait-for-text';
+  text?: string;
+  pattern?: string;
+  match?: 'includes' | 'regex';
+  source?: MatchSource;
+  timeoutMs?: number;
+}
+
+interface WaitForIdleAction extends BaseAction {
+  type: 'wait-for-idle';
+  idleMs?: number;
+  timeoutMs?: number;
+}
+
+interface SendKeysAction extends BaseAction {
+  type: 'send-keys';
+  keys: string;
+  delayMs?: number;
+  settleMs?: number;
+}
+
+interface SendTextAction extends BaseAction {
+  type: 'send-text';
+  text: string;
+  delayMsBetweenChars?: number;
+  pressEnter?: boolean;
+  settleMs?: number;
+}
+
+interface SnapshotAction extends BaseAction {
+  type: 'snapshot';
+  path: string;
+}
+
+interface ResizeAction extends BaseAction {
+  type: 'resize';
+  columns: number;
+  rows: number;
+  settleMs?: number;
+}
+
+interface WaitForExitAction extends BaseAction {
+  type: 'wait-for-exit';
+  timeoutMs?: number;
+}
+
+interface ResolvedCommand {
+  program: string;
+  args: string[];
+  cwd: string;
+  env: Record<string, string>;
+  commandDescription: string;
+}
+
+interface SnapshotResult {
+  name: string;
+  txtPath: string;
+  jsonPath: string;
+  ansiPath: string;
+  pngPath: string;
+}
+
+interface StepResult {
+  index: number;
+  type: Action['type'];
+  label?: string;
+  startedAtUtc: string;
+  finishedAtUtc: string;
+  details?: Record<string, unknown>;
+}
+
+interface DriveSummary {
+  surface: 'terminal';
+  scenario: string;
+  actionScript: string;
+  fixture?: string;
+  command: {
+    description: string;
+    cwd: string;
+    columns: number;
+    rows: number;
+  };
+  outputRoot: string;
+  transcriptPath: string;
+  artifacts: string[];
+  steps: StepResult[];
+  exitCode: number | null;
+  signal?: number;
+  capturedAtUtc: string;
+  durationMs: number;
+}
+
+interface ExitResult {
+  exitCode: number;
+  signal?: number;
+}
+
+interface CliOptions {
+  actionScript: string;
+  outputRoot?: string;
+}
+
+interface SnapshotRenderer {
+  render(options: {
+    ansiText: string;
+    pngPath: string;
+    columns: number;
+    rows: number;
+  }): Promise<void>;
+  dispose(): Promise<void>;
+}
+
+const repoRoot = process.cwd();
+const uxRoot = path.join(repoRoot, 'artifacts', 'ux');
+const currentRoot = path.join(uxRoot, 'current');
+const defaultColumns = 100;
+const defaultRows = 30;
+const defaultScrollback = 5_000;
+const sampleFixtureName = 'sample-tui';
+const xtermBrowserScriptPath = path.join(repoRoot, 'node_modules', '@xterm', 'xterm', 'lib', 'xterm.js');
+const xtermBrowserCssPath = path.join(repoRoot, 'node_modules', '@xterm', 'xterm', 'css', 'xterm.css');
+const terminalRenderTheme = {
+  background: '#263238',
+  foreground: '#eeffff',
+  cursor: '#ffcc00',
+  cursorAccent: '#263238',
+  black: '#000000',
+  red: '#ff5370',
+  green: '#c3e88d',
+  yellow: '#ffcb6b',
+  blue: '#82aaff',
+  magenta: '#c792ea',
+  cyan: '#89ddff',
+  white: '#ffffff',
+  brightBlack: '#546e7a',
+  brightRed: '#ff5370',
+  brightGreen: '#c3e88d',
+  brightYellow: '#ffcb6b',
+  brightBlue: '#82aaff',
+  brightMagenta: '#c792ea',
+  brightCyan: '#89ddff',
+  brightWhite: '#ffffff'
+} as const;
+
+async function main(): Promise<void> {
+  const options = parseCliOptions(process.argv.slice(2));
+  const actionScriptPath = path.resolve(options.actionScript);
+  const actionScript = await loadActionScript(actionScriptPath);
+  const scenario = actionScript.scenario?.trim() || path.basename(actionScriptPath, path.extname(actionScriptPath));
+  const outputRoot = path.resolve(
+    options.outputRoot ?? path.join(currentRoot, scenario)
+  );
+  const transcriptPath = path.join(outputRoot, 'transcript.txt');
+  const reportPath = path.join(outputRoot, 'report.json');
+
+  await Promise.all([
+    mkdir(currentRoot, { recursive: true }),
+    mkdir(path.join(uxRoot, 'baseline'), { recursive: true }),
+    mkdir(path.join(uxRoot, 'diff'), { recursive: true }),
+    mkdir(outputRoot, { recursive: true })
+  ]);
+
+  const columns = actionScript.terminal?.columns ?? defaultColumns;
+  const rows = actionScript.terminal?.rows ?? defaultRows;
+  const scrollback = actionScript.terminal?.scrollback ?? defaultScrollback;
+  const resolvedCommand = resolveCommand(actionScript);
+  const terminal = new Terminal({
+    cols: columns,
+    rows,
+    scrollback,
+    allowProposedApi: true
+  });
+  const serializeAddon = new SerializeAddon();
+  terminal.loadAddon(serializeAddon);
+  const snapshotRenderer = await createSnapshotRenderer();
+
+  let transcript = '';
+  let writeQueue = Promise.resolve();
+  let lastOutputAt = Date.now();
+  const artifacts = new Set<string>();
+  const steps: StepResult[] = [];
+  const startedAt = Date.now();
+
+  const ptyProcess = nodePty.spawn(resolvedCommand.program, resolvedCommand.args, {
+    name: 'xterm-color',
+    cols: columns,
+    rows,
+    cwd: resolvedCommand.cwd,
+    env: resolvedCommand.env
+  });
+
+  const exitPromise = new Promise<ExitResult>((resolve) => {
+    ptyProcess.onExit((event) => {
+      resolve({
+        exitCode: event.exitCode,
+        signal: event.signal
+      });
+    });
+  });
+
+  ptyProcess.onData((chunk) => {
+    transcript += chunk;
+    lastOutputAt = Date.now();
+    writeQueue = writeQueue.then(
+      () =>
+        new Promise<void>((resolve) => {
+          terminal.write(chunk, () => resolve());
+        })
+    );
+  });
+
+  let exitResult: ExitResult | undefined;
+
+  try {
+    for (let index = 0; index < actionScript.actions.length; index += 1) {
+      const action = actionScript.actions[index]!;
+      const stepStartedAtUtc = new Date().toISOString();
+      const details = await runAction({
+        action,
+        index,
+        outputRoot,
+        ptyProcess,
+        terminal,
+        serializeAddon,
+        snapshotRenderer,
+        columnsRef: () => terminal.cols,
+        rowsRef: () => terminal.rows,
+        ensureFlushed: async () => {
+          await writeQueue;
+          await delay(10);
+        },
+        waitForCondition: async (predicate, timeoutMs) => {
+          const deadline = Date.now() + timeoutMs;
+          while (Date.now() < deadline) {
+            await writeQueue;
+            if (predicate()) {
+              return;
+            }
+
+            await delay(25);
+          }
+
+          await writeQueue;
+          if (!predicate()) {
+            throw new Error(`Timed out after ${timeoutMs} ms.`);
+          }
+        },
+        getTranscript: () => transcript,
+        getAnsiScreen: () => serializeAddon.serialize(),
+        getScreenText: () => captureVisibleScreen(terminal),
+        getLastOutputAt: () => lastOutputAt,
+        exitPromise,
+        addArtifact: (artifactPath) => artifacts.add(artifactPath)
+      });
+
+      steps.push({
+        index,
+        type: action.type,
+        label: action.label,
+        startedAtUtc: stepStartedAtUtc,
+        finishedAtUtc: new Date().toISOString(),
+        details
+      });
+    }
+
+    exitResult = await Promise.race([
+      exitPromise,
+      delay(50).then(() => undefined)
+    ]);
+  } finally {
+    await writeQueue;
+    await snapshotRenderer.dispose();
+
+    if (!exitResult) {
+      try {
+        ptyProcess.kill();
+      } catch {
+        // Ignore shutdown errors in cleanup.
+      }
+
+      exitResult = await Promise.race([
+        exitPromise,
+        delay(1_000).then(() => undefined)
+      ]);
+    }
+
+    await writeFile(transcriptPath, normalizeNewlines(transcript), 'utf8');
+    artifacts.add(transcriptPath);
+
+    const summary: DriveSummary = {
+      surface: 'terminal',
+      scenario,
+      actionScript: actionScriptPath,
+      fixture: actionScript.fixture,
+      command: {
+        description: resolvedCommand.commandDescription,
+        cwd: resolvedCommand.cwd,
+        columns: terminal.cols,
+        rows: terminal.rows
+      },
+      outputRoot,
+      transcriptPath,
+      artifacts: Array.from(artifacts).sort(),
+      steps,
+      exitCode: exitResult?.exitCode ?? null,
+      signal: exitResult?.signal,
+      capturedAtUtc: new Date().toISOString(),
+      durationMs: Date.now() - startedAt
+    };
+
+    await writeJson(reportPath, summary);
+    console.log(`Saved terminal automation artifacts to ${outputRoot}`);
+    console.log(`Summary: ${reportPath}`);
+  }
+}
+
+async function runAction(context: {
+  action: Action;
+  index: number;
+  outputRoot: string;
+  ptyProcess: nodePty.IPty;
+  terminal: HeadlessTerminal;
+  serializeAddon: XtermSerializeAddon;
+  snapshotRenderer: SnapshotRenderer;
+  columnsRef(): number;
+  rowsRef(): number;
+  ensureFlushed(): Promise<void>;
+  waitForCondition(predicate: () => boolean, timeoutMs: number): Promise<void>;
+  getTranscript(): string;
+  getAnsiScreen(): string;
+  getScreenText(): string;
+  getLastOutputAt(): number;
+  exitPromise: Promise<ExitResult>;
+  addArtifact(artifactPath: string): void;
+}): Promise<Record<string, unknown> | undefined> {
+  const { action } = context;
+
+  switch (action.type) {
+    case 'wait':
+      await delay(action.milliseconds);
+      return { milliseconds: action.milliseconds };
+
+    case 'wait-for-text': {
+      const source = action.source ?? 'any';
+      const timeoutMs = action.timeoutMs ?? 10_000;
+      const matcher = createMatcher(action);
+      await context.waitForCondition(() => matcher(matchesFromSource(source, context)), timeoutMs);
+      return {
+        source,
+        timeoutMs,
+        match: action.match ?? (action.pattern ? 'regex' : 'includes'),
+        text: action.text,
+        pattern: action.pattern
+      };
+    }
+
+    case 'wait-for-idle': {
+      const idleMs = action.idleMs ?? 250;
+      const timeoutMs = action.timeoutMs ?? 10_000;
+      await context.waitForCondition(
+        () => Date.now() - context.getLastOutputAt() >= idleMs,
+        timeoutMs
+      );
+      return {
+        idleMs,
+        timeoutMs
+      };
+    }
+
+    case 'send-keys': {
+      const sequence = parseKeys(action.keys);
+      const delayMs = action.delayMs ?? 0;
+      for (const chunk of sequence) {
+        context.ptyProcess.write(chunk);
+        if (delayMs > 0) {
+          await delay(delayMs);
+        }
+      }
+
+      if ((action.settleMs ?? 0) > 0) {
+        await delay(action.settleMs!);
+      }
+
+      return {
+        keys: action.keys,
+        chunks: sequence.length
+      };
+    }
+
+    case 'send-text': {
+      const delayMsBetweenChars = action.delayMsBetweenChars ?? 0;
+      for (const character of action.text) {
+        context.ptyProcess.write(character);
+        if (delayMsBetweenChars > 0) {
+          await delay(delayMsBetweenChars);
+        }
+      }
+
+      if (action.pressEnter) {
+        context.ptyProcess.write('\r');
+      }
+
+      if ((action.settleMs ?? 0) > 0) {
+        await delay(action.settleMs!);
+      }
+
+      return {
+        textLength: action.text.length,
+        pressEnter: action.pressEnter ?? false
+      };
+    }
+
+    case 'snapshot': {
+      await context.ensureFlushed();
+      const snapshot = await writeSnapshot(
+        context.outputRoot,
+        action.path,
+        context.getScreenText(),
+        context.getAnsiScreen(),
+        context.columnsRef(),
+        context.rowsRef(),
+        context.snapshotRenderer
+      );
+      context.addArtifact(snapshot.txtPath);
+      context.addArtifact(snapshot.jsonPath);
+      context.addArtifact(snapshot.ansiPath);
+      context.addArtifact(snapshot.pngPath);
+      return {
+        name: snapshot.name,
+        txtPath: snapshot.txtPath,
+        jsonPath: snapshot.jsonPath,
+        ansiPath: snapshot.ansiPath,
+        pngPath: snapshot.pngPath
+      };
+    }
+
+    case 'resize':
+      context.ptyProcess.resize(action.columns, action.rows);
+      if ((action.settleMs ?? 0) > 0) {
+        await delay(action.settleMs!);
+      }
+
+      return {
+        columns: action.columns,
+        rows: action.rows
+      };
+
+    case 'wait-for-exit': {
+      const timeoutMs = action.timeoutMs ?? 10_000;
+      const exitResult = await waitForExit(context.exitPromise, timeoutMs);
+      return {
+        timeoutMs,
+        exitCode: exitResult.exitCode,
+        signal: exitResult.signal
+      };
+    }
+  }
+}
+
+function matchesFromSource(source: MatchSource, context: {
+  getTranscript(): string;
+  getAnsiScreen(): string;
+  getScreenText(): string;
+}): string {
+  switch (source) {
+    case 'screen':
+      return context.getScreenText();
+    case 'transcript':
+      return context.getTranscript();
+    case 'ansi':
+      return context.getAnsiScreen();
+    case 'any':
+      return [
+        context.getScreenText(),
+        context.getTranscript(),
+        context.getAnsiScreen()
+      ].join('\n');
+  }
+}
+
+function createMatcher(action: WaitForTextAction): (content: string) => boolean {
+  const matchKind = action.match ?? (action.pattern ? 'regex' : 'includes');
+  if (matchKind === 'regex') {
+    const regex = new RegExp(action.pattern ?? action.text ?? '');
+    return (content) => regex.test(content);
+  }
+
+  const expected = action.text;
+  if (!expected) {
+    throw new Error('wait-for-text requires text when match is includes.');
+  }
+
+  return (content) => content.includes(expected);
+}
+
+function captureVisibleScreen(terminal: HeadlessTerminal): string {
+  const buffer = terminal.buffer.active;
+  const lines: string[] = [];
+  const start = buffer.viewportY;
+  for (let row = 0; row < terminal.rows; row += 1) {
+    const line = buffer.getLine(start + row);
+    lines.push((line?.translateToString(false) ?? '').replace(/\s+$/u, ''));
+  }
+
+  return normalizeNewlines(lines.join('\n'));
+}
+
+async function writeSnapshot(
+  outputRoot: string,
+  requestedPath: string,
+  screenText: string,
+  ansiText: string,
+  columns: number,
+  rows: number,
+  snapshotRenderer: SnapshotRenderer
+): Promise<SnapshotResult> {
+  const sanitizedBaseName = stripKnownExtension(requestedPath);
+  const resolvedBase = path.resolve(outputRoot, sanitizedBaseName);
+  const txtPath = `${resolvedBase}.screen.txt`;
+  const jsonPath = `${resolvedBase}.screen.json`;
+  const ansiPath = `${resolvedBase}.ansi.txt`;
+  const pngPath = `${resolvedBase}.screen.png`;
+
+  await Promise.all([
+    writeTextFile(txtPath, screenText),
+    writeTextFile(ansiPath, ansiText),
+    writeJson(jsonPath, {
+      name: path.basename(sanitizedBaseName),
+      columns,
+      rows,
+      screenText,
+      lines: screenText.split('\n')
+    })
+  ]);
+  await snapshotRenderer.render({
+    ansiText,
+    pngPath,
+    columns,
+    rows
+  });
+
+  return {
+    name: path.basename(sanitizedBaseName),
+    txtPath,
+    jsonPath,
+    ansiPath,
+    pngPath
+  };
+}
+
+async function createSnapshotRenderer(): Promise<SnapshotRenderer> {
+  let browser: Browser | undefined;
+  let page: Page | undefined;
+
+  try {
+    browser = await chromium.launch({ headless: true });
+    page = await browser.newPage({
+      deviceScaleFactor: 1,
+      viewport: { width: 1440, height: 960 }
+    });
+    await page.setContent(`
+      <!DOCTYPE html>
+      <html lang="en">
+        <head>
+          <meta charset="utf-8" />
+          <title>QsoRipper TUI Snapshot Renderer</title>
+        </head>
+        <body>
+          <div id="terminal-shell">
+            <div id="terminal-host"></div>
+          </div>
+        </body>
+      </html>
+    `);
+    await page.addStyleTag({ path: xtermBrowserCssPath });
+    await page.addStyleTag({
+      content: [
+        'html, body { margin: 0; padding: 0; background: #263238; }',
+        'body { display: inline-block; }',
+        '#terminal-shell { display: inline-block; padding: 12px; background: #263238; }',
+        '#terminal-host { display: inline-block; }',
+        '.xterm { padding: 0; }',
+        '.xterm .xterm-viewport { overflow: hidden !important; background: #263238 !important; }',
+        '.xterm .xterm-screen canvas { image-rendering: pixelated; }',
+        '.xterm .xterm-helper-textarea, .xterm .xterm-accessibility { display: none !important; }',
+        '.xterm .xterm-cursor-layer { visibility: hidden !important; }'
+      ].join('\n')
+    });
+    await page.addScriptTag({ path: xtermBrowserScriptPath });
+    await page.evaluate((theme) => {
+      const globalTerminal = (globalThis as {
+        Terminal?: new (options?: Record<string, unknown>) => {
+          open(element: Element): void;
+          write(data: string, callback?: () => void): void;
+          dispose(): void;
+          refresh(start: number, end: number): void;
+        };
+        __qsoripperRenderer?: {
+          render(snapshot: {
+            ansiText: string;
+            columns: number;
+            rows: number;
+          }): Promise<void>;
+        };
+      });
+
+      if (!globalTerminal.Terminal) {
+        throw new Error('Browser xterm bundle did not expose a Terminal constructor.');
+      }
+
+      const TerminalCtor = globalTerminal.Terminal;
+      let terminalInstance: {
+        open(element: Element): void;
+        write(data: string, callback?: () => void): void;
+        dispose(): void;
+        refresh(start: number, end: number): void;
+      } | undefined;
+
+      globalTerminal.__qsoripperRenderer = {
+        async render(snapshot): Promise<void> {
+          const host = document.getElementById('terminal-host');
+          if (!host) {
+            throw new Error('Missing terminal host element.');
+          }
+
+          terminalInstance?.dispose();
+          host.replaceChildren();
+
+          terminalInstance = new TerminalCtor({
+            cols: snapshot.columns,
+            rows: snapshot.rows,
+            convertEol: true,
+            cursorBlink: false,
+            cursorStyle: 'block',
+            fontFamily: 'Cascadia Mono, Consolas, Monaco, Lucida Console, monospace',
+            fontSize: 14,
+            lineHeight: 1,
+            allowTransparency: false,
+            theme
+          });
+
+          terminalInstance.open(host);
+          await new Promise<void>((resolve) => {
+            terminalInstance!.write(snapshot.ansiText, () => resolve());
+          });
+          terminalInstance.refresh(0, snapshot.rows - 1);
+          await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+        }
+      };
+    }, terminalRenderTheme);
+  } catch (error) {
+    await page?.close().catch(() => undefined);
+    await browser?.close().catch(() => undefined);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unable to initialize browser-backed TUI snapshot rendering. Ensure Playwright Chromium is installed with 'npx playwright install chromium'. ${message}`
+    );
+  }
+
+  return {
+    async render(options): Promise<void> {
+      const estimatedWidth = Math.max(640, options.columns * 12 + 48);
+      const estimatedHeight = Math.max(320, options.rows * 24 + 48);
+      await page!.setViewportSize({
+        width: estimatedWidth,
+        height: estimatedHeight
+      });
+      await page!.evaluate((snapshot) => {
+        const renderer = (globalThis as {
+          __qsoripperRenderer?: {
+            render(config: {
+              ansiText: string;
+              columns: number;
+              rows: number;
+            }): Promise<void>;
+          };
+        }).__qsoripperRenderer;
+
+        if (!renderer) {
+          throw new Error('QsoRipper TUI snapshot renderer is not available.');
+        }
+
+        return renderer.render(snapshot);
+      }, {
+        ansiText: options.ansiText,
+        columns: options.columns,
+        rows: options.rows
+      });
+      await mkdir(path.dirname(options.pngPath), { recursive: true });
+      await page!.locator('#terminal-shell').screenshot({
+        path: options.pngPath
+      });
+    },
+    async dispose(): Promise<void> {
+      await page?.close().catch(() => undefined);
+      await browser?.close().catch(() => undefined);
+    }
+  };
+}
+
+function parseCliOptions(argv: string[]): CliOptions {
+  let actionScript = '';
+  let outputRoot: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index]!;
+    const next = argv[index + 1];
+
+    switch (argument) {
+      case '--action-script':
+        actionScript = next ?? '';
+        index += 1;
+        break;
+      case '--output-root':
+        outputRoot = next;
+        index += 1;
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (!actionScript.trim()) {
+    throw new Error('Missing required option --action-script.');
+  }
+
+  return {
+    actionScript,
+    outputRoot
+  };
+}
+
+async function loadActionScript(actionScriptPath: string): Promise<ActionScript> {
+  const raw = await readFile(actionScriptPath, 'utf8');
+  const parsed = JSON.parse(raw) as ActionScript;
+  if (!Array.isArray(parsed.actions) || parsed.actions.length === 0) {
+    throw new Error(`Action script '${actionScriptPath}' must contain a non-empty actions array.`);
+  }
+
+  return parsed;
+}
+
+function resolveCommand(actionScript: ActionScript): ResolvedCommand {
+  if (actionScript.fixture?.trim()) {
+    return resolveFixtureCommand(actionScript.fixture.trim(), actionScript);
+  }
+
+  if (typeof actionScript.command === 'string') {
+    return resolveShellCommand(actionScript.command, actionScript.cwd, actionScript.env);
+  }
+
+  if (actionScript.command) {
+    const command = actionScript.command;
+    if (command.commandLine?.trim()) {
+      return resolveShellCommand(command.commandLine.trim(), command.cwd ?? actionScript.cwd, mergeEnv(actionScript.env, command.env));
+    }
+
+    if (!command.program?.trim()) {
+      throw new Error('Command objects require program or commandLine.');
+    }
+
+    return {
+      program: command.program,
+      args: command.args ?? [],
+      cwd: resolveWorkingDirectory(command.cwd ?? actionScript.cwd),
+      env: mergeEnv(actionScript.env, command.env),
+      commandDescription: [command.program, ...(command.args ?? [])].join(' ')
+    };
+  }
+
+  throw new Error('Action script must define fixture or command.');
+}
+
+function resolveFixtureCommand(fixtureName: string, actionScript: ActionScript): ResolvedCommand {
+  if (fixtureName !== sampleFixtureName) {
+    throw new Error(`Unknown built-in fixture '${fixtureName}'.`);
+  }
+
+  const tsxCliPath = path.join(repoRoot, 'node_modules', 'tsx', 'dist', 'cli.mjs');
+  const fixturePath = path.join(repoRoot, 'scripts', 'fixtures', 'sample-tui.ts');
+  return {
+    program: process.execPath,
+    args: [tsxCliPath, fixturePath],
+    cwd: resolveWorkingDirectory(actionScript.cwd),
+    env: mergeEnv(actionScript.env),
+    commandDescription: `fixture:${fixtureName}`
+  };
+}
+
+function resolveShellCommand(
+  commandLine: string,
+  cwd: string | undefined,
+  envOverrides: Record<string, string> | undefined
+): ResolvedCommand {
+  const program = process.platform === 'win32'
+    ? process.env.ComSpec ?? 'cmd.exe'
+    : process.env.SHELL ?? '/bin/bash';
+  const args = process.platform === 'win32'
+    ? ['/d', '/s', '/c', commandLine]
+    : ['-lc', commandLine];
+
+  return {
+    program,
+    args,
+    cwd: resolveWorkingDirectory(cwd),
+    env: mergeEnv(envOverrides),
+    commandDescription: commandLine
+  };
+}
+
+function mergeEnv(...overrides: Array<Record<string, string> | undefined>): Record<string, string> {
+  return Object.assign({}, process.env, ...overrides);
+}
+
+function resolveWorkingDirectory(cwd: string | undefined): string {
+  if (!cwd?.trim()) {
+    return repoRoot;
+  }
+
+  return path.resolve(repoRoot, cwd);
+}
+
+function parseKeys(input: string): string[] {
+  const result: string[] = [];
+  let current = '';
+
+  for (let index = 0; index < input.length; index += 1) {
+    const character = input[index]!;
+    if (character !== '{') {
+      current += character;
+      continue;
+    }
+
+    const closingIndex = input.indexOf('}', index);
+    if (closingIndex < 0) {
+      current += character;
+      continue;
+    }
+
+    if (current.length > 0) {
+      result.push(current);
+      current = '';
+    }
+
+    const token = input.slice(index + 1, closingIndex).trim().toLowerCase();
+    result.push(resolveKeyToken(token));
+    index = closingIndex;
+  }
+
+  if (current.length > 0) {
+    result.push(current);
+  }
+
+  return result;
+}
+
+function resolveKeyToken(token: string): string {
+  const directMap: Record<string, string> = {
+    enter: '\r',
+    tab: '\t',
+    escape: '\x1b',
+    esc: '\x1b',
+    up: '\x1b[A',
+    down: '\x1b[B',
+    right: '\x1b[C',
+    left: '\x1b[D',
+    home: '\x1b[H',
+    end: '\x1b[F',
+    pagedown: '\x1b[6~',
+    pageup: '\x1b[5~',
+    delete: '\x1b[3~',
+    backspace: '\x7f',
+    space: ' '
+  };
+
+  const direct = directMap[token];
+  if (direct) {
+    return direct;
+  }
+
+  const ctrlMatch = /^ctrl\+([a-z])$/u.exec(token);
+  if (ctrlMatch) {
+    return String.fromCharCode(ctrlMatch[1]!.toUpperCase().charCodeAt(0) - 64);
+  }
+
+  throw new Error(`Unsupported key token '{${token}}'.`);
+}
+
+async function waitForExit(exitPromise: Promise<ExitResult>, timeoutMs: number): Promise<ExitResult> {
+  const timed = await Promise.race([
+    exitPromise,
+    delay(timeoutMs).then(() => undefined)
+  ]);
+
+  if (!timed) {
+    throw new Error(`Timed out waiting ${timeoutMs} ms for process exit.`);
+  }
+
+  return timed;
+}
+
+function stripKnownExtension(filePath: string): string {
+  return filePath.replace(/\.(json|txt|ansi|screen)$/iu, '');
+}
+
+async function writeTextFile(targetPath: string, content: string): Promise<void> {
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, normalizeNewlines(content), 'utf8');
+}
+
+async function writeJson(targetPath: string, value: unknown): Promise<void> {
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+function normalizeNewlines(value: string): string {
+  return value.replace(/\r\n/gu, '\n');
+}
+
+await main();
+process.exit(0);

--- a/scripts/fixtures/sample-tui.ts
+++ b/scripts/fixtures/sample-tui.ts
@@ -1,0 +1,307 @@
+import process from 'node:process';
+
+type FocusArea = 'tabs' | 'filter' | 'list';
+type TabName = 'Recent' | 'Needed' | 'Review';
+
+interface SampleItem {
+  callsign: string;
+  band: string;
+  mode: string;
+  note: string;
+  tab: TabName;
+}
+
+const tabs: TabName[] = ['Recent', 'Needed', 'Review'];
+const items: SampleItem[] = [
+  { callsign: 'K1ABC', band: '20m', mode: 'FT8', note: 'Strong east coast signal.', tab: 'Recent' },
+  { callsign: 'DL1XYZ', band: '15m', mode: 'CW', note: 'Needed for DXCC challenge slot.', tab: 'Recent' },
+  { callsign: 'JA1AAA', band: '10m', mode: 'SSB', note: 'Morning opening from Tokyo.', tab: 'Recent' },
+  { callsign: 'VK2QSO', band: '20m', mode: 'CW', note: 'Low-noise path after sunset.', tab: 'Needed' },
+  { callsign: 'ZS6HAM', band: '17m', mode: 'FT8', note: 'Still needed on 17m digital.', tab: 'Needed' },
+  { callsign: 'LU5DX', band: '40m', mode: 'SSB', note: 'Potential greyline check.', tab: 'Needed' },
+  { callsign: 'EA8ZZ', band: '12m', mode: 'CW', note: 'Review lotw upload before sync.', tab: 'Review' },
+  { callsign: 'VE3LOG', band: '6m', mode: 'FT8', note: 'Operator note mentions Es opening.', tab: 'Review' },
+  { callsign: 'KH6PAC', band: '20m', mode: 'SSB', note: 'Review station profile before posting.', tab: 'Review' }
+];
+
+let activeTabIndex = 0;
+let focus: FocusArea = 'tabs';
+let filter = '';
+let selectedIndex = 0;
+let showDetails = false;
+let shouldExit = false;
+
+const stdin = process.stdin;
+const stdout = process.stdout;
+
+if (stdin.isTTY) {
+  stdin.setEncoding('utf8');
+  stdin.setRawMode(true);
+}
+
+stdin.resume();
+stdin.on('data', (chunk: string) => {
+  for (const key of splitKeys(chunk)) {
+    handleKey(key);
+    if (shouldExit) {
+      cleanupAndExit();
+      return;
+    }
+  }
+
+  render();
+});
+
+process.on('SIGINT', () => cleanupAndExit());
+process.on('SIGTERM', () => cleanupAndExit());
+process.on('exit', () => {
+  stdout.write('\x1b[?25h\x1b[?1049l');
+});
+
+stdout.write('\x1b[?1049h\x1b[?25l');
+render();
+
+function handleKey(key: string): void {
+  if (key === '\u0003') {
+    shouldExit = true;
+    return;
+  }
+
+  if (key === '\t') {
+    focus = focus === 'tabs'
+      ? 'filter'
+      : focus === 'filter'
+        ? 'list'
+        : 'tabs';
+    return;
+  }
+
+  if (focus === 'tabs') {
+    handleTabsKey(key);
+    return;
+  }
+
+  if (focus === 'filter') {
+    handleFilterKey(key);
+    return;
+  }
+
+  handleListKey(key);
+}
+
+function handleTabsKey(key: string): void {
+  if (key === '\x1b[C') {
+    activeTabIndex = (activeTabIndex + 1) % tabs.length;
+    selectedIndex = 0;
+    showDetails = false;
+    return;
+  }
+
+  if (key === '\x1b[D') {
+    activeTabIndex = (activeTabIndex + tabs.length - 1) % tabs.length;
+    selectedIndex = 0;
+    showDetails = false;
+    return;
+  }
+
+  if (key.toLowerCase() === 'q') {
+    shouldExit = true;
+  }
+}
+
+function handleFilterKey(key: string): void {
+  if (key === '\x1b') {
+    if (filter.length > 0) {
+      filter = '';
+      selectedIndex = 0;
+    } else {
+      focus = 'list';
+    }
+    return;
+  }
+
+  if (key === '\x7f' || key === '\b') {
+    if (filter.length > 0) {
+      filter = filter.slice(0, -1);
+      selectedIndex = 0;
+    }
+    return;
+  }
+
+  if (key.length === 1 && key >= ' ') {
+    filter += key;
+    selectedIndex = 0;
+    return;
+  }
+
+  if (key === '\r') {
+    focus = 'list';
+  }
+}
+
+function handleListKey(key: string): void {
+  const visibleItems = getVisibleItems();
+  if (key === '\x1b[A') {
+    selectedIndex = Math.max(0, selectedIndex - 1);
+    return;
+  }
+
+  if (key === '\x1b[B') {
+    selectedIndex = Math.min(Math.max(visibleItems.length - 1, 0), selectedIndex + 1);
+    return;
+  }
+
+  if (key === '\r') {
+    showDetails = !showDetails;
+    return;
+  }
+
+  if (key === '\x1b') {
+    showDetails = false;
+    return;
+  }
+
+  if (key.toLowerCase() === 'q') {
+    shouldExit = true;
+  }
+}
+
+function getVisibleItems(): SampleItem[] {
+  const activeTab = tabs[activeTabIndex]!;
+  const normalizedFilter = filter.trim().toLowerCase();
+  const filtered = items.filter((item) => item.tab === activeTab);
+  if (!normalizedFilter) {
+    return filtered;
+  }
+
+  return filtered.filter((item) =>
+    `${item.callsign} ${item.band} ${item.mode} ${item.note}`.toLowerCase().includes(normalizedFilter)
+  );
+}
+
+function render(): void {
+  const columns = stdout.columns || 100;
+  const rows = stdout.rows || 30;
+  const visibleItems = getVisibleItems();
+  selectedIndex = Math.min(selectedIndex, Math.max(visibleItems.length - 1, 0));
+  const selected = visibleItems[selectedIndex];
+  const divider = '-'.repeat(Math.max(1, columns));
+  const lines: string[] = [];
+
+  lines.push('QsoRipper Sample TUI');
+  lines.push(renderTabsLine(columns));
+  lines.push(divider);
+  lines.push(padRight(`Filter: ${filter || '(type to filter)'}`, columns));
+  lines.push(padRight(`Focus: ${focus} | Visible QSOs: ${visibleItems.length}`, columns));
+  lines.push(divider);
+  lines.push(padRight('Callsign    Band  Mode  Notes', columns));
+
+  const listHeight = Math.max(6, rows - 16);
+  for (let index = 0; index < listHeight; index += 1) {
+    const item = visibleItems[index];
+    if (!item) {
+      lines.push(padRight('', columns));
+      continue;
+    }
+
+    const prefix = focus === 'list' && index === selectedIndex ? '>' : ' ';
+    const detailMarker = showDetails && index === selectedIndex ? '*' : ' ';
+    const row = `${prefix}${detailMarker} ${item.callsign.padEnd(9)} ${item.band.padEnd(4)} ${item.mode.padEnd(4)} ${item.note}`;
+    lines.push(padRight(row.slice(0, columns), columns));
+  }
+
+  lines.push(divider);
+  if (selected) {
+    lines.push(padRight(`Selected: ${selected.callsign} on ${selected.band} ${selected.mode}`, columns));
+    if (showDetails) {
+      for (const line of wrapText(`Details: ${selected.note}`, columns)) {
+        lines.push(padRight(line, columns));
+      }
+    } else {
+      lines.push(padRight('Details: press Enter to expand the selected item.', columns));
+    }
+  } else {
+    lines.push(padRight('No rows match the current filter.', columns));
+    lines.push(padRight('Details: clear or change the filter to restore the list.', columns));
+  }
+
+  lines.push(divider);
+  lines.push(padRight('Keys: Left/Right tabs | Tab focus | Type filter | Up/Down select | Enter details | Esc clear/collapse | q quit', columns));
+
+  stdout.write(`\x1b[2J\x1b[H${lines.slice(0, rows).join('\n')}`);
+}
+
+function renderTabsLine(columns: number): string {
+  const parts = tabs.map((tab, index) => {
+    const active = index === activeTabIndex ? `[${tab}]` : ` ${tab} `;
+    if (focus === 'tabs' && index === activeTabIndex) {
+      return `>${active}<`;
+    }
+
+    return ` ${active} `;
+  });
+
+  return padRight(parts.join(' '), columns);
+}
+
+function wrapText(text: string, width: number): string[] {
+  const safeWidth = Math.max(20, width);
+  const words = text.split(/\s+/u);
+  const lines: string[] = [];
+  let current = '';
+
+  for (const word of words) {
+    const next = current.length === 0 ? word : `${current} ${word}`;
+    if (next.length > safeWidth) {
+      if (current.length > 0) {
+        lines.push(current);
+      }
+      current = word;
+    } else {
+      current = next;
+    }
+  }
+
+  if (current.length > 0) {
+    lines.push(current);
+  }
+
+  return lines;
+}
+
+function padRight(value: string, width: number): string {
+  if (value.length >= width) {
+    return value.slice(0, width);
+  }
+
+  return `${value}${' '.repeat(width - value.length)}`;
+}
+
+function splitKeys(input: string): string[] {
+  const keys: string[] = [];
+  for (let index = 0; index < input.length; index += 1) {
+    const character = input[index]!;
+    if (character !== '\x1b') {
+      keys.push(character);
+      continue;
+    }
+
+    const next = input[index + 1];
+    const third = input[index + 2];
+    if (next === '[' && third) {
+      keys.push(input.slice(index, index + 3));
+      index += 2;
+      continue;
+    }
+
+    keys.push(character);
+  }
+
+  return keys;
+}
+
+function cleanupAndExit(): void {
+  stdout.write('\x1b[2J\x1b[H');
+  stdout.write('\x1b[?25h\x1b[?1049l');
+  process.exit(0);
+}


### PR DESCRIPTION
## Summary

Adds a first-class TUI automation lane so the `ui-reviewer` workflow can inspect terminal UX with real scripted interaction instead of relying only on GIF capture.

## What changed

- add `scripts\drive-tui.ts`, a PTY-backed terminal driver using `node-pty`, `@xterm/headless`, and Playwright Chromium rendering
- add `scripts\fixtures\sample-tui.ts` as a deterministic interactive sample TUI
- add `scripts\automation\tui-sample-smoke.json` as a ready-to-run smoke scenario
- extend package tooling with `npm run ux:drive:tui`
- update README and UX inspection docs/skill refs for the new terminal lane

## Artifacts

Snapshot actions now emit:

- `*.screen.png`
- `*.screen.txt`
- `*.screen.json`
- `*.ansi.txt`
- `transcript.txt`
- `report.json`

## Validation

- `npm install`
- `npx playwright install chromium`
- `npx tsc --noEmit`
- `npm run ux:drive:tui -- --action-script .\scripts\automation\tui-sample-smoke.json`
- `.\scripts\capture-tui.ps1 -Scenario cli-help`