### PR TITLE
Add rigctld-based rig control for engine-backed QSO autofill

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -74,8 +74,63 @@ function Build-Rust {
     }
 }
 
+function Find-VcVarsAll {
+    $vswherePath = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio' 'Installer' 'vswhere.exe'
+    if (-not (Test-Path $vswherePath)) {
+        return $null
+    }
+
+    # Try vswhere first (standard detection used by ILCompiler)
+    $vsPath = & $vswherePath -latest -prerelease -products * `
+        -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+        -property installationPath 2>$null
+    if ($vsPath) {
+        $vcvars = Join-Path $vsPath 'VC' 'Auxiliary' 'Build' 'vcvarsall.bat'
+        if (Test-Path $vcvars) {
+            return $vcvars
+        }
+    }
+
+    # Fallback: scan all VS installations for vcvarsall.bat
+    $allPaths = & $vswherePath -all -products * -property installationPath 2>$null
+    foreach ($path in $allPaths) {
+        $vcvars = Join-Path $path 'VC' 'Auxiliary' 'Build' 'vcvarsall.bat'
+        if (Test-Path $vcvars) {
+            return $vcvars
+        }
+    }
+
+    return $null
+}
+
 function Build-Dotnet {
-    Invoke-Build "Publishing QsoRipper.Cli Native AOT ($Configuration)" dotnet @(
+    # Native AOT requires the MSVC linker. ILCompiler's findvcvarsall.bat uses
+    # vswhere to locate it, but some VS installations (e.g., VS 18 BuildTools)
+    # may not register VC.Tools correctly. When that happens, set up the VC
+    # environment manually and pass IlcUseEnvironmentalTools=true.
+    $vcvarsAll = Find-VcVarsAll
+    $needsVcEnv = $false
+    $extraPublishArgs = @()
+
+    if ($vcvarsAll) {
+        # Test if ILCompiler's own detection works
+        $ilcFindScript = Join-Path $env:USERPROFILE '.nuget' 'packages' 'microsoft.dotnet.ilcompiler' '*' 'build' 'findvcvarsall.bat' |
+            Resolve-Path -ErrorAction SilentlyContinue |
+            Sort-Object -Descending |
+            Select-Object -First 1
+
+        if ($ilcFindScript) {
+            $testResult = cmd /c "`"$($ilcFindScript.Path)`" x64 >nul 2>&1 && echo OK" 2>$null
+            if ($testResult -ne 'OK') {
+                Write-Host "  ILCompiler cannot find the platform linker via vswhere." -ForegroundColor Yellow
+                Write-Host "  Using vcvarsall.bat workaround: $vcvarsAll" -ForegroundColor Yellow
+                $needsVcEnv = $true
+                $extraPublishArgs = @('-p:IlcUseEnvironmentalTools=true')
+            }
+        }
+    }
+
+    $publishArgs = @(
         'publish',
         $DotnetCliProject,
         '-c',
@@ -83,7 +138,20 @@ function Build-Dotnet {
         '--use-current-runtime',
         '-o',
         $DotnetCliPublishDir
-    )
+    ) + $extraPublishArgs
+
+    if ($needsVcEnv) {
+        $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq 'Arm64') { 'arm64' } else { 'amd64' }
+        Write-Step "Publishing QsoRipper.Cli Native AOT ($Configuration)"
+        cmd /c "call `"$vcvarsAll`" $arch >nul 2>&1 && dotnet $($publishArgs -join ' ')"
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "FAILED: Publishing QsoRipper.Cli Native AOT ($Configuration)" -ForegroundColor Red
+            exit $LASTEXITCODE
+        }
+    }
+    else {
+        Invoke-Build "Publishing QsoRipper.Cli Native AOT ($Configuration)" dotnet $publishArgs
+    }
 
     Invoke-Build "Publishing QsoRipper.Gui ($Configuration)" dotnet @(
         'publish',

--- a/proto/domain/rig_connection_status.proto
+++ b/proto/domain/rig_connection_status.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package qsoripper.domain;
+
+option csharp_namespace = "QsoRipper.Domain";
+
+// Connection status of the rig control provider.
+enum RigConnectionStatus {
+  RIG_CONNECTION_STATUS_UNSPECIFIED = 0;
+  RIG_CONNECTION_STATUS_CONNECTED = 1;
+  RIG_CONNECTION_STATUS_DISCONNECTED = 2;
+  RIG_CONNECTION_STATUS_ERROR = 3;
+  RIG_CONNECTION_STATUS_DISABLED = 4;
+}

--- a/proto/domain/rig_snapshot.proto
+++ b/proto/domain/rig_snapshot.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package qsoripper.domain;
+
+option csharp_namespace = "QsoRipper.Domain";
+
+import "domain/band.proto";
+import "domain/mode.proto";
+import "domain/rig_connection_status.proto";
+import "google/protobuf/timestamp.proto";
+
+// Normalized snapshot of the current rig state, derived from a rigctld read.
+message RigSnapshot {
+  uint64 frequency_hz = 1;
+  Band band = 2;
+  Mode mode = 3;
+  optional string submode = 4;
+  optional string raw_mode = 5;
+  RigConnectionStatus status = 6;
+  optional string error_message = 7;
+  google.protobuf.Timestamp sampled_at = 8;
+}

--- a/proto/services/get_rig_snapshot_request.proto
+++ b/proto/services/get_rig_snapshot_request.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+message GetRigSnapshotRequest {}

--- a/proto/services/get_rig_snapshot_response.proto
+++ b/proto/services/get_rig_snapshot_response.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "domain/rig_snapshot.proto";
+
+message GetRigSnapshotResponse {
+  qsoripper.domain.RigSnapshot snapshot = 1;
+}

--- a/proto/services/get_rig_status_request.proto
+++ b/proto/services/get_rig_status_request.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+message GetRigStatusRequest {}

--- a/proto/services/get_rig_status_response.proto
+++ b/proto/services/get_rig_status_response.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "domain/rig_connection_status.proto";
+
+message GetRigStatusResponse {
+  qsoripper.domain.RigConnectionStatus status = 1;
+  optional string error_message = 2;
+  optional string endpoint = 3;
+}

--- a/proto/services/rig_control_service.proto
+++ b/proto/services/rig_control_service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "services/get_rig_status_request.proto";
+import "services/get_rig_status_response.proto";
+import "services/get_rig_snapshot_request.proto";
+import "services/get_rig_snapshot_response.proto";
+import "services/test_rig_connection_request.proto";
+import "services/test_rig_connection_response.proto";
+
+service RigControlService {
+  rpc GetRigStatus(GetRigStatusRequest) returns (GetRigStatusResponse);
+  rpc GetRigSnapshot(GetRigSnapshotRequest) returns (GetRigSnapshotResponse);
+  rpc TestRigConnection(TestRigConnectionRequest) returns (TestRigConnectionResponse);
+}

--- a/proto/services/test_rig_connection_request.proto
+++ b/proto/services/test_rig_connection_request.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+// Allows testing rig connectivity with optional overrides before persisting config.
+message TestRigConnectionRequest {
+  optional string host = 1;
+  optional uint32 port = 2;
+}

--- a/proto/services/test_rig_connection_response.proto
+++ b/proto/services/test_rig_connection_response.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "domain/rig_snapshot.proto";
+
+message TestRigConnectionResponse {
+  bool success = 1;
+  optional string error_message = 2;
+  optional qsoripper.domain.RigSnapshot snapshot = 3;
+}

--- a/src/dotnet/QsoRipper.Cli.Tests/CliRegressionTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliRegressionTests.cs
@@ -11,7 +11,7 @@ public class CliRegressionTests
         var result = await CliProcessRunner.RunAsync("log", "--help");
 
         Assert.Equal(0, result.ExitCode);
-        Assert.Contains("Usage: log <callsign> <band> <mode> [options]", result.StandardOutput, StringComparison.Ordinal);
+        Assert.Contains("Usage: log <callsign> [band] [mode] [options]", result.StandardOutput, StringComparison.Ordinal);
         Assert.DoesNotContain("Usage: qsoripper-cli [options] <command> [arguments]", result.StandardOutput, StringComparison.Ordinal);
     }
 

--- a/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
@@ -138,6 +138,76 @@ public sealed class CommandHelperTests
     }
 
     [Fact]
+    public void TryBuildQso_from_rig_allows_omitting_band_mode()
+    {
+        var success = LogQsoCommand.TryBuildQso(
+            "W1AW",
+            ["--from-rig"],
+            out var qso,
+            out _,
+            out var fromRig,
+            out var error);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.True(fromRig);
+        Assert.NotNull(qso);
+        Assert.Equal(Band.Unspecified, qso!.Band);
+        Assert.Equal(Mode.Unspecified, qso.Mode);
+    }
+
+    [Fact]
+    public void TryBuildQso_from_rig_with_explicit_band_mode()
+    {
+        var success = LogQsoCommand.TryBuildQso(
+            "W1AW",
+            ["40m", "CW", "--from-rig"],
+            out var qso,
+            out _,
+            out var fromRig,
+            out var error);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.True(fromRig);
+        Assert.NotNull(qso);
+        Assert.Equal(Band._40M, qso!.Band);
+        Assert.Equal(Mode.Cw, qso.Mode);
+    }
+
+    [Fact]
+    public void TryBuildQso_from_rig_with_named_band_mode_overrides()
+    {
+        var success = LogQsoCommand.TryBuildQso(
+            "W1AW",
+            ["--from-rig", "--band", "20m", "--mode", "FT8"],
+            out var qso,
+            out _,
+            out var fromRig,
+            out var error);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.True(fromRig);
+        Assert.NotNull(qso);
+        Assert.Equal(Band._20M, qso!.Band);
+        Assert.Equal(Mode.Ft8, qso.Mode);
+    }
+
+    [Fact]
+    public void TryBuildQso_without_from_rig_requires_band_mode()
+    {
+        var success = LogQsoCommand.TryBuildQso(
+            "W1AW",
+            [],
+            out _,
+            out _,
+            out _);
+
+        Assert.False(success);
+    }
+
+    [Fact]
     public void TryParseArgs_populates_filters()
     {
         var success = ListQsosCommand.TryParseArgs(["--callsign", "w1aw", "--band", "20m", "--mode", "ft8", "--after", "2026-04-10T00:00:00Z", "--before", "2026-04-11T00:00:00Z", "--limit", "5"],

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -34,6 +34,9 @@ internal static class CliHelpText
               config [--set KEY=VALUE]         View or modify runtime config
               setup [--status | --from-env]    Interactive setup wizard or headless config
 
+            Rig Control:
+              rig-status                       Show rig connection and current state
+
             Options:
               --endpoint, -e <url>             Engine endpoint (default: http://127.0.0.1:50051)
               --skip-cache                     Bypass cache for lookup commands
@@ -47,10 +50,13 @@ internal static class CliHelpText
         return command switch
         {
             "log" => """
-                Usage: log <callsign> <band> <mode> [options]
+                Usage: log <callsign> [band] [mode] [options]
 
                 Log a new QSO. Auto-enriches with QRZ data (grid, country, etc.)
 
+                  --from-rig           Auto-fill band, mode, and frequency from the rig
+                  --band <band>        Override band (e.g., 20m)
+                  --mode <mode>        Override mode (e.g., CW)
                   --station <call>     Your station callsign (if not set via setup)
                   --at <time>          QSO time (default: now). Relative (30.minutes) or absolute.
                   --rst-sent <rst>     RST sent (e.g., 59, 599)
@@ -60,9 +66,14 @@ internal static class CliHelpText
                   --notes <text>       Notes text
                   --no-enrich          Skip automatic QRZ lookup enrichment
 
+                Without --from-rig, band and mode are required positional arguments.
+                With --from-rig, omitted values are filled from the rig. Explicit values
+                always take priority over rig-derived values.
+
                 Examples:
                   log W1AW 20m FT8
-                  log W1AW 40m CW --station AE7XI --rst-sent 599 --freq 7030 --comment "Nice signal"
+                  log W1AW --from-rig
+                  log W1AW 40m CW --from-rig --comment "Nice signal"
                   log K7ABV 20m SSB --at 30.minutes
                 """,
             "get" => """
@@ -179,6 +190,12 @@ internal static class CliHelpText
                 Usage: status
 
                 Show engine sync status and QSO counts.
+                """,
+            "rig-status" => """
+                Usage: rig-status
+
+                Show rig connection status, endpoint, and current radio state
+                (frequency, band, mode) when connected.
                 """,
             "sync" => """
                 Usage: sync [--force]

--- a/src/dotnet/QsoRipper.Cli/Commands/LogQsoCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/LogQsoCommand.cs
@@ -9,13 +9,35 @@ internal static class LogQsoCommand
 {
     public static async Task<int> RunAsync(GrpcChannel channel, string callsign, string[] args)
     {
-        if (!TryBuildQso(callsign, args, out var qso, out var noEnrich, out var error))
+        if (!TryBuildQso(callsign, args, out var qso, out var noEnrich, out var fromRig, out var error))
         {
-            Console.Error.WriteLine(error);
-            return 1;
+            if (error is not null)
+            {
+                Console.Error.WriteLine(error);
+            }
+            else
+            {
+                Console.WriteLine(CliHelpText.GetCommandHelp("log"));
+            }
+
+            return error is not null ? 1 : 0;
         }
 
         var requestQso = qso!;
+
+        if (fromRig)
+        {
+            if (!await ApplyRigSnapshot(channel, requestQso))
+            {
+                return 1;
+            }
+        }
+
+        if (requestQso.Band == Band.Unspecified || requestQso.Mode == Mode.Unspecified)
+        {
+            Console.Error.WriteLine("Band and mode are required. Provide them as positional args, with --band/--mode flags, or use --from-rig.");
+            return 1;
+        }
 
         ApplyDefaultRst(requestQso);
 
@@ -60,33 +82,69 @@ internal static class LogQsoCommand
 
     internal static bool TryBuildQso(string callsign, string[] args, out QsoRecord? qso, out bool noEnrich, out string? error)
     {
+        return TryBuildQso(callsign, args, out qso, out noEnrich, out _, out error);
+    }
+
+    internal static bool TryBuildQso(string callsign, string[] args, out QsoRecord? qso, out bool noEnrich, out bool fromRig, out string? error)
+    {
         qso = null;
         noEnrich = false;
+        fromRig = args.Any(static a => a is "--from-rig");
         error = null;
 
-        if (args.Length < 2 || args.Any(static a => a is "help" or "-?" or "--help"))
+        if (args.Any(static a => a is "help" or "-?" or "--help"))
         {
-            error = "Usage: log <callsign> <band> <mode> [--station call] [--at time] [--rst-sent 59] [--rst-rcvd 59] [--freq khz] [--comment text] [--notes text] [--no-enrich]";
+            error = null;
             return false;
         }
 
-        try
+        // With --from-rig, band and mode are optional positional args.
+        // Without --from-rig, the first two args must be band and mode.
+        Band? band = null;
+        Mode? mode = null;
+        var optionalArgsStart = 0;
+
+        if (args.Length >= 2 && !args[0].StartsWith('-') && !args[1].StartsWith('-'))
         {
-            qso = new QsoRecord
+            try
             {
-                WorkedCallsign = callsign.ToUpperInvariant(),
-                Band = EnumHelpers.ParseBand(args[0]),
-                Mode = EnumHelpers.ParseMode(args[1]),
-                UtcTimestamp = Timestamp.FromDateTime(DateTime.UtcNow),
-            };
+                band = EnumHelpers.ParseBand(args[0]);
+                mode = EnumHelpers.ParseMode(args[1]);
+                optionalArgsStart = 2;
+            }
+            catch (ArgumentException ex)
+            {
+                if (!fromRig)
+                {
+                    error = ex.Message;
+                    return false;
+                }
+                // With --from-rig, treat unparseable positional args as remaining args
+            }
         }
-        catch (ArgumentException ex)
+        else if (!fromRig)
         {
-            error = ex.Message;
+            error = "Usage: log <callsign> <band> <mode> [--station call] [--at time] [--rst-sent 59] [--rst-rcvd 59] [--freq khz] [--comment text] [--notes text] [--no-enrich] [--from-rig]";
             return false;
         }
 
-        return TryApplyOptionalArgs(args, qso, ref noEnrich, out error);
+        qso = new QsoRecord
+        {
+            WorkedCallsign = callsign.ToUpperInvariant(),
+            UtcTimestamp = Timestamp.FromDateTime(DateTime.UtcNow),
+        };
+
+        if (band.HasValue)
+        {
+            qso.Band = band.Value;
+        }
+
+        if (mode.HasValue)
+        {
+            qso.Mode = mode.Value;
+        }
+
+        return TryApplyOptionalArgs(args, qso, optionalArgsStart, ref noEnrich, out error);
     }
 
     internal static RstReport DefaultRst(Mode mode)
@@ -110,9 +168,14 @@ internal static class LogQsoCommand
 
     internal static bool TryApplyOptionalArgs(string[] args, QsoRecord qso, ref bool noEnrich, out string? error)
     {
+        return TryApplyOptionalArgs(args, qso, 2, ref noEnrich, out error);
+    }
+
+    internal static bool TryApplyOptionalArgs(string[] args, QsoRecord qso, int startIndex, ref bool noEnrich, out string? error)
+    {
         error = null;
 
-        for (var i = 2; i < args.Length; i++)
+        for (var i = startIndex; i < args.Length; i++)
         {
             switch (args[i])
             {
@@ -187,6 +250,39 @@ internal static class LogQsoCommand
                 case "--no-enrich":
                     noEnrich = true;
                     break;
+                case "--from-rig":
+                    // Already handled in TryBuildQso
+                    break;
+                case "--band" when i < args.Length - 1:
+                    try
+                    {
+                        qso.Band = EnumHelpers.ParseBand(args[++i]);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        error = ex.Message;
+                        return false;
+                    }
+
+                    break;
+                case "--band":
+                    error = "Missing value for --band.";
+                    return false;
+                case "--mode" when i < args.Length - 1:
+                    try
+                    {
+                        qso.Mode = EnumHelpers.ParseMode(args[++i]);
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        error = ex.Message;
+                        return false;
+                    }
+
+                    break;
+                case "--mode":
+                    error = "Missing value for --mode.";
+                    return false;
                 default:
                     error = $"Unknown option: {args[i]}";
                     return false;
@@ -214,6 +310,57 @@ internal static class LogQsoCommand
         }
 
         return true;
+    }
+
+    private static async Task<bool> ApplyRigSnapshot(GrpcChannel channel, QsoRecord qso)
+    {
+        try
+        {
+            var rigClient = new RigControlService.RigControlServiceClient(channel);
+            var response = await rigClient.GetRigSnapshotAsync(new GetRigSnapshotRequest());
+
+            if (response.Snapshot is not { } snapshot
+                || snapshot.Status != RigConnectionStatus.Connected)
+            {
+                var errorMsg = response.Snapshot?.ErrorMessage ?? "rig unavailable";
+                Console.Error.WriteLine($"  \u26a0 Rig read failed: {errorMsg}");
+                return false;
+            }
+
+            // Fill band, mode, frequency, submode from rig if not explicitly set
+            if (qso.Band == Band.Unspecified && snapshot.Band != Band.Unspecified)
+            {
+                qso.Band = snapshot.Band;
+            }
+
+            if (qso.Mode == Mode.Unspecified && snapshot.Mode != Mode.Unspecified)
+            {
+                qso.Mode = snapshot.Mode;
+            }
+
+            if (qso.FrequencyKhz == 0 && snapshot.FrequencyHz > 0)
+            {
+                qso.FrequencyKhz = (snapshot.FrequencyHz + 500) / 1000;
+            }
+
+            if (!qso.HasSubmode && snapshot.HasSubmode)
+            {
+                qso.Submode = snapshot.Submode;
+            }
+
+            var freq = snapshot.FrequencyHz > 0 ? $"{snapshot.FrequencyHz / 1_000_000.0:F3} MHz" : "unknown";
+            var rawMode = snapshot.HasRawMode ? snapshot.RawMode : "unknown";
+            Console.WriteLine($"  Rig: {freq} {rawMode}");
+
+            return true;
+        }
+        catch (Grpc.Core.RpcException ex)
+        {
+            var detail = ex.Status.Detail;
+            var message = string.IsNullOrEmpty(detail) ? ex.StatusCode.ToString() : detail;
+            Console.Error.WriteLine($"  \u26a0 Rig control unavailable: {message}");
+            return false;
+        }
     }
 
     private static async Task EnrichFromLookup(GrpcChannel channel, QsoRecord qso)

--- a/src/dotnet/QsoRipper.Cli/Commands/RigStatusCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/RigStatusCommand.cs
@@ -1,0 +1,63 @@
+using Grpc.Net.Client;
+using QsoRipper.Domain;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli.Commands;
+
+internal static class RigStatusCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel)
+    {
+        var client = new RigControlService.RigControlServiceClient(channel);
+
+        var statusResponse = await client.GetRigStatusAsync(new GetRigStatusRequest());
+        var status = statusResponse.Status;
+
+        Console.WriteLine($"Rig: {FormatStatus(status)}");
+
+        if (statusResponse.HasEndpoint)
+        {
+            Console.WriteLine($"  Endpoint: {statusResponse.Endpoint}");
+        }
+
+        if (statusResponse.HasErrorMessage)
+        {
+            Console.WriteLine($"  Error: {statusResponse.ErrorMessage}");
+        }
+
+        if (status != RigConnectionStatus.Connected)
+        {
+            return 0;
+        }
+
+        var snapshotResponse = await client.GetRigSnapshotAsync(new GetRigSnapshotRequest());
+        if (snapshotResponse.Snapshot is { } snapshot)
+        {
+            var freq = snapshot.FrequencyHz > 0 ? $"{snapshot.FrequencyHz / 1_000_000.0:F3} MHz" : "unknown";
+            var band = snapshot.Band != Band.Unspecified ? EnumHelpers.FormatBand(snapshot.Band) : "unknown";
+            var mode = snapshot.HasRawMode ? snapshot.RawMode : "unknown";
+
+            Console.WriteLine($"  Frequency: {freq} ({band})");
+            Console.WriteLine($"  Mode: {mode}");
+
+            if (snapshot.HasSubmode)
+            {
+                Console.WriteLine($"  Submode: {snapshot.Submode}");
+            }
+        }
+
+        return 0;
+    }
+
+    private static string FormatStatus(RigConnectionStatus status)
+    {
+        return status switch
+        {
+            RigConnectionStatus.Connected => "\u2705 Connected",
+            RigConnectionStatus.Disconnected => "\u274c Disconnected",
+            RigConnectionStatus.Error => "\u26a0 Error",
+            RigConnectionStatus.Disabled => "\u2b55 Disabled",
+            _ => "Unknown",
+        };
+    }
+}

--- a/src/dotnet/QsoRipper.Cli/Program.cs
+++ b/src/dotnet/QsoRipper.Cli/Program.cs
@@ -49,6 +49,7 @@ try
         "setup" => await SetupCommand.RunAsync(channel, arguments),
         "sync" => await SyncCommand.RunAsync(channel, arguments.Force),
         "sync-status" => await SyncStatusCommand.RunAsync(channel, arguments.JsonOutput),
+        "rig-status" => await RigStatusCommand.RunAsync(channel),
         "test-logbook" => await TestLogbookCommand.RunAsync(channel, arguments.RemainingArgs),
         _ => ShowHelp($"Unknown command: {arguments.Command}")
     };

--- a/src/rust/qsoripper-core/src/lib.rs
+++ b/src/rust/qsoripper-core/src/lib.rs
@@ -15,6 +15,8 @@ pub mod lookup;
 pub mod proto;
 /// QRZ Logbook API client for bidirectional QSO sync.
 pub mod qrz_logbook;
+/// Rig control providers, normalization, and cached rig state snapshots.
+pub mod rig_control;
 /// Space weather providers, caching, and normalization.
 pub mod space_weather;
 /// Storage ports, errors, and query types for engine-owned persistence.

--- a/src/rust/qsoripper-core/src/rig_control/band_mapping.rs
+++ b/src/rust/qsoripper-core/src/rig_control/band_mapping.rs
@@ -1,0 +1,126 @@
+//! Frequency-to-band mapping using IARU band plan ranges.
+
+use crate::proto::qsoripper::domain::Band;
+
+/// Map a frequency in Hz to the corresponding amateur radio band.
+///
+/// Returns [`Band::Unspecified`] if the frequency does not fall within any
+/// recognized amateur band.
+#[must_use]
+pub fn frequency_hz_to_band(hz: u64) -> Band {
+    match hz {
+        // 2200m: 135.7–137.8 kHz
+        135_700..=137_800 => Band::Band2190m,
+        // 630m: 472–479 kHz
+        472_000..=479_000 => Band::Band630m,
+        // 160m: 1.8–2.0 MHz
+        1_800_000..=2_000_000 => Band::Band160m,
+        // 80m: 3.5–4.0 MHz
+        3_500_000..=4_000_000 => Band::Band80m,
+        // 60m: 5.06–5.45 MHz (channelized in most countries)
+        5_060_000..=5_450_000 => Band::Band60m,
+        // 40m: 7.0–7.3 MHz
+        7_000_000..=7_300_000 => Band::Band40m,
+        // 30m: 10.1–10.15 MHz
+        10_100_000..=10_150_000 => Band::Band30m,
+        // 20m: 14.0–14.35 MHz
+        14_000_000..=14_350_000 => Band::Band20m,
+        // 17m: 18.068–18.168 MHz
+        18_068_000..=18_168_000 => Band::Band17m,
+        // 15m: 21.0–21.45 MHz
+        21_000_000..=21_450_000 => Band::Band15m,
+        // 12m: 24.89–24.99 MHz
+        24_890_000..=24_990_000 => Band::Band12m,
+        // 10m: 28.0–29.7 MHz
+        28_000_000..=29_700_000 => Band::Band10m,
+        // 6m: 50.0–54.0 MHz
+        50_000_000..=54_000_000 => Band::Band6m,
+        // 2m: 144.0–148.0 MHz
+        144_000_000..=148_000_000 => Band::Band2m,
+        // 1.25m: 219–225 MHz
+        219_000_000..=225_000_000 => Band::Band125m,
+        // 70cm: 420–450 MHz
+        420_000_000..=450_000_000 => Band::Band70cm,
+        // 33cm: 902–928 MHz
+        902_000_000..=928_000_000 => Band::Band33cm,
+        // 23cm: 1240–1300 MHz
+        1_240_000_000..=1_300_000_000 => Band::Band23cm,
+        _ => Band::Unspecified,
+    }
+}
+
+/// Convert a frequency in Hz to kHz, rounding to the nearest kHz.
+#[must_use]
+pub fn frequency_hz_to_khz(hz: u64) -> u64 {
+    (hz + 500) / 1_000
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn common_hf_frequencies() {
+        assert_eq!(Band::Band160m, frequency_hz_to_band(1_840_000));
+        assert_eq!(Band::Band80m, frequency_hz_to_band(3_573_000));
+        assert_eq!(Band::Band60m, frequency_hz_to_band(5_357_000));
+        assert_eq!(Band::Band40m, frequency_hz_to_band(7_074_000));
+        assert_eq!(Band::Band30m, frequency_hz_to_band(10_136_000));
+        assert_eq!(Band::Band20m, frequency_hz_to_band(14_074_000));
+        assert_eq!(Band::Band17m, frequency_hz_to_band(18_100_000));
+        assert_eq!(Band::Band15m, frequency_hz_to_band(21_074_000));
+        assert_eq!(Band::Band12m, frequency_hz_to_band(24_915_000));
+        assert_eq!(Band::Band10m, frequency_hz_to_band(28_074_000));
+    }
+
+    #[test]
+    fn vhf_uhf_frequencies() {
+        assert_eq!(Band::Band6m, frequency_hz_to_band(50_313_000));
+        assert_eq!(Band::Band2m, frequency_hz_to_band(144_174_000));
+        assert_eq!(Band::Band70cm, frequency_hz_to_band(432_065_000));
+    }
+
+    #[test]
+    fn band_edge_lower_boundary() {
+        assert_eq!(Band::Band20m, frequency_hz_to_band(14_000_000));
+        assert_eq!(Band::Band40m, frequency_hz_to_band(7_000_000));
+        assert_eq!(Band::Band80m, frequency_hz_to_band(3_500_000));
+    }
+
+    #[test]
+    fn band_edge_upper_boundary() {
+        assert_eq!(Band::Band20m, frequency_hz_to_band(14_350_000));
+        assert_eq!(Band::Band40m, frequency_hz_to_band(7_300_000));
+        assert_eq!(Band::Band10m, frequency_hz_to_band(29_700_000));
+    }
+
+    #[test]
+    fn out_of_range_returns_unspecified() {
+        assert_eq!(Band::Unspecified, frequency_hz_to_band(0));
+        assert_eq!(Band::Unspecified, frequency_hz_to_band(100_000));
+        assert_eq!(Band::Unspecified, frequency_hz_to_band(13_999_999));
+        assert_eq!(Band::Unspecified, frequency_hz_to_band(14_350_001));
+    }
+
+    #[test]
+    fn low_frequency_bands() {
+        assert_eq!(Band::Band2190m, frequency_hz_to_band(136_000));
+        assert_eq!(Band::Band630m, frequency_hz_to_band(475_000));
+    }
+
+    #[test]
+    fn microwave_bands() {
+        assert_eq!(Band::Band33cm, frequency_hz_to_band(903_000_000));
+        assert_eq!(Band::Band23cm, frequency_hz_to_band(1_296_000_000));
+    }
+
+    #[test]
+    fn hz_to_khz_rounds() {
+        assert_eq!(14_074, frequency_hz_to_khz(14_074_000));
+        assert_eq!(14_074, frequency_hz_to_khz(14_074_499));
+        assert_eq!(14_075, frequency_hz_to_khz(14_074_500));
+        assert_eq!(7_074, frequency_hz_to_khz(7_074_000));
+        assert_eq!(0, frequency_hz_to_khz(0));
+    }
+}

--- a/src/rust/qsoripper-core/src/rig_control/mod.rs
+++ b/src/rust/qsoripper-core/src/rig_control/mod.rs
@@ -1,0 +1,19 @@
+//! Rig control providers, normalization, and cached rig state snapshots.
+
+pub mod band_mapping;
+pub mod mode_mapping;
+mod monitor;
+mod provider;
+pub mod rigctld;
+
+pub use monitor::RigControlMonitor;
+pub use provider::{
+    DisabledRigControlProvider, RigControlProvider, RigControlProviderError,
+    RigControlProviderErrorKind,
+};
+pub use rigctld::{
+    RigctldConfig, RigctldProvider, DEFAULT_RIGCTLD_HOST, DEFAULT_RIGCTLD_PORT,
+    DEFAULT_RIGCTLD_READ_TIMEOUT_MS, DEFAULT_RIGCTLD_STALE_THRESHOLD_MS, RIGCTLD_ENABLED_ENV_VAR,
+    RIGCTLD_HOST_ENV_VAR, RIGCTLD_PORT_ENV_VAR, RIGCTLD_READ_TIMEOUT_MS_ENV_VAR,
+    RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR,
+};

--- a/src/rust/qsoripper-core/src/rig_control/mode_mapping.rs
+++ b/src/rust/qsoripper-core/src/rig_control/mode_mapping.rs
@@ -1,0 +1,157 @@
+//! Hamlib mode string to proto Mode/submode mapping.
+
+use crate::proto::qsoripper::domain::Mode;
+
+/// Result of mapping a Hamlib mode string to project-owned types.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ModeMapping {
+    /// The normalized project-owned mode.
+    pub mode: Mode,
+    /// Optional submode (e.g., `"USB"` for SSB).
+    pub submode: Option<String>,
+}
+
+/// Map a Hamlib/rigctld mode string to a project-owned [`Mode`] and optional submode.
+///
+/// The mapping is case-insensitive. Unknown modes map to [`Mode::Unspecified`].
+#[must_use]
+pub fn hamlib_mode_to_proto(raw: &str) -> ModeMapping {
+    match raw.to_uppercase().as_str() {
+        "USB" => ModeMapping {
+            mode: Mode::Ssb,
+            submode: Some("USB".to_string()),
+        },
+        "LSB" => ModeMapping {
+            mode: Mode::Ssb,
+            submode: Some("LSB".to_string()),
+        },
+        "CW" => ModeMapping {
+            mode: Mode::Cw,
+            submode: None,
+        },
+        "CWR" => ModeMapping {
+            mode: Mode::Cw,
+            submode: Some("CWR".to_string()),
+        },
+        "AM" => ModeMapping {
+            mode: Mode::Am,
+            submode: None,
+        },
+        "FM" | "WFM" => ModeMapping {
+            mode: Mode::Fm,
+            submode: None,
+        },
+        "RTTY" => ModeMapping {
+            mode: Mode::Rtty,
+            submode: None,
+        },
+        "RTTYR" => ModeMapping {
+            mode: Mode::Rtty,
+            submode: Some("RTTYR".to_string()),
+        },
+        // PKTUSB/PKTLSB: digital packet modes (FT8, JS8Call, etc.)
+        // Map to PKT, not SSB, to avoid wrong RST defaults.
+        "PKTUSB" => ModeMapping {
+            mode: Mode::Pkt,
+            submode: Some("PKTUSB".to_string()),
+        },
+        "PKTLSB" => ModeMapping {
+            mode: Mode::Pkt,
+            submode: Some("PKTLSB".to_string()),
+        },
+        "PKTFM" => ModeMapping {
+            mode: Mode::Pkt,
+            submode: Some("PKTFM".to_string()),
+        },
+        "FT8" => ModeMapping {
+            mode: Mode::Ft8,
+            submode: None,
+        },
+        "PSK" | "PSK31" => ModeMapping {
+            mode: Mode::Psk,
+            submode: None,
+        },
+        _ => ModeMapping {
+            mode: Mode::Unspecified,
+            submode: None,
+        },
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ssb_modes() {
+        let usb = hamlib_mode_to_proto("USB");
+        assert_eq!(Mode::Ssb, usb.mode);
+        assert_eq!(Some("USB".to_string()), usb.submode);
+
+        let lsb = hamlib_mode_to_proto("LSB");
+        assert_eq!(Mode::Ssb, lsb.mode);
+        assert_eq!(Some("LSB".to_string()), lsb.submode);
+    }
+
+    #[test]
+    fn cw_modes() {
+        let cw = hamlib_mode_to_proto("CW");
+        assert_eq!(Mode::Cw, cw.mode);
+        assert_eq!(None, cw.submode);
+
+        let cwr = hamlib_mode_to_proto("CWR");
+        assert_eq!(Mode::Cw, cwr.mode);
+        assert_eq!(Some("CWR".to_string()), cwr.submode);
+    }
+
+    #[test]
+    fn pktusb_maps_to_pkt() {
+        let result = hamlib_mode_to_proto("PKTUSB");
+        assert_eq!(Mode::Pkt, result.mode);
+        assert_eq!(Some("PKTUSB".to_string()), result.submode);
+    }
+
+    #[test]
+    fn pktlsb_maps_to_pkt() {
+        let result = hamlib_mode_to_proto("PKTLSB");
+        assert_eq!(Mode::Pkt, result.mode);
+        assert_eq!(Some("PKTLSB".to_string()), result.submode);
+    }
+
+    #[test]
+    fn fm_modes() {
+        assert_eq!(Mode::Fm, hamlib_mode_to_proto("FM").mode);
+        assert_eq!(Mode::Fm, hamlib_mode_to_proto("WFM").mode);
+    }
+
+    #[test]
+    fn rtty_modes() {
+        assert_eq!(Mode::Rtty, hamlib_mode_to_proto("RTTY").mode);
+
+        let rttyr = hamlib_mode_to_proto("RTTYR");
+        assert_eq!(Mode::Rtty, rttyr.mode);
+        assert_eq!(Some("RTTYR".to_string()), rttyr.submode);
+    }
+
+    #[test]
+    fn case_insensitive() {
+        assert_eq!(Mode::Ssb, hamlib_mode_to_proto("usb").mode);
+        assert_eq!(Mode::Cw, hamlib_mode_to_proto("cw").mode);
+        assert_eq!(Mode::Pkt, hamlib_mode_to_proto("pktusb").mode);
+    }
+
+    #[test]
+    fn unknown_mode() {
+        let result = hamlib_mode_to_proto("SOMETHING_NEW");
+        assert_eq!(Mode::Unspecified, result.mode);
+        assert_eq!(None, result.submode);
+    }
+
+    #[test]
+    fn ft8_mode() {
+        let result = hamlib_mode_to_proto("FT8");
+        assert_eq!(Mode::Ft8, result.mode);
+        assert_eq!(None, result.submode);
+    }
+}

--- a/src/rust/qsoripper-core/src/rig_control/monitor.rs
+++ b/src/rust/qsoripper-core/src/rig_control/monitor.rs
@@ -1,0 +1,193 @@
+//! Cached rig state snapshots with staleness tracking.
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use prost_types::Timestamp;
+use tokio::sync::RwLock;
+
+use crate::proto::qsoripper::domain::{RigConnectionStatus, RigSnapshot};
+
+use super::provider::RigControlProvider;
+
+#[derive(Clone)]
+struct CachedSnapshot {
+    snapshot: RigSnapshot,
+    fetched_monotonic: Instant,
+}
+
+/// Cached monitor around a rig control provider.
+///
+/// Caches the latest snapshot and refreshes it when the configured threshold
+/// elapses. Follows the same pattern as [`SpaceWeatherMonitor`].
+pub struct RigControlMonitor {
+    provider: Arc<dyn RigControlProvider>,
+    stale_threshold: Duration,
+    state: RwLock<Option<CachedSnapshot>>,
+}
+
+impl RigControlMonitor {
+    /// Create a monitor with a staleness threshold.
+    #[must_use]
+    pub fn new(provider: Arc<dyn RigControlProvider>, stale_threshold: Duration) -> Self {
+        Self {
+            provider,
+            stale_threshold,
+            state: RwLock::new(None),
+        }
+    }
+
+    /// Return the current snapshot, refreshing when stale or missing.
+    pub async fn current_snapshot(&self) -> RigSnapshot {
+        if let Some(cached) = self.state.read().await.clone() {
+            if cached.fetched_monotonic.elapsed() < self.stale_threshold {
+                return cached.snapshot.clone();
+            }
+        }
+
+        self.refresh_snapshot().await
+    }
+
+    /// Force a refresh and return the latest available snapshot.
+    pub async fn refresh_snapshot(&self) -> RigSnapshot {
+        let cached = self.state.read().await.clone();
+
+        match self.provider.get_snapshot().await {
+            Ok(mut snapshot) => {
+                snapshot.sampled_at = Some(now_timestamp());
+                snapshot.status = RigConnectionStatus::Connected as i32;
+                snapshot.error_message = None;
+                let cached_snapshot = CachedSnapshot {
+                    snapshot: snapshot.clone(),
+                    fetched_monotonic: Instant::now(),
+                };
+                *self.state.write().await = Some(cached_snapshot);
+                snapshot
+            }
+            Err(error) => {
+                if let Some(cached) = cached {
+                    let mut snapshot = cached.snapshot.clone();
+                    snapshot.status = RigConnectionStatus::Error as i32;
+                    snapshot.error_message = Some(error.to_string());
+                    snapshot
+                } else {
+                    let status =
+                        if error.kind() == super::provider::RigControlProviderErrorKind::Disabled {
+                            RigConnectionStatus::Disabled
+                        } else {
+                            RigConnectionStatus::Error
+                        };
+
+                    RigSnapshot {
+                        sampled_at: Some(now_timestamp()),
+                        status: status as i32,
+                        error_message: Some(error.to_string()),
+                        ..RigSnapshot::default()
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn now_timestamp() -> Timestamp {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    Timestamp {
+        seconds: i64::try_from(now.as_secs()).unwrap_or(i64::MAX),
+        nanos: i32::try_from(now.subsec_nanos()).unwrap_or(i32::MAX),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::rig_control::provider::{RigControlProvider, RigControlProviderError};
+
+    #[derive(Clone)]
+    struct FakeProvider {
+        result: Result<RigSnapshot, RigControlProviderError>,
+    }
+
+    #[tonic::async_trait]
+    impl RigControlProvider for FakeProvider {
+        async fn get_snapshot(&self) -> Result<RigSnapshot, RigControlProviderError> {
+            self.result.clone()
+        }
+    }
+
+    #[tokio::test]
+    async fn current_snapshot_returns_cached_value_within_threshold() {
+        let provider = Arc::new(FakeProvider {
+            result: Ok(RigSnapshot {
+                frequency_hz: 14_074_000,
+                ..RigSnapshot::default()
+            }),
+        });
+        let monitor = RigControlMonitor::new(provider, Duration::from_secs(60));
+
+        let initial = monitor.refresh_snapshot().await;
+        let cached = monitor.current_snapshot().await;
+
+        assert_eq!(initial.frequency_hz, cached.frequency_hz);
+        assert_eq!(RigConnectionStatus::Connected as i32, cached.status);
+    }
+
+    #[tokio::test]
+    async fn refresh_returns_error_snapshot_on_failure_without_cache() {
+        let provider = Arc::new(FakeProvider {
+            result: Err(RigControlProviderError::transport("connection refused")),
+        });
+        let monitor = RigControlMonitor::new(provider, Duration::from_secs(60));
+
+        let snapshot = monitor.refresh_snapshot().await;
+
+        assert_eq!(RigConnectionStatus::Error as i32, snapshot.status);
+        assert!(snapshot.error_message.is_some());
+    }
+
+    #[tokio::test]
+    async fn refresh_returns_stale_cached_on_failure_with_cache() {
+        let good_provider = Arc::new(FakeProvider {
+            result: Ok(RigSnapshot {
+                frequency_hz: 7_074_000,
+                ..RigSnapshot::default()
+            }),
+        });
+        let monitor = RigControlMonitor::new(good_provider, Duration::from_secs(0));
+        let _ = monitor.refresh_snapshot().await;
+
+        // Swap to a failing provider
+        let bad_provider = Arc::new(FakeProvider {
+            result: Err(RigControlProviderError::transport("offline")),
+        });
+        let existing = monitor.state.write().await.clone();
+        let monitor = RigControlMonitor {
+            provider: bad_provider,
+            stale_threshold: Duration::from_secs(0),
+            state: RwLock::new(existing),
+        };
+
+        let snapshot = monitor.refresh_snapshot().await;
+
+        assert_eq!(RigConnectionStatus::Error as i32, snapshot.status);
+        assert_eq!(7_074_000, snapshot.frequency_hz);
+        assert!(snapshot.error_message.is_some());
+    }
+
+    #[tokio::test]
+    async fn disabled_provider_returns_disabled_status() {
+        let provider = Arc::new(FakeProvider {
+            result: Err(RigControlProviderError::disabled("not configured")),
+        });
+        let monitor = RigControlMonitor::new(provider, Duration::from_secs(60));
+
+        let snapshot = monitor.refresh_snapshot().await;
+
+        assert_eq!(RigConnectionStatus::Disabled as i32, snapshot.status);
+    }
+}

--- a/src/rust/qsoripper-core/src/rig_control/provider.rs
+++ b/src/rust/qsoripper-core/src/rig_control/provider.rs
@@ -1,0 +1,146 @@
+//! Provider seam for rig control data.
+
+use crate::proto::qsoripper::domain::RigSnapshot;
+
+/// Abstraction over an external rig control provider (e.g., rigctld).
+#[tonic::async_trait]
+pub trait RigControlProvider: Send + Sync {
+    /// Read the current rig state and return a normalized snapshot.
+    async fn get_snapshot(&self) -> Result<RigSnapshot, RigControlProviderError>;
+}
+
+/// Stable provider error categories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RigControlProviderErrorKind {
+    /// Provider is disabled by configuration.
+    Disabled,
+    /// Transport failed before a valid response was received.
+    Transport,
+    /// Provider returned a payload that could not be parsed.
+    Parse,
+    /// Read timed out waiting for a response.
+    Timeout,
+}
+
+/// Errors surfaced by the rig control provider layer.
+#[derive(Debug, Clone)]
+pub struct RigControlProviderError {
+    kind: RigControlProviderErrorKind,
+    message: String,
+}
+
+impl RigControlProviderError {
+    /// Provider is disabled.
+    #[must_use]
+    pub fn disabled(message: impl Into<String>) -> Self {
+        Self::new(RigControlProviderErrorKind::Disabled, message)
+    }
+
+    /// Provider transport failed.
+    #[must_use]
+    pub fn transport(message: impl Into<String>) -> Self {
+        Self::new(RigControlProviderErrorKind::Transport, message)
+    }
+
+    /// Provider returned an unexpected payload.
+    #[must_use]
+    pub fn parse(message: impl Into<String>) -> Self {
+        Self::new(RigControlProviderErrorKind::Parse, message)
+    }
+
+    /// Read timed out.
+    #[must_use]
+    pub fn timeout(message: impl Into<String>) -> Self {
+        Self::new(RigControlProviderErrorKind::Timeout, message)
+    }
+
+    fn new(kind: RigControlProviderErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+
+    /// Returns the error kind.
+    #[must_use]
+    pub fn kind(&self) -> RigControlProviderErrorKind {
+        self.kind
+    }
+
+    /// Returns whether the error class is suitable for retry handling.
+    #[must_use]
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self.kind,
+            RigControlProviderErrorKind::Transport | RigControlProviderErrorKind::Timeout
+        )
+    }
+}
+
+impl std::fmt::Display for RigControlProviderError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Rig control provider {} error: {}",
+            match self.kind {
+                RigControlProviderErrorKind::Disabled => "disabled",
+                RigControlProviderErrorKind::Transport => "transport",
+                RigControlProviderErrorKind::Parse => "parse",
+                RigControlProviderErrorKind::Timeout => "timeout",
+            },
+            self.message
+        )
+    }
+}
+
+impl std::error::Error for RigControlProviderError {}
+
+/// Provider used when rig control is disabled by configuration.
+#[derive(Debug, Clone)]
+pub struct DisabledRigControlProvider {
+    reason: String,
+}
+
+impl DisabledRigControlProvider {
+    /// Create a disabled provider with a stable reason message.
+    #[must_use]
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl RigControlProvider for DisabledRigControlProvider {
+    async fn get_snapshot(&self) -> Result<RigSnapshot, RigControlProviderError> {
+        Err(RigControlProviderError::disabled(self.reason.clone()))
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retryable_errors_are_transport_and_timeout() {
+        assert!(RigControlProviderError::transport("offline").is_retryable());
+        assert!(RigControlProviderError::timeout("slow").is_retryable());
+        assert!(!RigControlProviderError::disabled("off").is_retryable());
+        assert!(!RigControlProviderError::parse("bad").is_retryable());
+    }
+
+    #[tokio::test]
+    async fn disabled_provider_returns_disabled_error() {
+        let provider = DisabledRigControlProvider::new("rig control not configured");
+
+        let error = provider.get_snapshot().await.expect_err("error");
+
+        assert_eq!(RigControlProviderErrorKind::Disabled, error.kind());
+        assert_eq!(
+            "Rig control provider disabled error: rig control not configured",
+            error.to_string()
+        );
+    }
+}

--- a/src/rust/qsoripper-core/src/rig_control/rigctld.rs
+++ b/src/rust/qsoripper-core/src/rig_control/rigctld.rs
@@ -1,0 +1,369 @@
+//! rigctld TCP adapter for reading live rig state.
+
+use std::time::Duration;
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+use tokio::time::timeout;
+
+use crate::proto::qsoripper::domain::{RigConnectionStatus, RigSnapshot};
+
+use super::band_mapping::frequency_hz_to_band;
+use super::mode_mapping::hamlib_mode_to_proto;
+use super::provider::{RigControlProvider, RigControlProviderError};
+
+/// Default rigctld host.
+pub const DEFAULT_RIGCTLD_HOST: &str = "127.0.0.1";
+
+/// Default rigctld TCP port.
+pub const DEFAULT_RIGCTLD_PORT: u16 = 4532;
+
+/// Default read timeout in milliseconds.
+pub const DEFAULT_RIGCTLD_READ_TIMEOUT_MS: u64 = 2_000;
+
+/// Environment variable to enable/disable rigctld integration.
+pub const RIGCTLD_ENABLED_ENV_VAR: &str = "QSORIPPER_RIGCTLD_ENABLED";
+/// Environment variable for rigctld host address.
+pub const RIGCTLD_HOST_ENV_VAR: &str = "QSORIPPER_RIGCTLD_HOST";
+/// Environment variable for rigctld TCP port.
+pub const RIGCTLD_PORT_ENV_VAR: &str = "QSORIPPER_RIGCTLD_PORT";
+/// Environment variable for rigctld read timeout in milliseconds.
+pub const RIGCTLD_READ_TIMEOUT_MS_ENV_VAR: &str = "QSORIPPER_RIGCTLD_READ_TIMEOUT_MS";
+/// Environment variable for rig snapshot stale threshold in milliseconds.
+pub const RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR: &str = "QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS";
+
+/// Default stale threshold in milliseconds.
+pub const DEFAULT_RIGCTLD_STALE_THRESHOLD_MS: u64 = 5_000;
+
+/// Configuration for the rigctld adapter.
+#[derive(Debug, Clone)]
+pub struct RigctldConfig {
+    /// rigctld host address.
+    pub host: String,
+    /// rigctld TCP port.
+    pub port: u16,
+    /// Read timeout for TCP operations.
+    pub read_timeout: Duration,
+}
+
+impl RigctldConfig {
+    /// Build configuration from a value provider closure.
+    ///
+    /// Returns `None` if rig control is not enabled.
+    pub fn from_value_provider(get_value: impl Fn(&str) -> Option<String>) -> Option<Self> {
+        let enabled = get_value(RIGCTLD_ENABLED_ENV_VAR)
+            .is_some_and(|value| value.eq_ignore_ascii_case("true") || value == "1");
+
+        if !enabled {
+            return None;
+        }
+
+        let host =
+            get_value(RIGCTLD_HOST_ENV_VAR).unwrap_or_else(|| DEFAULT_RIGCTLD_HOST.to_string());
+
+        let port = get_value(RIGCTLD_PORT_ENV_VAR)
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_RIGCTLD_PORT);
+
+        let read_timeout_ms = get_value(RIGCTLD_READ_TIMEOUT_MS_ENV_VAR)
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(DEFAULT_RIGCTLD_READ_TIMEOUT_MS);
+
+        Some(Self {
+            host,
+            port,
+            read_timeout: Duration::from_millis(read_timeout_ms),
+        })
+    }
+}
+
+/// rigctld-backed rig control provider.
+///
+/// Connects to a running `rigctld` daemon over TCP, reads frequency and mode,
+/// and normalizes the result into project-owned proto types.
+///
+/// Each [`get_snapshot`] call opens a fresh TCP connection, issues both
+/// commands on the same socket, and closes it. This avoids stale-connection
+/// bugs while keeping the protocol exchange atomic.
+pub struct RigctldProvider {
+    config: RigctldConfig,
+}
+
+impl RigctldProvider {
+    /// Create a provider with the given configuration.
+    #[must_use]
+    pub fn new(config: RigctldConfig) -> Self {
+        Self { config }
+    }
+
+    /// Read frequency and mode from rigctld on a single TCP connection.
+    async fn read_rig_state(&self) -> Result<(u64, String), RigControlProviderError> {
+        let address = format!("{}:{}", self.config.host, self.config.port);
+
+        let stream = timeout(self.config.read_timeout, TcpStream::connect(&address))
+            .await
+            .map_err(|_| {
+                RigControlProviderError::timeout(format!(
+                    "Connection to {address} timed out after {:?}",
+                    self.config.read_timeout
+                ))
+            })?
+            .map_err(|error| {
+                RigControlProviderError::transport(format!(
+                    "Failed to connect to {address}: {error}"
+                ))
+            })?;
+
+        let (reader, mut writer) = stream.into_split();
+        let mut reader = BufReader::new(reader);
+
+        // Read frequency: send "f\n", expect one line with Hz value
+        writer.write_all(b"f\n").await.map_err(|error| {
+            RigControlProviderError::transport(format!("Failed to send frequency command: {error}"))
+        })?;
+
+        let freq_line = read_line_with_timeout(&mut reader, self.config.read_timeout).await?;
+        let frequency_hz = parse_frequency(&freq_line)?;
+
+        // Read mode: send "m\n", expect two lines (mode string, passband)
+        writer.write_all(b"m\n").await.map_err(|error| {
+            RigControlProviderError::transport(format!("Failed to send mode command: {error}"))
+        })?;
+
+        let mode_line = read_line_with_timeout(&mut reader, self.config.read_timeout).await?;
+        // Read and discard passband line
+        let _passband = read_line_with_timeout(&mut reader, self.config.read_timeout).await;
+
+        Ok((frequency_hz, mode_line))
+    }
+}
+
+#[tonic::async_trait]
+impl RigControlProvider for RigctldProvider {
+    async fn get_snapshot(&self) -> Result<RigSnapshot, RigControlProviderError> {
+        let (frequency_hz, raw_mode) = self.read_rig_state().await?;
+        let band = frequency_hz_to_band(frequency_hz);
+        let mode_mapping = hamlib_mode_to_proto(&raw_mode);
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default();
+
+        Ok(RigSnapshot {
+            frequency_hz,
+            band: band as i32,
+            mode: mode_mapping.mode as i32,
+            submode: mode_mapping.submode,
+            raw_mode: Some(raw_mode),
+            status: RigConnectionStatus::Connected as i32,
+            error_message: None,
+            sampled_at: Some(prost_types::Timestamp {
+                seconds: i64::try_from(now.as_secs()).unwrap_or(i64::MAX),
+                nanos: i32::try_from(now.subsec_nanos()).unwrap_or(i32::MAX),
+            }),
+        })
+    }
+}
+
+async fn read_line_with_timeout<R: tokio::io::AsyncBufRead + Unpin>(
+    reader: &mut R,
+    read_timeout: Duration,
+) -> Result<String, RigControlProviderError> {
+    let mut line = String::new();
+    timeout(read_timeout, reader.read_line(&mut line))
+        .await
+        .map_err(|_| RigControlProviderError::timeout("Timed out reading from rigctld"))?
+        .map_err(|error| {
+            RigControlProviderError::transport(format!("Failed to read from rigctld: {error}"))
+        })?;
+
+    let trimmed = line.trim().to_string();
+
+    // rigctld reports errors as "RPRT -N" where N is the error code
+    if trimmed.starts_with("RPRT") {
+        return Err(RigControlProviderError::parse(format!(
+            "rigctld error: {trimmed}"
+        )));
+    }
+
+    Ok(trimmed)
+}
+
+fn parse_frequency(line: &str) -> Result<u64, RigControlProviderError> {
+    line.trim().parse::<u64>().map_err(|error| {
+        RigControlProviderError::parse(format!("Invalid frequency value '{line}': {error}"))
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::rig_control::provider::RigControlProviderErrorKind;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    async fn start_fake_rigctld(
+        frequency_hz: &str,
+        mode: &str,
+        passband: &str,
+    ) -> std::net::SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let freq = frequency_hz.to_string();
+        let mode = mode.to_string();
+        let passband = passband.to_string();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, mut writer) = stream.into_split();
+            let mut reader = BufReader::new(reader);
+
+            // Handle "f\n" command
+            let mut cmd = String::new();
+            reader.read_line(&mut cmd).await.unwrap();
+            assert_eq!("f\n", cmd);
+            writer
+                .write_all(format!("{freq}\n").as_bytes())
+                .await
+                .unwrap();
+
+            // Handle "m\n" command
+            cmd.clear();
+            reader.read_line(&mut cmd).await.unwrap();
+            assert_eq!("m\n", cmd);
+            writer
+                .write_all(format!("{mode}\n{passband}\n").as_bytes())
+                .await
+                .unwrap();
+        });
+
+        addr
+    }
+
+    #[tokio::test]
+    async fn reads_frequency_and_mode_from_rigctld() {
+        let addr = start_fake_rigctld("14074000", "USB", "2400").await;
+
+        let provider = RigctldProvider::new(RigctldConfig {
+            host: addr.ip().to_string(),
+            port: addr.port(),
+            read_timeout: Duration::from_secs(2),
+        });
+
+        let snapshot = provider.get_snapshot().await.expect("snapshot");
+
+        assert_eq!(14_074_000, snapshot.frequency_hz);
+        assert_eq!(
+            crate::proto::qsoripper::domain::Band::Band20m as i32,
+            snapshot.band
+        );
+        assert_eq!(
+            crate::proto::qsoripper::domain::Mode::Ssb as i32,
+            snapshot.mode
+        );
+        assert_eq!(Some("USB".to_string()), snapshot.submode);
+        assert_eq!(Some("USB".to_string()), snapshot.raw_mode);
+        assert_eq!(RigConnectionStatus::Connected as i32, snapshot.status);
+    }
+
+    #[tokio::test]
+    async fn reads_cw_mode() {
+        let addr = start_fake_rigctld("7030000", "CW", "500").await;
+
+        let provider = RigctldProvider::new(RigctldConfig {
+            host: addr.ip().to_string(),
+            port: addr.port(),
+            read_timeout: Duration::from_secs(2),
+        });
+
+        let snapshot = provider.get_snapshot().await.expect("snapshot");
+
+        assert_eq!(7_030_000, snapshot.frequency_hz);
+        assert_eq!(
+            crate::proto::qsoripper::domain::Band::Band40m as i32,
+            snapshot.band
+        );
+        assert_eq!(
+            crate::proto::qsoripper::domain::Mode::Cw as i32,
+            snapshot.mode
+        );
+        assert_eq!(None, snapshot.submode);
+    }
+
+    #[tokio::test]
+    async fn connection_refused_returns_transport_error() {
+        let provider = RigctldProvider::new(RigctldConfig {
+            host: "127.0.0.1".to_string(),
+            port: 1, // unlikely to be open
+            read_timeout: Duration::from_millis(500),
+        });
+
+        let error = provider.get_snapshot().await.expect_err("error");
+
+        assert!(error.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn rigctld_error_response_returns_parse_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let (reader, mut writer) = stream.into_split();
+            let mut reader = BufReader::new(reader);
+
+            let mut cmd = String::new();
+            reader.read_line(&mut cmd).await.unwrap();
+            writer.write_all(b"RPRT -1\n").await.unwrap();
+        });
+
+        let provider = RigctldProvider::new(RigctldConfig {
+            host: addr.ip().to_string(),
+            port: addr.port(),
+            read_timeout: Duration::from_secs(2),
+        });
+
+        let error = provider.get_snapshot().await.expect_err("error");
+
+        assert_eq!(RigControlProviderErrorKind::Parse, error.kind());
+        assert!(!error.is_retryable());
+    }
+
+    #[test]
+    fn config_from_value_provider_disabled_by_default() {
+        let config = RigctldConfig::from_value_provider(|_| None);
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn config_from_value_provider_with_defaults() {
+        let config = RigctldConfig::from_value_provider(|name| match name {
+            "QSORIPPER_RIGCTLD_ENABLED" => Some("true".to_string()),
+            _ => None,
+        });
+
+        let config = config.expect("config");
+        assert_eq!("127.0.0.1", config.host);
+        assert_eq!(4532, config.port);
+        assert_eq!(Duration::from_millis(2000), config.read_timeout);
+    }
+
+    #[test]
+    fn config_from_value_provider_with_overrides() {
+        let config = RigctldConfig::from_value_provider(|name| match name {
+            "QSORIPPER_RIGCTLD_ENABLED" => Some("1".to_string()),
+            "QSORIPPER_RIGCTLD_HOST" => Some("192.168.1.100".to_string()),
+            "QSORIPPER_RIGCTLD_PORT" => Some("4533".to_string()),
+            "QSORIPPER_RIGCTLD_READ_TIMEOUT_MS" => Some("5000".to_string()),
+            _ => None,
+        });
+
+        let config = config.expect("config");
+        assert_eq!("192.168.1.100", config.host);
+        assert_eq!(4533, config.port);
+        assert_eq!(Duration::from_millis(5000), config.read_timeout);
+    }
+}

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -23,6 +23,7 @@ use qsoripper_core::proto::qsoripper::services::{
     developer_control_service_server::{DeveloperControlService, DeveloperControlServiceServer},
     logbook_service_server::{LogbookService, LogbookServiceServer},
     lookup_service_server::{LookupService, LookupServiceServer},
+    rig_control_service_server::{RigControlService, RigControlServiceServer},
     setup_service_server::SetupServiceServer,
     space_weather_service_server::{SpaceWeatherService, SpaceWeatherServiceServer},
     station_profile_service_server::StationProfileServiceServer,
@@ -30,13 +31,18 @@ use qsoripper_core::proto::qsoripper::services::{
     BatchLookupResponse, DeleteQsoRequest, DeleteQsoResponse, ExportAdifRequest,
     ExportAdifResponse, GetCachedCallsignRequest, GetCachedCallsignResponse,
     GetCurrentSpaceWeatherRequest, GetCurrentSpaceWeatherResponse, GetDxccEntityRequest,
-    GetDxccEntityResponse, GetQsoRequest, GetQsoResponse, GetRuntimeConfigRequest,
+    GetDxccEntityResponse, GetQsoRequest, GetQsoResponse, GetRigSnapshotRequest,
+    GetRigSnapshotResponse, GetRigStatusRequest, GetRigStatusResponse, GetRuntimeConfigRequest,
     GetRuntimeConfigResponse, GetSyncStatusRequest, GetSyncStatusResponse, ImportAdifRequest,
     ImportAdifResponse, ListQsosRequest, ListQsosResponse, LogQsoRequest, LogQsoResponse,
     LookupRequest, LookupResponse, QsoSortOrder as ProtoQsoSortOrder, RefreshSpaceWeatherRequest,
     RefreshSpaceWeatherResponse, ResetRuntimeConfigRequest, ResetRuntimeConfigResponse,
     StreamLookupRequest, StreamLookupResponse, SyncWithQrzRequest, SyncWithQrzResponse,
-    UpdateQsoRequest, UpdateQsoResponse,
+    TestRigConnectionRequest, TestRigConnectionResponse, UpdateQsoRequest, UpdateQsoResponse,
+};
+use qsoripper_core::rig_control::{
+    RigControlProvider, RigctldConfig, RigctldProvider, DEFAULT_RIGCTLD_HOST, DEFAULT_RIGCTLD_PORT,
+    DEFAULT_RIGCTLD_READ_TIMEOUT_MS,
 };
 use runtime_config::RuntimeConfigManager;
 use setup::{
@@ -77,6 +83,7 @@ where
     let station_profile_service =
         StationProfileControlSurface::new(setup_state.clone(), runtime_config.clone());
     let space_weather_service = SpaceWeatherControlSurface::new(runtime_config.clone());
+    let rig_control_service = RigControlControlSurface::new(runtime_config.clone());
     let active_storage_backend = runtime_config.active_storage_backend().await;
     let setup_status = setup_state.status().await;
     let setup_completion = setup_completion_label(setup_status.setup_complete);
@@ -112,6 +119,7 @@ where
         .add_service(SetupServiceServer::new(setup_service))
         .add_service(StationProfileServiceServer::new(station_profile_service))
         .add_service(SpaceWeatherServiceServer::new(space_weather_service))
+        .add_service(RigControlServiceServer::new(rig_control_service))
         .add_service(DeveloperControlServiceServer::new(
             developer_control_service,
         ))
@@ -702,6 +710,102 @@ impl SpaceWeatherService for SpaceWeatherControlSurface {
         Ok(Response::new(RefreshSpaceWeatherResponse {
             snapshot: Some(snapshot),
         }))
+    }
+}
+
+#[derive(Clone)]
+struct RigControlControlSurface {
+    runtime_config: Arc<RuntimeConfigManager>,
+}
+
+impl RigControlControlSurface {
+    fn new(runtime_config: Arc<RuntimeConfigManager>) -> Self {
+        Self { runtime_config }
+    }
+}
+
+#[tonic::async_trait]
+impl RigControlService for RigControlControlSurface {
+    async fn get_rig_status(
+        &self,
+        _request: Request<GetRigStatusRequest>,
+    ) -> Result<Response<GetRigStatusResponse>, Status> {
+        let snapshot = self
+            .runtime_config
+            .rig_control_monitor()
+            .await
+            .current_snapshot()
+            .await;
+        Ok(Response::new(GetRigStatusResponse {
+            status: snapshot.status,
+            error_message: snapshot.error_message,
+            endpoint: None,
+        }))
+    }
+
+    async fn get_rig_snapshot(
+        &self,
+        _request: Request<GetRigSnapshotRequest>,
+    ) -> Result<Response<GetRigSnapshotResponse>, Status> {
+        let snapshot = self
+            .runtime_config
+            .rig_control_monitor()
+            .await
+            .current_snapshot()
+            .await;
+        Ok(Response::new(GetRigSnapshotResponse {
+            snapshot: Some(snapshot),
+        }))
+    }
+
+    async fn test_rig_connection(
+        &self,
+        request: Request<TestRigConnectionRequest>,
+    ) -> Result<Response<TestRigConnectionResponse>, Status> {
+        let inner = request.into_inner();
+        let effective_values = self.runtime_config.effective_values().await;
+
+        let host = inner.host.unwrap_or_else(|| {
+            effective_values
+                .get(qsoripper_core::rig_control::RIGCTLD_HOST_ENV_VAR)
+                .cloned()
+                .unwrap_or_else(|| DEFAULT_RIGCTLD_HOST.to_string())
+        });
+
+        let port = inner
+            .port
+            .and_then(|p| u16::try_from(p).ok())
+            .unwrap_or_else(|| {
+                effective_values
+                    .get(qsoripper_core::rig_control::RIGCTLD_PORT_ENV_VAR)
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(DEFAULT_RIGCTLD_PORT)
+            });
+
+        let read_timeout_ms = effective_values
+            .get(qsoripper_core::rig_control::RIGCTLD_READ_TIMEOUT_MS_ENV_VAR)
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_RIGCTLD_READ_TIMEOUT_MS);
+
+        let config = RigctldConfig {
+            host,
+            port,
+            read_timeout: std::time::Duration::from_millis(read_timeout_ms),
+        };
+
+        let provider = RigctldProvider::new(config);
+        match provider.get_snapshot().await {
+            Ok(snapshot) => Ok(Response::new(TestRigConnectionResponse {
+                success: true,
+                error_message: None,
+                snapshot: Some(snapshot),
+            })),
+            Err(error) => Ok(Response::new(TestRigConnectionResponse {
+                success: false,
+                error_message: Some(error.to_string()),
+                snapshot: None,
+            })),
+        }
     }
 }
 

--- a/src/rust/qsoripper-server/src/runtime_config.rs
+++ b/src/rust/qsoripper-server/src/runtime_config.rs
@@ -16,6 +16,12 @@ use qsoripper_core::proto::qsoripper::services::{
     RuntimeConfigMutation, RuntimeConfigMutationKind, RuntimeConfigSnapshot, RuntimeConfigValue,
     RuntimeConfigValueKind,
 };
+use qsoripper_core::rig_control::{
+    DisabledRigControlProvider, RigControlMonitor, RigControlProvider, RigctldConfig,
+    RigctldProvider, DEFAULT_RIGCTLD_HOST, DEFAULT_RIGCTLD_STALE_THRESHOLD_MS,
+    RIGCTLD_ENABLED_ENV_VAR, RIGCTLD_HOST_ENV_VAR, RIGCTLD_PORT_ENV_VAR,
+    RIGCTLD_READ_TIMEOUT_MS_ENV_VAR, RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR,
+};
 use qsoripper_core::space_weather::{
     DisabledSpaceWeatherProvider, NoaaSpaceWeatherConfig, NoaaSpaceWeatherProvider,
     SpaceWeatherMonitor, SpaceWeatherProvider, NOAA_HTTP_TIMEOUT_SECONDS_ENV_VAR,
@@ -68,6 +74,7 @@ struct RuntimeBindings {
     logbook_engine: LogbookEngine,
     lookup_coordinator: Arc<LookupCoordinator>,
     space_weather_monitor: Arc<SpaceWeatherMonitor>,
+    rig_control_monitor: Arc<RigControlMonitor>,
     active_storage_backend: String,
     lookup_provider_summary: String,
     active_station_profile: Option<StationProfile>,
@@ -177,6 +184,10 @@ impl RuntimeConfigManager {
 
     pub(crate) async fn space_weather_monitor(&self) -> Arc<SpaceWeatherMonitor> {
         self.bindings.read().await.space_weather_monitor.clone()
+    }
+
+    pub(crate) async fn rig_control_monitor(&self) -> Arc<RigControlMonitor> {
+        self.bindings.read().await.rig_control_monitor.clone()
     }
 
     pub(crate) async fn active_storage_backend(&self) -> String {
@@ -627,6 +638,51 @@ const SUPPORTED_FIELDS: &[ConfigFieldSpec] = &[
         allowed_values: &[],
         default_value: Some("3600"),
     },
+    ConfigFieldSpec {
+        key: RIGCTLD_ENABLED_ENV_VAR,
+        label: "Rig control enabled",
+        description: "Enable live rig control via rigctld.",
+        kind: RuntimeConfigValueKind::Boolean,
+        secret: false,
+        allowed_values: BOOLEAN_ALLOWED_VALUES,
+        default_value: Some("false"),
+    },
+    ConfigFieldSpec {
+        key: RIGCTLD_HOST_ENV_VAR,
+        label: "Rig control host",
+        description: "Host address of the running rigctld daemon.",
+        kind: RuntimeConfigValueKind::String,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some(DEFAULT_RIGCTLD_HOST),
+    },
+    ConfigFieldSpec {
+        key: RIGCTLD_PORT_ENV_VAR,
+        label: "Rig control port",
+        description: "TCP port used to connect to the rigctld daemon.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some("4532"),
+    },
+    ConfigFieldSpec {
+        key: RIGCTLD_READ_TIMEOUT_MS_ENV_VAR,
+        label: "Rig control read timeout ms",
+        description: "Read timeout in milliseconds for rigctld TCP operations.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some("2000"),
+    },
+    ConfigFieldSpec {
+        key: RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR,
+        label: "Rig control stale threshold ms",
+        description: "How long a cached rig snapshot is considered fresh before re-polling.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some("5000"),
+    },
 ];
 
 fn capture_supported_env() -> BTreeMap<String, String> {
@@ -755,6 +811,22 @@ fn normalize_value(key: &'static str, raw_value: &str) -> Result<String, String>
                 CONFLICT_POLICY_ALLOWED_VALUES.join(", ")
             ))
         }
+    } else if key == RIGCTLD_ENABLED_ENV_VAR {
+        parse_bool(trimmed).map(|value| {
+            if value {
+                "true".to_string()
+            } else {
+                "false".to_string()
+            }
+        })
+    } else if matches!(
+        key,
+        RIGCTLD_PORT_ENV_VAR | RIGCTLD_READ_TIMEOUT_MS_ENV_VAR | RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR
+    ) {
+        trimmed
+            .parse::<u64>()
+            .map(|value| value.to_string())
+            .map_err(|_| format!("'{key}' expects an integer value."))
     } else {
         Ok(trimmed.to_string())
     }
@@ -847,12 +919,14 @@ fn build_runtime_bindings(values: &BTreeMap<String, String>) -> Result<RuntimeBi
         LookupCoordinatorConfig::default(),
     ));
     let space_weather_monitor = build_space_weather_monitor(values);
+    let rig_control_monitor = build_rig_control_monitor(values);
     let active_station_profile = build_active_station_profile(values)?;
 
     Ok(RuntimeBindings {
         logbook_engine,
         lookup_coordinator,
         space_weather_monitor,
+        rig_control_monitor,
         active_storage_backend,
         lookup_provider_summary,
         active_station_profile,
@@ -980,6 +1054,24 @@ fn build_space_weather_monitor(values: &BTreeMap<String, String>) -> Arc<SpaceWe
             std::time::Duration::from_secs(900),
             std::time::Duration::from_secs(3600),
         )),
+    }
+}
+
+fn build_rig_control_monitor(values: &BTreeMap<String, String>) -> Arc<RigControlMonitor> {
+    let stale_threshold_ms = values
+        .get(RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR)
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(DEFAULT_RIGCTLD_STALE_THRESHOLD_MS);
+    let stale_threshold = std::time::Duration::from_millis(stale_threshold_ms);
+
+    if let Some(config) = RigctldConfig::from_value_provider(|name| values.get(name).cloned()) {
+        let provider: Arc<dyn RigControlProvider> = Arc::new(RigctldProvider::new(config));
+        Arc::new(RigControlMonitor::new(provider, stale_threshold))
+    } else {
+        let provider: Arc<dyn RigControlProvider> = Arc::new(DisabledRigControlProvider::new(
+            "Rig control is not enabled.",
+        ));
+        Arc::new(RigControlMonitor::new(provider, stale_threshold))
     }
 }
 

--- a/src/rust/qsoripper-server/src/setup.rs
+++ b/src/rust/qsoripper-server/src/setup.rs
@@ -26,6 +26,10 @@ use qsoripper_core::proto::qsoripper::services::{
     TestQrzLogbookCredentialsResponse, ValidateSetupStepRequest, ValidateSetupStepResponse,
 };
 use qsoripper_core::qrz_logbook::{QrzLogbookClient, QrzLogbookConfig};
+use qsoripper_core::rig_control::{
+    RIGCTLD_ENABLED_ENV_VAR, RIGCTLD_HOST_ENV_VAR, RIGCTLD_PORT_ENV_VAR,
+    RIGCTLD_READ_TIMEOUT_MS_ENV_VAR, RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR,
+};
 use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
@@ -519,6 +523,8 @@ struct PersistedSetupConfig {
     qrz_logbook: PersistedQrzLogbookConfig,
     #[serde(default, skip_serializing_if = "PersistedSyncConfig::is_empty")]
     sync: PersistedSyncConfig,
+    #[serde(default, skip_serializing_if = "PersistedRigControlConfig::is_empty")]
+    rig_control: PersistedRigControlConfig,
 }
 
 impl PersistedSetupConfig {
@@ -674,6 +680,29 @@ impl PersistedSetupConfig {
             values.insert(
                 SYNC_CONFLICT_POLICY_ENV_VAR.to_string(),
                 self.sync.conflict_policy.clone(),
+            );
+        }
+
+        // Rig control config
+        if let Some(enabled) = self.rig_control.enabled {
+            values.insert(RIGCTLD_ENABLED_ENV_VAR.to_string(), enabled.to_string());
+        }
+        if let Some(ref host) = self.rig_control.host {
+            values.insert(RIGCTLD_HOST_ENV_VAR.to_string(), host.clone());
+        }
+        if let Some(port) = self.rig_control.port {
+            values.insert(RIGCTLD_PORT_ENV_VAR.to_string(), port.to_string());
+        }
+        if let Some(read_timeout_ms) = self.rig_control.read_timeout_ms {
+            values.insert(
+                RIGCTLD_READ_TIMEOUT_MS_ENV_VAR.to_string(),
+                read_timeout_ms.to_string(),
+            );
+        }
+        if let Some(stale_threshold_ms) = self.rig_control.stale_threshold_ms {
+            values.insert(
+                RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR.to_string(),
+                stale_threshold_ms.to_string(),
             );
         }
 
@@ -1092,6 +1121,25 @@ impl PersistedSyncConfig {
             },
             conflict_policy: conflict_policy as i32,
         }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct PersistedRigControlConfig {
+    enabled: Option<bool>,
+    host: Option<String>,
+    port: Option<u16>,
+    read_timeout_ms: Option<u64>,
+    stale_threshold_ms: Option<u64>,
+}
+
+impl PersistedRigControlConfig {
+    fn is_empty(config: &Self) -> bool {
+        config.enabled.is_none()
+            && config.host.is_none()
+            && config.port.is_none()
+            && config.read_timeout_ms.is_none()
+            && config.stale_threshold_ms.is_none()
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #108: engine-backed rig control via Hamlib `rigctld` TCP protocol. The engine can now read live radio state (frequency, mode) and the CLI can auto-populate QSO fields during logging.

## Changes

### Proto contracts (9 new files)
- `RigSnapshot` domain message (`frequency_hz`, `band`, `mode`, `submode`, `raw_mode`, `status`, `sampled_at`)
- `RigConnectionStatus` enum (Connected/Disconnected/Error/Disabled)
- `RigControlService` with `GetRigStatus`, `GetRigSnapshot`, `TestRigConnection` RPCs
- All follow protobuf 1-1-1 with unique per-RPC envelopes

### Rust core — qsoripper-core (6 new files)
- `RigControlProvider` trait + `DisabledRigControlProvider` for graceful degradation
- `RigctldProvider`: TCP client issuing `f` and `m` commands on a single socket per snapshot
- `frequency_hz_to_band()` mapping for all IARU HF/VHF/UHF bands
- `hamlib_mode_to_proto()` mapping (USB/LSB to SSB, PKTUSB/PKTLSB to PKT, CW/CWR, RTTY/RTTYR, etc.)
- `RigControlMonitor` with caching and staleness tracking (follows `SpaceWeatherMonitor` pattern)
- 30 unit tests including a fake TCP rigctld server

### Rust server — qsoripper-server (3 files modified)
- Persisted `[rig_control]` config section in `config.toml` (enabled, host, port, read_timeout_ms, stale_threshold_ms)
- Runtime config definitions with validation for all 5 settings
- `RigControlService` gRPC implementation with `TestRigConnection` accepting optional host/port overrides

### .NET CLI (5 files modified, 1 new)
- `log W1AW --from-rig` — auto-fills band, mode, frequency, and submode from rig when omitted
- Named `--band`/`--mode` overrides work alongside `--from-rig` (explicit values always win)
- `rig-status` command — shows connection status and current radio state
- 4 new tests for `--from-rig` parsing and override semantics

### Build infrastructure
- `build.ps1`: auto-detects and works around vswhere not finding VC tools for Native AOT linking

## Design decisions
- `frequency_hz` (not kHz) in `RigSnapshot` to preserve rigctld precision; converted to kHz at QSO-build site
- PKTUSB/PKTLSB map to `Mode::PKT` (not SSB) to avoid wrong RST defaults for digital modes
- Connect-per-request TCP (rigctld handles short-lived connections well; monitor cache minimizes actual TCP calls)
- Rig config in `config.toml` `[rig_control]` section, not station profiles (single global rig for MVP)

## Testing

To test locally with a dummy rig:

```powershell
rigctld -m 1 -t 4532
rigctl -m 2 -r localhost:4532 F 14074000
rigctl -m 2 -r localhost:4532 M USB 2400

qr config --set QSORIPPER_RIGCTLD_ENABLED=true
qr rig-status
qr log W1AW --from-rig
```

## Out of scope (deferred)
- TUI rig autofill integration
- Documentation page
- Direct libhamlib integration
- Write/control commands to the rig

Closes #108