### PR TITLE
GUI overhaul: callsign card, color grid, dark theme, delete QSO

### DIFF
--- a/scripts/automation/avalonia-callsign-card.json
+++ b/scripts/automation/avalonia-callsign-card.json
@@ -1,0 +1,57 @@
+{
+  "inspectSurface": "MainWindow",
+  "window": {
+    "title": "QsoRipper",
+    "x": 80,
+    "y": 80,
+    "width": 1280,
+    "height": 760
+  },
+  "actions": [
+    {
+      "type": "wait",
+      "milliseconds": 600
+    },
+    {
+      "type": "screenshot",
+      "path": "callsign-card-before.png"
+    },
+    {
+      "type": "click",
+      "name": "W1AW",
+      "controlType": "Text"
+    },
+    {
+      "type": "wait",
+      "milliseconds": 300
+    },
+    {
+      "type": "screenshot",
+      "path": "callsign-card-row-selected.png"
+    },
+    {
+      "type": "send-keys",
+      "keys": "{F8}"
+    },
+    {
+      "type": "wait",
+      "milliseconds": 1500
+    },
+    {
+      "type": "screenshot",
+      "path": "callsign-card-open.png"
+    },
+    {
+      "type": "send-keys",
+      "keys": "{ESC}"
+    },
+    {
+      "type": "wait",
+      "milliseconds": 500
+    },
+    {
+      "type": "screenshot",
+      "path": "callsign-card-closed.png"
+    }
+  ]
+}

--- a/scripts/automation/avalonia-cell-select-test.json
+++ b/scripts/automation/avalonia-cell-select-test.json
@@ -1,0 +1,43 @@
+{
+  "inspectSurface": "MainWindow",
+  "window": {
+    "title": "QsoRipper",
+    "x": 80,
+    "y": 80,
+    "width": 1280,
+    "height": 760
+  },
+  "actions": [
+    { "type": "wait", "milliseconds": 800 },
+    { "type": "screenshot", "path": "cell-select-before.png" },
+
+    {
+      "comment": "Click a cell in the Name column to select it",
+      "type": "click",
+      "name": "ARRL HQ",
+      "controlType": "Text"
+    },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "cell-select-after.png" },
+
+    {
+      "comment": "Click a different cell in Country column",
+      "type": "click",
+      "name": "Canada",
+      "controlType": "Text"
+    },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "cell-select-country.png" },
+
+    {
+      "comment": "Click a cell in UTC column",
+      "type": "click",
+      "name": "26-04-13 22:12",
+      "controlType": "Edit"
+    },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "cell-select-utc.png" },
+
+    { "type": "dump-tree", "path": "cell-select-tree.json" }
+  ]
+}

--- a/scripts/automation/avalonia-cell-tree-dump.json
+++ b/scripts/automation/avalonia-cell-tree-dump.json
@@ -1,0 +1,22 @@
+{
+  "inspectSurface": "MainWindow",
+  "window": {
+    "title": "QsoRipper",
+    "x": 80,
+    "y": 80,
+    "width": 1280,
+    "height": 760
+  },
+  "actions": [
+    { "type": "wait", "milliseconds": 800 },
+    {
+      "comment": "Click the Name cell in first row to select it",
+      "type": "click",
+      "name": "ARRL HQ",
+      "controlType": "Text"
+    },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "dump-tree", "path": "cell-tree.json" },
+    { "type": "screenshot", "path": "cell-selected.png" }
+  ]
+}

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
@@ -412,5 +412,11 @@ public class RecentQsoListViewModelTests
 
         public Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default) =>
             Task.FromResult(new GetSyncStatusResponse());
+
+        public Task<LookupResponse> LookupCallsignAsync(string callsign, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<DeleteQsoResponse> DeleteQsoAsync(string localId, bool deleteFromQrz = false, CancellationToken ct = default) =>
+            throw new NotImplementedException();
     }
 }

--- a/src/dotnet/QsoRipper.Gui/App.axaml
+++ b/src/dotnet/QsoRipper.Gui/App.axaml
@@ -1,9 +1,24 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="QsoRipper.Gui.App"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Dark">
   <Application.Styles>
     <FluentTheme />
     <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
   </Application.Styles>
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.ThemeDictionaries>
+        <ResourceDictionary x:Key="Dark">
+          <!-- Accent color: QsoRipper cyan -->
+          <Color x:Key="SystemAccentColor">#0096D6</Color>
+          <Color x:Key="SystemAccentColorDark1">#0078AB</Color>
+          <Color x:Key="SystemAccentColorDark2">#005A80</Color>
+          <Color x:Key="SystemAccentColorLight1">#33AADD</Color>
+          <Color x:Key="SystemAccentColorLight2">#66C0E8</Color>
+          <Color x:Key="SystemAccentColorLight3">#99D6F2</Color>
+        </ResourceDictionary>
+      </ResourceDictionary.ThemeDictionaries>
+    </ResourceDictionary>
+  </Application.Resources>
 </Application>

--- a/src/dotnet/QsoRipper.Gui/App.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/App.axaml.cs
@@ -22,7 +22,9 @@ internal sealed partial class App : Application
             if (Program.CaptureOptions is { } captureOptions)
             {
                 RequestedThemeVariant = captureOptions.ThemeVariant;
-                desktop.MainWindow = UxCaptureRunner.CreateWindow(desktop, captureOptions);
+                desktop.MainWindow = captureOptions.Scenario.StartsWith("diag-", StringComparison.Ordinal)
+                    ? Views.ButtonClipTestWindow.CreateForCapture(desktop, captureOptions)
+                    : UxCaptureRunner.CreateWindow(desktop, captureOptions);
             }
             else if (Program.InspectionOptions is { } inspectionOptions)
             {

--- a/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
@@ -334,6 +334,66 @@ internal sealed class UxFixtureEngineClient : IEngineClient
         }
     }
 
+    public Task<LookupResponse> LookupCallsignAsync(string callsign, CancellationToken ct = default)
+    {
+        var record = new CallsignRecord
+        {
+            Callsign = callsign.ToUpperInvariant(),
+            FirstName = "Randy",
+            LastName = "Treit",
+            Nickname = "Randy",
+            FormattedName = "Randy Treit",
+            LicenseClass = "Extra",
+            Addr1 = "1234 Ham Radio Ln",
+            Addr2 = "Redmond",
+            State = "WA",
+            Zip = "98052",
+            Country = "United States",
+            GridSquare = "CN87",
+            County = "King",
+            Latitude = 47.6740,
+            Longitude = -122.1215,
+            Email = "fixture@example.com",
+            WebUrl = "https://www.qrz.com/db/" + callsign.ToUpperInvariant(),
+            CqZone = 3,
+            ItuZone = 2,
+            DxccCountryName = "United States",
+            DxccContinent = "NA",
+            Eqsl = QslPreference.Yes,
+            Lotw = QslPreference.Yes,
+            PaperQsl = QslPreference.No,
+            TimeZone = "America/Los_Angeles",
+        };
+
+        record.Aliases.Add("KD7BBJ");
+
+        var result = new LookupResult
+        {
+            State = LookupState.Found,
+            Record = record,
+            CacheHit = false,
+            LookupLatencyMs = 42,
+            QueriedCallsign = callsign,
+        };
+
+        return Task.FromResult(new LookupResponse { Result = result });
+    }
+
+    public Task<DeleteQsoResponse> DeleteQsoAsync(string localId, bool deleteFromQrz = false, CancellationToken ct = default)
+    {
+        lock (_gate)
+        {
+            var index = _recentQsos.FindIndex(item => string.Equals(item.LocalId, localId, StringComparison.Ordinal));
+            if (index < 0)
+            {
+                return Task.FromResult(new DeleteQsoResponse { Success = false, Error = "QSO not found." });
+            }
+
+            _recentQsos.RemoveAt(index);
+            return Task.FromResult(new DeleteQsoResponse { Success = true });
+        }
+    }
+
     private SetupStatus BuildSetupStatus()
     {
         var status = new SetupStatus

--- a/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
@@ -17,12 +17,14 @@ internal sealed class EngineGrpcService : IEngineClient, IDisposable
     private readonly GrpcChannel _channel;
     private readonly SetupService.SetupServiceClient _setupClient;
     private readonly LogbookService.LogbookServiceClient _logbookClient;
+    private readonly LookupService.LookupServiceClient _lookupClient;
 
     public EngineGrpcService(GrpcChannel channel)
     {
         _channel = channel;
         _setupClient = new SetupService.SetupServiceClient(channel);
         _logbookClient = new LogbookService.LogbookServiceClient(channel);
+        _lookupClient = new LookupService.LookupServiceClient(channel);
     }
 
     public async Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default)
@@ -136,6 +138,31 @@ internal sealed class EngineGrpcService : IEngineClient, IDisposable
     {
         return await _logbookClient.GetSyncStatusAsync(
             new GetSyncStatusRequest(), cancellationToken: ct);
+    }
+
+    public async Task<LookupResponse> LookupCallsignAsync(string callsign, CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(callsign);
+
+        return await _lookupClient.LookupAsync(
+            new LookupRequest { Callsign = callsign },
+            cancellationToken: ct);
+    }
+
+    public async Task<DeleteQsoResponse> DeleteQsoAsync(
+        string localId,
+        bool deleteFromQrz = false,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localId);
+
+        return await _logbookClient.DeleteQsoAsync(
+            new DeleteQsoRequest
+            {
+                LocalId = localId,
+                DeleteFromQrz = deleteFromQrz
+            },
+            cancellationToken: ct);
     }
 
     public void Dispose()

--- a/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
@@ -39,4 +39,8 @@ internal interface IEngineClient
     Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default);
 
     Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default);
+
+    Task<LookupResponse> LookupCallsignAsync(string callsign, CancellationToken ct = default);
+
+    Task<DeleteQsoResponse> DeleteQsoAsync(string localId, bool deleteFromQrz = false, CancellationToken ct = default);
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/CallsignCardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/CallsignCardViewModel.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Avalonia.Media.Imaging;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using QsoRipper.Domain;
+using QsoRipper.Gui.Services;
+
+namespace QsoRipper.Gui.ViewModels;
+
+internal sealed partial class CallsignCardViewModel : ObservableObject
+{
+    private static readonly HttpClient SharedHttpClient = new()
+    {
+        Timeout = TimeSpan.FromSeconds(10)
+    };
+
+    private readonly IEngineClient _engine;
+
+    [ObservableProperty]
+    private string _callsign = string.Empty;
+
+    [ObservableProperty]
+    private bool _isLoading;
+
+    [ObservableProperty]
+    private bool _isLoaded;
+
+    [ObservableProperty]
+    private bool _isError;
+
+    [ObservableProperty]
+    private string _errorMessage = string.Empty;
+
+    // Identity
+    [ObservableProperty]
+    private string _fullName = string.Empty;
+
+    [ObservableProperty]
+    private string _nickname = string.Empty;
+
+    [ObservableProperty]
+    private string _licenseClass = string.Empty;
+
+    // Location
+    [ObservableProperty]
+    private string _address = string.Empty;
+
+    [ObservableProperty]
+    private string _country = string.Empty;
+
+    [ObservableProperty]
+    private string _grid = string.Empty;
+
+    [ObservableProperty]
+    private string _county = string.Empty;
+
+    [ObservableProperty]
+    private string _state = string.Empty;
+
+    [ObservableProperty]
+    private string _timeZone = string.Empty;
+
+    // QRZ / Zones
+    [ObservableProperty]
+    private string _dxccCountry = string.Empty;
+
+    [ObservableProperty]
+    private string _dxccContinent = string.Empty;
+
+    [ObservableProperty]
+    private string _cqZone = string.Empty;
+
+    [ObservableProperty]
+    private string _ituZone = string.Empty;
+
+    [ObservableProperty]
+    private string _iota = string.Empty;
+
+    // QSL
+    [ObservableProperty]
+    private string _eqslStatus = string.Empty;
+
+    [ObservableProperty]
+    private string _lotwStatus = string.Empty;
+
+    [ObservableProperty]
+    private string _paperQslStatus = string.Empty;
+
+    [ObservableProperty]
+    private string _qslManager = string.Empty;
+
+    // Profile
+    [ObservableProperty]
+    private string? _imageUrl;
+
+    [ObservableProperty]
+    private Bitmap? _profileImage;
+
+    [ObservableProperty]
+    private string _webUrl = string.Empty;
+
+    [ObservableProperty]
+    private string _email = string.Empty;
+
+    [ObservableProperty]
+    private string _aliases = string.Empty;
+
+    [ObservableProperty]
+    private string _previousCall = string.Empty;
+
+    [ObservableProperty]
+    private bool _hasImage;
+
+    [ObservableProperty]
+    private string _latencyText = string.Empty;
+
+    public CallsignCardViewModel(IEngineClient engine)
+    {
+        _engine = engine;
+    }
+
+    // Computed
+    public bool HasNickname => !string.IsNullOrEmpty(Nickname);
+
+    public bool HasAliases => !string.IsNullOrEmpty(Aliases);
+
+    public bool HasPreviousCall => !string.IsNullOrEmpty(PreviousCall);
+
+    public bool HasQslManager => !string.IsNullOrEmpty(QslManager);
+
+    public bool HasIota => !string.IsNullOrEmpty(Iota);
+
+    public bool HasWebUrl => !string.IsNullOrEmpty(WebUrl);
+
+    public bool HasEmail => !string.IsNullOrEmpty(Email);
+
+    public bool HasCounty => !string.IsNullOrEmpty(County);
+
+    public bool HasTimeZone => !string.IsNullOrEmpty(TimeZone);
+
+    public async Task LoadAsync(string callsign)
+    {
+        Callsign = callsign.ToUpperInvariant();
+        IsLoading = true;
+        IsLoaded = false;
+        IsError = false;
+        ErrorMessage = string.Empty;
+        ProfileImage = null;
+        HasImage = false;
+
+        try
+        {
+            var response = await _engine.LookupCallsignAsync(callsign);
+            var result = response.Result;
+
+            if (result.State == LookupState.Found && result.Record is { } record)
+            {
+                MapRecord(record);
+                LatencyText = result.LookupLatencyMs > 0
+                    ? $"{result.LookupLatencyMs}ms{(result.CacheHit ? " (cached)" : string.Empty)}"
+                    : string.Empty;
+
+                if (!string.IsNullOrEmpty(record.ImageUrl))
+                {
+                    await LoadImageAsync(record.ImageUrl);
+                }
+
+                IsLoaded = true;
+            }
+            else if (result.State == LookupState.NotFound)
+            {
+                IsError = true;
+                ErrorMessage = $"Callsign '{callsign}' not found.";
+            }
+            else
+            {
+                IsError = true;
+                ErrorMessage = result.ErrorMessage ?? $"Lookup failed ({result.State}).";
+            }
+        }
+        catch (Grpc.Core.RpcException ex)
+        {
+            IsError = true;
+            ErrorMessage = $"Lookup error: {ex.Status.Detail}";
+        }
+        catch (InvalidOperationException ex)
+        {
+            IsError = true;
+            ErrorMessage = $"Lookup error: {ex.Message}";
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    [RelayCommand]
+    private void Close()
+    {
+        CloseRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    internal event EventHandler? CloseRequested;
+
+    private void MapRecord(CallsignRecord record)
+    {
+        Callsign = record.Callsign;
+        FullName = BuildFullName(record);
+        Nickname = record.Nickname ?? string.Empty;
+        LicenseClass = record.LicenseClass ?? string.Empty;
+
+        Address = BuildAddress(record);
+        Country = record.Country ?? string.Empty;
+        Grid = record.GridSquare ?? string.Empty;
+        County = record.County ?? string.Empty;
+        State = record.State ?? string.Empty;
+        TimeZone = record.TimeZone ?? string.Empty;
+
+        DxccCountry = record.DxccCountryName ?? string.Empty;
+        DxccContinent = record.DxccContinent ?? string.Empty;
+        CqZone = record.HasCqZone ? record.CqZone.ToString(CultureInfo.InvariantCulture) : string.Empty;
+        ItuZone = record.HasItuZone ? record.ItuZone.ToString(CultureInfo.InvariantCulture) : string.Empty;
+        Iota = record.Iota ?? string.Empty;
+
+        EqslStatus = FormatQslStatus(record.Eqsl);
+        LotwStatus = FormatQslStatus(record.Lotw);
+        PaperQslStatus = FormatQslStatus(record.PaperQsl);
+        QslManager = record.QslManager ?? string.Empty;
+
+        ImageUrl = record.ImageUrl;
+        WebUrl = record.WebUrl ?? string.Empty;
+        Email = record.Email ?? string.Empty;
+        Aliases = record.Aliases.Count > 0 ? string.Join(", ", record.Aliases) : string.Empty;
+        PreviousCall = record.PreviousCall ?? string.Empty;
+
+        OnPropertyChanged(nameof(HasNickname));
+        OnPropertyChanged(nameof(HasAliases));
+        OnPropertyChanged(nameof(HasPreviousCall));
+        OnPropertyChanged(nameof(HasQslManager));
+        OnPropertyChanged(nameof(HasIota));
+        OnPropertyChanged(nameof(HasWebUrl));
+        OnPropertyChanged(nameof(HasEmail));
+        OnPropertyChanged(nameof(HasCounty));
+        OnPropertyChanged(nameof(HasTimeZone));
+    }
+
+    private async Task LoadImageAsync(string url)
+    {
+        try
+        {
+            var bytes = await SharedHttpClient.GetByteArrayAsync(new Uri(url));
+            using var stream = new MemoryStream(bytes);
+            ProfileImage = new Bitmap(stream);
+            HasImage = true;
+        }
+        catch (HttpRequestException)
+        {
+            // Image download failed — leave HasImage false.
+        }
+        catch (TaskCanceledException)
+        {
+            // Image download timed out — leave HasImage false.
+        }
+    }
+
+    private static string BuildFullName(CallsignRecord record)
+    {
+        if (!string.IsNullOrWhiteSpace(record.FormattedName))
+        {
+            return record.FormattedName;
+        }
+
+        var first = record.FirstName ?? string.Empty;
+        var last = record.LastName ?? string.Empty;
+        return string.IsNullOrWhiteSpace(first) && string.IsNullOrWhiteSpace(last)
+            ? string.Empty
+            : $"{first} {last}".Trim();
+    }
+
+    private static string BuildAddress(CallsignRecord record)
+    {
+        var city = record.Addr2 ?? string.Empty;
+        var state = record.State ?? string.Empty;
+        var zip = record.Zip ?? string.Empty;
+
+        if (string.IsNullOrWhiteSpace(city) && string.IsNullOrWhiteSpace(state))
+        {
+            return string.Empty;
+        }
+
+        var parts = new[] { city, state, zip }
+            .Where(part => !string.IsNullOrWhiteSpace(part));
+        return string.Join(", ", parts);
+    }
+
+    private static string FormatQslStatus(QslPreference preference) => preference switch
+    {
+        QslPreference.Yes => "Yes",
+        QslPreference.No => "No",
+        _ => "?"
+    };
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -63,6 +63,12 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     [ObservableProperty]
     private string _currentUtcDate = string.Empty;
 
+    [ObservableProperty]
+    private bool _isCallsignCardOpen;
+
+    [ObservableProperty]
+    private CallsignCardViewModel? _callsignCard;
+
     internal MainWindowViewModel(string endpoint)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(endpoint);
@@ -232,10 +238,44 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     }
 
     [RelayCommand]
+    private void OpenCallsignCard()
+    {
+        var selectedQso = RecentQsos.SelectedQso;
+        if (selectedQso is null || string.IsNullOrWhiteSpace(selectedQso.WorkedCallsign))
+        {
+            return;
+        }
+
+        var vm = new CallsignCardViewModel(_engine);
+        vm.CloseRequested += OnCallsignCardCloseRequested;
+        CallsignCard = vm;
+        IsCallsignCardOpen = true;
+        _ = vm.LoadAsync(selectedQso.WorkedCallsign);
+    }
+
+    [RelayCommand]
+    private void CloseCallsignCard()
+    {
+        if (CallsignCard is { } card)
+        {
+            card.CloseRequested -= OnCallsignCardCloseRequested;
+        }
+
+        IsCallsignCardOpen = false;
+        CallsignCard = null;
+    }
+
+    private void OnCallsignCardCloseRequested(object? sender, EventArgs e)
+    {
+        CloseCallsignCard();
+    }
+
+    [RelayCommand]
     private void CloseTransientPanels()
     {
         IsSortChooserOpen = false;
         IsColumnChooserOpen = false;
+        CloseCallsignCard();
     }
 
     [RelayCommand]

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -271,6 +271,70 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         }
     }
 
+    [ObservableProperty]
+    private bool _isDeletePending;
+
+    [ObservableProperty]
+    private string _deleteConfirmCallsign = string.Empty;
+
+    private string? _pendingDeleteLocalId;
+
+    internal void RequestDeleteSelectedQso()
+    {
+        var selected = SelectedQso;
+        if (selected is null || string.IsNullOrWhiteSpace(selected.LocalId))
+        {
+            return;
+        }
+
+        _pendingDeleteLocalId = selected.LocalId;
+        DeleteConfirmCallsign = selected.WorkedCallsign;
+        IsDeletePending = true;
+    }
+
+    [RelayCommand]
+    internal async Task ConfirmDeleteAsync()
+    {
+        if (_pendingDeleteLocalId is null)
+        {
+            return;
+        }
+
+        var localId = _pendingDeleteLocalId;
+        IsDeletePending = false;
+        _pendingDeleteLocalId = null;
+        DeleteConfirmCallsign = string.Empty;
+
+        try
+        {
+            var response = await _engine.DeleteQsoAsync(localId);
+            if (response.Success)
+            {
+                await RefreshAsync();
+            }
+            else
+            {
+                ErrorMessage = response.Error ?? "Delete failed.";
+                NotifyStatusPropertiesChanged();
+            }
+        }
+        catch (RpcException ex)
+        {
+            ErrorMessage = string.IsNullOrWhiteSpace(ex.Status.Detail)
+                ? $"Delete failed ({ex.StatusCode})."
+                : ex.Status.Detail;
+            NotifyStatusPropertiesChanged();
+        }
+    }
+
+    [RelayCommand]
+    private void CancelDelete()
+    {
+        IsDeletePending = false;
+        _pendingDeleteLocalId = null;
+        DeleteConfirmCallsign = string.Empty;
+    }
+
     [RelayCommand]
     private void ZoomIn()
     {

--- a/src/dotnet/QsoRipper.Gui/Views/ButtonClipTestWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/ButtonClipTestWindow.axaml
@@ -1,0 +1,259 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="QsoRipper.Gui.Views.ButtonClipTestWindow"
+        Title="Button Clip Diagnostic"
+        Width="880" Height="820"
+        WindowStartupLocation="CenterScreen">
+
+  <Window.Styles>
+    <!-- Template-level ContentPresenter padding override -->
+    <Style Selector="Button.tpl-pad /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Padding" Value="10,2,10,2"/>
+    </Style>
+
+    <!-- Template-level ContentPresenter vertical alignment override -->
+    <Style Selector="Button.tpl-va /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="VerticalAlignment" Value="Center"/>
+    </Style>
+
+    <!-- Template-level combo: tighter pad + centered -->
+    <Style Selector="Button.tpl-combo /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Padding" Value="8,1,8,1"/>
+      <Setter Property="VerticalAlignment" Value="Center"/>
+    </Style>
+
+    <!-- Zero-pad template override -->
+    <Style Selector="Button.tpl-zero /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Padding" Value="0"/>
+    </Style>
+
+    <!-- Override with asymmetric bottom-heavy padding -->
+    <Style Selector="Button.tpl-bot /template/ ContentPresenter#PART_ContentPresenter">
+      <Setter Property="Padding" Value="10,3,10,5"/>
+    </Style>
+
+    <!-- Row label style -->
+    <Style Selector="TextBlock.rowLabel">
+      <Setter Property="Width" Value="220"/>
+      <Setter Property="VerticalAlignment" Value="Center"/>
+      <Setter Property="FontSize" Value="11"/>
+      <Setter Property="FontFamily" Value="Cascadia Mono, Consolas, monospace"/>
+    </Style>
+  </Window.Styles>
+
+  <ScrollViewer Margin="12">
+    <StackPanel Spacing="6">
+      <TextBlock Text="Button Text Clipping Diagnostic"
+                 FontWeight="Bold" FontSize="15" Margin="0,0,0,2"/>
+      <TextBlock Text="Each row: ⟳ Sync (has descender y), Sort, Cols, gyjpq (all descenders)"
+                 FontSize="11" Opacity="0.7" Margin="0,0,0,8"/>
+
+      <!-- Row 1: Current config (the bug) -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="1. H=28 (CURRENT BUG)"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54"/>
+        <Button Content="Sort" Height="28" MinWidth="54"/>
+        <Button Content="Cols" Height="28" MinWidth="54"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54"/>
+      </StackPanel>
+
+      <!-- Row 2: No explicit Height -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="2. No Height (auto)"/>
+        <Button Content="⟳ Sync" MinWidth="54"/>
+        <Button Content="Sort" MinWidth="54"/>
+        <Button Content="Cols" MinWidth="54"/>
+        <Button Content="gyjpq" MinWidth="54"/>
+      </StackPanel>
+
+      <!-- Row 3: Height=30 -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="3. H=30"/>
+        <Button Content="⟳ Sync" Height="30" MinWidth="54"/>
+        <Button Content="Sort" Height="30" MinWidth="54"/>
+        <Button Content="Cols" Height="30" MinWidth="54"/>
+        <Button Content="gyjpq" Height="30" MinWidth="54"/>
+      </StackPanel>
+
+      <!-- Row 4: Height=32 -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="4. H=32"/>
+        <Button Content="⟳ Sync" Height="32" MinWidth="54"/>
+        <Button Content="Sort" Height="32" MinWidth="54"/>
+        <Button Content="Cols" Height="32" MinWidth="54"/>
+        <Button Content="gyjpq" Height="32" MinWidth="54"/>
+      </StackPanel>
+
+      <!-- Row 5: Height=36 -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="5. H=36"/>
+        <Button Content="⟳ Sync" Height="36" MinWidth="54"/>
+        <Button Content="Sort" Height="36" MinWidth="54"/>
+        <Button Content="Cols" Height="36" MinWidth="54"/>
+        <Button Content="gyjpq" Height="36" MinWidth="54"/>
+      </StackPanel>
+
+      <!-- Row 6: MinHeight=28 (no explicit Height) -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="6. MinH=28 no H"/>
+        <Button Content="⟳ Sync" MinHeight="28" MinWidth="54"/>
+        <Button Content="Sort" MinHeight="28" MinWidth="54"/>
+        <Button Content="Cols" MinHeight="28" MinWidth="54"/>
+        <Button Content="gyjpq" MinHeight="28" MinWidth="54"/>
+      </StackPanel>
+
+      <!-- Row 7: MinHeight=32 -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="7. MinH=32 no H"/>
+        <Button Content="⟳ Sync" MinHeight="32" MinWidth="54"/>
+        <Button Content="Sort" MinHeight="32" MinWidth="54"/>
+        <Button Content="Cols" MinHeight="32" MinWidth="54"/>
+        <Button Content="gyjpq" MinHeight="32" MinWidth="54"/>
+      </StackPanel>
+
+      <!-- Row 8: H=28 + symmetric Padding -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="8. H=28 Pad=10,5"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" Padding="10,5"/>
+        <Button Content="Sort" Height="28" MinWidth="54" Padding="10,5"/>
+        <Button Content="Cols" Height="28" MinWidth="54" Padding="10,5"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" Padding="10,5"/>
+      </StackPanel>
+
+      <!-- Row 9: H=28 + asymmetric bottom-heavy -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="9. H=28 Pad=10,3,10,7"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" Padding="10,3,10,7"/>
+        <Button Content="Sort" Height="28" MinWidth="54" Padding="10,3,10,7"/>
+        <Button Content="Cols" Height="28" MinWidth="54" Padding="10,3,10,7"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" Padding="10,3,10,7"/>
+      </StackPanel>
+
+      <!-- Row 10: H=28 + VCA=Center -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="10. H=28 VCA=Center"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" VerticalContentAlignment="Center"/>
+        <Button Content="Sort" Height="28" MinWidth="54" VerticalContentAlignment="Center"/>
+        <Button Content="Cols" Height="28" MinWidth="54" VerticalContentAlignment="Center"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" VerticalContentAlignment="Center"/>
+      </StackPanel>
+
+      <!-- Row 11: No H + VCA=Center -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="11. No H VCA=Center"/>
+        <Button Content="⟳ Sync" MinWidth="54" VerticalContentAlignment="Center"/>
+        <Button Content="Sort" MinWidth="54" VerticalContentAlignment="Center"/>
+        <Button Content="Cols" MinWidth="54" VerticalContentAlignment="Center"/>
+        <Button Content="gyjpq" MinWidth="54" VerticalContentAlignment="Center"/>
+      </StackPanel>
+
+      <!-- Row 12: H=28 with TextBlock child -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="12. H=28 TextBlock child"/>
+        <Button Height="28" MinWidth="54">
+          <TextBlock Text="⟳ Sync" VerticalAlignment="Center"/>
+        </Button>
+        <Button Height="28" MinWidth="54">
+          <TextBlock Text="Sort" VerticalAlignment="Center"/>
+        </Button>
+        <Button Height="28" MinWidth="54">
+          <TextBlock Text="Cols" VerticalAlignment="Center"/>
+        </Button>
+        <Button Height="28" MinWidth="54">
+          <TextBlock Text="gyjpq" VerticalAlignment="Center"/>
+        </Button>
+      </StackPanel>
+
+      <!-- Row 13: tpl-pad (template ContentPresenter pad) -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="13. tpl-pad CP=10,2"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" Classes="tpl-pad"/>
+        <Button Content="Sort" Height="28" MinWidth="54" Classes="tpl-pad"/>
+        <Button Content="Cols" Height="28" MinWidth="54" Classes="tpl-pad"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" Classes="tpl-pad"/>
+      </StackPanel>
+
+      <!-- Row 14: tpl-va (template ContentPresenter VA=Center) -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="14. tpl-va CP VA=Center"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" Classes="tpl-va"/>
+        <Button Content="Sort" Height="28" MinWidth="54" Classes="tpl-va"/>
+        <Button Content="Cols" Height="28" MinWidth="54" Classes="tpl-va"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" Classes="tpl-va"/>
+      </StackPanel>
+
+      <!-- Row 15: tpl-combo (pad + VA) -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="15. tpl-combo pad+VA"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" Classes="tpl-combo"/>
+        <Button Content="Sort" Height="28" MinWidth="54" Classes="tpl-combo"/>
+        <Button Content="Cols" Height="28" MinWidth="54" Classes="tpl-combo"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" Classes="tpl-combo"/>
+      </StackPanel>
+
+      <!-- Row 16: tpl-zero (zero ContentPresenter padding) -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="16. tpl-zero CP Pad=0"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" Classes="tpl-zero"/>
+        <Button Content="Sort" Height="28" MinWidth="54" Classes="tpl-zero"/>
+        <Button Content="Cols" Height="28" MinWidth="54" Classes="tpl-zero"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" Classes="tpl-zero"/>
+      </StackPanel>
+
+      <!-- Row 17: tpl-bot (bottom-heavy template pad) -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="17. tpl-bot CP=10,3,10,5"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" Classes="tpl-bot"/>
+        <Button Content="Sort" Height="28" MinWidth="54" Classes="tpl-bot"/>
+        <Button Content="Cols" Height="28" MinWidth="54" Classes="tpl-bot"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" Classes="tpl-bot"/>
+      </StackPanel>
+
+      <!-- Row 18: H=32 Pad=10,5 VCA=Center -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="18. H=32 Pad=10,5 VCA=C"/>
+        <Button Content="⟳ Sync" Height="32" MinWidth="54" Padding="10,5" VerticalContentAlignment="Center"/>
+        <Button Content="Sort" Height="32" MinWidth="54" Padding="10,5" VerticalContentAlignment="Center"/>
+        <Button Content="Cols" Height="32" MinWidth="54" Padding="10,5" VerticalContentAlignment="Center"/>
+        <Button Content="gyjpq" Height="32" MinWidth="54" Padding="10,5" VerticalContentAlignment="Center"/>
+      </StackPanel>
+
+      <!-- Row 19: UseLayoutRounding -->
+      <StackPanel Orientation="Horizontal" Spacing="6" UseLayoutRounding="True">
+        <TextBlock Classes="rowLabel" Text="19. H=28 LayoutRounding"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" UseLayoutRounding="True"/>
+        <Button Content="Sort" Height="28" MinWidth="54" UseLayoutRounding="True"/>
+        <Button Content="Cols" Height="28" MinWidth="54" UseLayoutRounding="True"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" UseLayoutRounding="True"/>
+      </StackPanel>
+
+      <!-- Row 20: H=28 Pad=11,5,11,5 (explicit symmetric Fluent) -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="20. H=28 Pad=11,5,11,5"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" Padding="11,5,11,5"/>
+        <Button Content="Sort" Height="28" MinWidth="54" Padding="11,5,11,5"/>
+        <Button Content="Cols" Height="28" MinWidth="54" Padding="11,5,11,5"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" Padding="11,5,11,5"/>
+      </StackPanel>
+
+      <!-- Row 21: H=28 Pad=11,4,11,6 (WinUI-like asymmetric) -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="21. H=28 Pad=11,4,11,6"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" Padding="11,4,11,6"/>
+        <Button Content="Sort" Height="28" MinWidth="54" Padding="11,4,11,6"/>
+        <Button Content="Cols" Height="28" MinWidth="54" Padding="11,4,11,6"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" Padding="11,4,11,6"/>
+      </StackPanel>
+
+      <!-- Row 22: H=28 + Pad=8,2 + tpl-va -->
+      <StackPanel Orientation="Horizontal" Spacing="6">
+        <TextBlock Classes="rowLabel" Text="22. H=28 Pad=8,2 tpl-va"/>
+        <Button Content="⟳ Sync" Height="28" MinWidth="54" Padding="8,2" Classes="tpl-va"/>
+        <Button Content="Sort" Height="28" MinWidth="54" Padding="8,2" Classes="tpl-va"/>
+        <Button Content="Cols" Height="28" MinWidth="54" Padding="8,2" Classes="tpl-va"/>
+        <Button Content="gyjpq" Height="28" MinWidth="54" Padding="8,2" Classes="tpl-va"/>
+      </StackPanel>
+
+    </StackPanel>
+  </ScrollViewer>
+</Window>

--- a/src/dotnet/QsoRipper.Gui/Views/ButtonClipTestWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/ButtonClipTestWindow.axaml.cs
@@ -1,0 +1,85 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Media.Imaging;
+using Avalonia.Threading;
+using QsoRipper.Gui.Inspection;
+
+namespace QsoRipper.Gui.Views;
+
+internal sealed partial class ButtonClipTestWindow : Window
+{
+    public ButtonClipTestWindow()
+    {
+        InitializeComponent();
+    }
+
+    internal static Window CreateForCapture(
+        IClassicDesktopStyleApplicationLifetime desktop,
+        UxCaptureOptions options)
+    {
+        var window = new ButtonClipTestWindow();
+
+        window.Opened += async (_, _) =>
+        {
+            try
+            {
+                await WaitForRenderAsync();
+                await CaptureAndShutdownAsync(window, desktop, options);
+            }
+            catch (InvalidOperationException ex)
+            {
+                Console.Error.WriteLine($"Diagnostic capture failed: {ex.Message}");
+                desktop.Shutdown(1);
+            }
+            catch (IOException ex)
+            {
+                Console.Error.WriteLine($"Diagnostic capture failed: {ex.Message}");
+                desktop.Shutdown(1);
+            }
+        };
+
+        return window;
+    }
+
+    private static async Task CaptureAndShutdownAsync(
+        Window window,
+        IClassicDesktopStyleApplicationLifetime desktop,
+        UxCaptureOptions options)
+    {
+        var logicalSize = new Size(window.Bounds.Width, window.Bounds.Height);
+        if (logicalSize.Width <= 0 || logicalSize.Height <= 0)
+        {
+            throw new InvalidOperationException("Diagnostic window has no rendered size.");
+        }
+
+        var pixelSize = new PixelSize(
+            Math.Max(1, (int)Math.Ceiling(logicalSize.Width * window.RenderScaling)),
+            Math.Max(1, (int)Math.Ceiling(logicalSize.Height * window.RenderScaling)));
+
+        Directory.CreateDirectory(Path.GetDirectoryName(options.OutputPath)!);
+
+        using var bitmap = new RenderTargetBitmap(
+            pixelSize,
+            new Vector(96 * window.RenderScaling, 96 * window.RenderScaling));
+        bitmap.Render(window);
+        bitmap.Save(options.OutputPath);
+
+        Console.WriteLine($"Diagnostic captured: {options.OutputPath}");
+        Console.WriteLine($"  Logical: {logicalSize.Width}x{logicalSize.Height}");
+        Console.WriteLine($"  Pixel: {pixelSize.Width}x{pixelSize.Height}");
+        Console.WriteLine($"  Scale: {window.RenderScaling}");
+
+        desktop.Shutdown(0);
+    }
+
+    private static async Task WaitForRenderAsync()
+    {
+        await Dispatcher.UIThread.InvokeAsync(static () => { }, DispatcherPriority.Render);
+        await Task.Delay(100);
+        await Dispatcher.UIThread.InvokeAsync(static () => { }, DispatcherPriority.Background);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Views/CallsignCardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/CallsignCardView.axaml
@@ -1,0 +1,241 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:QsoRipper.Gui.ViewModels"
+             x:Class="QsoRipper.Gui.Views.CallsignCardView"
+             x:DataType="vm:CallsignCardViewModel">
+
+  <UserControl.Styles>
+    <Style Selector="TextBlock.cardLabel">
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="Foreground" Value="#888888" />
+      <Setter Property="Margin" Value="0,0,12,0" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+    </Style>
+    <Style Selector="TextBlock.cardValue">
+      <Setter Property="FontSize" Value="13" />
+      <Setter Property="Foreground" Value="White" />
+      <Setter Property="VerticalAlignment" Value="Center" />
+      <Setter Property="TextWrapping" Value="Wrap" />
+    </Style>
+    <Style Selector="TextBlock.sectionHeader">
+      <Setter Property="FontSize" Value="12" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Foreground" Value="#aaaacc" />
+      <Setter Property="Margin" Value="0,4,0,2" />
+    </Style>
+    <Style Selector="Border.sectionDivider">
+      <Setter Property="Height" Value="1" />
+      <Setter Property="Background" Value="#333355" />
+      <Setter Property="Margin" Value="0,4,0,4" />
+    </Style>
+    <Style Selector="TextBlock.qslYes">
+      <Setter Property="Foreground" Value="#44ff44" />
+    </Style>
+    <Style Selector="TextBlock.qslNo">
+      <Setter Property="Foreground" Value="#888888" />
+    </Style>
+    <Style Selector="TextBlock.qslUnknown">
+      <Setter Property="Foreground" Value="#ffaa00" />
+    </Style>
+  </UserControl.Styles>
+
+  <Border Background="#1a1a2e"
+          CornerRadius="12"
+          Padding="20"
+          MaxWidth="520"
+          MinWidth="420"
+          BoxShadow="0 8 32 0 #40000000">
+    <Panel>
+      <!-- Loading State -->
+      <StackPanel HorizontalAlignment="Center"
+                  VerticalAlignment="Center"
+                  Spacing="12"
+                  IsVisible="{Binding IsLoading}">
+        <TextBlock Text="Looking up callsign…"
+                   FontSize="14"
+                   Foreground="#888888"
+                   HorizontalAlignment="Center" />
+        <ProgressBar IsIndeterminate="True"
+                     Width="200"
+                     Height="4"
+                     Foreground="#00d4ff" />
+      </StackPanel>
+
+      <!-- Error State -->
+      <StackPanel HorizontalAlignment="Center"
+                  VerticalAlignment="Center"
+                  Spacing="12"
+                  IsVisible="{Binding IsError}">
+        <TextBlock Text="⚠"
+                   FontSize="36"
+                   HorizontalAlignment="Center"
+                   Foreground="#ff4444" />
+        <TextBlock Text="{Binding ErrorMessage}"
+                   FontSize="13"
+                   Foreground="#ff4444"
+                   TextWrapping="Wrap"
+                   TextAlignment="Center"
+                   MaxWidth="400"
+                   HorizontalAlignment="Center" />
+      </StackPanel>
+
+      <!-- Loaded Content -->
+      <ScrollViewer VerticalScrollBarVisibility="Auto"
+                    IsVisible="{Binding IsLoaded}">
+        <StackPanel Spacing="12">
+
+          <!-- Header: Callsign + Image -->
+          <Grid ColumnDefinitions="*,Auto">
+            <StackPanel Grid.Column="0" Spacing="2">
+              <TextBlock Text="{Binding Callsign}"
+                         FontSize="28"
+                         FontWeight="Bold"
+                         Foreground="#00d4ff" />
+              <TextBlock Text="{Binding FullName}"
+                         FontSize="16"
+                         Foreground="White" />
+              <StackPanel Orientation="Horizontal" Spacing="8">
+                <TextBlock Text="{Binding LicenseClass}"
+                           FontSize="12"
+                           Foreground="#888888"
+                           IsVisible="{Binding LicenseClass, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                <TextBlock Text="{Binding Nickname, StringFormat='({0})'}"
+                           FontSize="12"
+                           Foreground="#aaaaaa"
+                           IsVisible="{Binding HasNickname}" />
+              </StackPanel>
+              <TextBlock Text="{Binding LatencyText}"
+                         FontSize="10"
+                         Foreground="#666666"
+                         Margin="0,4,0,0"
+                         IsVisible="{Binding LatencyText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+            </StackPanel>
+            <Border Grid.Column="1"
+                    Width="120"
+                    Height="120"
+                    CornerRadius="8"
+                    ClipToBounds="True"
+                    Background="#222244"
+                    IsVisible="{Binding HasImage}">
+              <Image Source="{Binding ProfileImage}"
+                     Stretch="UniformToFill" />
+            </Border>
+            <!-- Placeholder when no image -->
+            <Border Grid.Column="1"
+                    Width="120"
+                    Height="120"
+                    CornerRadius="8"
+                    Background="#222244"
+                    IsVisible="{Binding !HasImage}">
+              <TextBlock Text="📻"
+                         FontSize="48"
+                         HorizontalAlignment="Center"
+                         VerticalAlignment="Center"
+                         Foreground="#444466" />
+            </Border>
+          </Grid>
+
+          <!-- Location Section -->
+          <Border Classes="sectionDivider" />
+          <TextBlock Classes="sectionHeader" Text="LOCATION" />
+          <Grid ColumnDefinitions="90,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto">
+            <TextBlock Classes="cardLabel" Grid.Row="0" Text="QTH" />
+            <TextBlock Classes="cardValue" Grid.Row="0" Grid.Column="1" Text="{Binding Address}" />
+            <TextBlock Classes="cardLabel" Grid.Row="1" Text="Country" />
+            <TextBlock Classes="cardValue" Grid.Row="1" Grid.Column="1" Text="{Binding Country}" />
+            <TextBlock Classes="cardLabel" Grid.Row="2" Text="Grid" />
+            <TextBlock Classes="cardValue" Grid.Row="2" Grid.Column="1" Text="{Binding Grid}" />
+            <TextBlock Classes="cardLabel" Grid.Row="3" Text="State" />
+            <TextBlock Classes="cardValue" Grid.Row="3" Grid.Column="1" Text="{Binding State}" />
+            <TextBlock Classes="cardLabel" Grid.Row="4" Text="County"
+                       IsVisible="{Binding HasCounty}" />
+            <TextBlock Classes="cardValue" Grid.Row="4" Grid.Column="1" Text="{Binding County}"
+                       IsVisible="{Binding HasCounty}" />
+            <TextBlock Classes="cardLabel" Grid.Row="5" Text="Time Zone"
+                       IsVisible="{Binding HasTimeZone}" />
+            <TextBlock Classes="cardValue" Grid.Row="5" Grid.Column="1" Text="{Binding TimeZone}"
+                       IsVisible="{Binding HasTimeZone}" />
+          </Grid>
+
+          <!-- Zones Section -->
+          <Border Classes="sectionDivider" />
+          <TextBlock Classes="sectionHeader" Text="DXCC / ZONES" />
+          <Grid ColumnDefinitions="90,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+            <TextBlock Classes="cardLabel" Grid.Row="0" Text="DXCC" />
+            <TextBlock Classes="cardValue" Grid.Row="0" Grid.Column="1" Text="{Binding DxccCountry}" />
+            <TextBlock Classes="cardLabel" Grid.Row="1" Text="Continent" />
+            <TextBlock Classes="cardValue" Grid.Row="1" Grid.Column="1" Text="{Binding DxccContinent}" />
+            <TextBlock Classes="cardLabel" Grid.Row="2" Text="CQ Zone" />
+            <TextBlock Classes="cardValue" Grid.Row="2" Grid.Column="1" Text="{Binding CqZone}" />
+            <TextBlock Classes="cardLabel" Grid.Row="3" Text="ITU Zone" />
+            <TextBlock Classes="cardValue" Grid.Row="3" Grid.Column="1" Text="{Binding ItuZone}" />
+            <TextBlock Classes="cardLabel" Grid.Row="4" Text="IOTA"
+                       IsVisible="{Binding HasIota}" />
+            <TextBlock Classes="cardValue" Grid.Row="4" Grid.Column="1" Text="{Binding Iota}"
+                       IsVisible="{Binding HasIota}" />
+          </Grid>
+
+          <!-- QSL Section -->
+          <Border Classes="sectionDivider" />
+          <TextBlock Classes="sectionHeader" Text="QSL STATUS" />
+          <Grid ColumnDefinitions="90,*" RowDefinitions="Auto,Auto,Auto,Auto">
+            <TextBlock Classes="cardLabel" Grid.Row="0" Text="eQSL" />
+            <TextBlock Grid.Row="0" Grid.Column="1"
+                       Text="{Binding EqslStatus}"
+                       FontSize="13"
+                       VerticalAlignment="Center" />
+            <TextBlock Classes="cardLabel" Grid.Row="1" Text="LoTW" />
+            <TextBlock Grid.Row="1" Grid.Column="1"
+                       Text="{Binding LotwStatus}"
+                       FontSize="13"
+                       VerticalAlignment="Center" />
+            <TextBlock Classes="cardLabel" Grid.Row="2" Text="Paper QSL" />
+            <TextBlock Grid.Row="2" Grid.Column="1"
+                       Text="{Binding PaperQslStatus}"
+                       FontSize="13"
+                       VerticalAlignment="Center" />
+            <TextBlock Classes="cardLabel" Grid.Row="3" Text="QSL Mgr"
+                       IsVisible="{Binding HasQslManager}" />
+            <TextBlock Classes="cardValue" Grid.Row="3" Grid.Column="1" Text="{Binding QslManager}"
+                       IsVisible="{Binding HasQslManager}" />
+          </Grid>
+
+          <!-- Profile Section -->
+          <Border Classes="sectionDivider" />
+          <TextBlock Classes="sectionHeader" Text="PROFILE" />
+          <Grid ColumnDefinitions="90,*" RowDefinitions="Auto,Auto,Auto,Auto">
+            <TextBlock Classes="cardLabel" Grid.Row="0" Text="Aliases"
+                       IsVisible="{Binding HasAliases}" />
+            <TextBlock Classes="cardValue" Grid.Row="0" Grid.Column="1" Text="{Binding Aliases}"
+                       IsVisible="{Binding HasAliases}" />
+            <TextBlock Classes="cardLabel" Grid.Row="1" Text="Previous"
+                       IsVisible="{Binding HasPreviousCall}" />
+            <TextBlock Classes="cardValue" Grid.Row="1" Grid.Column="1" Text="{Binding PreviousCall}"
+                       IsVisible="{Binding HasPreviousCall}" />
+            <TextBlock Classes="cardLabel" Grid.Row="2" Text="Web"
+                       IsVisible="{Binding HasWebUrl}" />
+            <TextBlock Classes="cardValue" Grid.Row="2" Grid.Column="1" Text="{Binding WebUrl}"
+                       IsVisible="{Binding HasWebUrl}" />
+            <TextBlock Classes="cardLabel" Grid.Row="3" Text="Email"
+                       IsVisible="{Binding HasEmail}" />
+            <TextBlock Classes="cardValue" Grid.Row="3" Grid.Column="1" Text="{Binding Email}"
+                       IsVisible="{Binding HasEmail}" />
+          </Grid>
+
+        </StackPanel>
+      </ScrollViewer>
+
+      <!-- Close button -->
+      <Button HorizontalAlignment="Right"
+              VerticalAlignment="Top"
+              Margin="0,-8,-8,0"
+              Padding="8,4"
+              Background="Transparent"
+              Foreground="#888888"
+              FontSize="16"
+              Content="✕"
+              Command="{Binding CloseCommand}"
+              ToolTip.Tip="Close (Esc)" />
+    </Panel>
+  </Border>
+</UserControl>

--- a/src/dotnet/QsoRipper.Gui/Views/CallsignCardView.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/CallsignCardView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace QsoRipper.Gui.Views;
+
+internal sealed partial class CallsignCardView : UserControl
+{
+    public CallsignCardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -172,7 +172,7 @@
                     Command="{Binding OpenWizardCommand}"
                     Classes="accent"
                     MinWidth="62"
-                    Height="28"
+                    MinHeight="28"
                     IsVisible="{Binding IsSetupIncomplete}" />
             <TextBlock Classes="commandCaption"
                        Text="{Binding RecentQsos.RefreshIndicatorText}"
@@ -182,7 +182,7 @@
                     AutomationProperties.AutomationId="SyncNowButton"
                     Content="⟳ Sync"
                     Command="{Binding SyncNowCommand}"
-                    Height="28"
+                    MinHeight="28"
                     MinWidth="54"
                     ToolTip.Tip="Sync with QRZ (F6)" />
             <TextBlock Text="{Binding CurrentUtcTime}"
@@ -196,13 +196,13 @@
                     AutomationProperties.AutomationId="SortButton"
                     Content="Sort"
                     Command="{Binding ToggleSortChooserCommand}"
-                    Height="28"
+                    MinHeight="28"
                     MinWidth="54" />
             <Button x:Name="ColumnsButton"
                     AutomationProperties.AutomationId="ColumnsButton"
                     Content="Cols"
                     Command="{Binding ToggleColumnChooserCommand}"
-                    Height="28"
+                    MinHeight="28"
                     MinWidth="54" />
           </StackPanel>
         </Grid>

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -57,11 +57,13 @@
       <Setter Property="BorderThickness" Value="0" />
     </Style>
 
-    <!-- Current cell: subtle background highlight instead of white vertical border lines -->
+    <!-- Hide white border lines on current/focused cell; use subtle background instead -->
     <Style Selector="DataGrid#RecentQsoGrid DataGridCell:current /template/ Rectangle#CurrencyVisual">
       <Setter Property="IsVisible" Value="False" />
     </Style>
-
+    <Style Selector="DataGrid#RecentQsoGrid DataGridCell:focus /template/ Grid#FocusVisual">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
     <Style Selector="DataGrid#RecentQsoGrid DataGridCell:current">
       <Setter Property="Background" Value="#400078D7" />
       <Setter Property="BorderBrush" Value="Transparent" />

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -19,6 +19,7 @@
     <KeyBinding Gesture="Ctrl+Shift+S" Command="{Binding ToggleSortChooserCommand}" />
     <KeyBinding Gesture="Ctrl+H" Command="{Binding ToggleColumnChooserCommand}" />
     <KeyBinding Gesture="Alt+Enter" Command="{Binding ToggleInspectorCommand}" />
+    <KeyBinding Gesture="F8" Command="{Binding OpenCallsignCardCommand}" />
     <KeyBinding Gesture="F6" Command="{Binding SyncNowCommand}" />
   </Window.KeyBindings>
 
@@ -105,6 +106,8 @@
                   Command="{Binding ToggleColumnChooserCommand}" />
         <MenuItem Header="_Inspector" InputGesture="Alt+Enter"
                   Command="{Binding ToggleInspectorCommand}" />
+        <MenuItem Header="Callsign _Card" InputGesture="F8"
+                  Command="{Binding OpenCallsignCardCommand}" />
       </MenuItem>
       <MenuItem Header="_Tools">
         <MenuItem Header="Sync _Now" InputGesture="F6"
@@ -237,26 +240,90 @@
                                       MinWidth="96"
                                       Binding="{ReflectionBinding UtcDisplay, Mode=TwoWay}"
                                       SortMemberPath="UtcSortKey" />
-                  <DataGridTextColumn Header="Call"
-                                      Width="88"
-                                      MinWidth="80"
-                                      Binding="{ReflectionBinding WorkedCallsign, Mode=TwoWay}"
-                                      SortMemberPath="WorkedCallsign" />
-                  <DataGridTextColumn Header="Band"
-                                      Width="72"
-                                      MinWidth="64"
-                                      Binding="{ReflectionBinding Band, Mode=TwoWay}"
-                                      SortMemberPath="Band" />
-                  <DataGridTextColumn Header="Mode"
-                                      Width="76"
-                                      MinWidth="64"
-                                      Binding="{ReflectionBinding Mode, Mode=TwoWay}"
-                                      SortMemberPath="Mode" />
-                  <DataGridTextColumn Header="Freq"
-                                      Width="82"
-                                      MinWidth="80"
-                                      Binding="{ReflectionBinding Frequency, Mode=TwoWay}"
-                                      SortMemberPath="FrequencySortKey" />
+                  <DataGridTemplateColumn Header="Call"
+                                          Width="88"
+                                          MinWidth="80"
+                                          SortMemberPath="WorkedCallsign">
+                    <DataGridTemplateColumn.CellTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBlock Text="{Binding WorkedCallsign}"
+                                   FontWeight="SemiBold"
+                                   Foreground="#00d4ff"
+                                   TextTrimming="CharacterEllipsis"
+                                   VerticalAlignment="Center"
+                                   ToolTip.Tip="{Binding WorkedCallsign}" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBox Text="{Binding WorkedCallsign, Mode=TwoWay}"
+                                 BorderThickness="0"
+                                 Padding="0"
+                                 Background="Transparent" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                  </DataGridTemplateColumn>
+                  <DataGridTemplateColumn Header="Band"
+                                          Width="72"
+                                          MinWidth="64"
+                                          SortMemberPath="Band">
+                    <DataGridTemplateColumn.CellTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBlock Text="{Binding Band}"
+                                   Foreground="#FFB347"
+                                   VerticalAlignment="Center" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBox Text="{Binding Band, Mode=TwoWay}"
+                                 BorderThickness="0"
+                                 Padding="0"
+                                 Background="Transparent" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                  </DataGridTemplateColumn>
+                  <DataGridTemplateColumn Header="Mode"
+                                          Width="76"
+                                          MinWidth="64"
+                                          SortMemberPath="Mode">
+                    <DataGridTemplateColumn.CellTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBlock Text="{Binding Mode}"
+                                   Foreground="#77DD77"
+                                   VerticalAlignment="Center" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBox Text="{Binding Mode, Mode=TwoWay}"
+                                 BorderThickness="0"
+                                 Padding="0"
+                                 Background="Transparent" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                  </DataGridTemplateColumn>
+                  <DataGridTemplateColumn Header="Freq"
+                                          Width="82"
+                                          MinWidth="80"
+                                          SortMemberPath="FrequencySortKey">
+                    <DataGridTemplateColumn.CellTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBlock Text="{Binding Frequency}"
+                                   FontFamily="Cascadia Mono, Consolas, monospace"
+                                   Foreground="#B0B0B0"
+                                   VerticalAlignment="Center" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBox Text="{Binding Frequency, Mode=TwoWay}"
+                                 BorderThickness="0"
+                                 Padding="0"
+                                 Background="Transparent" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                  </DataGridTemplateColumn>
                   <DataGridTextColumn Header="RST"
                                       Width="88"
                                       MinWidth="64"
@@ -580,6 +647,16 @@
               </ScrollViewer>
             </StackPanel>
           </Border>
+
+          <!-- Callsign Card overlay -->
+          <Border x:Name="CallsignCardPanel"
+                  AutomationProperties.AutomationId="CallsignCardPanel"
+                  HorizontalAlignment="Right"
+                  VerticalAlignment="Top"
+                  Margin="0,8,14,8"
+                  IsVisible="{Binding IsCallsignCardOpen}">
+            <v:CallsignCardView DataContext="{Binding CallsignCard}" />
+          </Border>
         </Panel>
 
         <Border Grid.Row="2"
@@ -616,7 +693,7 @@
             </StackPanel>
 
             <TextBlock Grid.Column="1"
-                       Text="F2 Edit • Ctrl+S Save • F5 Refresh • F6 Sync • Alt+Enter Details"
+                       Text="F2 Edit • Del Delete • Ctrl+S Save • F5 Refresh • F6 Sync • F8 Card • Alt+Enter Details"
                        FontSize="11.5"
                        Opacity="0.68"
                        VerticalAlignment="Center"
@@ -624,6 +701,45 @@
           </Grid>
         </Border>
       </Grid>
+
+      <!-- Delete confirmation overlay -->
+      <Border x:Name="DeleteConfirmOverlay"
+              AutomationProperties.AutomationId="DeleteConfirmOverlay"
+              IsVisible="{Binding RecentQsos.IsDeletePending}"
+              Background="#80000000">
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                CornerRadius="8"
+                Padding="24"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                BoxShadow="0 8 24 0 #40000000"
+                MinWidth="320">
+          <StackPanel Spacing="16">
+            <TextBlock Text="Delete QSO?"
+                       FontSize="16"
+                       FontWeight="SemiBold" />
+            <TextBlock FontSize="13"
+                       TextWrapping="Wrap">
+              <Run Text="Permanently delete the QSO with " />
+              <Run Text="{Binding RecentQsos.DeleteConfirmCallsign}"
+                   FontWeight="Bold"
+                   Foreground="#00d4ff" />
+              <Run Text="?" />
+            </TextBlock>
+            <StackPanel Orientation="Horizontal"
+                        Spacing="10"
+                        HorizontalAlignment="Right">
+              <Button Content="Cancel"
+                      MinWidth="80"
+                      Command="{Binding RecentQsos.CancelDeleteCommand}" />
+              <Button Content="Delete"
+                      MinWidth="80"
+                      Classes="accent"
+                      Command="{Binding RecentQsos.ConfirmDeleteCommand}" />
+            </StackPanel>
+          </StackPanel>
+        </Border>
+      </Border>
 
       <Border x:Name="SetupWizardOverlay"
               AutomationProperties.AutomationId="SetupWizardOverlay"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -57,6 +57,16 @@
       <Setter Property="BorderThickness" Value="0" />
     </Style>
 
+    <!-- Current cell: subtle background highlight instead of white vertical border lines -->
+    <Style Selector="DataGrid#RecentQsoGrid DataGridCell:current /template/ Rectangle#CurrencyVisual">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+
+    <Style Selector="DataGrid#RecentQsoGrid DataGridCell:current">
+      <Setter Property="Background" Value="#400078D7" />
+      <Setter Property="BorderBrush" Value="Transparent" />
+    </Style>
+
   </Window.Styles>
 
   <DockPanel ClipToBounds="True">
@@ -221,7 +231,7 @@
                          SelectedItem="{Binding RecentQsos.SelectedQso, Mode=TwoWay}">
                 <DataGrid.Columns>
                   <DataGridTextColumn Header="UTC"
-                                      Width="130"
+                                      Width="138"
                                       MinWidth="96"
                                       Binding="{ReflectionBinding UtcDisplay, Mode=TwoWay}"
                                       SortMemberPath="UtcSortKey" />
@@ -264,6 +274,7 @@
                         <TextBlock Text="{Binding Country}"
                                    TextWrapping="NoWrap"
                                    TextTrimming="CharacterEllipsis"
+                                   VerticalAlignment="Center"
                                    ToolTip.Tip="{Binding Country}" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
@@ -285,6 +296,7 @@
                         <TextBlock Text="{Binding OperatorName}"
                                    TextWrapping="NoWrap"
                                    TextTrimming="CharacterEllipsis"
+                                   VerticalAlignment="Center"
                                    ToolTip.Tip="{Binding OperatorName}" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
@@ -316,6 +328,7 @@
                         <TextBlock Text="{Binding Contest}"
                                    TextWrapping="NoWrap"
                                    TextTrimming="CharacterEllipsis"
+                                   VerticalAlignment="Center"
                                    ToolTip.Tip="{Binding Contest}" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
@@ -342,6 +355,7 @@
                         <TextBlock Text="{Binding Note}"
                                    TextWrapping="NoWrap"
                                    TextTrimming="CharacterEllipsis"
+                                   VerticalAlignment="Center"
                                    ToolTip.Tip="{Binding Note}" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
@@ -383,6 +397,7 @@
                         <TextBlock Text="{Binding Qth}"
                                    TextWrapping="NoWrap"
                                    TextTrimming="CharacterEllipsis"
+                                   VerticalAlignment="Center"
                                    ToolTip.Tip="{Binding Qth}" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -112,6 +112,13 @@ internal sealed partial class MainWindow : Window
 
         if (e.Key == Key.Escape)
         {
+            if (_viewModel.IsCallsignCardOpen)
+            {
+                _viewModel.CloseCallsignCardCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
             if (_viewModel.IsColumnChooserOpen || _viewModel.IsSortChooserOpen)
             {
                 _viewModel.CloseTransientPanelsCommand.Execute(null);
@@ -159,6 +166,13 @@ internal sealed partial class MainWindow : Window
                 e.Handled = true;
                 return true;
             }
+        }
+
+        if (!isEditingTextBox && e.Key == Key.Delete)
+        {
+            _viewModel.RecentQsos.RequestDeleteSelectedQso();
+            e.Handled = true;
+            return true;
         }
 
         if (e.Key == Key.Enter && _recentQsoGrid.CommitEdit())


### PR DESCRIPTION
## Summary

Major GUI overhaul adding new features and fixing visual bugs reported in issues #122-#134.

### New Features

**Callsign Card (F8)** — Rich overlay showing full QRZ profile for the selected QSO's callsign:
- Profile image (downloaded from QRZ image_url)
- Identity: callsign, full name, nickname, license class
- Location: QTH, country, state, county, grid, timezone
- Zones: DXCC country/continent, CQ zone, ITU zone, IOTA
- QSL: eQSL, LoTW, paper QSL status, QSL manager
- Profile: aliases, previous call, web URL, email
- Dark navy card with cyan callsign header, close with Esc or X button

**Delete QSO (Del)** — Confirmation dialog before permanent deletion via gRPC DeleteQso.

**Color Grid** — Inspired by the TUI color palette:
- Cyan callsigns (`#00d4ff`) with SemiBold weight
- Amber bands (`#FFB347`)
- Green modes (`#77DD77`)
- Monospace frequency (Cascadia Mono)

**Dark Theme** — Explicit dark theme with custom QsoRipper-cyan accent colors via FluentTheme resource dictionary overrides in App.axaml.

### Bug Fixes

**Toolbar button text clipping** — Replaced `Height` with `MinHeight` on all toolbar buttons so Avalonia Fluent theme can auto-size without cutting off text descenders at fractional DPI.

**Cell alignment** — Added `VerticalAlignment="Center"` to Country, Name, Contest, Note, and QTH template columns so text is centered instead of smashed against the top.

**UTC time cutoff** — Widened UTC column from 130 to 138px to prevent initial clipping.

**Cell selection white lines** — Root-caused to Avalonia DataGridCell's `:focus` pseudo-class showing `Grid#FocusVisual` with two white-stroked Rectangles (not `CurrencyVisual` as previously assumed). Fixed by hiding both `CurrencyVisual` and `FocusVisual`, replaced with a subtle blue background (`#400078D7`).

### Service Layer

- Added `LookupCallsignAsync` and `DeleteQsoAsync` to `IEngineClient`
- Wired `LookupService.LookupServiceClient` in `EngineGrpcService`
- Added full fixture implementations in `UxFixtureEngineClient`

### Keyboard Shortcuts

| Key | Action |
|-----|--------|
| F2 | Edit cell |
| Del | Delete QSO (with confirmation) |
| Ctrl+S | Save edits |
| F5 | Refresh |
| F6 | Sync with QRZ |
| F8 | Callsign card |
| Alt+Enter | Inspector panel |
| Esc | Close card/panels |

### Testing

- **217/217 tests pass** (28 GUI + 149 CLI + 40 DebugHost)
- `dotnet format --verify-no-changes` clean
- Visual verification via `capture-avalonia.ps1`
- New automation scripts: `avalonia-callsign-card.json`, `avalonia-cell-select-test.json`

### Files Changed (18 files, +1418/-28)

New files:
- `CallsignCardViewModel.cs` — VM with 25+ observable properties, image download, QRZ lookup
- `CallsignCardView.axaml` / `.axaml.cs` — Dark-themed card UI with sections
- `ButtonClipTestWindow.axaml` / `.axaml.cs` — Diagnostic window for button clipping
- 3 automation action scripts

Modified:
- `App.axaml` — Dark theme, accent color overrides
- `MainWindow.axaml` — Color grid columns, callsign card overlay, delete dialog, status bar
- `MainWindow.axaml.cs` — Del key handler, Esc closes card
- `MainWindowViewModel.cs` — Card open/close commands
- `RecentQsoListViewModel.cs` — Delete confirmation flow
- `IEngineClient.cs` / `EngineGrpcService.cs` — Lookup + delete APIs
- `UxFixtureEngineClient.cs` — Fixture lookup + delete
- `RecentQsoListViewModelTests.cs` — Updated fake client