### PR TITLE
Add pure Win32 C GUI app with classic Windows theme

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -23,7 +23,7 @@
 
 param(
     [Parameter(Position = 0)]
-    [ValidateSet('build', 'check', 'rust', 'dotnet', 'check-rust', 'check-dotnet', 'proto', 'help')]
+    [ValidateSet('build', 'check', 'rust', 'dotnet', 'win32', 'check-rust', 'check-dotnet', 'proto', 'help')]
     [string]$Command = 'build',
 
     [ValidateSet('Release', 'Debug')]
@@ -56,6 +56,10 @@ function Invoke-Build([string]$Step, [string]$Command, [string[]]$Arguments) {
         exit $LASTEXITCODE
     }
 }
+
+$Win32SourceDir = Join-Path $PSScriptRoot 'src' 'c' 'qsoripper-win32'
+$Win32Source = Join-Path $Win32SourceDir 'src' 'main.c'
+$Win32PublishDir = Join-Path $PSScriptRoot 'artifacts' 'publish' | Join-Path -ChildPath 'qsoripper-win32' | Join-Path -ChildPath $Configuration
 
 function Build-Rust {
     $arguments = @('build', '--manifest-path', $RustManifest)
@@ -164,9 +168,56 @@ function Build-Dotnet {
     )
 }
 
+function Build-Win32 {
+    if (-not (Test-Path $Win32Source)) {
+        Write-Step 'Win32 GUI'
+        Write-Host 'Win32 source not found, skipping.' -ForegroundColor Yellow
+        return
+    }
+
+    $vcvars = Find-VcVarsAll
+    if (-not $vcvars) {
+        Write-Step 'Win32 GUI'
+        Write-Host 'MSVC toolchain not found, skipping Win32 build. Install the C++ Desktop workload.' -ForegroundColor Yellow
+        return
+    }
+
+    Write-Step "Building qsoripper-win32 ($Configuration)"
+    $null = New-Item -ItemType Directory -Force -Path $Win32PublishDir
+    $optFlags = if ($IsReleaseBuild) { '/O2' } else { '/Od /Zi' }
+    $exe = Join-Path $Win32PublishDir 'qsoripper-win32.exe'
+
+    $arch = if ([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture -eq 'Arm64') { 'arm64' } else { 'amd64' }
+    $buildScript = Join-Path $Win32PublishDir '_build.cmd'
+    @"
+@echo off
+call "$vcvars" $arch >nul 2>&1
+cl /W4 /WX $optFlags /DUNICODE /D_UNICODE "$Win32Source" /Fe:"$exe" /link user32.lib gdi32.lib shell32.lib comctl32.lib
+"@ | Set-Content -LiteralPath $buildScript -Encoding ASCII
+
+    Push-Location $Win32PublishDir
+    try {
+        cmd /c $buildScript
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host "FAILED: Building qsoripper-win32 ($Configuration)" -ForegroundColor Red
+            exit $LASTEXITCODE
+        }
+    }
+    finally {
+        Pop-Location
+    }
+
+    # Clean intermediate files
+    Remove-Item (Join-Path $Win32PublishDir '*.obj') -Force -ErrorAction SilentlyContinue
+    Remove-Item $buildScript -Force -ErrorAction SilentlyContinue
+
+    Write-Host "  -> $Win32PublishDir"
+}
+
 function Build-All {
     Build-Rust
     Build-Dotnet
+    Build-Win32
 }
 
 function Check-Proto {
@@ -226,10 +277,11 @@ QsoRipper Build Script
 Usage: ./build.ps1 [command] [-Configuration Release|Debug]
 
 Commands:
-  build         Build Rust (including qsoripper-tui) and publish the CLI and GUI apps (default: Release)
+  build         Build Rust, .NET, and Win32 apps (default: Release)
   check         Full CI-equivalent quality check
   rust          Build Rust only (copies qsoripper-tui binary to artifacts)
   dotnet        Publish the CLI and GUI apps only
+  win32         Build the Win32 C GUI app only
   check-rust    Rust quality: fmt, clippy, test, buf lint, cargo deny
   check-dotnet  .NET quality: format, build, test
   proto         Run buf lint
@@ -249,6 +301,7 @@ switch ($Command) {
     'check'        { Check-All }
     'rust'         { Build-Rust }
     'dotnet'       { Build-Dotnet }
+    'win32'        { Build-Win32 }
     'check-rust'   { Check-Rust }
     'check-dotnet' { Check-Dotnet }
     'proto'        { Check-Proto }

--- a/src/c/qsoripper-win32/CMakeLists.txt
+++ b/src/c/qsoripper-win32/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.20)
+project(qsoripper-win32 C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+add_executable(qsoripper-win32 WIN32 src/main.c)
+target_link_libraries(qsoripper-win32 PRIVATE user32 gdi32 shell32 comctl32)
+
+# Enable Unicode
+target_compile_definitions(qsoripper-win32 PRIVATE UNICODE _UNICODE)
+
+if(MSVC)
+    target_compile_options(qsoripper-win32 PRIVATE /W4)
+else()
+    target_compile_options(qsoripper-win32 PRIVATE -Wall -Wextra)
+endif()

--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -178,6 +178,12 @@ typedef struct {
     /* Cursor positions per field */
     int cursor_pos[FIELD_COUNT];
 
+    /* Hit-test rectangles for click-to-focus (populated during paint) */
+    RECT field_rects[FIELD_COUNT];
+    int  field_rects_valid;
+    int  qso_list_y;  /* top of QSO list panel for click detection */
+    int  qso_list_row_h; /* row height in QSO list */
+
     /* Search */
     char search_text[64];
     int search_cursor;
@@ -249,6 +255,8 @@ static int  PaintAdvancedForm(HDC hdc, int y_start, int w);
 static char *RunQrCommand(const char *args);
 static char *FieldBuffer(enum Field f);
 static int   FieldMaxLen(enum Field f);
+static void  DrawField(HDC, int, int, int, const char *, int, int, int, int);
+static void  DrawCycleField(HDC, int, int, int, const char *, int, int, int);
 
 /* ── Utility: safe string helpers ──────────────────────────────────────── */
 
@@ -1145,21 +1153,26 @@ static int PaintLogForm(HDC hdc, int y_start, int w)
     /* Row 1: Callsign, Band, Mode */
     {
         DrawText_A(hdc, pad, y + 3, CLR_LABEL, "Callsign");
+        int fw = 14 * cw + 6, fh = ch + 4;
         DrawField(hdc, pad + label_w, y, 14,
                   g_state.callsign, g_state.cursor_pos[FIELD_CALLSIGN],
                   focused_form && g_state.focused_field == FIELD_CALLSIGN, cw, ch);
+        SetRect(&g_state.field_rects[FIELD_CALLSIGN], pad + label_w, y, pad + label_w + fw, y + fh);
 
         int bx = pad + label_w + 14 * cw + 16;
         DrawText_A(hdc, bx, y + 3, CLR_LABEL, "Band");
+        int bfw = 8 * cw + 6;
         DrawCycleField(hdc, bx + 5 * cw, y, 8,
                        BANDS[g_state.band_idx],
                        focused_form && g_state.focused_field == FIELD_BAND, cw, ch);
+        SetRect(&g_state.field_rects[FIELD_BAND], bx + 5 * cw, y, bx + 5 * cw + bfw, y + fh);
 
         int mx = bx + 5 * cw + 8 * cw + 16;
         DrawText_A(hdc, mx, y + 3, CLR_LABEL, "Mode");
         DrawCycleField(hdc, mx + 5 * cw, y, 8,
                        MODES[g_state.mode_idx],
                        focused_form && g_state.focused_field == FIELD_MODE, cw, ch);
+        SetRect(&g_state.field_rects[FIELD_MODE], mx + 5 * cw, y, mx + 5 * cw + bfw, y + fh);
     }
     y += row_h;
 
@@ -2417,6 +2430,112 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
             InvalidateRect(hwnd, NULL, FALSE);
         }
         break;
+
+    case WM_LBUTTONDOWN:
+    {
+        int mx = LOWORD(lParam);
+        int my = HIWORD(lParam);
+        int cw = g_state.char_w;
+        int ch = g_state.char_h;
+        if (cw == 0 || ch == 0) break;
+
+        RECT rc;
+        GetClientRect(hwnd, &rc);
+        (void)rc; /* layout uses cw/ch relative math */
+
+        /* Compute layout positions matching PaintAll */
+        int header_h = ch * 3 + 4;
+        int status_h = ch + 4;
+        int row_h = ch + 8;
+        int form_start = header_h + status_h;
+        int form_h = g_state.advanced_view
+            ? (row_h * 12 + ch + 10)
+            : (row_h * 9 + ch + 10);
+        int form_end = form_start + form_h;
+        int lookup_h = ch * 5 + 8;
+        int qso_list_start = form_end + lookup_h;
+
+        /* Click in form area? */
+        if (my >= form_start && my < form_end && !g_state.advanced_view) {
+            int pad = cw * 2;
+            int label_w = cw * 10;
+            int fy = form_start + ch + 4; /* first row y */
+            int row = (my - fy) / row_h;
+            int clicked = -1;
+
+            if (row == 0) {
+                /* Callsign / Band / Mode */
+                int cx = pad + label_w;
+                int bx = cx + 14 * cw + 16 + 5 * cw;
+                int modex = bx + 8 * cw + 16 + 5 * cw;
+                if (mx >= cx && mx < cx + 14 * cw + 6) clicked = FIELD_CALLSIGN;
+                else if (mx >= bx && mx < bx + 8 * cw + 6) clicked = FIELD_BAND;
+                else if (mx >= modex && mx < modex + 8 * cw + 6) clicked = FIELD_MODE;
+            } else if (row == 1) {
+                /* RST Sent / RST Rcvd */
+                int cx = pad + label_w;
+                int rx = cx + 6 * cw + 16 + 9 * cw;
+                if (mx >= cx && mx < cx + 6 * cw + 6) clicked = FIELD_RST_SENT;
+                else if (mx >= rx && mx < rx + 6 * cw + 6) clicked = FIELD_RST_RCVD;
+            } else if (row == 2) {
+                clicked = FIELD_COMMENT;
+            } else if (row == 3) {
+                clicked = FIELD_NOTES;
+            } else if (row == 4) {
+                /* Freq / Date / Time */
+                int cx = pad + label_w;
+                int dx = cx + 10 * cw + 16 + 5 * cw;
+                int tx = dx + 12 * cw + 16 + 5 * cw;
+                if (mx >= cx && mx < cx + 10 * cw + 6) clicked = FIELD_FREQ;
+                else if (mx >= dx && mx < dx + 12 * cw + 6) clicked = FIELD_DATE;
+                else if (mx >= tx && mx < tx + 6 * cw + 6) clicked = FIELD_TIME;
+            }
+
+            if (clicked >= 0) {
+                g_state.focused_field = (enum Field)clicked;
+                g_state.qso_list_focused = 0;
+                g_state.search_focused = 0;
+                /* Place cursor at click position within the field */
+                char *buf = FieldBuffer((enum Field)clicked);
+                if (buf) {
+                    int field_x;
+                    if (clicked == FIELD_CALLSIGN) field_x = pad + label_w;
+                    else if (clicked == FIELD_COMMENT || clicked == FIELD_NOTES) field_x = pad + label_w;
+                    else if (clicked == FIELD_RST_SENT) field_x = pad + label_w;
+                    else if (clicked == FIELD_FREQ) field_x = pad + label_w;
+                    else field_x = 0;
+                    int pos = (mx - field_x - 3) / cw;
+                    int len = (int)strlen(buf);
+                    if (pos < 0) pos = 0;
+                    if (pos > len) pos = len;
+                    g_state.cursor_pos[clicked] = pos;
+                }
+                InvalidateRect(hwnd, NULL, FALSE);
+            }
+        }
+        /* Click in QSO list area? */
+        else if (my >= qso_list_start && g_state.recent_count > 0) {
+            int header_row_h = row_h + 2; /* header + separator */
+            int list_content_start = qso_list_start + ch + 4 + header_row_h;
+            if (my >= list_content_start) {
+                int row_idx = (my - list_content_start) / row_h + g_state.qso_scroll;
+                if (row_idx >= 0 && row_idx < g_state.recent_count) {
+                    g_state.qso_list_focused = 1;
+                    g_state.search_focused = 0;
+                    g_state.qso_selected = row_idx;
+                    InvalidateRect(hwnd, NULL, FALSE);
+                }
+            } else {
+                /* Clicked in QSO list header area — just focus the list */
+                g_state.qso_list_focused = 1;
+                g_state.search_focused = 0;
+                if (g_state.qso_selected < 0 && g_state.recent_count > 0)
+                    g_state.qso_selected = 0;
+                InvalidateRect(hwnd, NULL, FALSE);
+            }
+        }
+        break;
+    }
 
     case WM_GETMINMAXINFO:
     {

--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -1,0 +1,2496 @@
+/* ==========================================================================
+ * QsoRipper Win32 — Pure Win32/GDI ham radio logging application
+ * Single-file C implementation using owner-drawn controls.
+ * Compile: cl /W4 /DUNICODE /D_UNICODE main.c /link user32.lib gdi32.lib
+ *          shell32.lib comctl32.lib
+ * ========================================================================== */
+
+#define WIN32_LEAN_AND_MEAN
+#define _CRT_SECURE_NO_WARNINGS
+#include <windows.h>
+#include <commctrl.h>
+#include <shellapi.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+/* ── Compile-time settings ─────────────────────────────────────────────── */
+
+#define APP_TITLE       L"QsoRipper"
+#define WINDOW_CLASS    L"QsoRipperWin32"
+#define FONT_NAME       L"Consolas"
+#define FONT_SIZE       14
+#define TIMER_ID        1
+#define TIMER_MS        100
+#define STATUS_LIFETIME_MS  3000
+#define LOOKUP_DEBOUNCE_MS  500
+#define MAX_RECENT      50
+#define MAX_FIELD_LEN   256
+
+/* ── Color palette (Win2K classic theme) ────────────────────────────────── */
+
+#define CLR_BG          RGB(212, 208, 200)  /* COLOR_BTNFACE */
+#define CLR_FIELD_BG    RGB(255, 255, 255)  /* White field background */
+#define CLR_TEXT        RGB(0, 0, 0)        /* Black text */
+#define CLR_CYAN        RGB(0, 128, 128)    /* Teal for accents */
+#define CLR_YELLOW      RGB(255, 255, 0)
+#define CLR_WHITE       RGB(255, 255, 255)
+#define CLR_GRAY        RGB(128, 128, 128)
+#define CLR_DARKGRAY    RGB(80, 80, 80)
+#define CLR_GREEN       RGB(0, 128, 0)
+#define CLR_RED         RGB(192, 0, 0)
+#define CLR_BLUE_BG     RGB(0, 0, 128)      /* Navy selection */
+#define CLR_FORM_BORDER RGB(128, 128, 128)  /* Group box border */
+#define CLR_MAGENTA     RGB(128, 0, 128)
+#define CLR_FOOTER_BG   RGB(0, 0, 128)      /* Navy footer */
+#define CLR_FOOTER_FG   RGB(255, 255, 255)  /* White footer text */
+#define CLR_LABEL       RGB(0, 0, 0)        /* Black labels */
+#define CLR_HEADER_BG   RGB(0, 0, 128)      /* Navy header */
+#define CLR_HEADER_FG   RGB(255, 255, 255)  /* White header text */
+#define CLR_HIGHLIGHT   RGB(0, 0, 128)      /* Selection highlight */
+#define CLR_HILITE_FG   RGB(255, 255, 255)  /* Selection text */
+
+/* ── Band / Mode constants ─────────────────────────────────────────────── */
+
+static const char *BANDS[] = {
+    "160M","80M","60M","40M","30M","20M","17M","15M","12M","10M","6M","2M","70CM"
+};
+static const char *MODES[] = {
+    "SSB","CW","FT8","FT4","RTTY","PSK31","AM","FM"
+};
+static const double BAND_DEFAULT_FREQS[] = {
+    1.900, 3.750, 5.330, 7.150, 10.125, 14.225, 18.100,
+    21.200, 24.940, 28.400, 50.125, 146.520, 446.000
+};
+#define DEFAULT_BAND_IDX 5
+#define NUM_BANDS 13
+#define NUM_MODES 8
+
+/* ── Form fields ───────────────────────────────────────────────────────── */
+
+enum Field {
+    FIELD_CALLSIGN, FIELD_BAND, FIELD_MODE,
+    FIELD_RST_SENT, FIELD_RST_RCVD,
+    FIELD_COMMENT,  FIELD_NOTES,
+    FIELD_FREQ,     FIELD_DATE, FIELD_TIME,
+    /* Advanced fields */
+    FIELD_TIME_OFF, FIELD_QTH, FIELD_WORKED_NAME,
+    FIELD_TX_POWER, FIELD_SUBMODE, FIELD_CONTEST_ID,
+    FIELD_SERIAL_SENT, FIELD_SERIAL_RCVD,
+    FIELD_EXCHANGE_SENT, FIELD_EXCHANGE_RCVD,
+    FIELD_PROP_MODE, FIELD_SAT_NAME, FIELD_SAT_MODE,
+    FIELD_IOTA, FIELD_ARRL_SECTION, FIELD_WORKED_STATE, FIELD_WORKED_COUNTY,
+    FIELD_COUNT
+};
+
+static const char *FIELD_LABELS[] = {
+    "Callsign", "Band", "Mode",
+    "RST Sent", "RST Rcvd",
+    "Comment",  "Notes",
+    "Freq MHz", "Date", "Time",
+    /* Advanced labels */
+    "Time Off", "QTH", "Name",
+    "TX Power", "Submode", "Contest ID",
+    "Serial Sent", "Serial Rcvd",
+    "Exch Sent", "Exch Rcvd",
+    "Prop Mode", "Sat Name", "Sat Mode",
+    "IOTA", "ARRL Sect", "State", "County"
+};
+
+static const int FIELD_MAX_LEN[] = {
+    30, 0, 0,   /* callsign, band(cycle), mode(cycle) */
+    6,  6,      /* rst sent, rst rcvd */
+    250, 250,   /* comment, notes */
+    14, 14, 14, /* freq, date, time */
+    /* Advanced max lengths */
+    14, 60, 60,         /* time_off, qth, worked_name */
+    14, 14, 30,         /* tx_power, submode, contest_id */
+    14, 14,             /* serial_sent, serial_rcvd */
+    60, 60,             /* exchange_sent, exchange_rcvd */
+    14, 30, 14,         /* prop_mode, sat_name, sat_mode */
+    14, 14, 14, 30      /* iota, arrl_section, worked_state, worked_county */
+};
+
+/* ── Recent QSO record ─────────────────────────────────────────────────── */
+
+typedef struct {
+    char utc[24];
+    char callsign[16];
+    char band[8];
+    char mode[8];
+    char rst_sent[8];
+    char rst_rcvd[8];
+    char country[32];
+    char grid[8];
+    char local_id[64];
+} RecentQso;
+
+/* ── Application state ─────────────────────────────────────────────────── */
+
+typedef struct {
+    /* Focus / navigation */
+    enum Field focused_field;
+    int band_idx, mode_idx;
+    int qso_list_focused;
+    int search_focused;
+    int qso_selected;        /* -1 = none */
+    int running;
+    int help_visible;
+
+    /* QSO timer */
+    int qso_timer_active;
+    ULONGLONG qso_started_at;
+
+    /* Form field buffers */
+    char callsign[32];
+    char rst_sent[8];
+    char rst_rcvd[8];
+    char comment[256];
+    char notes[256];
+    char freq_mhz[16];
+    char date[16];
+    char time_str[16];
+
+    /* Advanced view state */
+    int advanced_view;        /* 0 = basic, 1 = advanced */
+    int advanced_tab;         /* 0=Main, 1=Contest, 2=Technical, 3=Awards */
+
+    /* Advanced field buffers */
+    char time_off[16];
+    char qth[64];
+    char worked_name[64];
+    char tx_power[16];
+    char submode[16];
+    char contest_id[32];
+    char serial_sent[16];
+    char serial_rcvd[16];
+    char exchange_sent[64];
+    char exchange_rcvd[64];
+    char prop_mode[16];
+    char sat_name[32];
+    char sat_mode[16];
+    char iota[16];
+    char arrl_section[16];
+    char worked_state[16];
+    char worked_county[32];
+
+    /* Cursor positions per field */
+    int cursor_pos[FIELD_COUNT];
+
+    /* Search */
+    char search_text[64];
+    int search_cursor;
+
+    /* Status bar */
+    char status_text[256];
+    int status_is_error;
+    ULONGLONG status_created_at;
+
+    /* Lookup */
+    char lookup_name[64];
+    char lookup_qth[64];
+    char lookup_grid[16];
+    char lookup_country[64];
+    int  lookup_cq_zone;
+    int  has_lookup;
+
+    /* Recent QSOs */
+    RecentQso recent_qsos[MAX_RECENT];
+    int recent_count;
+
+    /* Scroll offset for QSO list */
+    int qso_scroll;
+
+    /* Space weather */
+    double k_index;
+    double solar_flux;
+    int sunspot_number;
+    int has_weather;
+
+    /* Editing existing QSO */
+    char editing_local_id[64];
+
+    /* Lookup debounce */
+    ULONGLONG last_callsign_change;
+    char last_looked_up[32];
+
+    /* Confirm delete dialog */
+    int confirm_delete_visible;
+
+    /* GDI objects */
+    HFONT hFont;
+    HFONT hFontBold;
+    int char_w, char_h;
+
+    HWND hwnd;
+} AppState;
+
+static AppState g_state;
+
+/* ── Forward declarations ──────────────────────────────────────────────── */
+
+static LRESULT CALLBACK WndProc(HWND, UINT, WPARAM, LPARAM);
+static void PaintAll(HWND hwnd, HDC hdc, RECT *rc);
+static void OnKeyDown(HWND hwnd, WPARAM vk, LPARAM lp);
+static void OnChar(HWND hwnd, WPARAM ch);
+static void OnTimer(HWND hwnd);
+static void InitState(void);
+static void ClearForm(void);
+static void SetStatus(const char *msg, int is_error);
+static void LogQso(void);
+static void RefreshQsoList(void);
+static void LookupCallsign(const char *call);
+static void FetchSpaceWeather(void);
+static void LoadSelectedQso(void);
+static void DeleteSelectedQso(void);
+static int  PaintAdvancedForm(HDC hdc, int y_start, int w);
+
+static char *RunQrCommand(const char *args);
+static char *FieldBuffer(enum Field f);
+static int   FieldMaxLen(enum Field f);
+
+/* ── Utility: safe string helpers ──────────────────────────────────────── */
+
+static void safe_strcpy(char *dst, size_t dstsz, const char *src)
+{
+    if (!src) { dst[0] = 0; return; }
+    size_t len = strlen(src);
+    if (len >= dstsz) len = dstsz - 1;
+    memcpy(dst, src, len);
+    dst[len] = 0;
+}
+
+static void safe_strcat(char *dst, size_t dstsz, const char *src)
+{
+    size_t cur = strlen(dst);
+    size_t avail = dstsz - cur;
+    if (avail <= 1) return;
+    safe_strcpy(dst + cur, avail, src);
+}
+
+/* ── Minimal JSON value extractor (no dependency) ──────────────────────── */
+
+/* Finds "key": "value" or "key": number in a JSON string.
+   Returns a malloc'd string with the value, or NULL.  */
+static char *json_get_string(const char *json, const char *key)
+{
+    char pattern[128];
+    _snprintf(pattern, sizeof(pattern), "\"%s\"", key);
+    const char *p = strstr(json, pattern);
+    if (!p) return NULL;
+    p += strlen(pattern);
+    while (*p == ' ' || *p == ':' || *p == '\t') p++;
+    if (*p == '"') {
+        p++;
+        const char *end = strchr(p, '"');
+        if (!end) return NULL;
+        size_t len = (size_t)(end - p);
+        char *val = (char *)malloc(len + 1);
+        memcpy(val, p, len);
+        val[len] = 0;
+        return val;
+    }
+    /* Numeric or boolean */
+    {
+        const char *end = p;
+        while (*end && *end != ',' && *end != '}' && *end != ' ' && *end != '\n') end++;
+        size_t len = (size_t)(end - p);
+        char *val = (char *)malloc(len + 1);
+        memcpy(val, p, len);
+        val[len] = 0;
+        return val;
+    }
+}
+
+static double json_get_double(const char *json, const char *key, double dflt)
+{
+    char *v = json_get_string(json, key);
+    if (!v) return dflt;
+    double d = atof(v);
+    free(v);
+    return d;
+}
+
+static int json_get_int(const char *json, const char *key, int dflt)
+{
+    char *v = json_get_string(json, key);
+    if (!v) return dflt;
+    int i = atoi(v);
+    free(v);
+    return i;
+}
+
+/* ── Find entries in a JSON array ──────────────────────────────────────── */
+
+/* Returns pointer to the nth { in a JSON array, or NULL */
+static const char *json_array_nth(const char *json, int n)
+{
+    const char *p = strchr(json, '[');
+    if (!p) return NULL;
+    p++;
+    int depth = 0, idx = 0;
+    for (; *p; p++) {
+        if (*p == '{') {
+            if (depth == 0) {
+                if (idx == n) return p;
+                idx++;
+            }
+            depth++;
+        } else if (*p == '}') {
+            depth--;
+        } else if (*p == ']' && depth == 0) {
+            break;
+        }
+    }
+    return NULL;
+}
+
+/* Extract a substring from { to matching } inclusive */
+static char *json_extract_object(const char *start)
+{
+    if (!start || *start != '{') return NULL;
+    int depth = 0;
+    const char *p = start;
+    for (; *p; p++) {
+        if (*p == '{') depth++;
+        else if (*p == '}') { depth--; if (depth == 0) { p++; break; } }
+    }
+    size_t len = (size_t)(p - start);
+    char *obj = (char *)malloc(len + 1);
+    memcpy(obj, start, len);
+    obj[len] = 0;
+    return obj;
+}
+
+/* ── CLI runner: execute `qr <args>` and capture stdout ────────────────── */
+
+static char g_cli_path[MAX_PATH];
+
+static void FindCliPath(void)
+{
+    /* Try to find QsoRipper.Cli.exe relative to our own exe:
+       We're at: .../artifacts/publish/qsoripper-win32/Release/qsoripper-win32.exe
+       CLI is at: .../artifacts/publish/QsoRipper.Cli/Release/QsoRipper.Cli.exe */
+    char module[MAX_PATH];
+    GetModuleFileNameA(NULL, module, MAX_PATH);
+
+    /* Walk up to artifacts/publish */
+    char *p = strrchr(module, '\\');
+    if (p) *p = 0; /* strip exe name */
+    p = strrchr(module, '\\');
+    if (p) *p = 0; /* strip Release */
+    p = strrchr(module, '\\');
+    if (p) *p = 0; /* strip qsoripper-win32 */
+
+    /* Try sibling directory */
+    _snprintf(g_cli_path, MAX_PATH, "%s\\QsoRipper.Cli\\Release\\QsoRipper.Cli.exe", module);
+    if (GetFileAttributesA(g_cli_path) != INVALID_FILE_ATTRIBUTES)
+        return;
+
+    /* Try QSORIPPER_CLI_PATH env var */
+    if (GetEnvironmentVariableA("QSORIPPER_CLI_PATH", g_cli_path, MAX_PATH) > 0)
+        if (GetFileAttributesA(g_cli_path) != INVALID_FILE_ATTRIBUTES)
+            return;
+
+    /* Fallback: assume on PATH */
+    safe_strcpy(g_cli_path, MAX_PATH, "QsoRipper.Cli.exe");
+}
+
+static char *RunQrCommand(const char *args)
+{
+    SECURITY_ATTRIBUTES sa = {0};
+    sa.nLength = sizeof(sa);
+    sa.bInheritHandle = TRUE;
+
+    HANDLE hReadPipe, hWritePipe;
+    if (!CreatePipe(&hReadPipe, &hWritePipe, &sa, 0))
+        return NULL;
+    SetHandleInformation(hReadPipe, HANDLE_FLAG_INHERIT, 0);
+
+    char cmdline[2048];
+    _snprintf(cmdline, sizeof(cmdline), "\"%s\" %s", g_cli_path, args);
+
+    STARTUPINFOA si = {0};
+    si.cb = sizeof(si);
+    si.dwFlags = STARTF_USESTDHANDLES | STARTF_USESHOWWINDOW;
+    si.hStdOutput = hWritePipe;
+    si.hStdError  = hWritePipe;
+    si.hStdInput  = INVALID_HANDLE_VALUE;
+    si.wShowWindow = SW_HIDE;
+
+    PROCESS_INFORMATION pi = {0};
+
+    if (!CreateProcessA(NULL, cmdline, NULL, NULL, TRUE,
+                        CREATE_NO_WINDOW, NULL, NULL, &si, &pi)) {
+        CloseHandle(hReadPipe);
+        CloseHandle(hWritePipe);
+        return NULL;
+    }
+    CloseHandle(hWritePipe);
+
+    /* Read all stdout */
+    char *output = (char *)malloc(8192);
+    DWORD totalRead = 0;
+    DWORD capacity = 8192;
+    for (;;) {
+        if (totalRead + 1024 > capacity) {
+            capacity *= 2;
+            output = (char *)realloc(output, capacity);
+        }
+        DWORD bytesRead = 0;
+        if (!ReadFile(hReadPipe, output + totalRead, 1024, &bytesRead, NULL) || bytesRead == 0)
+            break;
+        totalRead += bytesRead;
+    }
+    output[totalRead] = 0;
+
+    WaitForSingleObject(pi.hProcess, 5000);
+    CloseHandle(pi.hProcess);
+    CloseHandle(pi.hThread);
+    CloseHandle(hReadPipe);
+
+    return output;
+}
+
+/* ── Field buffer accessor ─────────────────────────────────────────────── */
+
+static char *FieldBuffer(enum Field f)
+{
+    switch (f) {
+    case FIELD_CALLSIGN:      return g_state.callsign;
+    case FIELD_RST_SENT:      return g_state.rst_sent;
+    case FIELD_RST_RCVD:      return g_state.rst_rcvd;
+    case FIELD_COMMENT:       return g_state.comment;
+    case FIELD_NOTES:         return g_state.notes;
+    case FIELD_FREQ:          return g_state.freq_mhz;
+    case FIELD_DATE:          return g_state.date;
+    case FIELD_TIME:          return g_state.time_str;
+    case FIELD_TIME_OFF:      return g_state.time_off;
+    case FIELD_QTH:           return g_state.qth;
+    case FIELD_WORKED_NAME:   return g_state.worked_name;
+    case FIELD_TX_POWER:      return g_state.tx_power;
+    case FIELD_SUBMODE:       return g_state.submode;
+    case FIELD_CONTEST_ID:    return g_state.contest_id;
+    case FIELD_SERIAL_SENT:   return g_state.serial_sent;
+    case FIELD_SERIAL_RCVD:   return g_state.serial_rcvd;
+    case FIELD_EXCHANGE_SENT: return g_state.exchange_sent;
+    case FIELD_EXCHANGE_RCVD: return g_state.exchange_rcvd;
+    case FIELD_PROP_MODE:     return g_state.prop_mode;
+    case FIELD_SAT_NAME:      return g_state.sat_name;
+    case FIELD_SAT_MODE:      return g_state.sat_mode;
+    case FIELD_IOTA:          return g_state.iota;
+    case FIELD_ARRL_SECTION:  return g_state.arrl_section;
+    case FIELD_WORKED_STATE:  return g_state.worked_state;
+    case FIELD_WORKED_COUNTY: return g_state.worked_county;
+    default: return NULL; /* band/mode are cycle selectors, FIELD_COUNT sentinel */
+    }
+}
+
+static int FieldMaxLen(enum Field f)
+{
+    if (f >= 0 && f < FIELD_COUNT)
+        return FIELD_MAX_LEN[f];
+    return 0;
+}
+
+/* ── GDI drawing helpers ───────────────────────────────────────────────── */
+
+static void DrawText_A(HDC hdc, int x, int y, COLORREF fg, const char *text)
+{
+    SetTextColor(hdc, fg);
+    SetBkMode(hdc, TRANSPARENT);
+    int len = (int)strlen(text);
+    /* Convert to wide */
+    wchar_t wbuf[1024];
+    int wlen = MultiByteToWideChar(CP_ACP, 0, text, len, wbuf, 1024);
+    TextOutW(hdc, x, y, wbuf, wlen);
+}
+
+static void DrawText_A_BG(HDC hdc, int x, int y, COLORREF fg, COLORREF bg, const char *text)
+{
+    SetTextColor(hdc, fg);
+    SetBkColor(hdc, bg);
+    SetBkMode(hdc, OPAQUE);
+    int len = (int)strlen(text);
+    wchar_t wbuf[1024];
+    int wlen = MultiByteToWideChar(CP_ACP, 0, text, len, wbuf, 1024);
+    TextOutW(hdc, x, y, wbuf, wlen);
+    SetBkMode(hdc, TRANSPARENT);
+}
+
+static void FillRect_Color(HDC hdc, int x, int y, int w, int h, COLORREF clr)
+{
+    RECT r = { x, y, x + w, y + h };
+    HBRUSH br = CreateSolidBrush(clr);
+    FillRect(hdc, &r, br);
+    DeleteObject(br);
+}
+
+static void DrawBox(HDC hdc, int x, int y, int w, int h, COLORREF border)
+{
+    HPEN pen = CreatePen(PS_SOLID, 1, border);
+    HPEN oldPen = (HPEN)SelectObject(hdc, pen);
+    HBRUSH oldBr = (HBRUSH)SelectObject(hdc, GetStockObject(NULL_BRUSH));
+    Rectangle(hdc, x, y, x + w, y + h);
+    SelectObject(hdc, oldBr);
+    SelectObject(hdc, oldPen);
+    DeleteObject(pen);
+}
+
+static void DrawHLine(HDC hdc, int x1, int x2, int y, COLORREF clr)
+{
+    HPEN pen = CreatePen(PS_SOLID, 1, clr);
+    HPEN old = (HPEN)SelectObject(hdc, pen);
+    MoveToEx(hdc, x1, y, NULL);
+    LineTo(hdc, x2, y);
+    SelectObject(hdc, old);
+    DeleteObject(pen);
+}
+
+/* Draw a chip-style label: colored background with text */
+static void DrawChip(HDC hdc, int x, int y, COLORREF bg, COLORREF fg,
+                     const char *text, int cw, int ch)
+{
+    int tw = (int)strlen(text) * cw + 8;
+    FillRect_Color(hdc, x, y, tw, ch + 2, bg);
+    DrawText_A(hdc, x + 4, y + 1, fg, text);
+}
+
+/* ── Draw a text field (owner-drawn edit box) ──────────────────────────── */
+
+static void DrawField(HDC hdc, int x, int y, int width_chars,
+                      const char *value, int cursor, int focused,
+                      int cw, int ch)
+{
+    int box_w = width_chars * cw + 6;
+    int box_h = ch + 4;
+
+    /* Background — white field with sunken-style border */
+    COLORREF bg = CLR_FIELD_BG;
+    COLORREF fg = focused ? CLR_TEXT : CLR_DARKGRAY;
+    FillRect_Color(hdc, x, y, box_w, box_h, bg);
+
+    /* 3D sunken border */
+    if (focused) {
+        DrawBox(hdc, x, y, box_w, box_h, CLR_HIGHLIGHT);
+    } else {
+        HPEN dark = CreatePen(PS_SOLID, 1, RGB(128, 128, 128));
+        HPEN light = CreatePen(PS_SOLID, 1, RGB(255, 255, 255));
+        HPEN old = (HPEN)SelectObject(hdc, dark);
+        MoveToEx(hdc, x, y + box_h - 1, NULL);
+        LineTo(hdc, x, y); LineTo(hdc, x + box_w - 1, y);
+        SelectObject(hdc, light);
+        MoveToEx(hdc, x + box_w - 1, y, NULL);
+        LineTo(hdc, x + box_w - 1, y + box_h - 1); LineTo(hdc, x, y + box_h - 1);
+        SelectObject(hdc, old);
+        DeleteObject(dark); DeleteObject(light);
+    }
+
+    /* Text */
+    DrawText_A_BG(hdc, x + 3, y + 2, fg, bg, value);
+
+    /* Cursor */
+    if (focused) {
+        int cx = x + 3 + cursor * cw;
+        HPEN pen = CreatePen(PS_SOLID, 2, CLR_TEXT);
+        HPEN old = (HPEN)SelectObject(hdc, pen);
+        MoveToEx(hdc, cx, y + 2, NULL);
+        LineTo(hdc, cx, y + 2 + ch);
+        SelectObject(hdc, old);
+        DeleteObject(pen);
+    }
+}
+
+/* Draw a cycle selector (Band/Mode) with ◀ ▶ indicators */
+static void DrawCycleField(HDC hdc, int x, int y, int width_chars,
+                           const char *value, int focused, int cw, int ch)
+{
+    int box_w = width_chars * cw + 6;
+    int box_h = ch + 4;
+
+    COLORREF bg = CLR_FIELD_BG;
+    FillRect_Color(hdc, x, y, box_w, box_h, bg);
+    /* Sunken border, highlight when focused */
+    if (focused) {
+        DrawBox(hdc, x, y, box_w, box_h, CLR_HIGHLIGHT);
+    } else {
+        HPEN dark = CreatePen(PS_SOLID, 1, RGB(128, 128, 128));
+        HPEN light = CreatePen(PS_SOLID, 1, RGB(255, 255, 255));
+        HPEN old = (HPEN)SelectObject(hdc, dark);
+        MoveToEx(hdc, x, y + box_h - 1, NULL);
+        LineTo(hdc, x, y); LineTo(hdc, x + box_w - 1, y);
+        SelectObject(hdc, light);
+        MoveToEx(hdc, x + box_w - 1, y, NULL);
+        LineTo(hdc, x + box_w - 1, y + box_h - 1); LineTo(hdc, x, y + box_h - 1);
+        SelectObject(hdc, old);
+        DeleteObject(dark); DeleteObject(light);
+    }
+
+    COLORREF fg = focused ? CLR_HIGHLIGHT : CLR_DARKGRAY;
+
+    /* Arrow indicators */
+    if (focused) {
+        char buf[64];
+        _snprintf(buf, sizeof(buf), "\x11 %s \x10", value);
+        DrawText_A_BG(hdc, x + 3, y + 2, fg, bg, buf);
+    } else {
+        DrawText_A_BG(hdc, x + 3, y + 2, fg, bg, value);
+    }
+}
+
+/* ── Populate date/time with current UTC ───────────────────────────────── */
+
+static void SetCurrentDateTime(void)
+{
+    SYSTEMTIME st;
+    GetSystemTime(&st);
+    _snprintf(g_state.date, sizeof(g_state.date),
+              "%04d-%02d-%02d", st.wYear, st.wMonth, st.wDay);
+    _snprintf(g_state.time_str, sizeof(g_state.time_str),
+              "%02d:%02d", st.wHour, st.wMinute);
+}
+
+/* ── Initialize application state ──────────────────────────────────────── */
+
+static void InitState(void)
+{
+    memset(&g_state, 0, sizeof(g_state));
+    g_state.focused_field = FIELD_CALLSIGN;
+    g_state.band_idx = DEFAULT_BAND_IDX;
+    g_state.mode_idx = 0;
+    g_state.qso_selected = -1;
+    g_state.running = 1;
+    safe_strcpy(g_state.rst_sent, sizeof(g_state.rst_sent), "59");
+    safe_strcpy(g_state.rst_rcvd, sizeof(g_state.rst_rcvd), "59");
+
+    _snprintf(g_state.freq_mhz, sizeof(g_state.freq_mhz),
+              "%.3f", BAND_DEFAULT_FREQS[DEFAULT_BAND_IDX]);
+
+    SetCurrentDateTime();
+}
+
+static void ClearForm(void)
+{
+    g_state.callsign[0] = 0;
+    safe_strcpy(g_state.rst_sent, sizeof(g_state.rst_sent), "59");
+    safe_strcpy(g_state.rst_rcvd, sizeof(g_state.rst_rcvd), "59");
+    g_state.comment[0] = 0;
+    g_state.notes[0] = 0;
+    _snprintf(g_state.freq_mhz, sizeof(g_state.freq_mhz),
+              "%.3f", BAND_DEFAULT_FREQS[g_state.band_idx]);
+    SetCurrentDateTime();
+
+    g_state.has_lookup = 0;
+    g_state.editing_local_id[0] = 0;
+    g_state.qso_timer_active = 0;
+    g_state.qso_started_at = 0;
+    g_state.last_looked_up[0] = 0;
+    g_state.focused_field = FIELD_CALLSIGN;
+    g_state.qso_list_focused = 0;
+    g_state.search_focused = 0;
+    memset(g_state.cursor_pos, 0, sizeof(g_state.cursor_pos));
+    g_state.cursor_pos[FIELD_RST_SENT] = 2;
+    g_state.cursor_pos[FIELD_RST_RCVD] = 2;
+
+    /* Clear advanced field buffers */
+    g_state.time_off[0] = 0;
+    g_state.qth[0] = 0;
+    g_state.worked_name[0] = 0;
+    g_state.tx_power[0] = 0;
+    g_state.submode[0] = 0;
+    g_state.contest_id[0] = 0;
+    g_state.serial_sent[0] = 0;
+    g_state.serial_rcvd[0] = 0;
+    g_state.exchange_sent[0] = 0;
+    g_state.exchange_rcvd[0] = 0;
+    g_state.prop_mode[0] = 0;
+    g_state.sat_name[0] = 0;
+    g_state.sat_mode[0] = 0;
+    g_state.iota[0] = 0;
+    g_state.arrl_section[0] = 0;
+    g_state.worked_state[0] = 0;
+    g_state.worked_county[0] = 0;
+}
+
+static void SetStatus(const char *msg, int is_error)
+{
+    safe_strcpy(g_state.status_text, sizeof(g_state.status_text), msg);
+    g_state.status_is_error = is_error;
+    g_state.status_created_at = GetTickCount64();
+}
+
+/* ── CLI integration: Log QSO ──────────────────────────────────────────── */
+
+static void LogQso(void)
+{
+    if (g_state.callsign[0] == 0) {
+        SetStatus("Callsign is required", 1);
+        return;
+    }
+
+    char cmd[1024];
+    int is_update = g_state.editing_local_id[0] != 0;
+
+    if (is_update) {
+        _snprintf(cmd, sizeof(cmd),
+                  "update %s --band %s --mode %s --freq %s "
+                  "--rst-sent %s --rst-rcvd %s --comment \"%s\" --json",
+                  g_state.editing_local_id,
+                  BANDS[g_state.band_idx],
+                  MODES[g_state.mode_idx],
+                  g_state.freq_mhz,
+                  g_state.rst_sent,
+                  g_state.rst_rcvd,
+                  g_state.comment);
+    } else {
+        _snprintf(cmd, sizeof(cmd),
+                  "log %s %s %s --freq %s --at \"%s %s\" "
+                  "--rst-sent %s --rst-rcvd %s --comment \"%s\" --json",
+                  g_state.callsign,
+                  BANDS[g_state.band_idx],
+                  MODES[g_state.mode_idx],
+                  g_state.freq_mhz,
+                  g_state.date,
+                  g_state.time_str,
+                  g_state.rst_sent,
+                  g_state.rst_rcvd,
+                  g_state.comment);
+    }
+
+    char *result = RunQrCommand(cmd);
+    if (result) {
+        if (is_update) {
+            SetStatus("QSO updated", 0);
+        } else {
+            char msg[128];
+            _snprintf(msg, sizeof(msg), "Logged %s on %s %s",
+                      g_state.callsign, BANDS[g_state.band_idx],
+                      MODES[g_state.mode_idx]);
+            SetStatus(msg, 0);
+        }
+        free(result);
+    } else {
+        SetStatus("Failed to run qr command", 1);
+    }
+
+    ClearForm();
+    RefreshQsoList();
+}
+
+/* ── CLI integration: Refresh QSO list ─────────────────────────────────── */
+
+static void RefreshQsoList(void)
+{
+    char *result = RunQrCommand("list --limit 20 --json");
+    if (!result) return;
+
+    g_state.recent_count = 0;
+    for (int i = 0; i < MAX_RECENT; i++) {
+        const char *obj_start = json_array_nth(result, i);
+        if (!obj_start) break;
+
+        char *obj = json_extract_object(obj_start);
+        if (!obj) break;
+
+        RecentQso *q = &g_state.recent_qsos[g_state.recent_count];
+        memset(q, 0, sizeof(*q));
+
+        char *v;
+        v = json_get_string(obj, "utcTimestamp");
+        if (!v) v = json_get_string(obj, "utc");
+        if (v) {
+            /* Trim to HH:MM for display */
+            if (strlen(v) >= 16) {
+                char buf[6];
+                buf[0] = v[11]; buf[1] = v[12]; buf[2] = ':';
+                buf[3] = v[14]; buf[4] = v[15]; buf[5] = 0;
+                safe_strcpy(q->utc, sizeof(q->utc), buf);
+            } else {
+                safe_strcpy(q->utc, sizeof(q->utc), v);
+            }
+            free(v);
+        }
+
+        v = json_get_string(obj, "workedCallsign");
+        if (!v) v = json_get_string(obj, "callsign");
+        if (v) { safe_strcpy(q->callsign, sizeof(q->callsign), v); free(v); }
+
+        v = json_get_string(obj, "band");
+        if (v) {
+            /* Strip "BAND_" prefix: "BAND_40M" -> "40M" */
+            const char *display = v;
+            if (strncmp(display, "BAND_", 5) == 0) display += 5;
+            safe_strcpy(q->band, sizeof(q->band), display);
+            free(v);
+        }
+
+        v = json_get_string(obj, "mode");
+        if (v) {
+            /* Strip "MODE_" prefix: "MODE_CW" -> "CW" */
+            const char *display = v;
+            if (strncmp(display, "MODE_", 5) == 0) display += 5;
+            safe_strcpy(q->mode, sizeof(q->mode), display);
+            free(v);
+        }
+
+        /* RST is a nested object: {"readability":5,"strength":9,"tone":9} -> "599" */
+        {
+            int r = json_get_int(obj, "readability", 0);
+            int s = json_get_int(obj, "strength", 0);
+            int t = json_get_int(obj, "tone", 0);
+            if (r > 0) {
+                if (t > 0) _snprintf(q->rst_sent, sizeof(q->rst_sent), "%d%d%d", r, s, t);
+                else       _snprintf(q->rst_sent, sizeof(q->rst_sent), "%d%d", r, s);
+            }
+        }
+
+        /* Look for rstReceived nested object */
+        {
+            /* The JSON has rstSent and rstReceived as nested objects.
+               Our simple parser finds the first match for "readability" etc,
+               which is rstSent. For rstReceived, search from after rstReceived key. */
+            const char *rcvd_pos = strstr(obj, "rstReceived");
+            if (rcvd_pos) {
+                int r = json_get_int(rcvd_pos, "readability", 0);
+                int s = json_get_int(rcvd_pos, "strength", 0);
+                int t = json_get_int(rcvd_pos, "tone", 0);
+                if (r > 0) {
+                    if (t > 0) _snprintf(q->rst_rcvd, sizeof(q->rst_rcvd), "%d%d%d", r, s, t);
+                    else       _snprintf(q->rst_rcvd, sizeof(q->rst_rcvd), "%d%d", r, s);
+                }
+            }
+        }
+
+        v = json_get_string(obj, "country");
+        if (!v) {
+            /* Try stationSnapshot.country as a fallback */
+            const char *snap = strstr(obj, "stationSnapshot");
+            if (snap) v = json_get_string(snap, "country");
+        }
+        if (v) { safe_strcpy(q->country, sizeof(q->country), v); free(v); }
+
+        v = json_get_string(obj, "workedGrid");
+        if (!v) v = json_get_string(obj, "grid");
+        if (v) { safe_strcpy(q->grid, sizeof(q->grid), v); free(v); }
+
+        v = json_get_string(obj, "localId");
+        if (!v) v = json_get_string(obj, "local_id");
+        if (v) { safe_strcpy(q->local_id, sizeof(q->local_id), v); free(v); }
+
+        g_state.recent_count++;
+        free(obj);
+    }
+
+    free(result);
+}
+
+/* ── CLI integration: Lookup callsign ──────────────────────────────────── */
+
+static void LookupCallsign(const char *call)
+{
+    if (!call || call[0] == 0) {
+        g_state.has_lookup = 0;
+        return;
+    }
+
+    char cmd[128];
+    _snprintf(cmd, sizeof(cmd), "lookup %s --json", call);
+    char *result = RunQrCommand(cmd);
+    if (!result) return;
+
+    g_state.has_lookup = 0;
+    g_state.lookup_name[0] = 0;
+    g_state.lookup_qth[0] = 0;
+    g_state.lookup_grid[0] = 0;
+    g_state.lookup_country[0] = 0;
+    g_state.lookup_cq_zone = 0;
+
+    /* The lookup JSON is nested: { "result": { "record": { ... } } }
+       Navigate to the record object. */
+    const char *record_pos = strstr(result, "\"record\"");
+    if (!record_pos) { free(result); return; }
+
+    char *v;
+    v = json_get_string(record_pos, "formattedName");
+    if (!v) v = json_get_string(record_pos, "firstName");
+    if (v) {
+        safe_strcpy(g_state.lookup_name, sizeof(g_state.lookup_name), v);
+        g_state.has_lookup = 1;
+        free(v);
+    }
+
+    v = json_get_string(record_pos, "addr2");
+    if (!v) v = json_get_string(record_pos, "qth");
+    if (v) { safe_strcpy(g_state.lookup_qth, sizeof(g_state.lookup_qth), v); free(v); }
+
+    v = json_get_string(record_pos, "gridSquare");
+    if (!v) v = json_get_string(record_pos, "grid");
+    if (v) { safe_strcpy(g_state.lookup_grid, sizeof(g_state.lookup_grid), v); free(v); }
+
+    v = json_get_string(record_pos, "country");
+    if (v) { safe_strcpy(g_state.lookup_country, sizeof(g_state.lookup_country), v); free(v); }
+
+    g_state.lookup_cq_zone = json_get_int(record_pos, "cqZone", 0);
+
+    free(result);
+    safe_strcpy(g_state.last_looked_up, sizeof(g_state.last_looked_up), call);
+}
+
+/* ── CLI integration: Fetch space weather ──────────────────────────────── */
+
+static void FetchSpaceWeather(void)
+{
+    char *result = RunQrCommand("space-weather --json");
+    if (!result) return;
+
+    g_state.k_index = json_get_double(result, "planetaryKIndex", 0.0);
+    if (g_state.k_index == 0.0)
+        g_state.k_index = json_get_double(result, "k_index", 0.0);
+    g_state.solar_flux = json_get_double(result, "solarFluxIndex", 0.0);
+    if (g_state.solar_flux == 0.0)
+        g_state.solar_flux = json_get_double(result, "solar_flux", 0.0);
+    g_state.sunspot_number = json_get_int(result, "sunspotNumber", 0);
+    if (g_state.sunspot_number == 0)
+        g_state.sunspot_number = json_get_int(result, "sunspot_number", 0);
+    g_state.has_weather = 1;
+
+    free(result);
+}
+
+/* ── CLI integration: Load selected QSO into form ──────────────────────── */
+
+static void LoadSelectedQso(void)
+{
+    if (g_state.qso_selected < 0 || g_state.qso_selected >= g_state.recent_count)
+        return;
+
+    RecentQso *q = &g_state.recent_qsos[g_state.qso_selected];
+    safe_strcpy(g_state.callsign, sizeof(g_state.callsign), q->callsign);
+    safe_strcpy(g_state.rst_sent, sizeof(g_state.rst_sent), q->rst_sent);
+    safe_strcpy(g_state.rst_rcvd, sizeof(g_state.rst_rcvd), q->rst_rcvd);
+    safe_strcpy(g_state.editing_local_id, sizeof(g_state.editing_local_id), q->local_id);
+
+    /* Set band index */
+    for (int i = 0; i < NUM_BANDS; i++) {
+        if (_stricmp(BANDS[i], q->band) == 0) {
+            g_state.band_idx = i;
+            break;
+        }
+    }
+    /* Set mode index */
+    for (int i = 0; i < NUM_MODES; i++) {
+        if (_stricmp(MODES[i], q->mode) == 0) {
+            g_state.mode_idx = i;
+            break;
+        }
+    }
+
+    _snprintf(g_state.freq_mhz, sizeof(g_state.freq_mhz),
+              "%.3f", BAND_DEFAULT_FREQS[g_state.band_idx]);
+
+    /* Parse UTC for date/time */
+    if (strlen(q->utc) >= 10) {
+        safe_strcpy(g_state.date, sizeof(g_state.date), q->utc);
+        g_state.date[10] = 0;
+    }
+    if (strlen(q->utc) >= 16) {
+        safe_strcpy(g_state.time_str, sizeof(g_state.time_str), q->utc + 11);
+        g_state.time_str[5] = 0;
+    }
+
+    /* Update cursor positions */
+    g_state.cursor_pos[FIELD_CALLSIGN] = (int)strlen(g_state.callsign);
+    g_state.cursor_pos[FIELD_RST_SENT] = (int)strlen(g_state.rst_sent);
+    g_state.cursor_pos[FIELD_RST_RCVD] = (int)strlen(g_state.rst_rcvd);
+    g_state.cursor_pos[FIELD_FREQ] = (int)strlen(g_state.freq_mhz);
+    g_state.cursor_pos[FIELD_DATE] = (int)strlen(g_state.date);
+    g_state.cursor_pos[FIELD_TIME] = (int)strlen(g_state.time_str);
+
+    g_state.qso_list_focused = 0;
+    g_state.focused_field = FIELD_CALLSIGN;
+
+    SetStatus("QSO loaded for editing", 0);
+}
+
+/* ── CLI integration: Delete selected QSO ──────────────────────────────── */
+
+static void DeleteSelectedQso(void)
+{
+    if (g_state.qso_selected < 0 || g_state.qso_selected >= g_state.recent_count)
+        return;
+
+    RecentQso *q = &g_state.recent_qsos[g_state.qso_selected];
+    if (q->local_id[0] == 0) {
+        SetStatus("No QSO ID available for delete", 1);
+        return;
+    }
+
+    char cmd[128];
+    _snprintf(cmd, sizeof(cmd), "delete %s", q->local_id);
+    char *result = RunQrCommand(cmd);
+    if (result) {
+        char msg[128];
+        _snprintf(msg, sizeof(msg), "Deleted QSO with %s", q->callsign);
+        SetStatus(msg, 0);
+        free(result);
+    } else {
+        SetStatus("Failed to delete QSO", 1);
+    }
+
+    g_state.qso_selected = -1;
+    g_state.confirm_delete_visible = 0;
+    RefreshQsoList();
+}
+
+/* ── Drawing: Header bar ───────────────────────────────────────────────── */
+
+static void PaintHeader(HDC hdc, RECT *rc)
+{
+    int cw = g_state.char_w;
+    int ch = g_state.char_h;
+    int header_h = ch * 3 + 4;
+    int w = rc->right - rc->left;
+
+    FillRect_Color(hdc, 0, 0, w, header_h, CLR_HEADER_BG);
+
+    /* Left: title */
+    SelectObject(hdc, g_state.hFontBold);
+    DrawText_A(hdc, cw, ch, CLR_HEADER_FG, "QsoRipper");
+    SelectObject(hdc, g_state.hFont);
+
+    /* Center: space weather */
+    if (g_state.has_weather) {
+        char weather[128];
+        COLORREF kclr = g_state.k_index <= 3 ? CLR_GREEN :
+                        g_state.k_index <= 5 ? CLR_YELLOW : CLR_RED;
+        _snprintf(weather, sizeof(weather),
+                  "K:%.0f  SFI:%.0f  SN:%d",
+                  g_state.k_index, g_state.solar_flux,
+                  g_state.sunspot_number);
+        int tw = (int)strlen(weather) * cw;
+        int cx = (w - tw) / 2;
+        /* Draw K-index colored, rest white */
+        char kbuf[16];
+        _snprintf(kbuf, sizeof(kbuf), "K:%.0f", g_state.k_index);
+        DrawText_A_BG(hdc, cx, ch, kclr, CLR_HEADER_BG, kbuf);
+        int kw = (int)strlen(kbuf) * cw;
+        char rest[100];
+        _snprintf(rest, sizeof(rest), "  SFI:%.0f  SN:%d",
+                  g_state.solar_flux, g_state.sunspot_number);
+        DrawText_A_BG(hdc, cx + kw, ch, CLR_HEADER_FG, CLR_HEADER_BG, rest);
+    } else {
+        int cx = (w - 22 * cw) / 2;
+        DrawText_A_BG(hdc, cx, ch, CLR_GRAY, CLR_HEADER_BG, "Loading space weather...");
+    }
+
+    /* Right: UTC clock */
+    {
+        SYSTEMTIME st;
+        GetSystemTime(&st);
+        char clk[32];
+        _snprintf(clk, sizeof(clk), "%02d:%02d:%02d UTC",
+                  st.wHour, st.wMinute, st.wSecond);
+        int tw = (int)strlen(clk) * cw;
+        DrawText_A_BG(hdc, w - tw - cw, ch, CLR_YELLOW, CLR_HEADER_BG, clk);
+    }
+}
+
+/* ── Drawing: Status bar ───────────────────────────────────────────────── */
+
+static int PaintStatus(HDC hdc, int y, int w)
+{
+    int ch = g_state.char_h;
+    int bar_h = ch + 4;
+
+    FillRect_Color(hdc, 0, y, w, bar_h, CLR_BG);
+
+    if (g_state.status_text[0] != 0) {
+        ULONGLONG elapsed = GetTickCount64() - g_state.status_created_at;
+        if (elapsed < STATUS_LIFETIME_MS) {
+            COLORREF clr = g_state.status_is_error ? CLR_RED : CLR_GREEN;
+            DrawText_A(hdc, g_state.char_w * 2, y + 2, clr, g_state.status_text);
+        } else {
+            g_state.status_text[0] = 0;
+        }
+    }
+
+    return y + bar_h;
+}
+
+/* ── Drawing: Log form ─────────────────────────────────────────────────── */
+
+static int PaintLogForm(HDC hdc, int y_start, int w)
+{
+    int cw = g_state.char_w;
+    int ch = g_state.char_h;
+    int row_h = ch + 8;
+    int pad = cw * 2;
+    int label_w = cw * 10;
+    int form_h = row_h * 9 + ch + 10;
+    int focused_form = !g_state.qso_list_focused && !g_state.search_focused;
+
+    /* Form border */
+    COLORREF border_clr = focused_form ? CLR_FORM_BORDER : CLR_DARKGRAY;
+    DrawBox(hdc, 4, y_start, w - 8, form_h, border_clr);
+
+    /* Title */
+    {
+        const char *title = g_state.editing_local_id[0] ? " Edit QSO " : " Log QSO ";
+        DrawText_A_BG(hdc, pad, y_start, CLR_YELLOW, CLR_BG, title);
+    }
+
+    int y = y_start + ch + 4;
+
+    /* Row 1: Callsign, Band, Mode */
+    {
+        DrawText_A(hdc, pad, y + 3, CLR_LABEL, "Callsign");
+        DrawField(hdc, pad + label_w, y, 14,
+                  g_state.callsign, g_state.cursor_pos[FIELD_CALLSIGN],
+                  focused_form && g_state.focused_field == FIELD_CALLSIGN, cw, ch);
+
+        int bx = pad + label_w + 14 * cw + 16;
+        DrawText_A(hdc, bx, y + 3, CLR_LABEL, "Band");
+        DrawCycleField(hdc, bx + 5 * cw, y, 8,
+                       BANDS[g_state.band_idx],
+                       focused_form && g_state.focused_field == FIELD_BAND, cw, ch);
+
+        int mx = bx + 5 * cw + 8 * cw + 16;
+        DrawText_A(hdc, mx, y + 3, CLR_LABEL, "Mode");
+        DrawCycleField(hdc, mx + 5 * cw, y, 8,
+                       MODES[g_state.mode_idx],
+                       focused_form && g_state.focused_field == FIELD_MODE, cw, ch);
+    }
+    y += row_h;
+
+    /* Row 2: RST Sent, RST Rcvd */
+    {
+        DrawText_A(hdc, pad, y + 3, CLR_LABEL, "RST Sent");
+        DrawField(hdc, pad + label_w, y, 6,
+                  g_state.rst_sent, g_state.cursor_pos[FIELD_RST_SENT],
+                  focused_form && g_state.focused_field == FIELD_RST_SENT, cw, ch);
+
+        int rx = pad + label_w + 6 * cw + 16;
+        DrawText_A(hdc, rx, y + 3, CLR_LABEL, "RST Rcvd");
+        DrawField(hdc, rx + 10 * cw, y, 6,
+                  g_state.rst_rcvd, g_state.cursor_pos[FIELD_RST_RCVD],
+                  focused_form && g_state.focused_field == FIELD_RST_RCVD, cw, ch);
+    }
+    y += row_h;
+
+    /* Row 3: Comment */
+    {
+        int field_chars = (w - pad * 2 - label_w - 12) / cw;
+        if (field_chars > 60) field_chars = 60;
+        if (field_chars < 10) field_chars = 10;
+        DrawText_A(hdc, pad, y + 3, CLR_LABEL, "Comment");
+        DrawField(hdc, pad + label_w, y, field_chars,
+                  g_state.comment, g_state.cursor_pos[FIELD_COMMENT],
+                  focused_form && g_state.focused_field == FIELD_COMMENT, cw, ch);
+    }
+    y += row_h;
+
+    /* Row 4: Notes */
+    {
+        int field_chars = (w - pad * 2 - label_w - 12) / cw;
+        if (field_chars > 60) field_chars = 60;
+        if (field_chars < 10) field_chars = 10;
+        DrawText_A(hdc, pad, y + 3, CLR_LABEL, "Notes");
+        DrawField(hdc, pad + label_w, y, field_chars,
+                  g_state.notes, g_state.cursor_pos[FIELD_NOTES],
+                  focused_form && g_state.focused_field == FIELD_NOTES, cw, ch);
+    }
+    y += row_h;
+
+    /* Row 5: Freq, Date, Time */
+    {
+        DrawText_A(hdc, pad, y + 3, CLR_LABEL, "Freq MHz");
+        DrawField(hdc, pad + label_w, y, 10,
+                  g_state.freq_mhz, g_state.cursor_pos[FIELD_FREQ],
+                  focused_form && g_state.focused_field == FIELD_FREQ, cw, ch);
+
+        int dx = pad + label_w + 10 * cw + 16;
+        DrawText_A(hdc, dx, y + 3, CLR_LABEL, "Date");
+        DrawField(hdc, dx + 5 * cw, y, 12,
+                  g_state.date, g_state.cursor_pos[FIELD_DATE],
+                  focused_form && g_state.focused_field == FIELD_DATE, cw, ch);
+
+        int tx = dx + 5 * cw + 12 * cw + 16;
+        DrawText_A(hdc, tx, y + 3, CLR_LABEL, "Time");
+        DrawField(hdc, tx + 5 * cw, y, 6,
+                  g_state.time_str, g_state.cursor_pos[FIELD_TIME],
+                  focused_form && g_state.focused_field == FIELD_TIME, cw, ch);
+    }
+    y += row_h;
+
+    /* Row 6: QSO Duration */
+    {
+        char dur[32];
+        if (g_state.qso_timer_active) {
+            ULONGLONG elapsed = GetTickCount64() - g_state.qso_started_at;
+            int secs = (int)(elapsed / 1000);
+            int mins = secs / 60;
+            secs %= 60;
+            _snprintf(dur, sizeof(dur), "QSO Duration: %02d:%02d", mins, secs);
+            DrawText_A(hdc, pad, y + 3, CLR_GREEN, dur);
+        } else {
+            DrawText_A(hdc, pad, y + 3, CLR_DARKGRAY, "QSO Duration: 00:00");
+        }
+    }
+    y += row_h;
+
+    /* Row 7: padding */
+    y += 4;
+
+    /* Row 8: Hint chips */
+    {
+        int cx = pad;
+        const char *submit_label = g_state.editing_local_id[0]
+                                       ? "F10 Update QSO" : "F10 Log QSO";
+        DrawChip(hdc, cx, y, CLR_FOOTER_BG, CLR_FOOTER_FG, submit_label, cw, ch);
+        cx += ((int)strlen(submit_label) * cw + 16);
+
+        DrawChip(hdc, cx, y, CLR_FOOTER_BG, CLR_FOOTER_FG, "Esc Clear", cw, ch);
+        cx += (9 * cw + 16);
+
+        DrawChip(hdc, cx, y, CLR_FOOTER_BG, CLR_FOOTER_FG, "F3 QSO List", cw, ch);
+        cx += (11 * cw + 16);
+
+        DrawChip(hdc, cx, y, CLR_FOOTER_BG, CLR_FOOTER_FG, "F4 Search", cw, ch);
+    }
+    y += row_h;
+
+    return y_start + form_h;
+}
+
+/* ── Advanced view tab field definitions ────────────────────────────────── */
+
+#define ADV_TAB_COUNT 4
+
+static const enum Field ADV_TAB_MAIN[] = {
+    FIELD_CALLSIGN, FIELD_BAND, FIELD_MODE, FIELD_FREQ,
+    FIELD_DATE, FIELD_TIME, FIELD_TIME_OFF, FIELD_QTH,
+    FIELD_WORKED_NAME, FIELD_RST_SENT, FIELD_RST_RCVD,
+    FIELD_COMMENT, FIELD_NOTES
+};
+
+static const enum Field ADV_TAB_CONTEST[] = {
+    FIELD_TX_POWER, FIELD_SUBMODE, FIELD_CONTEST_ID,
+    FIELD_SERIAL_SENT, FIELD_SERIAL_RCVD,
+    FIELD_EXCHANGE_SENT, FIELD_EXCHANGE_RCVD
+};
+
+static const enum Field ADV_TAB_TECHNICAL[] = {
+    FIELD_PROP_MODE, FIELD_SAT_NAME, FIELD_SAT_MODE
+};
+
+static const enum Field ADV_TAB_AWARDS[] = {
+    FIELD_IOTA, FIELD_ARRL_SECTION, FIELD_WORKED_STATE, FIELD_WORKED_COUNTY
+};
+
+static const enum Field *ADV_TABS[] = {
+    ADV_TAB_MAIN, ADV_TAB_CONTEST, ADV_TAB_TECHNICAL, ADV_TAB_AWARDS
+};
+
+static const int ADV_TAB_COUNTS[] = {
+    sizeof(ADV_TAB_MAIN) / sizeof(ADV_TAB_MAIN[0]),
+    sizeof(ADV_TAB_CONTEST) / sizeof(ADV_TAB_CONTEST[0]),
+    sizeof(ADV_TAB_TECHNICAL) / sizeof(ADV_TAB_TECHNICAL[0]),
+    sizeof(ADV_TAB_AWARDS) / sizeof(ADV_TAB_AWARDS[0])
+};
+
+static const char *ADV_TAB_NAMES[] = { "Main", "Contest", "Technical", "Awards" };
+
+static const enum Field *AdvTabFields(int tab, int *count)
+{
+    *count = ADV_TAB_COUNTS[tab];
+    return ADV_TABS[tab];
+}
+
+static int AdvTabFieldIndex(int tab, enum Field f)
+{
+    int i, cnt;
+    const enum Field *fields = AdvTabFields(tab, &cnt);
+    for (i = 0; i < cnt; i++) {
+        if (fields[i] == f) return i;
+    }
+    return -1;
+}
+
+static int CountAdvancedRows(const enum Field *fields, int count)
+{
+    int rows = 0;
+    int i;
+    for (i = 0; i < count; ) {
+        if (fields[i] == FIELD_COMMENT || fields[i] == FIELD_NOTES) {
+            rows++; i++;
+        } else {
+            rows++; i++;
+            if (i < count && fields[i] != FIELD_COMMENT &&
+                fields[i] != FIELD_NOTES) {
+                i++; /* paired into same row */
+            }
+        }
+    }
+    return rows;
+}
+
+/* ── Drawing: Advanced log form ────────────────────────────────────────── */
+
+static int PaintAdvancedForm(HDC hdc, int y_start, int w)
+{
+    int cw = g_state.char_w;
+    int ch = g_state.char_h;
+    int row_h = ch + 8;
+    int pad = cw * 2;
+    int label_w = cw * 14;
+    int focused_form = !g_state.qso_list_focused && !g_state.search_focused;
+    int tab = g_state.advanced_tab;
+    int field_count, num_rows, form_h, y, i, t;
+    const enum Field *fields;
+    COLORREF border_clr;
+
+    fields = AdvTabFields(tab, &field_count);
+    num_rows = CountAdvancedRows(fields, field_count);
+    /* form_h: title + tab bar + field rows + padding + hint row + margin */
+    form_h = ch + 4 + row_h * (num_rows + 2) + 12;
+
+    border_clr = focused_form ? CLR_MAGENTA : CLR_DARKGRAY;
+    DrawBox(hdc, 4, y_start, w - 8, form_h, border_clr);
+
+    /* Title */
+    {
+        char title[64];
+        const char *pfx = g_state.editing_local_id[0] ? "Edit" : "Advanced";
+        _snprintf(title, sizeof(title), " %s - %s ", pfx, ADV_TAB_NAMES[tab]);
+        DrawText_A_BG(hdc, pad, y_start, CLR_MAGENTA, CLR_BG, title);
+    }
+
+    y = y_start + ch + 4;
+
+    /* Tab bar */
+    {
+        int tx = pad;
+        for (t = 0; t < ADV_TAB_COUNT; t++) {
+            char tab_label[32];
+            COLORREF bg = (t == tab) ? CLR_CYAN : CLR_DARKGRAY;
+            COLORREF fg = (t == tab) ? CLR_BG : CLR_GRAY;
+            _snprintf(tab_label, sizeof(tab_label), " %s ", ADV_TAB_NAMES[t]);
+            DrawChip(hdc, tx, y, bg, fg, tab_label, cw, ch);
+            tx += (int)strlen(tab_label) * cw + 12;
+        }
+    }
+    y += row_h;
+
+    /* Two-column field layout */
+    {
+        int col_w = (w - pad * 2 - 16) / 2;
+        int field_w = (col_w - label_w - 8) / cw;
+        if (field_w > 30) field_w = 30;
+        if (field_w < 8) field_w = 8;
+
+        for (i = 0; i < field_count; ) {
+            enum Field f1 = fields[i];
+            int full_w = (f1 == FIELD_COMMENT || f1 == FIELD_NOTES);
+
+            /* First field */
+            DrawText_A(hdc, pad, y + 3, CLR_CYAN, FIELD_LABELS[f1]);
+            if (f1 == FIELD_BAND) {
+                DrawCycleField(hdc, pad + label_w, y, 8,
+                               BANDS[g_state.band_idx],
+                               focused_form && g_state.focused_field == f1,
+                               cw, ch);
+            } else if (f1 == FIELD_MODE) {
+                DrawCycleField(hdc, pad + label_w, y, 8,
+                               MODES[g_state.mode_idx],
+                               focused_form && g_state.focused_field == f1,
+                               cw, ch);
+            } else {
+                int fw = full_w ? ((w - pad * 2 - label_w - 12) / cw)
+                                : field_w;
+                char *buf = FieldBuffer(f1);
+                if (fw > 60) fw = 60;
+                if (fw < 8) fw = 8;
+                DrawField(hdc, pad + label_w, y, fw,
+                          buf ? buf : "", g_state.cursor_pos[f1],
+                          focused_form && g_state.focused_field == f1,
+                          cw, ch);
+            }
+            i++;
+
+            /* Second field in same row (if first wasn't full-width) */
+            if (!full_w && i < field_count) {
+                enum Field f2 = fields[i];
+                if (f2 != FIELD_COMMENT && f2 != FIELD_NOTES) {
+                    int col2_x = pad + col_w + 8;
+                    DrawText_A(hdc, col2_x, y + 3, CLR_CYAN,
+                               FIELD_LABELS[f2]);
+                    if (f2 == FIELD_BAND) {
+                        DrawCycleField(hdc, col2_x + label_w, y, 8,
+                                       BANDS[g_state.band_idx],
+                                       focused_form &&
+                                           g_state.focused_field == f2,
+                                       cw, ch);
+                    } else if (f2 == FIELD_MODE) {
+                        DrawCycleField(hdc, col2_x + label_w, y, 8,
+                                       MODES[g_state.mode_idx],
+                                       focused_form &&
+                                           g_state.focused_field == f2,
+                                       cw, ch);
+                    } else {
+                        char *buf2 = FieldBuffer(f2);
+                        DrawField(hdc, col2_x + label_w, y, field_w,
+                                  buf2 ? buf2 : "", g_state.cursor_pos[f2],
+                                  focused_form &&
+                                      g_state.focused_field == f2,
+                                  cw, ch);
+                    }
+                    i++;
+                }
+            }
+
+            y += row_h;
+        }
+    }
+
+    y += 4;
+
+    /* Hint chips */
+    {
+        int cx = pad;
+        const char *submit_label = g_state.editing_local_id[0]
+                                       ? "F10 Update QSO" : "F10 Log QSO";
+        DrawChip(hdc, cx, y, CLR_FOOTER_BG, CLR_FOOTER_FG, submit_label,
+                 cw, ch);
+        cx += ((int)strlen(submit_label) * cw + 16);
+
+        DrawChip(hdc, cx, y, CLR_FOOTER_BG, CLR_FOOTER_FG, "Esc Basic View",
+                 cw, ch);
+        cx += (14 * cw + 16);
+
+        DrawChip(hdc, cx, y, CLR_FOOTER_BG, CLR_FOOTER_FG, "F5/F6 Tabs",
+                 cw, ch);
+        cx += (10 * cw + 16);
+
+        DrawChip(hdc, cx, y, CLR_FOOTER_BG, CLR_FOOTER_FG, "F3 QSO List",
+                 cw, ch);
+    }
+
+    return y_start + form_h;
+}
+
+/* ── Drawing: Lookup panel─────────────────────────────────────────────── */
+
+static int PaintLookup(HDC hdc, int y_start, int w)
+{
+    int cw = g_state.char_w;
+    int ch = g_state.char_h;
+    int panel_h = ch * 5 + 8;
+    int pad = cw * 2;
+
+    DrawBox(hdc, 4, y_start, w - 8, panel_h, CLR_CYAN);
+    DrawText_A_BG(hdc, pad, y_start, CLR_CYAN, CLR_BG, " Callsign Lookup ");
+
+    int y = y_start + ch + 4;
+
+    if (g_state.has_lookup) {
+        char line[128];
+
+        SelectObject(hdc, g_state.hFontBold);
+        DrawText_A(hdc, pad + cw, y, CLR_WHITE, g_state.lookup_name);
+        SelectObject(hdc, g_state.hFont);
+        y += ch + 2;
+
+        _snprintf(line, sizeof(line), "QTH: %s", g_state.lookup_qth);
+        DrawText_A(hdc, pad + cw, y, CLR_GRAY, line);
+
+        if (g_state.lookup_grid[0]) {
+            int gx = pad + cw + (int)(strlen(line) + 2) * cw;
+            _snprintf(line, sizeof(line), "Grid: %s", g_state.lookup_grid);
+            DrawText_A(hdc, gx, y, CLR_GRAY, line);
+        }
+        y += ch + 2;
+
+        _snprintf(line, sizeof(line), "Country: %s   CQ Zone: %d",
+                  g_state.lookup_country, g_state.lookup_cq_zone);
+        DrawText_A(hdc, pad + cw, y, CLR_GRAY, line);
+    } else {
+        DrawText_A(hdc, pad + cw, y + ch, CLR_DARKGRAY,
+                   "Type a callsign to look up");
+    }
+
+    return y_start + panel_h + 2;
+}
+
+/* ── Drawing: Recent QSOs table ────────────────────────────────────────── */
+
+static int PaintRecentQsos(HDC hdc, int y_start, int w, int bottom)
+{
+    int cw = g_state.char_w;
+    int ch = g_state.char_h;
+    int pad = cw * 2;
+    int row_h = ch + 4;
+    int panel_h = bottom - y_start - row_h - 4; /* Leave room for footer */
+    if (panel_h < row_h * 3) panel_h = row_h * 3;
+
+    /* Border color depends on focus state */
+    COLORREF border_clr = CLR_CYAN;
+    if (g_state.search_focused)
+        border_clr = CLR_MAGENTA;
+    else if (g_state.qso_list_focused)
+        border_clr = CLR_YELLOW;
+
+    DrawBox(hdc, 4, y_start, w - 8, panel_h, border_clr);
+
+    /* Title */
+    {
+        const char *title;
+        if (g_state.search_focused)
+            title = " Search QSOs ";
+        else if (g_state.qso_list_focused)
+            title = " Recent QSOs (focused) ";
+        else
+            title = " Recent QSOs ";
+        DrawText_A_BG(hdc, pad, y_start, border_clr, CLR_BG, title);
+    }
+
+    int y = y_start + 4;
+
+    /* Search bar (if search focused) */
+    if (g_state.search_focused) {
+        DrawText_A(hdc, pad + cw, y + 1, CLR_CYAN, "Search:");
+        DrawField(hdc, pad + cw + 8 * cw, y, 30,
+                  g_state.search_text, g_state.search_cursor, 1, cw, ch);
+        y += row_h + 2;
+    }
+
+    /* Table header */
+    {
+        char hdr[256];
+        _snprintf(hdr, sizeof(hdr),
+                  "%-19s %-10s %-5s %-5s %-4s %-4s %-16s %-6s",
+                  "UTC", "Callsign", "Band", "Mode",
+                  "RST\x18", "RST\x19", "Country", "Grid");
+        SelectObject(hdc, g_state.hFontBold);
+        DrawText_A(hdc, pad + cw, y + 1, CLR_HIGHLIGHT, hdr);
+        SelectObject(hdc, g_state.hFont);
+        y += row_h;
+        DrawHLine(hdc, pad, w - pad, y, CLR_DARKGRAY);
+        y += 2;
+    }
+
+    /* Rows */
+    int max_rows = (y_start + panel_h - y) / row_h;
+    if (max_rows < 1) max_rows = 1;
+
+    /* Adjust scroll to keep selection visible */
+    if (g_state.qso_selected >= 0) {
+        if (g_state.qso_selected < g_state.qso_scroll)
+            g_state.qso_scroll = g_state.qso_selected;
+        if (g_state.qso_selected >= g_state.qso_scroll + max_rows)
+            g_state.qso_scroll = g_state.qso_selected - max_rows + 1;
+    }
+    if (g_state.qso_scroll < 0) g_state.qso_scroll = 0;
+
+    for (int i = 0; i < max_rows && (g_state.qso_scroll + i) < g_state.recent_count; i++) {
+        int idx = g_state.qso_scroll + i;
+        RecentQso *q = &g_state.recent_qsos[idx];
+
+        /* Filter by search text */
+        if (g_state.search_text[0]) {
+            /* Simple case-insensitive substring match on callsign */
+            char upper_call[16], upper_search[64];
+            int j;
+            for (j = 0; q->callsign[j]; j++)
+                upper_call[j] = (char)toupper((unsigned char)q->callsign[j]);
+            upper_call[j] = 0;
+            for (j = 0; g_state.search_text[j]; j++)
+                upper_search[j] = (char)toupper((unsigned char)g_state.search_text[j]);
+            upper_search[j] = 0;
+            if (!strstr(upper_call, upper_search) &&
+                !strstr(q->country, g_state.search_text))
+                continue;
+        }
+
+        int selected = (idx == g_state.qso_selected) && g_state.qso_list_focused;
+
+        char row[256];
+        _snprintf(row, sizeof(row),
+                  "%-19s %-10s %-5s %-5s %-4s %-4s %-16s %-6s",
+                  q->utc, q->callsign, q->band, q->mode,
+                  q->rst_sent, q->rst_rcvd, q->country, q->grid);
+
+        if (selected) {
+            FillRect_Color(hdc, pad, y, w - pad * 2, row_h, CLR_HIGHLIGHT);
+            DrawText_A_BG(hdc, pad + cw, y + 2, CLR_HILITE_FG, CLR_HIGHLIGHT, row);
+        } else {
+            /* Callsign in bold, rest in normal text */
+            char utc_part[24];
+            _snprintf(utc_part, sizeof(utc_part), "%-19s ", q->utc);
+            DrawText_A(hdc, pad + cw, y + 2, CLR_TEXT, utc_part);
+
+            int call_x = pad + cw + 20 * cw;
+            char call_part[16];
+            _snprintf(call_part, sizeof(call_part), "%-10s ", q->callsign);
+            SelectObject(hdc, g_state.hFontBold);
+            DrawText_A(hdc, call_x, y + 2, CLR_HIGHLIGHT, call_part);
+            SelectObject(hdc, g_state.hFont);
+
+            int rest_x = call_x + 11 * cw;
+            char rest_part[128];
+            _snprintf(rest_part, sizeof(rest_part),
+                      "%-5s %-5s %-4s %-4s %-16s %-6s",
+                      q->band, q->mode, q->rst_sent, q->rst_rcvd,
+                      q->country, q->grid);
+            DrawText_A(hdc, rest_x, y + 2, CLR_TEXT, rest_part);
+        }
+
+        y += row_h;
+    }
+
+    if (g_state.recent_count == 0) {
+        DrawText_A(hdc, pad + cw, y + 2, CLR_DARKGRAY, "No QSOs logged yet");
+    }
+
+    return y_start + panel_h;
+}
+
+/* ── Drawing: Footer ───────────────────────────────────────────────────── */
+
+static void PaintFooter(HDC hdc, int y, int w)
+{
+    int cw = g_state.char_w;
+    int ch = g_state.char_h;
+    int bar_h = ch + 4;
+
+    FillRect_Color(hdc, 0, y, w, bar_h, CLR_BG);
+    DrawHLine(hdc, 0, w, y, CLR_CYAN);
+
+    int x = cw;
+    y += 2;
+
+    const char *shortcuts[] = {
+        "Ctrl+Q Quit", "F1 Help", "F2 Advanced", "F10 Log", "Tab Next",
+        "F3 List", "F4 Search", "F7 Timer", NULL
+    };
+    for (int i = 0; shortcuts[i]; i++) {
+        DrawChip(hdc, x, y, CLR_FOOTER_BG, CLR_FOOTER_FG, shortcuts[i], cw, ch);
+        x += (int)strlen(shortcuts[i]) * cw + 14;
+        if (x > w - 10 * cw) break;
+    }
+}
+
+/* ── Drawing: Help overlay ─────────────────────────────────────────────── */
+
+static void PaintHelp(HDC hdc, int w, int h)
+{
+    int cw = g_state.char_w;
+    int ch = g_state.char_h;
+
+    /* Semi-transparent overlay (approximate with dark fill) */
+    int ow = cw * 52;
+    int oh = ch * 24;
+    int ox = (w - ow) / 2;
+    int oy = (h - oh) / 2;
+
+    FillRect_Color(hdc, ox, oy, ow, oh, CLR_BG);
+    DrawBox(hdc, ox, oy, ow, oh, CLR_YELLOW);
+
+    SelectObject(hdc, g_state.hFontBold);
+    DrawText_A(hdc, ox + cw * 2, oy + ch, CLR_YELLOW, "QsoRipper Help");
+    SelectObject(hdc, g_state.hFont);
+
+    int y = oy + ch * 3;
+    const char *lines[] = {
+        "Ctrl+Q          Quit application",
+        "F1              Toggle this help",
+        "F2              Toggle advanced view",
+        "F3              Toggle QSO list focus",
+        "F4              Toggle search",
+        "F7              Reset QSO timer",
+        "F5 / F6         Adv tab next/prev",
+        "F10 / Alt+Enter Log QSO (or update)",
+        "Tab / Shift+Tab Navigate fields",
+        "Left / Right    Cycle Band/Mode",
+        "Esc             Clear form / exit focus",
+        "Backspace       Delete character",
+        "Alt+C/B/M/S/R   Jump to field",
+        "Alt+O/N/F/D/T   Jump to field",
+        "Up / Down       Navigate QSO list",
+        "Enter           Load selected QSO",
+        "D / Delete      Delete selected QSO",
+        "",
+        "      Press F1 or Esc to close",
+        NULL
+    };
+    for (int i = 0; lines[i]; i++) {
+        DrawText_A(hdc, ox + cw * 2, y, CLR_GRAY, lines[i]);
+        y += ch + 2;
+    }
+}
+
+/* ── Drawing: Delete confirmation dialog ───────────────────────────────── */
+
+static void PaintConfirmDelete(HDC hdc, int w, int h)
+{
+    int cw = g_state.char_w;
+    int ch = g_state.char_h;
+
+    int ow = cw * 40;
+    int oh = ch * 8;
+    int ox = (w - ow) / 2;
+    int oy = (h - oh) / 2;
+
+    FillRect_Color(hdc, ox, oy, ow, oh, RGB(40, 0, 0));
+    DrawBox(hdc, ox, oy, ow, oh, CLR_RED);
+
+    SelectObject(hdc, g_state.hFontBold);
+    DrawText_A(hdc, ox + cw * 2, oy + ch, CLR_RED, "Delete QSO?");
+    SelectObject(hdc, g_state.hFont);
+
+    if (g_state.qso_selected >= 0 && g_state.qso_selected < g_state.recent_count) {
+        char msg[128];
+        _snprintf(msg, sizeof(msg), "Delete QSO with %s?",
+                  g_state.recent_qsos[g_state.qso_selected].callsign);
+        DrawText_A(hdc, ox + cw * 2, oy + ch * 3, CLR_WHITE, msg);
+    }
+
+    DrawText_A(hdc, ox + cw * 2, oy + ch * 5, CLR_GRAY,
+               "Y = confirm   N/Esc = cancel");
+}
+
+/* ── Main paint routine (double-buffered) ──────────────────────────────── */
+
+static void PaintAll(HWND hwnd, HDC hdc_screen, RECT *rc)
+{
+    int w = rc->right - rc->left;
+    int h = rc->bottom - rc->top;
+    int ch = g_state.char_h;
+
+    /* Create back buffer */
+    HDC hdc = CreateCompatibleDC(hdc_screen);
+    HBITMAP hbm = CreateCompatibleBitmap(hdc_screen, w, h);
+    HBITMAP oldBm = (HBITMAP)SelectObject(hdc, hbm);
+    HFONT oldFont = (HFONT)SelectObject(hdc, g_state.hFont);
+
+    /* Clear background */
+    FillRect_Color(hdc, 0, 0, w, h, CLR_BG);
+
+    int y = 0;
+
+    /* Header (3 rows) */
+    PaintHeader(hdc, rc);
+    y = ch * 3 + 4;
+
+    /* Status bar */
+    y = PaintStatus(hdc, y, w);
+
+    /* Log form */
+    if (g_state.advanced_view)
+        y = PaintAdvancedForm(hdc, y, w);
+    else
+        y = PaintLogForm(hdc, y, w);
+    y += 2;
+
+    /* Lookup panel */
+    y = PaintLookup(hdc, y, w);
+    y += 2;
+
+    /* Footer position */
+    int footer_y = h - ch - 6;
+
+    /* Recent QSOs (fill between lookup and footer) */
+    PaintRecentQsos(hdc, y, w, footer_y);
+
+    /* Footer */
+    PaintFooter(hdc, footer_y, w);
+
+    /* Overlays */
+    if (g_state.help_visible) {
+        PaintHelp(hdc, w, h);
+    }
+    if (g_state.confirm_delete_visible) {
+        PaintConfirmDelete(hdc, w, h);
+    }
+
+    /* Blit to screen */
+    BitBlt(hdc_screen, 0, 0, w, h, hdc, 0, 0, SRCCOPY);
+
+    SelectObject(hdc, oldFont);
+    SelectObject(hdc, oldBm);
+    DeleteObject(hbm);
+    DeleteDC(hdc);
+
+    (void)hwnd;
+}
+
+/* ── Keyboard: field editing ───────────────────────────────────────────── */
+
+static void InsertChar(enum Field f, char c)
+{
+    char *buf = FieldBuffer(f);
+    if (!buf) return;
+    int maxlen = FieldMaxLen(f);
+    int len = (int)strlen(buf);
+    if (len >= maxlen - 1) return;
+
+    int pos = g_state.cursor_pos[f];
+    if (pos > len) pos = len;
+
+    /* Shift right */
+    memmove(buf + pos + 1, buf + pos, (size_t)(len - pos + 1));
+    buf[pos] = c;
+    g_state.cursor_pos[f] = pos + 1;
+
+    /* Auto-uppercase callsign */
+    if (f == FIELD_CALLSIGN) {
+        for (int i = 0; buf[i]; i++)
+            buf[i] = (char)toupper((unsigned char)buf[i]);
+    }
+}
+
+static void DeleteChar(enum Field f)
+{
+    char *buf = FieldBuffer(f);
+    if (!buf) return;
+    int pos = g_state.cursor_pos[f];
+    if (pos <= 0) return;
+    int len = (int)strlen(buf);
+    memmove(buf + pos - 1, buf + pos, (size_t)(len - pos + 1));
+    g_state.cursor_pos[f] = pos - 1;
+}
+
+/* ── Keyboard: Band/Mode type-select ───────────────────────────────────── */
+
+static void TypeSelectBand(char c)
+{
+    c = (char)toupper((unsigned char)c);
+    /* Find next band starting with this char after current */
+    for (int attempt = 0; attempt < NUM_BANDS; attempt++) {
+        int idx = (g_state.band_idx + 1 + attempt) % NUM_BANDS;
+        if (toupper((unsigned char)BANDS[idx][0]) == c ||
+            (c >= '0' && c <= '9' && BANDS[idx][0] == c)) {
+            g_state.band_idx = idx;
+            _snprintf(g_state.freq_mhz, sizeof(g_state.freq_mhz),
+                      "%.3f", BAND_DEFAULT_FREQS[idx]);
+            g_state.cursor_pos[FIELD_FREQ] = (int)strlen(g_state.freq_mhz);
+            return;
+        }
+    }
+}
+
+static void TypeSelectMode(char c)
+{
+    c = (char)toupper((unsigned char)c);
+    for (int attempt = 0; attempt < NUM_MODES; attempt++) {
+        int idx = (g_state.mode_idx + 1 + attempt) % NUM_MODES;
+        if (toupper((unsigned char)MODES[idx][0]) == c) {
+            g_state.mode_idx = idx;
+            return;
+        }
+    }
+}
+
+/* ── Keyboard: main handler ────────────────────────────────────────────── */
+
+static void OnKeyDown(HWND hwnd, WPARAM vk, LPARAM lp)
+{
+    int alt_down = (GetKeyState(VK_MENU) & 0x8000) != 0;
+    int ctrl_down = (GetKeyState(VK_CONTROL) & 0x8000) != 0;
+    int shift_down = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
+
+    (void)lp;
+
+    /* ── Confirm delete dialog ───────────────────────────────────── */
+    if (g_state.confirm_delete_visible) {
+        if (vk == 'Y') {
+            DeleteSelectedQso();
+        } else {
+            g_state.confirm_delete_visible = 0;
+        }
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* ── Help overlay ────────────────────────────────────────────── */
+    if (g_state.help_visible) {
+        if (vk == VK_F1 || vk == VK_ESCAPE) {
+            g_state.help_visible = 0;
+            InvalidateRect(hwnd, NULL, FALSE);
+        }
+        return;
+    }
+
+    /* ── Global shortcuts ────────────────────────────────────────── */
+
+    /* Ctrl+Q: quit */
+    if (ctrl_down && vk == 'Q') {
+        PostQuitMessage(0);
+        return;
+    }
+
+    /* F1: help */
+    if (vk == VK_F1) {
+        g_state.help_visible = !g_state.help_visible;
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* F2: toggle advanced view */
+    if (vk == VK_F2) {
+        g_state.advanced_view = !g_state.advanced_view;
+        if (g_state.advanced_view) {
+            /* Keep field if it exists in current tab, else focus first */
+            if (AdvTabFieldIndex(g_state.advanced_tab,
+                                 g_state.focused_field) < 0) {
+                int cnt;
+                const enum Field *flds =
+                    AdvTabFields(g_state.advanced_tab, &cnt);
+                g_state.focused_field = flds[0];
+            }
+        } else {
+            /* Return to basic: ensure field is in basic range */
+            if (g_state.focused_field > FIELD_TIME)
+                g_state.focused_field = FIELD_CALLSIGN;
+        }
+        g_state.qso_list_focused = 0;
+        g_state.search_focused = 0;
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* F5: next advanced tab */
+    if (vk == VK_F5 && g_state.advanced_view) {
+        int cnt;
+        const enum Field *flds;
+        g_state.advanced_tab = (g_state.advanced_tab + 1) % ADV_TAB_COUNT;
+        flds = AdvTabFields(g_state.advanced_tab, &cnt);
+        g_state.focused_field = flds[0];
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* F6: previous advanced tab */
+    if (vk == VK_F6 && g_state.advanced_view) {
+        int cnt;
+        const enum Field *flds;
+        g_state.advanced_tab =
+            (g_state.advanced_tab + ADV_TAB_COUNT - 1) % ADV_TAB_COUNT;
+        flds = AdvTabFields(g_state.advanced_tab, &cnt);
+        g_state.focused_field = flds[0];
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* F3: toggle QSO list focus */
+    if (vk == VK_F3) {
+        g_state.search_focused = 0;
+        g_state.qso_list_focused = !g_state.qso_list_focused;
+        if (g_state.qso_list_focused && g_state.qso_selected < 0 &&
+            g_state.recent_count > 0) {
+            g_state.qso_selected = 0;
+        }
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* F4: toggle search */
+    if (vk == VK_F4) {
+        g_state.search_focused = !g_state.search_focused;
+        if (g_state.search_focused) {
+            g_state.qso_list_focused = 1;
+        }
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* F7: reset QSO timer */
+    if (vk == VK_F7) {
+        g_state.qso_timer_active = 1;
+        g_state.qso_started_at = GetTickCount64();
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* F10 or Alt+Enter: log/update QSO */
+    if (vk == VK_F10 || (alt_down && vk == VK_RETURN)) {
+        LogQso();
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* ── Alt+key: jump to field ──────────────────────────────────── */
+    if (alt_down && !ctrl_down) {
+        enum Field target = FIELD_COUNT;
+        switch (vk) {
+        case 'C': target = FIELD_CALLSIGN; break;
+        case 'B': target = FIELD_BAND; break;
+        case 'M': target = FIELD_MODE; break;
+        case 'S': target = FIELD_RST_SENT; break;
+        case 'R': target = FIELD_RST_RCVD; break;
+        case 'O': target = FIELD_COMMENT; break;
+        case 'N': target = FIELD_NOTES; break;
+        case 'F': target = FIELD_FREQ; break;
+        case 'D': target = FIELD_DATE; break;
+        case 'T': target = FIELD_TIME; break;
+        }
+        if (target != FIELD_COUNT) {
+            g_state.focused_field = target;
+            g_state.qso_list_focused = 0;
+            g_state.search_focused = 0;
+            InvalidateRect(hwnd, NULL, FALSE);
+            return;
+        }
+    }
+
+    /* ── Search mode ─────────────────────────────────────────────── */
+    if (g_state.search_focused) {
+        if (vk == VK_ESCAPE) {
+            g_state.search_focused = 0;
+            g_state.search_text[0] = 0;
+            g_state.search_cursor = 0;
+            InvalidateRect(hwnd, NULL, FALSE);
+            return;
+        }
+        if (vk == VK_BACK) {
+            if (g_state.search_cursor > 0) {
+                int len = (int)strlen(g_state.search_text);
+                memmove(g_state.search_text + g_state.search_cursor - 1,
+                        g_state.search_text + g_state.search_cursor,
+                        (size_t)(len - g_state.search_cursor + 1));
+                g_state.search_cursor--;
+            }
+            InvalidateRect(hwnd, NULL, FALSE);
+            return;
+        }
+        if (vk == VK_LEFT) {
+            if (g_state.search_cursor > 0) g_state.search_cursor--;
+            InvalidateRect(hwnd, NULL, FALSE);
+            return;
+        }
+        if (vk == VK_RIGHT) {
+            if (g_state.search_cursor < (int)strlen(g_state.search_text))
+                g_state.search_cursor++;
+            InvalidateRect(hwnd, NULL, FALSE);
+            return;
+        }
+        /* Tab exits search to list */
+        if (vk == VK_TAB) {
+            g_state.search_focused = 0;
+            g_state.qso_list_focused = 1;
+            InvalidateRect(hwnd, NULL, FALSE);
+            return;
+        }
+        /* Other keys handled in OnChar */
+        return;
+    }
+
+    /* ── QSO list navigation ─────────────────────────────────────── */
+    if (g_state.qso_list_focused) {
+        if (vk == VK_ESCAPE) {
+            g_state.qso_list_focused = 0;
+            g_state.qso_selected = -1;
+            InvalidateRect(hwnd, NULL, FALSE);
+            return;
+        }
+        if (vk == VK_UP) {
+            if (g_state.qso_selected > 0)
+                g_state.qso_selected--;
+            else if (g_state.recent_count > 0)
+                g_state.qso_selected = 0;
+            InvalidateRect(hwnd, NULL, FALSE);
+            return;
+        }
+        if (vk == VK_DOWN) {
+            if (g_state.qso_selected < g_state.recent_count - 1)
+                g_state.qso_selected++;
+            InvalidateRect(hwnd, NULL, FALSE);
+            return;
+        }
+        if (vk == VK_RETURN) {
+            LoadSelectedQso();
+            InvalidateRect(hwnd, NULL, FALSE);
+            return;
+        }
+        if (vk == 'D' || vk == VK_DELETE) {
+            if (g_state.qso_selected >= 0) {
+                g_state.confirm_delete_visible = 1;
+                InvalidateRect(hwnd, NULL, FALSE);
+            }
+            return;
+        }
+        if (vk == VK_TAB) {
+            g_state.qso_list_focused = 0;
+            g_state.focused_field = FIELD_CALLSIGN;
+            InvalidateRect(hwnd, NULL, FALSE);
+            return;
+        }
+        return;
+    }
+
+    /* ── Form navigation ─────────────────────────────────────────── */
+
+    /* Escape: in advanced view return to basic, otherwise clear form */
+    if (vk == VK_ESCAPE) {
+        if (g_state.advanced_view) {
+            g_state.advanced_view = 0;
+            if (g_state.focused_field > FIELD_TIME)
+                g_state.focused_field = FIELD_CALLSIGN;
+        } else {
+            ClearForm();
+        }
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* Tab: next field */
+    if (vk == VK_TAB) {
+        if (g_state.advanced_view) {
+            /* Navigate within current tab's fields */
+            int cnt;
+            const enum Field *flds =
+                AdvTabFields(g_state.advanced_tab, &cnt);
+            int idx = AdvTabFieldIndex(g_state.advanced_tab,
+                                       g_state.focused_field);
+            if (idx < 0) idx = 0;
+            if (shift_down)
+                idx = (idx + cnt - 1) % cnt;
+            else
+                idx = (idx + 1) % cnt;
+            g_state.focused_field = flds[idx];
+        } else {
+            /* Basic view: cycle through basic fields only */
+            if (shift_down) {
+                if (g_state.focused_field > FIELD_CALLSIGN)
+                    g_state.focused_field =
+                        (enum Field)(g_state.focused_field - 1);
+                else
+                    g_state.focused_field = FIELD_TIME;
+            } else {
+                if (g_state.focused_field < FIELD_TIME)
+                    g_state.focused_field =
+                        (enum Field)(g_state.focused_field + 1);
+                else
+                    g_state.focused_field = FIELD_CALLSIGN;
+            }
+        }
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* Left/Right: cycle for band/mode, cursor move for text fields */
+    if (vk == VK_LEFT) {
+        if (g_state.focused_field == FIELD_BAND) {
+            g_state.band_idx = (g_state.band_idx + NUM_BANDS - 1) % NUM_BANDS;
+            _snprintf(g_state.freq_mhz, sizeof(g_state.freq_mhz),
+                      "%.3f", BAND_DEFAULT_FREQS[g_state.band_idx]);
+            g_state.cursor_pos[FIELD_FREQ] = (int)strlen(g_state.freq_mhz);
+        } else if (g_state.focused_field == FIELD_MODE) {
+            g_state.mode_idx = (g_state.mode_idx + NUM_MODES - 1) % NUM_MODES;
+        } else {
+            enum Field f = g_state.focused_field;
+            if (g_state.cursor_pos[f] > 0)
+                g_state.cursor_pos[f]--;
+        }
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+    if (vk == VK_RIGHT) {
+        if (g_state.focused_field == FIELD_BAND) {
+            g_state.band_idx = (g_state.band_idx + 1) % NUM_BANDS;
+            _snprintf(g_state.freq_mhz, sizeof(g_state.freq_mhz),
+                      "%.3f", BAND_DEFAULT_FREQS[g_state.band_idx]);
+            g_state.cursor_pos[FIELD_FREQ] = (int)strlen(g_state.freq_mhz);
+        } else if (g_state.focused_field == FIELD_MODE) {
+            g_state.mode_idx = (g_state.mode_idx + 1) % NUM_MODES;
+        } else {
+            enum Field f = g_state.focused_field;
+            char *buf = FieldBuffer(f);
+            if (buf && g_state.cursor_pos[f] < (int)strlen(buf))
+                g_state.cursor_pos[f]++;
+        }
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* Backspace */
+    if (vk == VK_BACK) {
+        enum Field f = g_state.focused_field;
+        if (f != FIELD_BAND && f != FIELD_MODE) {
+            DeleteChar(f);
+
+            /* Trigger lookup debounce if callsign changed */
+            if (f == FIELD_CALLSIGN) {
+                g_state.last_callsign_change = GetTickCount64();
+            }
+        }
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* Home / End */
+    if (vk == VK_HOME) {
+        g_state.cursor_pos[g_state.focused_field] = 0;
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+    if (vk == VK_END) {
+        char *buf = FieldBuffer(g_state.focused_field);
+        if (buf)
+            g_state.cursor_pos[g_state.focused_field] = (int)strlen(buf);
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+}
+
+/* ── Character input ───────────────────────────────────────────────────── */
+
+static void OnChar(HWND hwnd, WPARAM ch)
+{
+    /* Filter control characters */
+    if (ch < 32 || ch == 127) return;
+
+    /* Search mode */
+    if (g_state.search_focused) {
+        int len = (int)strlen(g_state.search_text);
+        if (len < (int)sizeof(g_state.search_text) - 1) {
+            int pos = g_state.search_cursor;
+            memmove(g_state.search_text + pos + 1,
+                    g_state.search_text + pos,
+                    (size_t)(len - pos + 1));
+            g_state.search_text[pos] = (char)ch;
+            g_state.search_cursor++;
+        }
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* QSO list: should not receive chars normally */
+    if (g_state.qso_list_focused) return;
+
+    /* Band/Mode: type-select */
+    if (g_state.focused_field == FIELD_BAND) {
+        TypeSelectBand((char)ch);
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+    if (g_state.focused_field == FIELD_MODE) {
+        TypeSelectMode((char)ch);
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    /* Normal field input */
+    InsertChar(g_state.focused_field, (char)ch);
+
+    /* Start QSO timer on first callsign character */
+    if (g_state.focused_field == FIELD_CALLSIGN && !g_state.qso_timer_active) {
+        g_state.qso_timer_active = 1;
+        g_state.qso_started_at = GetTickCount64();
+    }
+
+    /* Callsign lookup debounce */
+    if (g_state.focused_field == FIELD_CALLSIGN) {
+        g_state.last_callsign_change = GetTickCount64();
+    }
+
+    InvalidateRect(hwnd, NULL, FALSE);
+}
+
+/* ── Timer tick ────────────────────────────────────────────────────────── */
+
+static void OnTimer(HWND hwnd)
+{
+    /* Check callsign lookup debounce */
+    if (g_state.last_callsign_change > 0 &&
+        g_state.callsign[0] != 0 &&
+        strlen(g_state.callsign) >= 3) {
+        ULONGLONG elapsed = GetTickCount64() - g_state.last_callsign_change;
+        if (elapsed >= LOOKUP_DEBOUNCE_MS) {
+            if (_stricmp(g_state.callsign, g_state.last_looked_up) != 0) {
+                LookupCallsign(g_state.callsign);
+            }
+            g_state.last_callsign_change = 0;
+        }
+    }
+
+    InvalidateRect(hwnd, NULL, FALSE);
+}
+
+/* ── Window procedure ──────────────────────────────────────────────────── */
+
+static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+    switch (msg) {
+    case WM_CREATE:
+    {
+        /* Create fonts */
+        HDC hdc = GetDC(hwnd);
+        int dpi = GetDeviceCaps(hdc, LOGPIXELSY);
+        int fontHeight = -MulDiv(FONT_SIZE, dpi, 72);
+
+        g_state.hFont = CreateFontW(
+            fontHeight, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE,
+            DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+            CLEARTYPE_QUALITY, FIXED_PITCH | FF_MODERN, FONT_NAME);
+
+        g_state.hFontBold = CreateFontW(
+            fontHeight, 0, 0, 0, FW_BOLD, FALSE, FALSE, FALSE,
+            DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS,
+            CLEARTYPE_QUALITY, FIXED_PITCH | FF_MODERN, FONT_NAME);
+
+        /* Measure character size */
+        HFONT old = (HFONT)SelectObject(hdc, g_state.hFont);
+        TEXTMETRICW tm;
+        GetTextMetricsW(hdc, &tm);
+        g_state.char_w = tm.tmAveCharWidth;
+        g_state.char_h = tm.tmHeight;
+        SelectObject(hdc, old);
+        ReleaseDC(hwnd, hdc);
+
+        g_state.hwnd = hwnd;
+
+        /* Start timer */
+        SetTimer(hwnd, TIMER_ID, TIMER_MS, NULL);
+
+        /* Initial data load (async-ish — runs synchronously but fast) */
+        RefreshQsoList();
+        FetchSpaceWeather();
+        break;
+    }
+
+    case WM_DESTROY:
+        KillTimer(hwnd, TIMER_ID);
+        if (g_state.hFont) DeleteObject(g_state.hFont);
+        if (g_state.hFontBold) DeleteObject(g_state.hFontBold);
+        PostQuitMessage(0);
+        break;
+
+    case WM_ERASEBKGND:
+        return 1; /* Prevent flicker — we paint everything */
+
+    case WM_PAINT:
+    {
+        PAINTSTRUCT ps;
+        HDC hdc = BeginPaint(hwnd, &ps);
+        RECT rc;
+        GetClientRect(hwnd, &rc);
+        PaintAll(hwnd, hdc, &rc);
+        EndPaint(hwnd, &ps);
+        break;
+    }
+
+    case WM_SIZE:
+        InvalidateRect(hwnd, NULL, FALSE);
+        break;
+
+    case WM_TIMER:
+        if (wParam == TIMER_ID)
+            OnTimer(hwnd);
+        break;
+
+    case WM_KEYDOWN:
+        OnKeyDown(hwnd, wParam, lParam);
+        break;
+
+    case WM_CHAR:
+        OnChar(hwnd, wParam);
+        break;
+
+    case WM_SYSKEYDOWN:
+        /* Handle Alt+key combinations */
+        OnKeyDown(hwnd, wParam, lParam);
+        /* Return 0 to prevent the default system menu behavior */
+        return 0;
+
+    case WM_SYSCHAR:
+        /* Eat Alt+char to prevent system menu beep */
+        return 0;
+
+    case WM_MOUSEWHEEL:
+        if (g_state.qso_list_focused) {
+            int delta = GET_WHEEL_DELTA_WPARAM(wParam);
+            if (delta > 0 && g_state.qso_selected > 0)
+                g_state.qso_selected--;
+            else if (delta < 0 && g_state.qso_selected < g_state.recent_count - 1)
+                g_state.qso_selected++;
+            InvalidateRect(hwnd, NULL, FALSE);
+        }
+        break;
+
+    case WM_GETMINMAXINFO:
+    {
+        MINMAXINFO *mmi = (MINMAXINFO *)lParam;
+        mmi->ptMinTrackSize.x = 800;
+        mmi->ptMinTrackSize.y = 600;
+        break;
+    }
+
+    default:
+        return DefWindowProcW(hwnd, msg, wParam, lParam);
+    }
+    return 0;
+}
+
+/* ── Entry point ───────────────────────────────────────────────────────── */
+
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
+                    LPWSTR lpCmdLine, int nCmdShow)
+{
+    (void)hPrevInstance;
+    (void)lpCmdLine;
+
+    /* Initialize common controls (for visual styles if needed) */
+    INITCOMMONCONTROLSEX icc = { sizeof(icc), ICC_STANDARD_CLASSES };
+    InitCommonControlsEx(&icc);
+
+    /* Initialize app state */
+    InitState();
+    FindCliPath();
+
+    /* Register window class */
+    WNDCLASSEXW wc = {0};
+    wc.cbSize        = sizeof(wc);
+    wc.style         = CS_HREDRAW | CS_VREDRAW;
+    wc.lpfnWndProc   = WndProc;
+    wc.hInstance      = hInstance;
+    wc.hCursor       = LoadCursor(NULL, IDC_ARROW);
+    wc.hbrBackground = NULL; /* We handle all painting */
+    wc.lpszClassName = WINDOW_CLASS;
+    wc.hIcon         = LoadIcon(NULL, IDI_APPLICATION);
+    wc.hIconSm       = LoadIcon(NULL, IDI_APPLICATION);
+
+    if (!RegisterClassExW(&wc)) {
+        MessageBoxW(NULL, L"Failed to register window class",
+                    APP_TITLE, MB_ICONERROR);
+        return 1;
+    }
+
+    /* Calculate initial window size: 100 cols x 45 rows equivalent */
+    int init_w = 1100;
+    int init_h = 780;
+
+    HWND hwnd = CreateWindowExW(
+        0, WINDOW_CLASS, APP_TITLE,
+        WS_OVERLAPPEDWINDOW | WS_CLIPCHILDREN,
+        CW_USEDEFAULT, CW_USEDEFAULT, init_w, init_h,
+        NULL, NULL, hInstance, NULL);
+
+    if (!hwnd) {
+        MessageBoxW(NULL, L"Failed to create window",
+                    APP_TITLE, MB_ICONERROR);
+        return 1;
+    }
+
+    ShowWindow(hwnd, nCmdShow);
+    UpdateWindow(hwnd);
+
+    /* Message loop */
+    MSG msg;
+    while (GetMessageW(&msg, NULL, 0, 0)) {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    return (int)msg.wParam;
+}


### PR DESCRIPTION
## Summary

A single-file (~2500 lines) pure Win32 GDI application that replicates the Rust TUI's QSO logging functionality with a classic Windows 2000 visual style. Zero external dependencies beyond the Windows SDK.

## What's included

### UI
- **Basic view**: Callsign, Band, Mode, RST, Comment, Notes, Frequency, Date, Time, QSO Duration
- **Advanced view** (F2): 4 tabs — Main, Contest, Technical, Awards — with 17 additional fields
- **Header bar**: App title, space weather (K-index/SFI/sunspots), live UTC clock
- **Lookup panel**: QRZ callsign info (name, QTH, grid, CQ zone, country)
- **Recent QSOs table**: Scrollable, selectable, with search (F4)
- **Help overlay** (F1) and delete confirmation dialog

### Keyboard shortcuts (all TUI shortcuts work)
Ctrl+Q quit, F1 help, F2 advanced, F3 QSO list, F4 search, F5/F6 tabs, F7 reset timer, F10 log QSO, Tab/Shift+Tab navigate, Left/Right cycle band/mode, Alt+letter field jumps, type-select for band/mode

### Win2K classic theme
Light gray background, white fields with 3D sunken borders, navy header and selection highlights, black labels

### Build integration
- `.\build.ps1 win32` builds the Win32 app
- `.\build.ps1` now builds Rust + .NET + Win32
- Auto-detects `vcvarsall.bat` with workaround for vswhere registration issues
- Compiles clean with `/W4 /WX`

### CLI integration
Auto-discovers `QsoRipper.Cli.exe` relative to its own path (sibling under `artifacts\publish\`). Falls back to `QSORIPPER_CLI_PATH` env var.

## Files changed

| File | Lines | Description |
|------|-------|-------------|
| `src/c/qsoripper-win32/src/main.c` | +2496 | Complete Win32 GUI application |
| `src/c/qsoripper-win32/CMakeLists.txt` | +17 | CMake build file |
| `build.ps1` | +55/-2 | Win32 build command + vcvarsall workaround |