### PR TITLE
Add --at flag to CLI update command for timestamp editing

### DIFF
--- a/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
@@ -291,7 +291,42 @@ public sealed class CommandHelperTests
         Assert.Equal(9u, qso.RstReceived.Tone);
     }
 
+    [Fact]
+    public void TryApplyUpdates_sets_timestamp_with_at_flag()
+    {
+        var qso = new QsoRecord { WorkedCallsign = "W1AW", Band = Band._20M, Mode = Mode.Cw };
+        var enrich = false;
+
+        var success = UpdateQsoCommand.TryApplyUpdates(
+            ["--at", "2026-04-12T01:51:00Z"],
+            qso,
+            ref enrich,
+            out var error);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.NotNull(qso.UtcTimestamp);
+        Assert.Equal(2026, qso.UtcTimestamp.ToDateTime().Year);
+        Assert.Equal(4, qso.UtcTimestamp.ToDateTime().Month);
+        Assert.Equal(12, qso.UtcTimestamp.ToDateTime().Day);
+        Assert.Equal(1, qso.UtcTimestamp.ToDateTime().Hour);
+        Assert.Equal(51, qso.UtcTimestamp.ToDateTime().Minute);
+    }
+
+    [Fact]
+    public void TryApplyUpdates_rejects_invalid_at_value()
+    {
+        var qso = new QsoRecord { WorkedCallsign = "W1AW" };
+        var enrich = false;
+
+        var success = UpdateQsoCommand.TryApplyUpdates(["--at", "not-a-time"], qso, ref enrich, out var error);
+
+        Assert.False(success);
+        Assert.Contains("Invalid --at value", error, StringComparison.Ordinal);
+    }
+
     [Theory]
+    [InlineData("--at", "Missing value for --at.")]
     [InlineData("--grid", "Missing value for --grid.")]
     [InlineData("--country", "Missing value for --country.")]
     [InlineData("--state", "Missing value for --state.")]

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -90,6 +90,7 @@ internal static class CliHelpText
 
                 Update fields on an existing QSO.
 
+                  --at <time>          Change timestamp. Relative (30.minutes) or absolute.
                   --grid <grid>        Set grid square (e.g., CN87)
                   --country <name>     Set country
                   --state <abbr>       Set state (e.g., WA)
@@ -103,6 +104,7 @@ internal static class CliHelpText
 
                 Examples:
                   update abc123 --grid CN87 --freq 14074
+                  update abc123 --at "2026-04-12T01:51:00Z"
                   update abc123 --enrich
                 """,
             "delete" => """

--- a/src/dotnet/QsoRipper.Cli/Commands/UpdateQsoCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/UpdateQsoCommand.cs
@@ -165,6 +165,19 @@ internal static class UpdateQsoCommand
                 case "--rst-rcvd":
                     error = "Missing value for --rst-rcvd.";
                     return false;
+                case "--at" when i < args.Length - 1:
+                    var ts = TimeParser.Parse(args[++i]);
+                    if (ts is null)
+                    {
+                        error = "Invalid --at value. Use relative (30.minutes, 2.hours) or absolute (2026-04-12T19:30:00Z).";
+                        return false;
+                    }
+
+                    qso.UtcTimestamp = ts;
+                    break;
+                case "--at":
+                    error = "Missing value for --at.";
+                    return false;
                 case "--enrich":
                     enrich = true;
                     break;


### PR DESCRIPTION
Allow operators to correct the date/time of a QSO after logging:

  qr update <id> --at "2026-04-12T01:51:00Z"
  qr update <id> --at 30.minutes

Reuses the existing TimeParser from the log command. The proto, engine, and storage layers already supported timestamp updates; this wires the CLI surface.