### PR TITLE
feat: QSO Logger, rig control, callsign lookup, continent colors & 10 bug fixes

### DIFF
--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
@@ -115,7 +115,7 @@ public class RecentQsoListViewModelTests
 
         Assert.Single(viewModel.VisibleItems);
         Assert.Equal("qso-1", viewModel.VisibleItems[0].LocalId);
-        Assert.Equal(3, viewModel.ActiveFilterTokens.Count);
+        Assert.Equal(2, viewModel.ActiveFilterTokens.Count);
         Assert.Equal("1 filtered", viewModel.FilterStatusText);
     }
 
@@ -124,7 +124,7 @@ public class RecentQsoListViewModelTests
     {
         var original = CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States");
         var updated = original.Clone();
-        updated.Comment = "Updated note";
+        updated.Notes = "Updated note";
 
         var engine = new FakeEngineClient
         {
@@ -145,7 +145,7 @@ public class RecentQsoListViewModelTests
         await viewModel.SaveEditsCommand.ExecuteAsync(null);
 
         Assert.Single(engine.UpdatedQsos);
-        Assert.Equal("Updated note", engine.UpdatedQsos[0].Comment);
+        Assert.Equal("Updated note", engine.UpdatedQsos[0].Notes);
         Assert.Equal(0, viewModel.PendingEditCount);
         Assert.Equal("No pending edits", viewModel.EditStatusText);
         Assert.Equal("Updated note", viewModel.SelectedQso?.Note);
@@ -217,7 +217,7 @@ public class RecentQsoListViewModelTests
                 contestId: "CQ-WW",
                 exchangeReceived: "WA"));
 
-        Assert.True(RecentQsoListViewModel.MatchesSearch(item, "call:w1aw band:40m contest:cq note:evening"));
+        Assert.True(RecentQsoListViewModel.MatchesSearch(item, "call:w1aw band:40m contest:cq comment:evening"));
         Assert.False(RecentQsoListViewModel.MatchesSearch(item, "call:w1aw band:20m"));
     }
 

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
@@ -418,5 +418,17 @@ public class RecentQsoListViewModelTests
 
         public Task<DeleteQsoResponse> DeleteQsoAsync(string localId, bool deleteFromQrz = false, CancellationToken ct = default) =>
             throw new NotImplementedException();
+
+        public Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetRigSnapshotResponse> GetRigSnapshotAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetRigStatusResponse> GetRigStatusAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
     }
 }

--- a/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
@@ -394,6 +394,47 @@ internal sealed class UxFixtureEngineClient : IEngineClient
         }
     }
 
+    public Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default)
+    {
+        return Task.FromResult(new LogQsoResponse { LocalId = Guid.NewGuid().ToString() });
+    }
+
+    public Task<GetRigSnapshotResponse> GetRigSnapshotAsync(CancellationToken ct = default)
+    {
+        return Task.FromResult(new GetRigSnapshotResponse
+        {
+            Snapshot = new RigSnapshot
+            {
+                FrequencyHz = 14225000,
+                Band = Band._20M,
+                Mode = Mode.Ssb,
+                Status = RigConnectionStatus.Connected,
+            }
+        });
+    }
+
+    public Task<GetRigStatusResponse> GetRigStatusAsync(CancellationToken ct = default)
+    {
+        return Task.FromResult(new GetRigStatusResponse
+        {
+            Status = RigConnectionStatus.Connected,
+        });
+    }
+
+    public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default)
+    {
+        return Task.FromResult(new GetCurrentSpaceWeatherResponse
+        {
+            Snapshot = new SpaceWeatherSnapshot
+            {
+                PlanetaryKIndex = 2.0,
+                SolarFluxIndex = 148.0,
+                SunspotNumber = 95,
+                Status = SpaceWeatherStatus.Current,
+            }
+        });
+    }
+
     private SetupStatus BuildSetupStatus()
     {
         var status = new SetupStatus

--- a/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
@@ -18,6 +18,8 @@ internal sealed class EngineGrpcService : IEngineClient, IDisposable
     private readonly SetupService.SetupServiceClient _setupClient;
     private readonly LogbookService.LogbookServiceClient _logbookClient;
     private readonly LookupService.LookupServiceClient _lookupClient;
+    private readonly RigControlService.RigControlServiceClient _rigClient;
+    private readonly SpaceWeatherService.SpaceWeatherServiceClient _spaceWeatherClient;
 
     public EngineGrpcService(GrpcChannel channel)
     {
@@ -25,6 +27,8 @@ internal sealed class EngineGrpcService : IEngineClient, IDisposable
         _setupClient = new SetupService.SetupServiceClient(channel);
         _logbookClient = new LogbookService.LogbookServiceClient(channel);
         _lookupClient = new LookupService.LookupServiceClient(channel);
+        _rigClient = new RigControlService.RigControlServiceClient(channel);
+        _spaceWeatherClient = new SpaceWeatherService.SpaceWeatherServiceClient(channel);
     }
 
     public async Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default)
@@ -163,6 +167,40 @@ internal sealed class EngineGrpcService : IEngineClient, IDisposable
                 DeleteFromQrz = deleteFromQrz
             },
             cancellationToken: ct);
+    }
+
+    public async Task<LogQsoResponse> LogQsoAsync(
+        QsoRecord qso,
+        bool syncToQrz = false,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(qso);
+
+        return await _logbookClient.LogQsoAsync(
+            new LogQsoRequest
+            {
+                Qso = qso,
+                SyncToQrz = syncToQrz,
+            },
+            cancellationToken: ct);
+    }
+
+    public async Task<GetRigSnapshotResponse> GetRigSnapshotAsync(CancellationToken ct = default)
+    {
+        return await _rigClient.GetRigSnapshotAsync(
+            new GetRigSnapshotRequest(), cancellationToken: ct);
+    }
+
+    public async Task<GetRigStatusResponse> GetRigStatusAsync(CancellationToken ct = default)
+    {
+        return await _rigClient.GetRigStatusAsync(
+            new GetRigStatusRequest(), cancellationToken: ct);
+    }
+
+    public async Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default)
+    {
+        return await _spaceWeatherClient.GetCurrentSpaceWeatherAsync(
+            new GetCurrentSpaceWeatherRequest(), cancellationToken: ct);
     }
 
     public void Dispose()

--- a/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
@@ -43,4 +43,12 @@ internal interface IEngineClient
     Task<LookupResponse> LookupCallsignAsync(string callsign, CancellationToken ct = default);
 
     Task<DeleteQsoResponse> DeleteQsoAsync(string localId, bool deleteFromQrz = false, CancellationToken ct = default);
+
+    Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default);
+
+    Task<GetRigSnapshotResponse> GetRigSnapshotAsync(CancellationToken ct = default);
+
+    Task<GetRigStatusResponse> GetRigStatusAsync(CancellationToken ct = default);
+
+    Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default);
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
@@ -1,0 +1,71 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace QsoRipper.Gui.ViewModels;
+
+internal sealed partial class FullQsoCardViewModel : ObservableObject
+{
+    private readonly QsoLoggerViewModel _logger;
+
+    public FullQsoCardViewModel(QsoLoggerViewModel logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Proxy to the logger's core fields so the card can bind them directly.
+    /// </summary>
+    public QsoLoggerViewModel Logger => _logger;
+
+    // Additional fields for full entry beyond the compact logger.
+
+    [ObservableProperty]
+    private string _gridSquare = string.Empty;
+
+    [ObservableProperty]
+    private string _name = string.Empty;
+
+    [ObservableProperty]
+    private string _country = string.Empty;
+
+    [ObservableProperty]
+    private string _state = string.Empty;
+
+    [ObservableProperty]
+    private string _contest = string.Empty;
+
+    [ObservableProperty]
+    private string _exchange = string.Empty;
+
+    [ObservableProperty]
+    private string _notes = string.Empty;
+
+    public event EventHandler? CloseRequested;
+
+    [RelayCommand]
+    private void Close()
+    {
+        CloseRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>
+    /// Populate extra fields from a lookup result.
+    /// </summary>
+    public void ApplyLookup(string? name, string? grid, string? country)
+    {
+        if (!string.IsNullOrWhiteSpace(name))
+        {
+            Name = name;
+        }
+
+        if (!string.IsNullOrWhiteSpace(grid))
+        {
+            GridSquare = grid;
+        }
+
+        if (!string.IsNullOrWhiteSpace(country))
+        {
+            Country = country;
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/HelpOverlayViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/HelpOverlayViewModel.cs
@@ -1,0 +1,53 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace QsoRipper.Gui.ViewModels;
+
+internal sealed partial class HelpOverlayViewModel : ObservableObject
+{
+    internal record ShortcutEntry(string Key, string Description);
+
+    internal record ShortcutGroup(string Title, ShortcutEntry[] Entries);
+
+    public ShortcutGroup[] Groups { get; } =
+    [
+        new("Navigation", [
+            new("F1", "Toggle help"),
+            new("F3", "Focus QSO grid"),
+            new("F4 / Ctrl+F", "Focus search"),
+            new("Ctrl+N", "Focus QSO logger"),
+            new("Tab / Shift+Tab", "Cycle logger fields"),
+            new("Esc", "Close overlay / clear"),
+        ]),
+        new("QSO Logging", [
+            new("Ctrl+Enter", "Log QSO"),
+            new("F7", "Reset QSO timer"),
+            new("\u2190 / \u2192", "Cycle band/mode (when focused)"),
+        ]),
+        new("Grid", [
+            new("F2", "Edit selected cell"),
+            new("Ctrl+S", "Save edits"),
+            new("Ctrl+D / Delete", "Delete selected QSO"),
+            new("F5", "Refresh"),
+            new("F8", "Callsign card"),
+            new("Alt+Enter", "Toggle inspector"),
+        ]),
+        new("System", [
+            new("F6", "Sync with QRZ"),
+            new("Ctrl+R", "Toggle rig control"),
+            new("Ctrl+W", "Toggle space weather"),
+            new("Ctrl+,", "Settings"),
+            new("Ctrl+Shift+S", "Sort chooser"),
+            new("Ctrl+H", "Column chooser"),
+            new("Ctrl+Q / Alt+X", "Quit"),
+        ]),
+    ];
+
+    public event EventHandler? CloseRequested;
+
+    [RelayCommand]
+    private void Close()
+    {
+        CloseRequested?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -90,6 +90,15 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     [ObservableProperty]
     private HelpOverlayViewModel? _helpOverlay;
 
+    [ObservableProperty]
+    private bool _isFullQsoCardOpen;
+
+    [ObservableProperty]
+    private FullQsoCardViewModel? _fullQsoCard;
+
+    [ObservableProperty]
+    private bool _isLoggerFocused;
+
     internal MainWindowViewModel(string endpoint)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(endpoint);
@@ -324,6 +333,21 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     }
 
     [RelayCommand]
+    private void ToggleFullQsoCard()
+    {
+        if (IsFullQsoCardOpen)
+        {
+            CloseFullQsoCard();
+            return;
+        }
+
+        var vm = new FullQsoCardViewModel(Logger);
+        vm.CloseRequested += OnFullQsoCardCloseRequested;
+        FullQsoCard = vm;
+        IsFullQsoCardOpen = true;
+    }
+
+    [RelayCommand]
     private void ToggleInspector()
     {
         IsInspectorOpen = !IsInspectorOpen;
@@ -362,8 +386,22 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
             return;
         }
 
-        var selectedQso = RecentQsos.SelectedQso;
-        if (selectedQso is null || string.IsNullOrWhiteSpace(selectedQso.WorkedCallsign))
+        // If logger has focus and has a callsign, use that
+        string? callsign = null;
+        if (IsLoggerFocused && !string.IsNullOrWhiteSpace(Logger.Callsign))
+        {
+            callsign = Logger.Callsign.Trim().ToUpperInvariant();
+        }
+        else
+        {
+            var selectedQso = RecentQsos.SelectedQso;
+            if (selectedQso is not null && !string.IsNullOrWhiteSpace(selectedQso.WorkedCallsign))
+            {
+                callsign = selectedQso.WorkedCallsign;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(callsign))
         {
             return;
         }
@@ -372,7 +410,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         vm.CloseRequested += OnCallsignCardCloseRequested;
         CallsignCard = vm;
         IsCallsignCardOpen = true;
-        _ = vm.LoadAsync(selectedQso.WorkedCallsign);
+        _ = vm.LoadAsync(callsign);
     }
 
     [RelayCommand]
@@ -383,9 +421,18 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
             card.CloseRequested -= OnCallsignCardCloseRequested;
         }
 
+        var wasLoggerFocused = IsLoggerFocused;
         IsCallsignCardOpen = false;
         CallsignCard = null;
-        GridFocusRequested?.Invoke(this, EventArgs.Empty);
+
+        if (wasLoggerFocused)
+        {
+            Logger.FocusLogger();
+        }
+        else
+        {
+            GridFocusRequested?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     private void OnCallsignCardCloseRequested(object? sender, EventArgs e)
@@ -408,6 +455,23 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     private void OnHelpCloseRequested(object? sender, EventArgs e)
     {
         CloseHelp();
+    }
+
+    private void CloseFullQsoCard()
+    {
+        if (FullQsoCard is { } card)
+        {
+            card.CloseRequested -= OnFullQsoCardCloseRequested;
+        }
+
+        IsFullQsoCardOpen = false;
+        FullQsoCard = null;
+        Logger.FocusLogger();
+    }
+
+    private void OnFullQsoCardCloseRequested(object? sender, EventArgs e)
+    {
+        CloseFullQsoCard();
     }
 
     private async void OnQsoLogged(object? sender, EventArgs e)
@@ -573,7 +637,8 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         }
         else
         {
-            GridFocusRequested?.Invoke(this, EventArgs.Empty);
+            // Default: focus the QSO logger callsign field for immediate entry
+            Logger.FocusLogger();
         }
     }
 

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -16,6 +17,8 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 {
     private readonly IEngineClient _engine;
     private readonly DispatcherTimer _utcTimer;
+    private readonly DispatcherTimer _rigTimer;
+    private readonly DispatcherTimer _spaceWeatherTimer;
     private bool _setupCompleteBeforeWizard;
 
     [ObservableProperty]
@@ -69,6 +72,24 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     [ObservableProperty]
     private CallsignCardViewModel? _callsignCard;
 
+    [ObservableProperty]
+    private bool _isRigEnabled;
+
+    [ObservableProperty]
+    private string _rigStatusText = "Rig: OFF";
+
+    [ObservableProperty]
+    private bool _isSpaceWeatherVisible;
+
+    [ObservableProperty]
+    private string _spaceWeatherText = string.Empty;
+
+    [ObservableProperty]
+    private bool _isHelpOpen;
+
+    [ObservableProperty]
+    private HelpOverlayViewModel? _helpOverlay;
+
     internal MainWindowViewModel(string endpoint)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(endpoint);
@@ -76,8 +97,15 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         _engine = new EngineGrpcService(GrpcChannel.ForAddress(endpoint));
         RecentQsos = new RecentQsoListViewModel(_engine);
         RecentQsos.PropertyChanged += OnRecentQsosPropertyChanged;
+        Logger = new QsoLoggerViewModel(_engine);
+        Logger.QsoLogged += OnQsoLogged;
+        Logger.LoggerFocusRequested += OnLoggerFocusRequested;
         UpdateUtcClock();
         _utcTimer = CreateUtcTimer();
+        _rigTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        _rigTimer.Tick += OnRigTimerTick;
+        _spaceWeatherTimer = new DispatcherTimer { Interval = TimeSpan.FromMinutes(5) };
+        _spaceWeatherTimer.Tick += OnSpaceWeatherTimerTick;
     }
 
     internal MainWindowViewModel(IEngineClient engine)
@@ -85,11 +113,20 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         _engine = engine;
         RecentQsos = new RecentQsoListViewModel(engine);
         RecentQsos.PropertyChanged += OnRecentQsosPropertyChanged;
+        Logger = new QsoLoggerViewModel(engine);
+        Logger.QsoLogged += OnQsoLogged;
+        Logger.LoggerFocusRequested += OnLoggerFocusRequested;
         UpdateUtcClock();
         _utcTimer = CreateUtcTimer();
+        _rigTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        _rigTimer.Tick += OnRigTimerTick;
+        _spaceWeatherTimer = new DispatcherTimer { Interval = TimeSpan.FromMinutes(5) };
+        _spaceWeatherTimer.Tick += OnSpaceWeatherTimerTick;
     }
 
     public RecentQsoListViewModel RecentQsos { get; }
+
+    public QsoLoggerViewModel Logger { get; }
 
     /// <summary>
     /// Proxy for <see cref="RecentQsoListViewModel.SelectedQso"/> so the Inspector
@@ -102,6 +139,8 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     public event EventHandler? SearchFocusRequested;
 
     public event EventHandler? GridFocusRequested;
+
+    public event EventHandler? LoggerFocusRequested;
 
     /// <summary>
     /// Raised when the user requests the Settings dialog. The View subscribes to
@@ -224,6 +263,67 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     }
 
     [RelayCommand]
+    private void FocusLogger()
+    {
+        if (!IsWizardOpen)
+        {
+            CloseTransientPanels();
+            Logger.FocusLogger();
+        }
+    }
+
+    [RelayCommand]
+    private void FocusGrid()
+    {
+        if (!IsWizardOpen)
+        {
+            CloseTransientPanels();
+            GridFocusRequested?.Invoke(this, EventArgs.Empty);
+        }
+    }
+
+    [RelayCommand]
+    private void ToggleRigControl()
+    {
+        IsRigEnabled = !IsRigEnabled;
+        if (IsRigEnabled)
+        {
+            RigStatusText = "Rig: connecting\u2026";
+            _rigTimer.Start();
+        }
+        else
+        {
+            _rigTimer.Stop();
+            RigStatusText = "Rig: OFF";
+        }
+    }
+
+    [RelayCommand]
+    private void ToggleSpaceWeather()
+    {
+        IsSpaceWeatherVisible = !IsSpaceWeatherVisible;
+        if (IsSpaceWeatherVisible && string.IsNullOrEmpty(SpaceWeatherText))
+        {
+            _ = FetchSpaceWeatherAsync();
+        }
+    }
+
+    [RelayCommand]
+    private void ToggleHelp()
+    {
+        if (IsHelpOpen)
+        {
+            CloseHelp();
+            return;
+        }
+
+        var vm = new HelpOverlayViewModel();
+        vm.CloseRequested += OnHelpCloseRequested;
+        HelpOverlay = vm;
+        IsHelpOpen = true;
+    }
+
+    [RelayCommand]
     private void ToggleInspector()
     {
         IsInspectorOpen = !IsInspectorOpen;
@@ -293,6 +393,99 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         CloseCallsignCard();
     }
 
+    private void CloseHelp()
+    {
+        if (HelpOverlay is { } h)
+        {
+            h.CloseRequested -= OnHelpCloseRequested;
+        }
+
+        IsHelpOpen = false;
+        HelpOverlay = null;
+        GridFocusRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void OnHelpCloseRequested(object? sender, EventArgs e)
+    {
+        CloseHelp();
+    }
+
+    private async void OnQsoLogged(object? sender, EventArgs e)
+    {
+        await RecentQsos.RefreshAsync();
+    }
+
+    private void OnLoggerFocusRequested(object? sender, EventArgs e)
+    {
+        LoggerFocusRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    private async void OnRigTimerTick(object? sender, EventArgs e)
+    {
+        try
+        {
+            var response = await _engine.GetRigSnapshotAsync();
+            if (response.Snapshot is { } snapshot)
+            {
+                if (snapshot.Status == QsoRipper.Domain.RigConnectionStatus.Connected)
+                {
+                    var freqMhz = snapshot.FrequencyHz / 1_000_000.0;
+                    RigStatusText = $"Rig: {freqMhz.ToString("F3", CultureInfo.InvariantCulture)} {snapshot.Mode}";
+                    Logger.ApplyRigSnapshot(snapshot);
+                }
+                else
+                {
+                    RigStatusText = $"Rig: {snapshot.Status}";
+                }
+            }
+        }
+        catch (Grpc.Core.RpcException)
+        {
+            RigStatusText = "Rig: error";
+        }
+    }
+
+    private async void OnSpaceWeatherTimerTick(object? sender, EventArgs e)
+    {
+        await FetchSpaceWeatherAsync();
+    }
+
+    private async Task FetchSpaceWeatherAsync()
+    {
+        try
+        {
+            var response = await _engine.GetCurrentSpaceWeatherAsync();
+            if (response.Snapshot is { } sw && sw.Status == QsoRipper.Domain.SpaceWeatherStatus.Current)
+            {
+                var parts = new List<string>();
+                if (sw.HasPlanetaryKIndex)
+                {
+                    parts.Add($"K:{sw.PlanetaryKIndex.ToString("F0", CultureInfo.InvariantCulture)}");
+                }
+
+                if (sw.HasSolarFluxIndex)
+                {
+                    parts.Add($"SFI:{sw.SolarFluxIndex.ToString("F0", CultureInfo.InvariantCulture)}");
+                }
+
+                if (sw.HasSunspotNumber)
+                {
+                    parts.Add($"SN:{sw.SunspotNumber.ToString(CultureInfo.InvariantCulture)}");
+                }
+
+                SpaceWeatherText = parts.Count > 0 ? string.Join(" ", parts) : "Weather: no data";
+            }
+            else
+            {
+                SpaceWeatherText = "Weather: unavailable";
+            }
+        }
+        catch (Grpc.Core.RpcException)
+        {
+            SpaceWeatherText = "Weather: error";
+        }
+    }
+
     [RelayCommand]
     private void CloseTransientPanels()
     {
@@ -348,6 +541,12 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         _utcTimer.Stop();
         _utcTimer.Tick -= UtcTimerOnTick;
 
+        _rigTimer.Stop();
+        _rigTimer.Tick -= OnRigTimerTick;
+
+        _spaceWeatherTimer.Stop();
+        _spaceWeatherTimer.Tick -= OnSpaceWeatherTimerTick;
+
         if (_engine is IDisposable disposable)
         {
             disposable.Dispose();
@@ -359,6 +558,9 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         StatusMessage = "Ready";
         await RecentQsos.RefreshAsync();
         await RefreshSyncStatusAsync();
+
+        _ = FetchSpaceWeatherAsync();
+        _spaceWeatherTimer.Start();
 
         if (IsWizardOpen)
         {

--- a/src/dotnet/QsoRipper.Gui/ViewModels/OperatorOptions.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/OperatorOptions.cs
@@ -1,0 +1,75 @@
+using QsoRipper.Domain;
+
+namespace QsoRipper.Gui.ViewModels;
+
+internal sealed record BandOption(string Label, Band ProtoBand, double DefaultFrequencyMhz);
+
+internal sealed record ModeOption(string Label, Mode ProtoMode, string? Submode, string DefaultRst);
+
+internal static class OperatorOptions
+{
+    public static BandOption[] Bands { get; } =
+    [
+        new("160m", Band._160M, 1.900),
+        new("80m", Band._80M, 3.750),
+        new("60m", Band._60M, 5.330),
+        new("40m", Band._40M, 7.150),
+        new("30m", Band._30M, 10.125),
+        new("20m", Band._20M, 14.225),
+        new("17m", Band._17M, 18.100),
+        new("15m", Band._15M, 21.200),
+        new("12m", Band._12M, 24.940),
+        new("10m", Band._10M, 28.400),
+        new("6m", Band._6M, 50.125),
+        new("2m", Band._2M, 146.520),
+        new("70cm", Band._70Cm, 446.000),
+    ];
+
+    public static ModeOption[] Modes { get; } =
+    [
+        new("SSB", Mode.Ssb, null, "59"),
+        new("CW", Mode.Cw, null, "599"),
+        new("FT8", Mode.Ft8, null, "599"),
+        new("FT4", Mode.Mfsk, "FT4", "599"),
+        new("RTTY", Mode.Rtty, null, "599"),
+        new("PSK31", Mode.Psk, "PSK31", "599"),
+        new("AM", Mode.Am, null, "59"),
+        new("FM", Mode.Fm, null, "59"),
+    ];
+
+    public static int FindBandIndex(Band band)
+    {
+        for (int i = 0; i < Bands.Length; i++)
+        {
+            if (Bands[i].ProtoBand == band)
+            {
+                return i;
+            }
+        }
+
+        return 0;
+    }
+
+    public static int FindModeIndex(Mode mode, string? submode)
+    {
+        for (int i = 0; i < Modes.Length; i++)
+        {
+            var opt = Modes[i];
+            if (opt.ProtoMode == mode && string.Equals(opt.Submode, submode, StringComparison.OrdinalIgnoreCase))
+            {
+                return i;
+            }
+        }
+
+        // Fall back to just matching proto mode
+        for (int i = 0; i < Modes.Length; i++)
+        {
+            if (Modes[i].ProtoMode == mode)
+            {
+                return i;
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
@@ -1,6 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -21,6 +23,7 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
     private readonly DispatcherTimer _elapsedTimer;
     private DateTimeOffset _qsoStartTime;
     private bool _timerRunning;
+    private CancellationTokenSource? _lookupCts;
 
     // Manual-override tracking: when true the field was explicitly typed by
     // the operator and should not be overwritten by band/mode defaults or
@@ -61,6 +64,18 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
 
     [ObservableProperty]
     private string _logStatusText = string.Empty;
+
+    [ObservableProperty]
+    private string _lookupName = string.Empty;
+
+    [ObservableProperty]
+    private string _lookupGrid = string.Empty;
+
+    [ObservableProperty]
+    private string _lookupCountry = string.Empty;
+
+    [ObservableProperty]
+    private string _lookupStatusText = string.Empty;
 
     // ── Constructor ──────────────────────────────────────────────────────
 
@@ -110,6 +125,19 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
         {
             StopTimer();
         }
+
+        // Cancel any pending lookup
+        _lookupCts?.Cancel();
+
+        if (string.IsNullOrWhiteSpace(value) || value.Trim().Length < 3)
+        {
+            ClearLookupFields();
+            return;
+        }
+
+        // Debounced lookup
+        _lookupCts = new CancellationTokenSource();
+        _ = DebouncedLookupAsync(value.Trim().ToUpperInvariant(), _lookupCts.Token);
     }
 
     partial void OnSelectedBandIndexChanged(int value)
@@ -235,9 +263,11 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
     [RelayCommand]
     private void Clear()
     {
+        _lookupCts?.Cancel();
         Callsign = string.Empty;
         Comment = string.Empty;
         LogStatusText = string.Empty;
+        ClearLookupFields();
         _frequencyManuallySet = false;
         _rstManuallySet = false;
         _bandManuallySet = false;
@@ -315,6 +345,90 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
     public void FocusLogger()
     {
         LoggerFocusRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    // ── Debounced callsign lookup ───────────────────────────────────────
+
+    private async Task DebouncedLookupAsync(string callsign, CancellationToken ct)
+    {
+        try
+        {
+            await Task.Delay(800, ct);
+        }
+        catch (TaskCanceledException)
+        {
+            return;
+        }
+
+        if (ct.IsCancellationRequested)
+        {
+            return;
+        }
+
+        LookupStatusText = "Looking up\u2026";
+
+        try
+        {
+            var response = await _engine.LookupCallsignAsync(callsign, ct);
+            if (ct.IsCancellationRequested)
+            {
+                return;
+            }
+
+            var result = response.Result;
+            if (result is not null && result.State == LookupState.Found)
+            {
+                var record = result.Record;
+                if (record is not null)
+                {
+                    LookupName = BuildName(record.FirstName, record.LastName);
+                    LookupGrid = record.GridSquare ?? string.Empty;
+                    LookupCountry = record.Country ?? string.Empty;
+                    LookupStatusText = string.Empty;
+                }
+                else
+                {
+                    LookupStatusText = "No data";
+                }
+            }
+            else
+            {
+                ClearLookupFields();
+                LookupStatusText = "Not found";
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            // Lookup was cancelled — expected when user keeps typing
+        }
+        catch (Grpc.Core.RpcException)
+        {
+            LookupStatusText = "Lookup error";
+        }
+    }
+
+    private void ClearLookupFields()
+    {
+        LookupName = string.Empty;
+        LookupGrid = string.Empty;
+        LookupCountry = string.Empty;
+        LookupStatusText = string.Empty;
+    }
+
+    private static string BuildName(string? first, string? last)
+    {
+        var parts = new List<string>(2);
+        if (!string.IsNullOrWhiteSpace(first))
+        {
+            parts.Add(first.Trim());
+        }
+
+        if (!string.IsNullOrWhiteSpace(last))
+        {
+            parts.Add(last.Trim());
+        }
+
+        return string.Join(" ", parts);
     }
 
     // ── Timer helpers ────────────────────────────────────────────────────

--- a/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
@@ -1,0 +1,371 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Domain;
+using QsoRipper.Gui.Services;
+
+namespace QsoRipper.Gui.ViewModels;
+
+/// <summary>
+/// ViewModel for the QSO creation panel. Manages callsign entry, band/mode
+/// cycling, elapsed-time tracking, and submission to the engine.
+/// </summary>
+internal sealed partial class QsoLoggerViewModel : ObservableObject
+{
+    private readonly IEngineClient _engine;
+    private readonly DispatcherTimer _elapsedTimer;
+    private DateTimeOffset _qsoStartTime;
+    private bool _timerRunning;
+
+    // Manual-override tracking: when true the field was explicitly typed by
+    // the operator and should not be overwritten by band/mode defaults or
+    // rig snapshots.
+    private bool _frequencyManuallySet;
+    private bool _rstManuallySet;
+    private bool _bandManuallySet;
+    private bool _modeManuallySet;
+
+    // ── Observable properties ────────────────────────────────────────────
+
+    [ObservableProperty]
+    private string _callsign = string.Empty;
+
+    [ObservableProperty]
+    private int _selectedBandIndex;
+
+    [ObservableProperty]
+    private int _selectedModeIndex;
+
+    [ObservableProperty]
+    private string _rstSent = "59";
+
+    [ObservableProperty]
+    private string _rstRcvd = "59";
+
+    [ObservableProperty]
+    private string _frequencyMhz = "14.225";
+
+    [ObservableProperty]
+    private string _comment = string.Empty;
+
+    [ObservableProperty]
+    private string _elapsedTimeText = "00:00";
+
+    [ObservableProperty]
+    private bool _isLogEnabled;
+
+    [ObservableProperty]
+    private string _logStatusText = string.Empty;
+
+    // ── Constructor ──────────────────────────────────────────────────────
+
+    public QsoLoggerViewModel(IEngineClient engine)
+    {
+        _engine = engine;
+        _selectedBandIndex = 5;  // 20 m
+        _selectedModeIndex = 0;  // SSB
+        _qsoStartTime = DateTimeOffset.UtcNow;
+
+        _elapsedTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        _elapsedTimer.Tick += OnElapsedTimerTick;
+
+        UpdateLogEnabled();
+    }
+
+    // ── Computed / read-only ─────────────────────────────────────────────
+
+    public static BandOption[] BandOptions => OperatorOptions.Bands;
+    public static ModeOption[] ModeOptions => OperatorOptions.Modes;
+
+    public BandOption SelectedBand => OperatorOptions.Bands[SelectedBandIndex];
+    public ModeOption SelectedMode => OperatorOptions.Modes[SelectedModeIndex];
+
+    public string BandLabel => SelectedBand.Label;
+    public string ModeLabel => SelectedMode.Label;
+
+    // ── Events ───────────────────────────────────────────────────────────
+
+    /// <summary>Raised after a QSO is successfully logged.</summary>
+    public event EventHandler? QsoLogged;
+
+    /// <summary>Raised when the view should move focus to the callsign field.</summary>
+    public event EventHandler? LoggerFocusRequested;
+
+    // ── Property-change hooks ────────────────────────────────────────────
+
+    partial void OnCallsignChanged(string value)
+    {
+        UpdateLogEnabled();
+
+        if (!string.IsNullOrWhiteSpace(value) && !_timerRunning)
+        {
+            StartTimer();
+        }
+        else if (string.IsNullOrWhiteSpace(value) && _timerRunning)
+        {
+            StopTimer();
+        }
+    }
+
+    partial void OnSelectedBandIndexChanged(int value)
+    {
+        if (value < 0 || value >= OperatorOptions.Bands.Length)
+            return;
+
+        OnPropertyChanged(nameof(SelectedBand));
+        OnPropertyChanged(nameof(BandLabel));
+
+        if (!_frequencyManuallySet)
+        {
+            FrequencyMhz = OperatorOptions.Bands[value].DefaultFrequencyMhz
+                .ToString("F3", CultureInfo.InvariantCulture);
+        }
+    }
+
+    partial void OnSelectedModeIndexChanged(int value)
+    {
+        if (value < 0 || value >= OperatorOptions.Modes.Length)
+            return;
+
+        OnPropertyChanged(nameof(SelectedMode));
+        OnPropertyChanged(nameof(ModeLabel));
+
+        if (!_rstManuallySet)
+        {
+            var defaultRst = OperatorOptions.Modes[value].DefaultRst;
+            RstSent = defaultRst;
+            RstRcvd = defaultRst;
+        }
+    }
+
+    // ── Band / mode cycling commands ─────────────────────────────────────
+
+    [RelayCommand]
+    private void CycleBandForward()
+    {
+        _bandManuallySet = true;
+        SelectedBandIndex = (SelectedBandIndex + 1) % OperatorOptions.Bands.Length;
+    }
+
+    [RelayCommand]
+    private void CycleBandBackward()
+    {
+        _bandManuallySet = true;
+        SelectedBandIndex = (SelectedBandIndex - 1 + OperatorOptions.Bands.Length) % OperatorOptions.Bands.Length;
+    }
+
+    [RelayCommand]
+    private void CycleModeForward()
+    {
+        _modeManuallySet = true;
+        SelectedModeIndex = (SelectedModeIndex + 1) % OperatorOptions.Modes.Length;
+    }
+
+    [RelayCommand]
+    private void CycleModeBackward()
+    {
+        _modeManuallySet = true;
+        SelectedModeIndex = (SelectedModeIndex - 1 + OperatorOptions.Modes.Length) % OperatorOptions.Modes.Length;
+    }
+
+    // ── Log QSO command ──────────────────────────────────────────────────
+
+    [RelayCommand]
+    private async Task LogQsoAsync()
+    {
+        var callsign = Callsign.Trim().ToUpperInvariant();
+        if (string.IsNullOrWhiteSpace(callsign))
+        {
+            return;
+        }
+
+        var band = SelectedBand;
+        var mode = SelectedMode;
+
+        var qso = new QsoRecord
+        {
+            WorkedCallsign = callsign,
+            Band = band.ProtoBand,
+            Mode = mode.ProtoMode,
+            RstSent = ParseRst(RstSent.Trim()),
+            RstReceived = ParseRst(RstRcvd.Trim()),
+            UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+        };
+
+        if (!string.IsNullOrWhiteSpace(mode.Submode))
+        {
+            qso.Submode = mode.Submode;
+        }
+
+        if (double.TryParse(FrequencyMhz, NumberStyles.Float, CultureInfo.InvariantCulture, out var freqMhz)
+            && freqMhz > 0)
+        {
+            qso.FrequencyKhz = (ulong)(freqMhz * 1000.0);
+        }
+
+        if (!string.IsNullOrWhiteSpace(Comment))
+        {
+            qso.Comment = Comment.Trim();
+        }
+
+        LogStatusText = "Logging\u2026";
+        IsLogEnabled = false;
+
+        try
+        {
+            var response = await _engine.LogQsoAsync(qso);
+            LogStatusText = $"Logged {callsign}";
+            Clear();
+            QsoLogged?.Invoke(this, EventArgs.Empty);
+        }
+        catch (Grpc.Core.RpcException ex)
+        {
+            LogStatusText = $"Error: {ex.Status.Detail}";
+            IsLogEnabled = true;
+        }
+    }
+
+    // ── Clear / reset commands ───────────────────────────────────────────
+
+    [RelayCommand]
+    private void Clear()
+    {
+        Callsign = string.Empty;
+        Comment = string.Empty;
+        LogStatusText = string.Empty;
+        _frequencyManuallySet = false;
+        _rstManuallySet = false;
+        _bandManuallySet = false;
+        _modeManuallySet = false;
+
+        // Restore defaults — triggers OnSelectedBand/ModeIndexChanged which
+        // will repopulate FrequencyMhz and RST from the default band/mode.
+        SelectedBandIndex = 5;  // 20 m
+        SelectedModeIndex = 0;  // SSB
+
+        StopTimer();
+        ElapsedTimeText = "00:00";
+        UpdateLogEnabled();
+    }
+
+    [RelayCommand]
+    private void ResetTimer()
+    {
+        _qsoStartTime = DateTimeOffset.UtcNow;
+        ElapsedTimeText = "00:00";
+    }
+
+    // ── Manual-override notifications ────────────────────────────────────
+    // Called by the view when the user explicitly types in a field, so we
+    // know not to overwrite that value on subsequent band/mode changes.
+
+    public void NotifyFrequencyManuallySet()
+    {
+        _frequencyManuallySet = true;
+    }
+
+    public void NotifyRstManuallySet()
+    {
+        _rstManuallySet = true;
+    }
+
+    // ── Rig integration ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Apply a rig snapshot to untouched fields. Only fills band, mode and
+    /// frequency when the callsign is empty (fresh/cleared form) and the
+    /// field has not been manually overridden by the operator.
+    /// </summary>
+    public void ApplyRigSnapshot(RigSnapshot snapshot)
+    {
+        if (snapshot.Status != RigConnectionStatus.Connected)
+        {
+            return;
+        }
+
+        // Only auto-fill when callsign is empty (fresh form).
+        if (!string.IsNullOrWhiteSpace(Callsign))
+        {
+            return;
+        }
+
+        if (!_bandManuallySet && snapshot.Band != Band.Unspecified)
+        {
+            SelectedBandIndex = OperatorOptions.FindBandIndex(snapshot.Band);
+        }
+
+        if (!_modeManuallySet && snapshot.Mode != Mode.Unspecified)
+        {
+            SelectedModeIndex = OperatorOptions.FindModeIndex(snapshot.Mode, snapshot.Submode);
+        }
+
+        if (!_frequencyManuallySet && snapshot.FrequencyHz > 0)
+        {
+            var mhz = snapshot.FrequencyHz / 1_000_000.0;
+            FrequencyMhz = mhz.ToString("F3", CultureInfo.InvariantCulture);
+        }
+    }
+
+    /// <summary>Request the view to focus the callsign entry field.</summary>
+    public void FocusLogger()
+    {
+        LoggerFocusRequested?.Invoke(this, EventArgs.Empty);
+    }
+
+    // ── Timer helpers ────────────────────────────────────────────────────
+
+    private void StartTimer()
+    {
+        _qsoStartTime = DateTimeOffset.UtcNow;
+        _timerRunning = true;
+        _elapsedTimer.Start();
+    }
+
+    private void StopTimer()
+    {
+        _timerRunning = false;
+        _elapsedTimer.Stop();
+    }
+
+    private void OnElapsedTimerTick(object? sender, EventArgs e)
+    {
+        var elapsed = DateTimeOffset.UtcNow - _qsoStartTime;
+        ElapsedTimeText = elapsed.TotalHours >= 1
+            ? elapsed.ToString(@"h\:mm\:ss", CultureInfo.InvariantCulture)
+            : elapsed.ToString(@"mm\:ss", CultureInfo.InvariantCulture);
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────
+
+    private void UpdateLogEnabled()
+    {
+        IsLogEnabled = !string.IsNullOrWhiteSpace(Callsign);
+    }
+
+    /// <summary>
+    /// Parse an RST string (e.g. "59", "599") into a <see cref="RstReport"/>
+    /// with the individual digit fields populated alongside the raw text.
+    /// </summary>
+    private static RstReport ParseRst(string value)
+    {
+        var report = new RstReport { Raw = value };
+
+        if (value.Length is (2 or 3) && value.All(static c => char.IsAsciiDigit(c)))
+        {
+            report.Readability = (uint)(value[0] - '0');
+            report.Strength = (uint)(value[1] - '0');
+
+            if (value.Length == 3)
+            {
+                report.Tone = (uint)(value[2] - '0');
+            }
+        }
+
+        return report;
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoGridColumn.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoGridColumn.cs
@@ -25,5 +25,6 @@ internal enum RecentQsoGridColumn
     RstSent,
     RstReceived,
     State,
-    County
+    County,
+    Comment
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
@@ -38,6 +38,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
     private string _contest = "-";
     private string _station = "-";
     private string _note = "-";
+    private string _comment = "-";
     private string _utcEndDisplay = "-";
     private string _cqZone = "-";
     private string _ituZone = "-";
@@ -138,6 +139,12 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         set => SetProperty(ref _note, value);
     }
 
+    public string Comment
+    {
+        get => _comment;
+        set => SetProperty(ref _comment, value);
+    }
+
     public string UtcEndDisplay
     {
         get => _utcEndDisplay;
@@ -210,6 +217,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         Exchange,
         Station,
         Note,
+        Comment,
         CqZone,
         ItuZone,
         SyncStatus,
@@ -290,7 +298,8 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         Qth = BuildQth(_sourceQso);
         SyncStatus = BuildSyncStatus(_sourceQso.SyncStatus);
         State = NoteOrNull(_sourceQso.WorkedState) ?? string.Empty;
-        County = NoteOrNull(_sourceQso.WorkedCounty) ?? string.Empty;
+        County = ParseCountyName(_sourceQso.WorkedCounty);
+        Comment = NoteOrNull(_sourceQso.Comment) ?? "-";
         RecomputeDirty();
     }
 
@@ -316,7 +325,8 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
             "EXCH" or "EXCHANGE" => ContainsNormalized(Exchange, normalizedValue),
             "CONTEST" => ContainsNormalized(Contest, normalizedValue),
             "STATION" => ContainsNormalized(Station, normalizedValue),
-            "NOTE" or "COMMENT" => ContainsNormalized(Note, normalizedValue),
+            "NOTE" => ContainsNormalized(Note, normalizedValue),
+            "COMMENT" => ContainsNormalized(Comment, normalizedValue),
             "CQ" => ContainsNormalized(CqZone, normalizedValue),
             "ITU" => ContainsNormalized(ItuZone, normalizedValue),
             "QTH" => ContainsNormalized(Qth, normalizedValue),
@@ -408,6 +418,11 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
             ApplyNote(updated);
         }
 
+        if (!StringComparer.Ordinal.Equals(Comment, sourceState.Comment))
+        {
+            ApplyComment(updated);
+        }
+
         qso = updated;
         return true;
     }
@@ -421,7 +436,8 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         SyncStatus = BuildSyncStatus(_sourceQso.SyncStatus);
         Continent = NoteOrNull(_sourceQso.WorkedContinent) ?? "-";
         State = NoteOrNull(_sourceQso.WorkedState) ?? string.Empty;
-        County = NoteOrNull(_sourceQso.WorkedCounty) ?? string.Empty;
+        County = ParseCountyName(_sourceQso.WorkedCounty);
+        Comment = NoteOrNull(_sourceQso.Comment) ?? "-";
         RecomputeDirty();
     }
 
@@ -440,6 +456,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         Contest,
         Station,
         Note,
+        Comment,
         UtcEndDisplay,
         CqZone,
         ItuZone);
@@ -460,6 +477,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         Contest = state.Contest;
         Station = state.Station;
         Note = state.Note;
+        Comment = state.Comment;
         UtcEndDisplay = state.UtcEndDisplay;
         CqZone = state.CqZone;
         ItuZone = state.ItuZone;
@@ -605,13 +623,23 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         var note = NoteOrNull(Note);
         if (note is null)
         {
-            updated.ClearComment();
             updated.ClearNotes();
             return;
         }
 
-        updated.Comment = note;
-        updated.ClearNotes();
+        updated.Notes = note;
+    }
+
+    private void ApplyComment(QsoRecord updated)
+    {
+        var comment = NoteOrNull(Comment);
+        if (comment is null)
+        {
+            updated.ClearComment();
+            return;
+        }
+
+        updated.Comment = comment;
     }
 
     private static EditableQsoState EditableQsoStateFromQso(QsoRecord qso) => new(
@@ -629,23 +657,13 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         DisplayOrDash(qso.ContestId),
         DisplayOrDash(qso.StationCallsign),
         BuildNote(qso),
+        NoteOrNull(qso.Comment) ?? "-",
         FormatTimestamp(qso.UtcEndTimestamp),
         BuildOptionalNumber(qso.WorkedCqZone),
         BuildOptionalNumber(qso.WorkedItuZone));
 
-    private static string BuildNote(QsoRecord qso)
-    {
-        var parts = new[]
-            {
-                NoteOrNull(qso.Comment),
-                NoteOrNull(qso.Notes)
-            }
-            .Where(static value => value is not null)
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
-
-        return parts.Length == 0 ? "-" : string.Join(" / ", parts!);
-    }
+    private static string BuildNote(QsoRecord qso) =>
+        NoteOrNull(qso.Notes) ?? "-";
 
     private static string BuildCountry(QsoRecord qso)
     {
@@ -655,6 +673,18 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
                    qso.WorkedCounty,
                    qso.WorkedContinent)
                ?? "-";
+    }
+
+    private static string ParseCountyName(string? rawCounty)
+    {
+        var value = NoteOrNull(rawCounty);
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        var lastComma = value.LastIndexOf(',');
+        return lastComma >= 0 ? value[(lastComma + 1)..].Trim() : value;
     }
 
     private static string BuildOperatorName(QsoRecord qso) =>
@@ -901,6 +931,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         string Contest,
         string Station,
         string Note,
+        string Comment,
         string UtcEndDisplay,
         string CqZone,
         string ItuZone)

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
+using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
@@ -97,7 +98,14 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
     public string Rst
     {
         get => _rst;
-        set => SetProperty(ref _rst, value);
+        set
+        {
+            if (SetProperty(ref _rst, value))
+            {
+                OnPropertyChanged(nameof(RstSent));
+                OnPropertyChanged(nameof(RstReceived));
+            }
+        }
     }
 
     public string RstSent => SplitCombinedReport(Rst).Sent;
@@ -179,8 +187,26 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
     public string Continent
     {
         get => _continent;
-        private set => SetProperty(ref _continent, value);
+        private set
+        {
+            if (SetProperty(ref _continent, value))
+            {
+                OnPropertyChanged(nameof(ContinentBrush));
+            }
+        }
     }
+
+    public IBrush ContinentBrush => Continent switch
+    {
+        "NA" => new SolidColorBrush(Color.Parse("#18FFB347")),
+        "EU" => new SolidColorBrush(Color.Parse("#184488FF")),
+        "AS" => new SolidColorBrush(Color.Parse("#18FF6B6B")),
+        "AF" => new SolidColorBrush(Color.Parse("#1877DD77")),
+        "SA" => new SolidColorBrush(Color.Parse("#18FFD700")),
+        "OC" => new SolidColorBrush(Color.Parse("#1800CED1")),
+        "AN" => new SolidColorBrush(Color.Parse("#18E0E0E0")),
+        _ => Brushes.Transparent,
+    };
 
     public string State
     {

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
@@ -24,6 +24,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
 
     private QsoRecord _sourceQso = new();
     private EditableQsoState? _editSnapshot;
+    private string _displayTimestampFormat = TimestampFormatOption.Default.FormatString;
     private string _utcDisplay = "-";
     private string _workedCallsign = "-";
     private string _band = "-";
@@ -257,11 +258,18 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
             ? timestamp
             : DateTimeOffset.MinValue;
 
-    public static RecentQsoItemViewModel FromQso(QsoRecord qso)
+    public static RecentQsoItemViewModel FromQso(QsoRecord qso) => FromQso(qso, null);
+
+    public static RecentQsoItemViewModel FromQso(QsoRecord qso, string? timestampFormat)
     {
         ArgumentNullException.ThrowIfNull(qso);
 
         var item = new RecentQsoItemViewModel();
+        if (timestampFormat is not null)
+        {
+            item._displayTimestampFormat = timestampFormat;
+        }
+
         item.LoadSourceQso(qso);
         return item;
     }
@@ -286,6 +294,25 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
     public void EndEdit()
     {
         _editSnapshot = null;
+        RecomputeDirty();
+    }
+
+    /// <summary>
+    /// Updates the display timestamp format and re-formats the UTC columns.
+    /// Called by the parent list view model when the user cycles the format.
+    /// </summary>
+    public void UpdateTimestampFormat(string format)
+    {
+        if (string.Equals(_displayTimestampFormat, format, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        _displayTimestampFormat = format;
+
+        // Re-format timestamps from the source QSO (not from the display string).
+        UtcDisplay = FormatTimestamp(_sourceQso.UtcTimestamp, _displayTimestampFormat);
+        UtcEndDisplay = FormatTimestamp(_sourceQso.UtcEndTimestamp, _displayTimestampFormat);
         RecomputeDirty();
     }
 
@@ -343,7 +370,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         qso = null;
 
         var updated = _sourceQso.Clone();
-        var sourceState = EditableQsoState.FromQso(_sourceQso);
+        var sourceState = EditableQsoState.FromQso(_sourceQso, _displayTimestampFormat);
 
         if (!TryParseTimestamp(UtcDisplay, required: true, out var utcTimestamp))
         {
@@ -431,7 +458,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
     {
         _sourceQso = qso.Clone();
         _editSnapshot = null;
-        ApplyState(EditableQsoState.FromQso(_sourceQso));
+        ApplyState(EditableQsoState.FromQso(_sourceQso, _displayTimestampFormat));
         Qth = BuildQth(_sourceQso);
         SyncStatus = BuildSyncStatus(_sourceQso.SyncStatus);
         Continent = NoteOrNull(_sourceQso.WorkedContinent) ?? "-";
@@ -485,7 +512,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
 
     private void RecomputeDirty()
     {
-        IsDirty = CaptureState() != EditableQsoState.FromQso(_sourceQso);
+        IsDirty = CaptureState() != EditableQsoState.FromQso(_sourceQso, _displayTimestampFormat);
     }
 
     private bool TryApplyFrequency(QsoRecord updated, out string? error)
@@ -642,8 +669,8 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         updated.Comment = comment;
     }
 
-    private static EditableQsoState EditableQsoStateFromQso(QsoRecord qso) => new(
-        FormatTimestamp(qso.UtcTimestamp),
+    private static EditableQsoState EditableQsoStateFromQso(QsoRecord qso, string format) => new(
+        FormatTimestamp(qso.UtcTimestamp, format),
         DisplayOrDash(qso.WorkedCallsign),
         ProtoEnumDisplay.ForBand(qso.Band),
         ProtoEnumDisplay.ForMode(qso.Mode),
@@ -658,7 +685,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         DisplayOrDash(qso.StationCallsign),
         BuildNote(qso),
         NoteOrNull(qso.Comment) ?? "-",
-        FormatTimestamp(qso.UtcEndTimestamp),
+        FormatTimestamp(qso.UtcEndTimestamp, format),
         BuildOptionalNumber(qso.WorkedCqZone),
         BuildOptionalNumber(qso.WorkedItuZone));
 
@@ -909,11 +936,11 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         return null;
     }
 
-    private static string FormatTimestamp(Timestamp? timestamp)
+    private static string FormatTimestamp(Timestamp? timestamp, string format)
     {
         return timestamp is null
             ? "-"
-            : timestamp.ToDateTimeOffset().ToUniversalTime().ToString("yy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+            : timestamp.ToDateTimeOffset().ToUniversalTime().ToString(format, CultureInfo.InvariantCulture);
     }
 
     private readonly record struct EditableQsoState(
@@ -936,6 +963,6 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         string CqZone,
         string ItuZone)
     {
-        public static EditableQsoState FromQso(QsoRecord qso) => EditableQsoStateFromQso(qso);
+        public static EditableQsoState FromQso(QsoRecord qso, string format) => EditableQsoStateFromQso(qso, format);
     }
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -676,6 +676,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         RecentQsoSortColumn.Qth => nameof(RecentQsoItemViewModel.Qth),
         RecentQsoSortColumn.State => nameof(RecentQsoItemViewModel.State),
         RecentQsoSortColumn.County => nameof(RecentQsoItemViewModel.County),
+        RecentQsoSortColumn.Comment => nameof(RecentQsoItemViewModel.Comment),
         RecentQsoSortColumn.Sync => nameof(RecentQsoItemViewModel.SyncStatus),
         _ => nameof(RecentQsoItemViewModel.UtcSortKey)
     };
@@ -704,6 +705,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         nameof(RecentQsoItemViewModel.Qth) => RecentQsoSortColumn.Qth,
         nameof(RecentQsoItemViewModel.State) => RecentQsoSortColumn.State,
         nameof(RecentQsoItemViewModel.County) => RecentQsoSortColumn.County,
+        nameof(RecentQsoItemViewModel.Comment) => RecentQsoSortColumn.Comment,
         nameof(RecentQsoItemViewModel.SyncStatus) => RecentQsoSortColumn.Sync,
         _ => RecentQsoSortColumn.Utc
     };
@@ -732,7 +734,6 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
             else
             {
                 freeTextTokens.Add(rawToken.ToUpperInvariant());
-                displayTokens.Add(rawToken.Trim());
             }
         }
 
@@ -759,6 +760,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Contest, "Contest", true);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Station, "Station", true);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Note, "Note", true);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Comment, "Comment", false);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.UtcEnd, "End", false);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.CqZone, "CQ", false);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.ItuZone, "ITU", false);

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -161,11 +161,23 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
     [NotifyPropertyChangedFor(nameof(SortStatusText))]
     private bool _sortAscending;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(TimestampFormatLabel))]
+    private string _timestampFormat = TimestampFormatOption.Default.FormatString;
+
+    public string TimestampFormatLabel =>
+        TimestampFormatOption.FindOrDefault(TimestampFormat).Label;
+
     partial void OnSearchTextChanged(string value)
     {
         _parsedSearchQuery = ParseSearchQuery(value);
         UpdateFilterTokens();
         RefreshView();
+    }
+
+    partial void OnTimestampFormatChanged(string value)
+    {
+        RefreshTimestampDisplay();
     }
 
     [RelayCommand(CanExecute = nameof(CanRefresh))]
@@ -179,7 +191,8 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
             var selectedLocalId = SelectedQso?.LocalId;
             var qsos = await _engine.ListRecentQsosAsync(DefaultLimit);
 
-            ReplaceItems(qsos.Select(RecentQsoItemViewModel.FromQso));
+            var format = TimestampFormat;
+            ReplaceItems(qsos.Select(q => RecentQsoItemViewModel.FromQso(q, format)));
 
             HasLoaded = true;
             LastLoadedAtUtc = DateTimeOffset.UtcNow;
@@ -353,6 +366,12 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         ResetGridZoom();
     }
 
+    [RelayCommand]
+    private void CycleTimestampFormat()
+    {
+        TimestampFormat = TimestampFormatOption.CycleNext(TimestampFormat).FormatString;
+    }
+
     internal void ApplyPersistedSort(RecentQsoSortColumn column, bool ascending)
     {
         CurrentSortColumn = column;
@@ -368,6 +387,11 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         }
 
         GridFontSize = Math.Clamp(fontSize, MinGridFontSize, MaxGridFontSize);
+    }
+
+    internal void ApplyPersistedTimestampFormat(string? format)
+    {
+        TimestampFormat = TimestampFormatOption.FindOrDefault(format).FormatString;
     }
 
     internal void ApplySort(RecentQsoSortColumn column)
@@ -580,6 +604,15 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         }
 
         UpdatePendingEditCount();
+    }
+
+    private void RefreshTimestampDisplay()
+    {
+        var format = TimestampFormat;
+        foreach (var item in _allItems)
+        {
+            item.UpdateTimestampFormat(format);
+        }
     }
 
     private void OnItemPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoSortColumn.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoSortColumn.cs
@@ -24,5 +24,6 @@ internal enum RecentQsoSortColumn
     RstSent,
     RstReceived,
     State,
-    County
+    County,
+    Comment
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/TimestampFormatOption.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/TimestampFormatOption.cs
@@ -1,0 +1,40 @@
+namespace QsoRipper.Gui.ViewModels;
+
+/// <summary>
+/// Represents a selectable UTC timestamp display format for the QSO grid.
+/// </summary>
+internal sealed record TimestampFormatOption(string Label, string FormatString)
+{
+    /// <summary>All available format options, ordered for cycling.</summary>
+    public static TimestampFormatOption[] All { get; } =
+    [
+        new("yy-MM-dd", "yy-MM-dd HH:mm"),
+        new("yyyy-MM-dd", "yyyy-MM-dd HH:mm"),
+        new("MM/dd/yyyy", "MM/dd/yyyy HH:mm"),
+        new("dd-MM-yyyy", "dd-MM-yyyy HH:mm"),
+    ];
+
+    /// <summary>The default format used when no preference is set.</summary>
+    public static TimestampFormatOption Default => All[0];
+
+    /// <summary>
+    /// Returns the next option in the cycle after the given format string,
+    /// wrapping to the first option if the current is not found or is last.
+    /// </summary>
+    public static TimestampFormatOption CycleNext(string currentFormatString)
+    {
+        var options = All;
+        var currentIndex = Array.FindIndex(options, o =>
+            string.Equals(o.FormatString, currentFormatString, StringComparison.Ordinal));
+        var nextIndex = (currentIndex + 1) % options.Length;
+        return options[nextIndex];
+    }
+
+    /// <summary>
+    /// Finds the option matching a format string, or returns <see cref="Default"/>.
+    /// </summary>
+    public static TimestampFormatOption FindOrDefault(string? formatString) =>
+        Array.Find(All, o =>
+            string.Equals(o.FormatString, formatString, StringComparison.Ordinal))
+        ?? Default;
+}

--- a/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
@@ -1,0 +1,96 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:QsoRipper.Gui.ViewModels"
+             x:Class="QsoRipper.Gui.Views.FullQsoCardView"
+             x:DataType="vm:FullQsoCardViewModel">
+
+  <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+          CornerRadius="8" Padding="20" MinWidth="480" MaxWidth="560"
+          BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+          BorderThickness="1" BoxShadow="0 8 24 0 #40000000">
+    <DockPanel>
+      <StackPanel DockPanel.Dock="Top" Orientation="Horizontal" Spacing="8" Margin="0,0,0,12">
+        <TextBlock Text="Full QSO Entry" FontSize="16" FontWeight="SemiBold"
+                   VerticalAlignment="Center" />
+        <TextBlock Text="(Esc to close)" FontSize="11" Opacity="0.5"
+                   VerticalAlignment="Center" />
+      </StackPanel>
+
+      <StackPanel DockPanel.Dock="Bottom" Orientation="Horizontal"
+                  Spacing="10" HorizontalAlignment="Right" Margin="0,12,0,0">
+        <Button Content="Cancel" MinWidth="80" Command="{Binding CloseCommand}" />
+        <Button Content="Log QSO" MinWidth="80" Classes="accent"
+                Command="{Binding Logger.LogQsoCommand}" />
+      </StackPanel>
+
+      <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <Grid ColumnDefinitions="Auto,*,16,Auto,*"
+              RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+              RowSpacing="6" ColumnSpacing="8">
+          <!-- Left column -->
+          <TextBlock Grid.Row="0" Grid.Column="0" Text="Callsign" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="0" Grid.Column="1"
+                   Text="{Binding Logger.Callsign, Mode=TwoWay}"
+                   FontWeight="SemiBold" />
+
+          <TextBlock Grid.Row="1" Grid.Column="0" Text="Band" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBlock Grid.Row="1" Grid.Column="1"
+                     Text="{Binding Logger.BandLabel}" FontSize="13"
+                     Foreground="#FFB347" VerticalAlignment="Center" />
+
+          <TextBlock Grid.Row="2" Grid.Column="0" Text="Mode" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBlock Grid.Row="2" Grid.Column="1"
+                     Text="{Binding Logger.ModeLabel}" FontSize="13"
+                     Foreground="#77DD77" VerticalAlignment="Center" />
+
+          <TextBlock Grid.Row="3" Grid.Column="0" Text="Freq" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="3" Grid.Column="1"
+                   Text="{Binding Logger.FrequencyMhz, Mode=TwoWay}"
+                   FontFamily="Cascadia Mono, Consolas, monospace" />
+
+          <TextBlock Grid.Row="4" Grid.Column="0" Text="RST Sent" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="4" Grid.Column="1"
+                   Text="{Binding Logger.RstSent, Mode=TwoWay}" />
+
+          <TextBlock Grid.Row="5" Grid.Column="0" Text="RST Rcvd" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="5" Grid.Column="1"
+                   Text="{Binding Logger.RstRcvd, Mode=TwoWay}" />
+
+          <TextBlock Grid.Row="6" Grid.Column="0" Text="Comment" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="6" Grid.Column="1"
+                   Text="{Binding Logger.Comment, Mode=TwoWay}" />
+
+          <TextBlock Grid.Row="7" Grid.Column="0" Text="Notes" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="7" Grid.Column="1"
+                   Text="{Binding Notes, Mode=TwoWay}" AcceptsReturn="True"
+                   Height="48" TextWrapping="Wrap" />
+
+          <!-- Right column -->
+          <TextBlock Grid.Row="0" Grid.Column="3" Text="Name" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="0" Grid.Column="4"
+                   Text="{Binding Name, Mode=TwoWay}" />
+
+          <TextBlock Grid.Row="1" Grid.Column="3" Text="Grid" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="1" Grid.Column="4"
+                   Text="{Binding GridSquare, Mode=TwoWay}" />
+
+          <TextBlock Grid.Row="2" Grid.Column="3" Text="Country" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="2" Grid.Column="4"
+                   Text="{Binding Country, Mode=TwoWay}" />
+
+          <TextBlock Grid.Row="3" Grid.Column="3" Text="State" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="3" Grid.Column="4"
+                   Text="{Binding State, Mode=TwoWay}" />
+
+          <TextBlock Grid.Row="4" Grid.Column="3" Text="Contest" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="4" Grid.Column="4"
+                   Text="{Binding Contest, Mode=TwoWay}" />
+
+          <TextBlock Grid.Row="5" Grid.Column="3" Text="Exchange" Opacity="0.6" VerticalAlignment="Center" />
+          <TextBox Grid.Row="5" Grid.Column="4"
+                   Text="{Binding Exchange, Mode=TwoWay}" />
+        </Grid>
+      </ScrollViewer>
+    </DockPanel>
+  </Border>
+</UserControl>

--- a/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace QsoRipper.Gui.Views;
+
+internal sealed partial class FullQsoCardView : UserControl
+{
+    public FullQsoCardView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Views/HelpOverlayView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/HelpOverlayView.axaml
@@ -1,0 +1,46 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:QsoRipper.Gui.ViewModels"
+             x:Class="QsoRipper.Gui.Views.HelpOverlayView"
+             x:DataType="vm:HelpOverlayViewModel">
+
+  <Border Background="#E0202020" CornerRadius="8" Padding="24" MaxWidth="640" MaxHeight="520"
+          HorizontalAlignment="Center" VerticalAlignment="Center"
+          BorderBrush="#60FFFFFF" BorderThickness="1">
+    <DockPanel>
+      <TextBlock DockPanel.Dock="Top" Text="Keyboard Shortcuts"
+                 FontSize="18" FontWeight="Bold" Foreground="White"
+                 Margin="0,0,0,16" HorizontalAlignment="Center" />
+
+      <TextBlock DockPanel.Dock="Bottom" Text="Press F1 or Esc to close"
+                 FontSize="11" Foreground="#80FFFFFF"
+                 Margin="0,12,0,0" HorizontalAlignment="Center" />
+
+      <ScrollViewer VerticalScrollBarVisibility="Auto">
+        <ItemsControl ItemsSource="{Binding Groups}">
+          <ItemsControl.ItemTemplate>
+            <DataTemplate x:DataType="vm:HelpOverlayViewModel+ShortcutGroup">
+              <StackPanel Margin="0,0,0,12">
+                <TextBlock Text="{Binding Title}" FontWeight="SemiBold"
+                           FontSize="13" Foreground="#FFB0B0B0" Margin="0,0,0,4" />
+                <ItemsControl ItemsSource="{Binding Entries}">
+                  <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="vm:HelpOverlayViewModel+ShortcutEntry">
+                      <Grid ColumnDefinitions="140,*" Margin="8,1,0,1">
+                        <TextBlock Grid.Column="0" Text="{Binding Key}"
+                                   FontFamily="Consolas,Courier New,monospace"
+                                   FontSize="12" Foreground="#FFE0E0E0" />
+                        <TextBlock Grid.Column="1" Text="{Binding Description}"
+                                   FontSize="12" Foreground="#FFA0A0A0" />
+                      </Grid>
+                    </DataTemplate>
+                  </ItemsControl.ItemTemplate>
+                </ItemsControl>
+              </StackPanel>
+            </DataTemplate>
+          </ItemsControl.ItemTemplate>
+        </ItemsControl>
+      </ScrollViewer>
+    </DockPanel>
+  </Border>
+</UserControl>

--- a/src/dotnet/QsoRipper.Gui/Views/HelpOverlayView.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/HelpOverlayView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace QsoRipper.Gui.Views;
+
+internal sealed partial class HelpOverlayView : UserControl
+{
+    public HelpOverlayView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -325,14 +325,14 @@
                     </DataGridTemplateColumn.CellEditingTemplate>
                   </DataGridTemplateColumn>
                   <DataGridTextColumn Header="S"
-                                      Width="48"
-                                      MinWidth="40"
+                                      Width="56"
+                                      MinWidth="48"
                                       Binding="{ReflectionBinding RstSent}"
                                       SortMemberPath="RstSent"
                                       IsReadOnly="True" />
                   <DataGridTextColumn Header="R"
-                                      Width="48"
-                                      MinWidth="40"
+                                      Width="56"
+                                      MinWidth="48"
                                       Binding="{ReflectionBinding RstReceived}"
                                       SortMemberPath="RstReceived"
                                       IsReadOnly="True" />
@@ -444,6 +444,28 @@
                       </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
                   </DataGridTemplateColumn>
+                  <DataGridTemplateColumn Header="Comment"
+                                          Width="120"
+                                          MinWidth="80"
+                                          SortMemberPath="Comment">
+                    <DataGridTemplateColumn.CellTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBlock Text="{Binding Comment}"
+                                   TextWrapping="NoWrap"
+                                   TextTrimming="CharacterEllipsis"
+                                   VerticalAlignment="Center"
+                                   ToolTip.Tip="{Binding Comment}" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                    <DataGridTemplateColumn.CellEditingTemplate>
+                      <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
+                        <TextBox Text="{Binding Comment, Mode=TwoWay}"
+                                 BorderThickness="0"
+                                 Padding="0"
+                                 Background="Transparent" />
+                      </DataTemplate>
+                    </DataGridTemplateColumn.CellEditingTemplate>
+                  </DataGridTemplateColumn>
                   <DataGridTextColumn Header="End"
                                       Width="104"
                                       MinWidth="96"
@@ -539,39 +561,53 @@
                               IsVisible="{Binding HasInspectorQso}">
                     <Grid ColumnDefinitions="Auto,*"
                           ColumnSpacing="10"
-                          RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
+                          RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto">
                       <TextBlock Text="Call" Grid.Row="0" Opacity="0.68" />
                       <TextBlock Grid.Row="0" Grid.Column="1" Text="{Binding InspectorQso.WorkedCallsign}" />
                       <TextBlock Text="UTC" Grid.Row="1" Opacity="0.68" />
                       <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding InspectorQso.UtcDisplay}" />
-                      <TextBlock Text="Band / Mode" Grid.Row="2" Opacity="0.68" />
+                      <TextBlock Text="Band" Grid.Row="2" Opacity="0.68" />
                       <TextBlock Grid.Row="2" Grid.Column="1" Text="{Binding InspectorQso.Band}" />
-                      <TextBlock Grid.Row="2" Grid.Column="1" Margin="44,0,0,0" Text="{Binding InspectorQso.Mode}" />
-                      <TextBlock Text="Freq / RST" Grid.Row="3" Opacity="0.68" />
-                      <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding InspectorQso.Frequency}" />
-                      <TextBlock Grid.Row="3" Grid.Column="1" Margin="74,0,0,0" Text="{Binding InspectorQso.Rst}" />
-                      <TextBlock Text="DXCC / Country" Grid.Row="4" Opacity="0.68" />
-                      <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding InspectorQso.Dxcc}" />
-                      <TextBlock Grid.Row="4" Grid.Column="1" Margin="42,0,0,0" Text="{Binding InspectorQso.Country}" />
-                      <TextBlock Text="Name" Grid.Row="5" Opacity="0.68" />
-                      <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding InspectorQso.OperatorName}" TextWrapping="Wrap" />
-                      <TextBlock Text="Grid / QTH" Grid.Row="6" Opacity="0.68" />
-                      <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding InspectorQso.Grid}" />
-                      <TextBlock Grid.Row="6" Grid.Column="1" Margin="52,0,0,0" Text="{Binding InspectorQso.Qth}" TextWrapping="Wrap" />
-                      <TextBlock Text="Contest / Exch" Grid.Row="7" Opacity="0.68" />
-                      <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding InspectorQso.Contest}" />
-                      <TextBlock Grid.Row="7" Grid.Column="1" Margin="92,0,0,0" Text="{Binding InspectorQso.Exchange}" />
-                      <TextBlock Text="Station" Grid.Row="8" Opacity="0.68" />
-                      <TextBlock Grid.Row="8" Grid.Column="1" Text="{Binding InspectorQso.Station}" />
-                      <TextBlock Text="Zones" Grid.Row="9" Opacity="0.68" />
-                      <TextBlock Grid.Row="9" Grid.Column="1" Text="{Binding InspectorQso.CqZone}" />
-                      <TextBlock Grid.Row="9" Grid.Column="1" Margin="34,0,0,0" Text="{Binding InspectorQso.ItuZone}" />
-                      <TextBlock Text="End" Grid.Row="10" Opacity="0.68" />
-                      <TextBlock Grid.Row="10" Grid.Column="1" Text="{Binding InspectorQso.UtcEndDisplay}" />
-                      <TextBlock Text="Sync" Grid.Row="11" Opacity="0.68" />
-                      <TextBlock Grid.Row="11" Grid.Column="1" Text="{Binding InspectorQso.SyncStatus}" />
-                      <TextBlock Text="Note" Grid.Row="12" Opacity="0.68" />
-                      <TextBlock Grid.Row="12" Grid.Column="1" Text="{Binding InspectorQso.Note}" TextWrapping="Wrap" />
+                      <TextBlock Text="Mode" Grid.Row="3" Opacity="0.68" />
+                      <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding InspectorQso.Mode}" />
+                      <TextBlock Text="Freq" Grid.Row="4" Opacity="0.68" />
+                      <TextBlock Grid.Row="4" Grid.Column="1" Text="{Binding InspectorQso.Frequency}" />
+                      <TextBlock Text="RST" Grid.Row="5" Opacity="0.68" />
+                      <TextBlock Grid.Row="5" Grid.Column="1" Text="{Binding InspectorQso.Rst}" />
+                      <TextBlock Text="DXCC" Grid.Row="6" Opacity="0.68" />
+                      <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding InspectorQso.Dxcc}" />
+                      <TextBlock Text="Country" Grid.Row="7" Opacity="0.68" />
+                      <TextBlock Grid.Row="7" Grid.Column="1" Text="{Binding InspectorQso.Country}" />
+                      <TextBlock Text="Name" Grid.Row="8" Opacity="0.68" />
+                      <TextBlock Grid.Row="8" Grid.Column="1" Text="{Binding InspectorQso.OperatorName}" TextWrapping="Wrap" />
+                      <TextBlock Text="Grid" Grid.Row="9" Opacity="0.68" />
+                      <TextBlock Grid.Row="9" Grid.Column="1" Text="{Binding InspectorQso.Grid}" />
+                      <TextBlock Text="QTH" Grid.Row="10" Opacity="0.68" />
+                      <TextBlock Grid.Row="10" Grid.Column="1" Text="{Binding InspectorQso.Qth}" TextWrapping="Wrap" />
+                      <TextBlock Text="State" Grid.Row="11" Opacity="0.68" />
+                      <TextBlock Grid.Row="11" Grid.Column="1" Text="{Binding InspectorQso.State}" />
+                      <TextBlock Text="County" Grid.Row="12" Opacity="0.68" />
+                      <TextBlock Grid.Row="12" Grid.Column="1" Text="{Binding InspectorQso.County}" />
+                      <TextBlock Text="Cont" Grid.Row="13" Opacity="0.68" />
+                      <TextBlock Grid.Row="13" Grid.Column="1" Text="{Binding InspectorQso.Continent}" />
+                      <TextBlock Text="CQ Zone" Grid.Row="14" Opacity="0.68" />
+                      <TextBlock Grid.Row="14" Grid.Column="1" Text="{Binding InspectorQso.CqZone}" />
+                      <TextBlock Text="ITU Zone" Grid.Row="15" Opacity="0.68" />
+                      <TextBlock Grid.Row="15" Grid.Column="1" Text="{Binding InspectorQso.ItuZone}" />
+                      <TextBlock Text="Contest" Grid.Row="16" Opacity="0.68" />
+                      <TextBlock Grid.Row="16" Grid.Column="1" Text="{Binding InspectorQso.Contest}" />
+                      <TextBlock Text="Exch" Grid.Row="17" Opacity="0.68" />
+                      <TextBlock Grid.Row="17" Grid.Column="1" Text="{Binding InspectorQso.Exchange}" />
+                      <TextBlock Text="Station" Grid.Row="18" Opacity="0.68" />
+                      <TextBlock Grid.Row="18" Grid.Column="1" Text="{Binding InspectorQso.Station}" />
+                      <TextBlock Text="End" Grid.Row="19" Opacity="0.68" />
+                      <TextBlock Grid.Row="19" Grid.Column="1" Text="{Binding InspectorQso.UtcEndDisplay}" />
+                      <TextBlock Text="Sync" Grid.Row="20" Opacity="0.68" />
+                      <TextBlock Grid.Row="20" Grid.Column="1" Text="{Binding InspectorQso.SyncStatus}" />
+                      <TextBlock Text="Comment" Grid.Row="21" Opacity="0.68" />
+                      <TextBlock Grid.Row="21" Grid.Column="1" Text="{Binding InspectorQso.Comment}" TextWrapping="Wrap" />
+                      <TextBlock Text="Note" Grid.Row="22" Opacity="0.68" />
+                      <TextBlock Grid.Row="22" Grid.Column="1" Text="{Binding InspectorQso.Note}" TextWrapping="Wrap" />
                     </Grid>
                   </StackPanel>
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -30,6 +30,7 @@
     <KeyBinding Gesture="Ctrl+N" Command="{Binding FocusLoggerCommand}" />
     <KeyBinding Gesture="Ctrl+R" Command="{Binding ToggleRigControlCommand}" />
     <KeyBinding Gesture="Ctrl+W" Command="{Binding ToggleSpaceWeatherCommand}" />
+    <KeyBinding Gesture="Ctrl+L" Command="{Binding ToggleFullQsoCardCommand}" />
   </Window.KeyBindings>
 
   <Window.Styles>
@@ -83,6 +84,11 @@
     <Style Selector="DataGrid#RecentQsoGrid DataGridCell:editing TextBox">
       <Setter Property="Padding" Value="4,2" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+
+    <!-- Consistent text styling for data grid content -->
+    <Style Selector="DataGrid#RecentQsoGrid DataGridCell TextBlock">
+      <Setter Property="VerticalAlignment" Value="Center" />
     </Style>
 
   </Window.Styles>
@@ -238,7 +244,8 @@
         </Grid>
 
         <!-- QSO Logger Panel -->
-        <Border Grid.Row="1"
+        <Border x:Name="LoggerPanel"
+                Grid.Row="1"
                 Margin="10,0,10,4"
                 Padding="8,4"
                 CornerRadius="4"
@@ -248,7 +255,7 @@
           <Grid RowDefinitions="Auto,Auto" RowSpacing="2">
             <!-- Row 1: Input fields -->
             <Grid Grid.Row="0"
-                  ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                  ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
                   ColumnSpacing="8"
                   VerticalAlignment="Center">
               <StackPanel Grid.Column="0" Spacing="1">
@@ -261,27 +268,35 @@
               </StackPanel>
 
               <StackPanel Grid.Column="1" Spacing="1">
-                <TextBlock Text="Band" FontSize="10" Opacity="0.6" />
-                <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
-                        CornerRadius="3" Padding="6,3" Height="28"
-                        VerticalAlignment="Bottom">
+                <TextBlock Text="Band ◄►" FontSize="10" Opacity="0.6" />
+                <Button x:Name="LoggerBandButton"
+                        AutomationProperties.AutomationId="LoggerBandButton"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        BorderThickness="0" CornerRadius="3"
+                        Padding="6,3" Height="28" MinWidth="52"
+                        VerticalAlignment="Bottom"
+                        ToolTip.Tip="← → to cycle band"
+                        Focusable="True">
                   <TextBlock Text="{Binding Logger.BandLabel}"
                              FontSize="13" Foreground="#FFB347"
-                             VerticalAlignment="Center"
-                             ToolTip.Tip="← → to cycle" />
-                </Border>
+                             VerticalAlignment="Center" />
+                </Button>
               </StackPanel>
 
               <StackPanel Grid.Column="2" Spacing="1">
-                <TextBlock Text="Mode" FontSize="10" Opacity="0.6" />
-                <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
-                        CornerRadius="3" Padding="6,3" Height="28"
-                        VerticalAlignment="Bottom">
+                <TextBlock Text="Mode ◄►" FontSize="10" Opacity="0.6" />
+                <Button x:Name="LoggerModeButton"
+                        AutomationProperties.AutomationId="LoggerModeButton"
+                        Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        BorderThickness="0" CornerRadius="3"
+                        Padding="6,3" Height="28" MinWidth="52"
+                        VerticalAlignment="Bottom"
+                        ToolTip.Tip="← → to cycle mode"
+                        Focusable="True">
                   <TextBlock Text="{Binding Logger.ModeLabel}"
                              FontSize="13" Foreground="#77DD77"
-                             VerticalAlignment="Center"
-                             ToolTip.Tip="← → to cycle" />
-                </Border>
+                             VerticalAlignment="Center" />
+                </Button>
               </StackPanel>
 
               <StackPanel Grid.Column="3" Spacing="1">
@@ -324,6 +339,13 @@
                       MinHeight="28" MinWidth="48"
                       VerticalAlignment="Bottom"
                       ToolTip.Tip="Clear form (Esc)" />
+
+              <Button Grid.Column="9"
+                      Content="▼"
+                      Command="{Binding ToggleFullQsoCardCommand}"
+                      MinHeight="28" MinWidth="28"
+                      VerticalAlignment="Bottom"
+                      ToolTip.Tip="Full QSO entry (Ctrl+L)" />
             </Grid>
 
             <!-- Row 2: Status line (rig, space weather, timer, log status) -->
@@ -331,9 +353,14 @@
                         Orientation="Horizontal"
                         Spacing="12"
                         Margin="0,1,0,0">
-              <TextBlock Text="{Binding RigStatusText}"
-                         FontSize="11" Opacity="0.7"
-                         FontFamily="Cascadia Mono, Consolas, monospace" />
+              <Button Command="{Binding ToggleRigControlCommand}"
+                      Background="Transparent" BorderThickness="0"
+                      Padding="2,0" Cursor="Hand"
+                      ToolTip.Tip="Toggle rig control (Ctrl+R)">
+                <TextBlock Text="{Binding RigStatusText}"
+                           FontSize="11" Opacity="0.7"
+                           FontFamily="Cascadia Mono, Consolas, monospace" />
+              </Button>
               <TextBlock Text="{Binding SpaceWeatherText}"
                          FontSize="11" Opacity="0.7"
                          IsVisible="{Binding IsSpaceWeatherVisible}"
@@ -342,6 +369,19 @@
               <TextBlock FontSize="11" Opacity="0.7"
                          FontFamily="Cascadia Mono, Consolas, monospace"
                          Text="{Binding Logger.ElapsedTimeText, StringFormat='Timer: {0}'}" />
+              <TextBlock Text="{Binding Logger.LookupName}"
+                         FontSize="11" Opacity="0.8"
+                         IsVisible="{Binding Logger.LookupName, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+              <TextBlock Text="{Binding Logger.LookupGrid}"
+                         FontSize="11" Opacity="0.6"
+                         FontFamily="Cascadia Mono, Consolas, monospace"
+                         IsVisible="{Binding Logger.LookupGrid, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+              <TextBlock Text="{Binding Logger.LookupCountry}"
+                         FontSize="11" Opacity="0.6"
+                         IsVisible="{Binding Logger.LookupCountry, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+              <TextBlock Text="{Binding Logger.LookupStatusText}"
+                         FontSize="11" Opacity="0.5"
+                         IsVisible="{Binding Logger.LookupStatusText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
               <TextBlock Text="{Binding Logger.LogStatusText}"
                          FontSize="11"
                          Foreground="#77DD77" />
@@ -471,6 +511,7 @@
                     <DataGridTemplateColumn.CellTemplate>
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBlock Text="{Binding Country}"
+                                   Foreground="#C0C0C0"
                                    TextWrapping="NoWrap"
                                    TextTrimming="CharacterEllipsis"
                                    VerticalAlignment="Center"
@@ -492,6 +533,7 @@
                     <DataGridTemplateColumn.CellTemplate>
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBlock Text="{Binding OperatorName}"
+                                   Foreground="#D0D0D0"
                                    TextWrapping="NoWrap"
                                    TextTrimming="CharacterEllipsis"
                                    VerticalAlignment="Center"
@@ -523,6 +565,7 @@
                     <DataGridTemplateColumn.CellTemplate>
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBlock Text="{Binding Contest}"
+                                   Foreground="#C0C0C0"
                                    TextWrapping="NoWrap"
                                    TextTrimming="CharacterEllipsis"
                                    VerticalAlignment="Center"
@@ -549,6 +592,7 @@
                     <DataGridTemplateColumn.CellTemplate>
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBlock Text="{Binding Note}"
+                                   Foreground="#C0C0C0"
                                    TextWrapping="NoWrap"
                                    TextTrimming="CharacterEllipsis"
                                    VerticalAlignment="Center"
@@ -858,7 +902,7 @@
             </StackPanel>
 
             <TextBlock Grid.Column="1"
-                       Text="Ctrl+Enter Log • F1 Help • F3 Grid • F4 Search • Ctrl+N Logger • Ctrl+R Rig • Ctrl+W Weather"
+                       Text="Ctrl+Enter Log &#x2022; Ctrl+L Expand &#x2022; F1 Help &#x2022; F3 Grid &#x2022; F4 Search &#x2022; Ctrl+N Logger &#x2022; Ctrl+R Rig &#x2022; Ctrl+W Weather"
                        FontSize="11.5"
                        Opacity="0.68"
                        VerticalAlignment="Center"
@@ -904,6 +948,18 @@
             </StackPanel>
           </StackPanel>
         </Border>
+      </Border>
+
+      <!-- Full QSO Card overlay -->
+      <Border x:Name="FullQsoCardOverlay"
+              AutomationProperties.AutomationId="FullQsoCardOverlay"
+              IsVisible="{Binding IsFullQsoCardOpen}"
+              Background="#80000000"
+              HorizontalAlignment="Stretch"
+              VerticalAlignment="Stretch">
+        <v:FullQsoCardView DataContext="{Binding FullQsoCard}"
+                           HorizontalAlignment="Center"
+                           VerticalAlignment="Center" />
       </Border>
 
       <!-- Help overlay -->

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -13,14 +13,23 @@
   <Window.KeyBindings>
     <KeyBinding Gesture="Ctrl+OemComma" Command="{Binding OpenSettingsCommand}" />
     <KeyBinding Gesture="Alt+X" Command="{Binding ExitCommand}" />
+    <KeyBinding Gesture="Ctrl+Q" Command="{Binding ExitCommand}" />
     <KeyBinding Gesture="Ctrl+F" Command="{Binding FocusSearchCommand}" />
     <KeyBinding Gesture="Ctrl+S" Command="{Binding RecentQsos.SaveEditsCommand}" />
+    <KeyBinding Gesture="F1" Command="{Binding ToggleHelpCommand}" />
+    <KeyBinding Gesture="F3" Command="{Binding FocusGridCommand}" />
+    <KeyBinding Gesture="F4" Command="{Binding FocusSearchCommand}" />
     <KeyBinding Gesture="F5" Command="{Binding RecentQsos.RefreshCommand}" />
+    <KeyBinding Gesture="F7" Command="{Binding Logger.ResetTimerCommand}" />
     <KeyBinding Gesture="Ctrl+Shift+S" Command="{Binding ToggleSortChooserCommand}" />
     <KeyBinding Gesture="Ctrl+H" Command="{Binding ToggleColumnChooserCommand}" />
     <KeyBinding Gesture="Alt+Enter" Command="{Binding ToggleInspectorCommand}" />
     <KeyBinding Gesture="F8" Command="{Binding OpenCallsignCardCommand}" />
     <KeyBinding Gesture="F6" Command="{Binding SyncNowCommand}" />
+    <KeyBinding Gesture="Ctrl+Enter" Command="{Binding Logger.LogQsoCommand}" />
+    <KeyBinding Gesture="Ctrl+N" Command="{Binding FocusLoggerCommand}" />
+    <KeyBinding Gesture="Ctrl+R" Command="{Binding ToggleRigControlCommand}" />
+    <KeyBinding Gesture="Ctrl+W" Command="{Binding ToggleSpaceWeatherCommand}" />
   </Window.KeyBindings>
 
   <Window.Styles>
@@ -70,6 +79,12 @@
       <Setter Property="BorderBrush" Value="Transparent" />
     </Style>
 
+    <!-- Prevent text clipping when editing cells -->
+    <Style Selector="DataGrid#RecentQsoGrid DataGridCell:editing TextBox">
+      <Setter Property="Padding" Value="4,2" />
+      <Setter Property="VerticalContentAlignment" Value="Center" />
+    </Style>
+
   </Window.Styles>
 
   <DockPanel ClipToBounds="True">
@@ -116,7 +131,7 @@
     </Menu>
 
     <Panel>
-      <Grid RowDefinitions="Auto,* ,Auto"
+      <Grid RowDefinitions="Auto,Auto,*,Auto"
             IsEnabled="{Binding !IsWizardOpen}">
         <Grid Grid.Row="0"
               MinHeight="44"
@@ -222,7 +237,119 @@
           </StackPanel>
         </Grid>
 
-        <Panel Grid.Row="1">
+        <!-- QSO Logger Panel -->
+        <Border Grid.Row="1"
+                Margin="10,0,10,4"
+                Padding="8,4"
+                CornerRadius="4"
+                Background="{DynamicResource SystemControlBackgroundAltMediumLowBrush}"
+                BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                BorderThickness="0,0,0,1">
+          <Grid RowDefinitions="Auto,Auto" RowSpacing="2">
+            <!-- Row 1: Input fields -->
+            <Grid Grid.Row="0"
+                  ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto"
+                  ColumnSpacing="8"
+                  VerticalAlignment="Center">
+              <StackPanel Grid.Column="0" Spacing="1">
+                <TextBlock Text="Callsign" FontSize="10" Opacity="0.6" />
+                <TextBox x:Name="LoggerCallsignBox"
+                         AutomationProperties.AutomationId="LoggerCallsignBox"
+                         Text="{Binding Logger.Callsign, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                         Width="110" Height="28"
+                         FontWeight="SemiBold" />
+              </StackPanel>
+
+              <StackPanel Grid.Column="1" Spacing="1">
+                <TextBlock Text="Band" FontSize="10" Opacity="0.6" />
+                <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        CornerRadius="3" Padding="6,3" Height="28"
+                        VerticalAlignment="Bottom">
+                  <TextBlock Text="{Binding Logger.BandLabel}"
+                             FontSize="13" Foreground="#FFB347"
+                             VerticalAlignment="Center"
+                             ToolTip.Tip="← → to cycle" />
+                </Border>
+              </StackPanel>
+
+              <StackPanel Grid.Column="2" Spacing="1">
+                <TextBlock Text="Mode" FontSize="10" Opacity="0.6" />
+                <Border Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
+                        CornerRadius="3" Padding="6,3" Height="28"
+                        VerticalAlignment="Bottom">
+                  <TextBlock Text="{Binding Logger.ModeLabel}"
+                             FontSize="13" Foreground="#77DD77"
+                             VerticalAlignment="Center"
+                             ToolTip.Tip="← → to cycle" />
+                </Border>
+              </StackPanel>
+
+              <StackPanel Grid.Column="3" Spacing="1">
+                <TextBlock Text="Freq" FontSize="10" Opacity="0.6" />
+                <TextBox Text="{Binding Logger.FrequencyMhz, Mode=TwoWay}"
+                         Width="72" Height="28"
+                         FontFamily="Cascadia Mono, Consolas, monospace"
+                         FontSize="12" />
+              </StackPanel>
+
+              <StackPanel Grid.Column="4" Spacing="1">
+                <TextBlock Text="S" FontSize="10" Opacity="0.6" />
+                <TextBox Text="{Binding Logger.RstSent, Mode=TwoWay}"
+                         Width="40" Height="28" FontSize="12" />
+              </StackPanel>
+
+              <StackPanel Grid.Column="5" Spacing="1">
+                <TextBlock Text="R" FontSize="10" Opacity="0.6" />
+                <TextBox Text="{Binding Logger.RstRcvd, Mode=TwoWay}"
+                         Width="40" Height="28" FontSize="12" />
+              </StackPanel>
+
+              <StackPanel Grid.Column="6" Spacing="1">
+                <TextBlock Text="Comment" FontSize="10" Opacity="0.6" />
+                <TextBox Text="{Binding Logger.Comment, Mode=TwoWay}"
+                         Width="140" Height="28" FontSize="12" />
+              </StackPanel>
+
+              <Button Grid.Column="7"
+                      Content="LOG"
+                      Command="{Binding Logger.LogQsoCommand}"
+                      Classes="accent"
+                      MinHeight="28" MinWidth="54"
+                      VerticalAlignment="Bottom"
+                      ToolTip.Tip="Log QSO (Ctrl+Enter)" />
+
+              <Button Grid.Column="8"
+                      Content="Clear"
+                      Command="{Binding Logger.ClearCommand}"
+                      MinHeight="28" MinWidth="48"
+                      VerticalAlignment="Bottom"
+                      ToolTip.Tip="Clear form (Esc)" />
+            </Grid>
+
+            <!-- Row 2: Status line (rig, space weather, timer, log status) -->
+            <StackPanel Grid.Row="1"
+                        Orientation="Horizontal"
+                        Spacing="12"
+                        Margin="0,1,0,0">
+              <TextBlock Text="{Binding RigStatusText}"
+                         FontSize="11" Opacity="0.7"
+                         FontFamily="Cascadia Mono, Consolas, monospace" />
+              <TextBlock Text="{Binding SpaceWeatherText}"
+                         FontSize="11" Opacity="0.7"
+                         IsVisible="{Binding IsSpaceWeatherVisible}"
+                         FontFamily="Cascadia Mono, Consolas, monospace" />
+              <TextBlock Text="|" Opacity="0.35" FontSize="11" />
+              <TextBlock FontSize="11" Opacity="0.7"
+                         FontFamily="Cascadia Mono, Consolas, monospace"
+                         Text="{Binding Logger.ElapsedTimeText, StringFormat='Timer: {0}'}" />
+              <TextBlock Text="{Binding Logger.LogStatusText}"
+                         FontSize="11"
+                         Foreground="#77DD77" />
+            </StackPanel>
+          </Grid>
+        </Border>
+
+        <Panel Grid.Row="2">
           <Grid ColumnDefinitions="*,Auto">
             <Grid Grid.Column="0">
               <DataGrid x:Name="RecentQsoGrid"
@@ -258,7 +385,6 @@
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBox Text="{Binding WorkedCallsign, Mode=TwoWay}"
                                  BorderThickness="0"
-                                 Padding="0"
                                  Background="Transparent" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
@@ -278,7 +404,6 @@
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBox Text="{Binding Band, Mode=TwoWay}"
                                  BorderThickness="0"
-                                 Padding="0"
                                  Background="Transparent" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
@@ -298,7 +423,6 @@
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBox Text="{Binding Mode, Mode=TwoWay}"
                                  BorderThickness="0"
-                                 Padding="0"
                                  Background="Transparent" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
@@ -319,7 +443,6 @@
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBox Text="{Binding Frequency, Mode=TwoWay}"
                                  BorderThickness="0"
-                                 Padding="0"
                                  Background="Transparent" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
@@ -358,7 +481,6 @@
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBox Text="{Binding Country, Mode=TwoWay}"
                                  BorderThickness="0"
-                                 Padding="0"
                                  Background="Transparent" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
@@ -380,7 +502,6 @@
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBox Text="{Binding OperatorName, Mode=TwoWay}"
                                  BorderThickness="0"
-                                 Padding="0"
                                  Background="Transparent" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
@@ -412,7 +533,6 @@
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBox Text="{Binding Contest, Mode=TwoWay}"
                                  BorderThickness="0"
-                                 Padding="0"
                                  Background="Transparent" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
@@ -439,7 +559,6 @@
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBox Text="{Binding Note, Mode=TwoWay}"
                                  BorderThickness="0"
-                                 Padding="0"
                                  Background="Transparent" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
@@ -461,7 +580,6 @@
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBox Text="{Binding Comment, Mode=TwoWay}"
                                  BorderThickness="0"
-                                 Padding="0"
                                  Background="Transparent" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
@@ -634,34 +752,34 @@
               <TextBlock Text="Sort recent QSOs"
                          FontSize="12.5"
                          FontWeight="SemiBold" />
-              <Button Content="UTC"
+              <Button Content="1  UTC"
                       Command="{Binding RecentQsos.SortByColumnCommand}"
                       CommandParameter="{x:Static vm:RecentQsoSortColumn.Utc}" />
-              <Button Content="Call"
+              <Button Content="2  Call"
                       Command="{Binding RecentQsos.SortByColumnCommand}"
                       CommandParameter="{x:Static vm:RecentQsoSortColumn.Callsign}" />
-              <Button Content="Band"
+              <Button Content="3  Band"
                       Command="{Binding RecentQsos.SortByColumnCommand}"
                       CommandParameter="{x:Static vm:RecentQsoSortColumn.Band}" />
-              <Button Content="Mode"
+              <Button Content="4  Mode"
                       Command="{Binding RecentQsos.SortByColumnCommand}"
                       CommandParameter="{x:Static vm:RecentQsoSortColumn.Mode}" />
-              <Button Content="Freq"
+              <Button Content="5  Freq"
                       Command="{Binding RecentQsos.SortByColumnCommand}"
                       CommandParameter="{x:Static vm:RecentQsoSortColumn.Frequency}" />
-              <Button Content="DXCC"
+              <Button Content="6  DXCC"
                       Command="{Binding RecentQsos.SortByColumnCommand}"
                       CommandParameter="{x:Static vm:RecentQsoSortColumn.Dxcc}" />
-              <Button Content="Country"
+              <Button Content="7  Country"
                       Command="{Binding RecentQsos.SortByColumnCommand}"
                       CommandParameter="{x:Static vm:RecentQsoSortColumn.Country}" />
-              <Button Content="Contest"
+              <Button Content="8  Contest"
                       Command="{Binding RecentQsos.SortByColumnCommand}"
                       CommandParameter="{x:Static vm:RecentQsoSortColumn.Contest}" />
-              <Button Content="Note"
+              <Button Content="9  Note"
                       Command="{Binding RecentQsos.SortByColumnCommand}"
                       CommandParameter="{x:Static vm:RecentQsoSortColumn.Note}" />
-              <Button Content="Reverse direction"
+              <Button Content="0  Reverse direction"
                       Command="{Binding RecentQsos.ReverseSortDirectionCommand}" />
             </StackPanel>
           </Border>
@@ -706,7 +824,7 @@
           </Border>
         </Panel>
 
-        <Border Grid.Row="2"
+        <Border Grid.Row="3"
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1,0,0,0"
                 Padding="10,4">
@@ -740,7 +858,7 @@
             </StackPanel>
 
             <TextBlock Grid.Column="1"
-                       Text="F2 Edit • Del Delete • Ctrl+S Save • F5 Refresh • F6 Sync • F8 Card • Alt+Enter Details"
+                       Text="Ctrl+Enter Log • F1 Help • F3 Grid • F4 Search • Ctrl+N Logger • Ctrl+R Rig • Ctrl+W Weather"
                        FontSize="11.5"
                        Opacity="0.68"
                        VerticalAlignment="Center"
@@ -786,6 +904,14 @@
             </StackPanel>
           </StackPanel>
         </Border>
+      </Border>
+
+      <!-- Help overlay -->
+      <Border x:Name="HelpOverlay"
+              AutomationProperties.AutomationId="HelpOverlay"
+              IsVisible="{Binding IsHelpOpen}"
+              Background="#80000000">
+        <v:HelpOverlayView DataContext="{Binding HelpOverlay}" />
       </Border>
 
       <Border x:Name="SetupWizardOverlay"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using QsoRipper.Gui.Utilities;
@@ -38,6 +40,11 @@ internal sealed partial class MainWindow : Window
         _fileMenuItem = this.FindControl<MenuItem>("FileMenuItem");
         _recentQsoSearchBox = this.FindControl<TextBox>("RecentQsoSearchBox");
         _recentQsoGrid = this.FindControl<DataGrid>("RecentQsoGrid");
+        if (_recentQsoGrid is not null)
+        {
+            _recentQsoGrid.LoadingRow += OnRecentQsoGridLoadingRow;
+        }
+
         DataContextChanged += OnDataContextChanged;
         BuildColumnMap();
     }
@@ -95,6 +102,11 @@ internal sealed partial class MainWindow : Window
             return;
         }
 
+        if (TryHandleLoggerKeyDown(e))
+        {
+            return;
+        }
+
         if (TryHandleRecentQsoZoomKey(e))
         {
             return;
@@ -123,6 +135,13 @@ internal sealed partial class MainWindow : Window
 
         if (e.Key == Key.Escape)
         {
+            if (_viewModel.IsFullQsoCardOpen)
+            {
+                _viewModel.ToggleFullQsoCardCommand.Execute(null);
+                e.Handled = true;
+                return;
+            }
+
             if (_viewModel.IsHelpOpen)
             {
                 _viewModel.ToggleHelpCommand.Execute(null);
@@ -208,6 +227,56 @@ internal sealed partial class MainWindow : Window
         return false;
     }
 
+    private bool TryHandleLoggerKeyDown(KeyEventArgs e)
+    {
+        if (_viewModel is null)
+        {
+            return false;
+        }
+
+        var source = e.Source as Control;
+        var bandButton = this.FindControl<Button>("LoggerBandButton");
+        var modeButton = this.FindControl<Button>("LoggerModeButton");
+
+        // Left/Right on band button cycles bands
+        if (source == bandButton)
+        {
+            if (e.Key == Key.Left)
+            {
+                _viewModel.Logger.CycleBandBackwardCommand.Execute(null);
+                e.Handled = true;
+                return true;
+            }
+
+            if (e.Key == Key.Right)
+            {
+                _viewModel.Logger.CycleBandForwardCommand.Execute(null);
+                e.Handled = true;
+                return true;
+            }
+        }
+
+        // Left/Right on mode button cycles modes
+        if (source == modeButton)
+        {
+            if (e.Key == Key.Left)
+            {
+                _viewModel.Logger.CycleModeBackwardCommand.Execute(null);
+                e.Handled = true;
+                return true;
+            }
+
+            if (e.Key == Key.Right)
+            {
+                _viewModel.Logger.CycleModeForwardCommand.Execute(null);
+                e.Handled = true;
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private bool TryHandleRecentQsoZoomKey(KeyEventArgs e)
     {
         if (_viewModel is null || !e.KeyModifiers.HasFlag(KeyModifiers.Control))
@@ -286,6 +355,7 @@ internal sealed partial class MainWindow : Window
             _viewModel.LoggerFocusRequested += OnLoggerFocusRequested;
             SubscribeColumnOptions(_viewModel.RecentQsos);
             ApplyDefaultColumnVisibility();
+            WireLoggerFocusTracking();
             if (!IsInspectionMode)
             {
                 ApplyPersistedGridLayout();
@@ -319,6 +389,68 @@ internal sealed partial class MainWindow : Window
                 loggerBox.SelectAll();
             }, DispatcherPriority.Input);
         }
+    }
+
+    private void WireLoggerFocusTracking()
+    {
+        var loggerBox = this.FindControl<TextBox>("LoggerCallsignBox");
+        if (loggerBox is not null)
+        {
+            loggerBox.GotFocus += OnLoggerGotFocus;
+            loggerBox.LostFocus += OnLoggerLostFocus;
+        }
+
+        var bandButton = this.FindControl<Button>("LoggerBandButton");
+        var modeButton = this.FindControl<Button>("LoggerModeButton");
+        if (bandButton is not null)
+        {
+            bandButton.GotFocus += OnLoggerGotFocus;
+            bandButton.LostFocus += OnLoggerLostFocus;
+        }
+
+        if (modeButton is not null)
+        {
+            modeButton.GotFocus += OnLoggerGotFocus;
+            modeButton.LostFocus += OnLoggerLostFocus;
+        }
+    }
+
+    private void OnLoggerGotFocus(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (_viewModel is not null)
+        {
+            _viewModel.IsLoggerFocused = true;
+        }
+    }
+
+    private void OnLoggerLostFocus(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        // Delay slightly — focus may be transitioning between logger fields
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (_viewModel is null)
+            {
+                return;
+            }
+
+            var focused = FocusManager?.GetFocusedElement() as Control;
+            var loggerPanel = this.FindControl<Border>("LoggerPanel");
+            // Check if focus moved to another control within the logger panel
+            bool isStillInLogger = false;
+            var parent = focused;
+            while (parent is not null)
+            {
+                if (parent == loggerPanel)
+                {
+                    isStillInLogger = true;
+                    break;
+                }
+
+                parent = parent.Parent as Control;
+            }
+
+            _viewModel.IsLoggerFocused = isStillInLogger;
+        }, DispatcherPriority.Background);
     }
 
     private void FocusRecentQsoSearchBox()
@@ -399,6 +531,14 @@ internal sealed partial class MainWindow : Window
         if (_viewModel.RecentQsos.AdjustZoom(Math.Sign(e.Delta.Y)))
         {
             e.Handled = true;
+        }
+    }
+
+    private void OnRecentQsoGridLoadingRow(object? sender, DataGridRowEventArgs e)
+    {
+        if (e.Row.DataContext is RecentQsoItemViewModel item)
+        {
+            e.Row.Background = item.ContinentBrush;
         }
     }
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -394,7 +394,7 @@ internal sealed partial class MainWindow : Window
 
     private void BuildColumnMap()
     {
-        if (_recentQsoGrid is null || _recentQsoGrid.Columns.Count < 22)
+        if (_recentQsoGrid is null || _recentQsoGrid.Columns.Count < 23)
         {
             return;
         }
@@ -416,13 +416,14 @@ internal sealed partial class MainWindow : Window
             [RecentQsoGridColumn.Contest] = _recentQsoGrid.Columns[12],
             [RecentQsoGridColumn.Station] = _recentQsoGrid.Columns[13],
             [RecentQsoGridColumn.Note] = _recentQsoGrid.Columns[14],
-            [RecentQsoGridColumn.UtcEnd] = _recentQsoGrid.Columns[15],
-            [RecentQsoGridColumn.CqZone] = _recentQsoGrid.Columns[16],
-            [RecentQsoGridColumn.ItuZone] = _recentQsoGrid.Columns[17],
-            [RecentQsoGridColumn.State] = _recentQsoGrid.Columns[18],
-            [RecentQsoGridColumn.County] = _recentQsoGrid.Columns[19],
-            [RecentQsoGridColumn.Sync] = _recentQsoGrid.Columns[20],
-            [RecentQsoGridColumn.Continent] = _recentQsoGrid.Columns[21]
+            [RecentQsoGridColumn.Comment] = _recentQsoGrid.Columns[15],
+            [RecentQsoGridColumn.UtcEnd] = _recentQsoGrid.Columns[16],
+            [RecentQsoGridColumn.CqZone] = _recentQsoGrid.Columns[17],
+            [RecentQsoGridColumn.ItuZone] = _recentQsoGrid.Columns[18],
+            [RecentQsoGridColumn.State] = _recentQsoGrid.Columns[19],
+            [RecentQsoGridColumn.County] = _recentQsoGrid.Columns[20],
+            [RecentQsoGridColumn.Sync] = _recentQsoGrid.Columns[21],
+            [RecentQsoGridColumn.Continent] = _recentQsoGrid.Columns[22]
         };
     }
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -6,6 +6,7 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
+using Avalonia.VisualTree;
 using QsoRipper.Gui.Utilities;
 using QsoRipper.Gui.ViewModels;
 
@@ -62,9 +63,11 @@ internal sealed partial class MainWindow : Window
 
         if (_viewModel is not null)
         {
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
             _viewModel.SearchFocusRequested -= OnSearchFocusRequested;
             _viewModel.GridFocusRequested -= OnGridFocusRequested;
             _viewModel.SettingsRequested -= OnSettingsRequested;
+            _viewModel.LoggerFocusRequested -= OnLoggerFocusRequested;
             UnsubscribeColumnOptions(_viewModel.RecentQsos);
             _viewModel = null;
         }
@@ -82,6 +85,13 @@ internal sealed partial class MainWindow : Window
         if (_viewModel is null || _viewModel.IsWizardOpen)
         {
             base.OnKeyDown(e);
+            return;
+        }
+
+        // Sort/column chooser keys take priority so digit and arrow keys
+        // aren't swallowed by the grid or other handlers.
+        if (TryHandleChooserKey(e))
+        {
             return;
         }
 
@@ -113,16 +123,16 @@ internal sealed partial class MainWindow : Window
 
         if (e.Key == Key.Escape)
         {
-            if (_viewModel.IsCallsignCardOpen)
+            if (_viewModel.IsHelpOpen)
             {
-                _viewModel.CloseCallsignCardCommand.Execute(null);
+                _viewModel.ToggleHelpCommand.Execute(null);
                 e.Handled = true;
                 return;
             }
 
-            if (_viewModel.IsColumnChooserOpen || _viewModel.IsSortChooserOpen)
+            if (_viewModel.IsCallsignCardOpen)
             {
-                _viewModel.CloseTransientPanelsCommand.Execute(null);
+                _viewModel.CloseCallsignCardCommand.Execute(null);
                 e.Handled = true;
                 return;
             }
@@ -170,6 +180,13 @@ internal sealed partial class MainWindow : Window
         }
 
         if (!isEditingTextBox && e.Key == Key.Delete)
+        {
+            _viewModel.RecentQsos.RequestDeleteSelectedQso();
+            e.Handled = true;
+            return true;
+        }
+
+        if (!isEditingTextBox && modifiers.HasFlag(KeyModifiers.Control) && e.Key == Key.D)
         {
             _viewModel.RecentQsos.RequestDeleteSelectedQso();
             e.Handled = true;
@@ -251,18 +268,22 @@ internal sealed partial class MainWindow : Window
     {
         if (_viewModel is not null)
         {
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
             _viewModel.SearchFocusRequested -= OnSearchFocusRequested;
             _viewModel.GridFocusRequested -= OnGridFocusRequested;
             _viewModel.SettingsRequested -= OnSettingsRequested;
+            _viewModel.LoggerFocusRequested -= OnLoggerFocusRequested;
             UnsubscribeColumnOptions(_viewModel.RecentQsos);
         }
 
         _viewModel = DataContext as MainWindowViewModel;
         if (_viewModel is not null)
         {
+            _viewModel.PropertyChanged += OnViewModelPropertyChanged;
             _viewModel.SearchFocusRequested += OnSearchFocusRequested;
             _viewModel.GridFocusRequested += OnGridFocusRequested;
             _viewModel.SettingsRequested += OnSettingsRequested;
+            _viewModel.LoggerFocusRequested += OnLoggerFocusRequested;
             SubscribeColumnOptions(_viewModel.RecentQsos);
             ApplyDefaultColumnVisibility();
             if (!IsInspectionMode)
@@ -285,6 +306,19 @@ internal sealed partial class MainWindow : Window
     private async void OnSettingsRequested(object? sender, EventArgs e)
     {
         await ShowSettingsDialogAsync();
+    }
+
+    private void OnLoggerFocusRequested(object? sender, EventArgs e)
+    {
+        var loggerBox = this.FindControl<TextBox>("LoggerCallsignBox");
+        if (loggerBox is not null)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                loggerBox.Focus();
+                loggerBox.SelectAll();
+            }, DispatcherPriority.Input);
+        }
     }
 
     private void FocusRecentQsoSearchBox()
@@ -546,5 +580,161 @@ internal sealed partial class MainWindow : Window
         handler();
         e.Handled = true;
         return true;
+    }
+
+    /// <summary>
+    /// Handles keyboard input when the sort chooser or column chooser is open.
+    /// </summary>
+    private bool TryHandleChooserKey(KeyEventArgs e)
+    {
+        if (_viewModel!.IsSortChooserOpen)
+        {
+            return HandleSortChooserKey(e);
+        }
+
+        if (_viewModel!.IsColumnChooserOpen)
+        {
+            return HandleColumnChooserKey(e);
+        }
+
+        return false;
+    }
+
+    private bool HandleSortChooserKey(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            CloseSortChooser();
+            e.Handled = true;
+            return true;
+        }
+
+        // Digit shortcuts: 1-9 select a sort column, 0 reverses direction.
+        RecentQsoSortColumn? column = e.Key switch
+        {
+            Key.D1 or Key.NumPad1 => RecentQsoSortColumn.Utc,
+            Key.D2 or Key.NumPad2 => RecentQsoSortColumn.Callsign,
+            Key.D3 or Key.NumPad3 => RecentQsoSortColumn.Band,
+            Key.D4 or Key.NumPad4 => RecentQsoSortColumn.Mode,
+            Key.D5 or Key.NumPad5 => RecentQsoSortColumn.Frequency,
+            Key.D6 or Key.NumPad6 => RecentQsoSortColumn.Dxcc,
+            Key.D7 or Key.NumPad7 => RecentQsoSortColumn.Country,
+            Key.D8 or Key.NumPad8 => RecentQsoSortColumn.Contest,
+            Key.D9 or Key.NumPad9 => RecentQsoSortColumn.Note,
+            _ => null
+        };
+
+        if (column is not null)
+        {
+            _viewModel!.RecentQsos.ApplySort(column.Value);
+            CloseSortChooser();
+            e.Handled = true;
+            return true;
+        }
+
+        if (e.Key is Key.D0 or Key.NumPad0)
+        {
+            _viewModel!.RecentQsos.ReverseCurrentSortDirection();
+            CloseSortChooser();
+            e.Handled = true;
+            return true;
+        }
+
+        // Arrow keys navigate between sort buttons.
+        if (e.Key is Key.Up or Key.Down)
+        {
+            NavigateFocusInPanel<Button>("SortChooserPanel", e.Key == Key.Down);
+            e.Handled = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool HandleColumnChooserKey(KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+        {
+            CloseColumnChooser();
+            e.Handled = true;
+            return true;
+        }
+
+        if (e.Key is Key.Up or Key.Down)
+        {
+            NavigateFocusInPanel<CheckBox>("ColumnChooserPanel", e.Key == Key.Down);
+            e.Handled = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    private void CloseSortChooser()
+    {
+        _viewModel!.IsSortChooserOpen = false;
+        _recentQsoGrid?.Focus();
+    }
+
+    private void CloseColumnChooser()
+    {
+        _viewModel!.IsColumnChooserOpen = false;
+        _recentQsoGrid?.Focus();
+    }
+
+    private void NavigateFocusInPanel<T>(string panelName, bool forward) where T : Control
+    {
+        var panel = this.FindControl<Border>(panelName);
+        if (panel is null)
+        {
+            return;
+        }
+
+        var items = panel.GetVisualDescendants().OfType<T>().ToList();
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        var focusedIndex = items.FindIndex(item => item.IsFocused);
+        int nextIndex;
+
+        if (forward)
+        {
+            nextIndex = focusedIndex < items.Count - 1 ? focusedIndex + 1 : 0;
+        }
+        else
+        {
+            nextIndex = focusedIndex > 0 ? focusedIndex - 1 : items.Count - 1;
+        }
+
+        items[nextIndex].Focus();
+        items[nextIndex].BringIntoView();
+    }
+
+    private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(MainWindowViewModel.IsSortChooserOpen)
+            && _viewModel?.IsSortChooserOpen == true)
+        {
+            FocusFirstInPanel<Button>("SortChooserPanel");
+        }
+        else if (e.PropertyName == nameof(MainWindowViewModel.IsColumnChooserOpen)
+            && _viewModel?.IsColumnChooserOpen == true)
+        {
+            FocusFirstInPanel<CheckBox>("ColumnChooserPanel");
+        }
+    }
+
+    private void FocusFirstInPanel<T>(string panelName) where T : Control
+    {
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                var panel = this.FindControl<Border>(panelName);
+                var first = panel?.GetVisualDescendants().OfType<T>().FirstOrDefault();
+                first?.Focus();
+            },
+            DispatcherPriority.Loaded);
     }
 }


### PR DESCRIPTION
## Summary

Major GUI overhaul adding the core QSO logging workflow, rig control integration, and fixing 10+ reported bugs.

### New Features

- **QSO Logger panel** — One-line rapid entry with callsign, band/mode cycling, frequency, RST, comment, timer
- **Callsign auto-lookup** — 800ms debounce lookup on callsign entry, displays name/grid/country
- **Full QSO card** — Expanded entry overlay (Ctrl+L) for all fields including grid, state, contest, exchange, notes
- **Rig control** — Ctrl+R toggles 1s polling, auto-fills band/mode/frequency from rig snapshot
- **Space weather** — Ctrl+W toggles K/SFI/SN display
- **Continent row coloring** — Subtle tints per continent (NA=orange, EU=blue, AS=red, AF=green, SA=gold, OC=teal)
- **Help overlay** — F1 shows all keyboard shortcuts
- **Timestamp format cycling** — Multiple UTC display formats

### Bug Fixes

- RST columns (S/R) showing blank — fixed PropertyChanged notification
- Band/Mode in logger not keyboard-interactive — now cycle with arrow keys
- Logger not focused on startup — callsign field gets focus by default
- Rig toggle not discoverable — clickable status text + Ctrl+R hint
- F8 in logger shows card for logger callsign, not grid selection
- F8 close restores focus to prior field
- Inconsistent grid field styling — unified foreground colors
- Search text showing twice — removed duplicate binding
- County showing state prefix — stripped
- Inspector layout cluttered — rewritten with multi-column layout
- Edit cell text clipping — fixed padding

### Keyboard Normalization

10 new keyboard bindings aligned with TUI/Win32 apps:

| Shortcut | Action |
|---|---|
| Ctrl+Enter | Log QSO |
| Ctrl+N | Focus Logger |
| Ctrl+L | Full QSO Card |
| Ctrl+R | Toggle Rig |
| Ctrl+W | Toggle Weather |
| F1 | Help Overlay |
| F3 | Focus Grid |
| F4 | Focus Search |
| F7 | Reset Timer |
| Ctrl+D | Delete QSO |

### Files Changed

- 3 new ViewModels: `QsoLoggerViewModel`, `FullQsoCardViewModel`, `HelpOverlayViewModel`
- 2 new Views: `FullQsoCardView`, `HelpOverlayView`
- 1 new model: `OperatorOptions` (band/mode definitions)
- Modified: `MainWindow.axaml`, `MainWindow.axaml.cs`, `MainWindowViewModel.cs`, `RecentQsoItemViewModel.cs`, `RecentQsoListViewModel.cs`, `IEngineClient.cs`, `EngineGrpcService.cs`, `UxFixtureEngineClient.cs`

### Validation

- Build: 0 errors, 0 warnings
- Tests: 217/217 passing
- Format: clean
- Visual: screenshot verified via capture-avalonia.ps1