### PR TITLE
Load all QSOs in TUI instead of last 20

### DIFF
--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -85,7 +85,7 @@ async fn run<B: ratatui::backend::Backend>(
         let ep = app.endpoint.clone();
         tokio::spawn(async move {
             if let Ok(ch) = grpc::create_channel(&ep).await {
-                if let Ok(qsos) = grpc::list_recent_qsos(ch, 20).await {
+                if let Ok(qsos) = grpc::list_recent_qsos(ch, 0).await {
                     let _ = tx.send(AppEvent::RecentQsos(qsos));
                 }
             }
@@ -196,10 +196,12 @@ fn handle_event(
                 }
             }
             // Enrich QSOs that have no operator name from the lookup cache.
+            // Cap to the first 50 to avoid flooding the engine with lookups.
             let unnamed: Vec<(String, String)> = app
                 .recent_qsos
                 .iter()
                 .filter(|q| q.name.is_none())
+                .take(50)
                 .map(|q| (q.local_id.clone(), q.callsign.clone()))
                 .collect();
             if !unnamed.is_empty() {
@@ -697,7 +699,7 @@ fn refresh_recent_qsos(event_tx: &mpsc::UnboundedSender<AppEvent>, endpoint: &st
     let ep = endpoint.to_string();
     tokio::spawn(async move {
         if let Ok(ch) = grpc::create_channel(&ep).await {
-            if let Ok(qsos) = grpc::list_recent_qsos(ch, 20).await {
+            if let Ok(qsos) = grpc::list_recent_qsos(ch, 0).await {
                 let _ = tx.send(AppEvent::RecentQsos(qsos));
             }
         }


### PR DESCRIPTION
## Summary

Removes the hardcoded limit of 20 from TUI QSO list loading, so the full logbook is available for scrolling and searching.

## Changes

- `list_recent_qsos(ch, 20)` → `list_recent_qsos(ch, 0)` at both call sites (startup prefetch and post-log refresh)
- Name enrichment capped to first 50 unnamed QSOs to avoid flooding the engine with individual lookups on large logs

## Why this is safe

- `limit: 0` already means "no limit" in the proto/engine/storage layers
- `App.recent_qsos` is a `Vec<RecentQso>` (dynamic), not a fixed array
- ~1200 QSOs ≈ 240KB — trivial memory
- TUI already has virtual scrolling (only visible rows are rendered)
- SQLite query is indexed by timestamp, returns in <10ms

The Win32 app equivalent change will come in a follow-up (requires dynamic allocation refactor).