### PR TITLE
Fix column width regression from PR #136

### DIFF
--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -104,8 +104,8 @@
       <Grid RowDefinitions="Auto,* ,Auto"
             IsEnabled="{Binding !IsWizardOpen}">
         <Grid Grid.Row="0"
-              MinHeight="40"
-              Margin="10,6,10,8"
+              MinHeight="44"
+              Margin="10,6,10,6"
               ColumnDefinitions="Auto,*,Auto"
               ColumnSpacing="12">
           <StackPanel Grid.Column="0"
@@ -226,8 +226,8 @@
                                       Binding="{ReflectionBinding UtcDisplay, Mode=TwoWay}"
                                       SortMemberPath="UtcSortKey" />
                   <DataGridTextColumn Header="Call"
-                                      Width="92"
-                                      MinWidth="88"
+                                      Width="88"
+                                      MinWidth="80"
                                       Binding="{ReflectionBinding WorkedCallsign, Mode=TwoWay}"
                                       SortMemberPath="WorkedCallsign" />
                   <DataGridTextColumn Header="Band"
@@ -236,7 +236,7 @@
                                       Binding="{ReflectionBinding Band, Mode=TwoWay}"
                                       SortMemberPath="Band" />
                   <DataGridTextColumn Header="Mode"
-                                      Width="74"
+                                      Width="76"
                                       MinWidth="64"
                                       Binding="{ReflectionBinding Mode, Mode=TwoWay}"
                                       SortMemberPath="Mode" />
@@ -246,17 +246,17 @@
                                       Binding="{ReflectionBinding Frequency, Mode=TwoWay}"
                                       SortMemberPath="FrequencySortKey" />
                   <DataGridTextColumn Header="RST"
-                                      Width="96"
+                                      Width="88"
                                       MinWidth="64"
                                       Binding="{ReflectionBinding Rst, Mode=TwoWay}"
                                       SortMemberPath="Rst" />
                   <DataGridTextColumn Header="DXCC"
-                                      Width="72"
+                                      Width="76"
                                       MinWidth="64"
                                       Binding="{ReflectionBinding Dxcc, Mode=TwoWay}"
                                       SortMemberPath="DxccSortKey" />
                   <DataGridTemplateColumn Header="Country"
-                                          Width="120"
+                                          Width="108"
                                           MinWidth="96"
                                           SortMemberPath="Country">
                     <DataGridTemplateColumn.CellTemplate>
@@ -277,7 +277,7 @@
                     </DataGridTemplateColumn.CellEditingTemplate>
                   </DataGridTemplateColumn>
                   <DataGridTemplateColumn Header="Name"
-                                          Width="122"
+                                          Width="108"
                                           MinWidth="96"
                                           SortMemberPath="OperatorName">
                     <DataGridTemplateColumn.CellTemplate>
@@ -298,17 +298,17 @@
                     </DataGridTemplateColumn.CellEditingTemplate>
                   </DataGridTemplateColumn>
                   <DataGridTextColumn Header="Grid"
-                                      Width="72"
-                                      MinWidth="64"
+                                      Width="66"
+                                      MinWidth="60"
                                       Binding="{ReflectionBinding Grid, Mode=TwoWay}"
                                       SortMemberPath="Grid" />
                   <DataGridTextColumn Header="Exch"
-                                      Width="76"
-                                      MinWidth="72"
+                                      Width="70"
+                                      MinWidth="64"
                                       Binding="{ReflectionBinding Exchange, Mode=TwoWay}"
                                       SortMemberPath="Exchange" />
                   <DataGridTemplateColumn Header="Contest"
-                                          Width="130"
+                                          Width="98"
                                           MinWidth="80"
                                           SortMemberPath="Contest">
                     <DataGridTemplateColumn.CellTemplate>
@@ -329,14 +329,13 @@
                     </DataGridTemplateColumn.CellEditingTemplate>
                   </DataGridTemplateColumn>
                   <DataGridTextColumn Header="Station"
-                                      Width="92"
-                                      MinWidth="80"
+                                      Width="82"
+                                      MinWidth="72"
                                       Binding="{ReflectionBinding Station, Mode=TwoWay}"
                                       SortMemberPath="Station" />
                   <DataGridTemplateColumn Header="Note"
-                                          Width="2*"
+                                          Width="*"
                                           MinWidth="80"
-                                          MaxWidth="240"
                                           SortMemberPath="Note">
                     <DataGridTemplateColumn.CellTemplate>
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
@@ -362,13 +361,13 @@
                                       SortMemberPath="UtcEndSortKey"
                                       IsVisible="False" />
                   <DataGridTextColumn Header="CQ"
-                                      Width="50"
+                                      Width="64"
                                       MinWidth="64"
                                       Binding="{ReflectionBinding CqZone, Mode=TwoWay}"
                                       SortMemberPath="CqZone"
                                       IsVisible="False" />
                   <DataGridTextColumn Header="ITU"
-                                      Width="50"
+                                      Width="64"
                                       MinWidth="64"
                                       Binding="{ReflectionBinding ItuZone, Mode=TwoWay}"
                                       SortMemberPath="ItuZone"


### PR DESCRIPTION
## Summary

Follow-up to #136. The original column widths overshot the viewport at 1280px — total fixed widths (1230px) plus Note MinWidth (80px) = 1310px, exceeding the ~1264px available DataGrid viewport. This caused Avalonia DataGrid to proportionally compress all fixed columns, so headers like Mode, DXCC, and UTC data were still clipped.

## Root cause

Avalonia DataGrid evaluates star columns after fixed columns. When `Note` had `MaxWidth="240"` with `Width="2*"`, the star column could inflate to 240px even when remaining viewport space was only ~34px. Total exceeded viewport → all columns proportionally compressed.

## Fixes

**Toolbar** — button bottom edges were clipped:
- `MinHeight` 40→44, bottom margin 8→6

**Column width budget** — tightened to fit 1280px viewport (1264px available after margins):

| Column | Before | After | Saved |
|---|---|---|---|
| Call | 92 | 88 | 4 |
| Mode | 74 | 76 | -2 (wider — 'M' is a wide character) |
| RST | 96 | 88 | 8 |
| DXCC | 72 | 76 | -4 (wider — needs room for 4 uppercase chars) |
| Country | 120 | 108 | 12 |
| Name | 122 | 108 | 14 |
| Grid | 72 | 66 | 6 |
| Exch | 76 | 70 | 6 |
| Contest | 130 | 98 | 32 |
| Station | 92 | 82 | 10 |
| **Note** | `2* MaxWidth=240` | `*` (no max) | prevents inflation |

New fixed total: **1144px**. Note star column gets ~120px of remaining space.

Also fixed hidden CQ/ITU columns where `Width="50"` was less than `MinWidth="64"` (same bug class as #128/#129).

## Verification

- `dotnet build` — 0 errors, 0 warnings
- `dotnet test QsoRipper.Gui.Tests` — 28/28 passed
- `capture-avalonia.ps1` screenshot confirms all 14 column headers display full text at default 1280×760