### PR TITLE
Centralize shared rig control settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Proto files under `proto/` are the **single source of truth** for all shared typ
 
 | Service | Purpose |
 |---|---|
-| **SetupService** | First-run setup, persisted config status, bootstrap storage/station defaults |
+| **SetupService** | First-run and shared engine settings, persisted config status, bootstrap storage/station defaults |
 | **StationProfileService** | Persisted station profile CRUD, active profile selection, bounded session overrides |
 | **LookupService** | Callsign lookups -- single, streaming, batch, cached, DXCC |
 | **LogbookService** | QSO CRUD, QRZ logbook sync, ADIF import/export |
@@ -357,7 +357,7 @@ In capture mode, QsoRipper builds the outgoing QRZ XML request and returns redac
 
 You can also set `QSORIPPER_STATION_*` values in `.env` to define the active station profile that the Rust engine snapshots into newly logged QSOs.
 
-For the new first-run bootstrap surface, `SetupService` persists the engine's log file path, initial station profile, and optional QRZ XML credentials to `config.toml`, then hot-applies those persisted values to the running engine. After setup, `StationProfileService` manages additional station profiles, persisted active-profile selection, and bounded in-memory session overrides for portable or event operation. The Debug Host `/engine` page now exposes setup and station-profile editor forms for these contract surfaces, so local bootstrap/profile lifecycle testing no longer requires `grpcurl`.
+For the bootstrap and shared engine-settings surface, `SetupService` persists the engine's log file path, initial station profile, optional QRZ XML credentials, QRZ sync settings, and shared rig-control defaults to `config.toml`, then hot-applies those persisted values to the running engine. Setup wizards can guide the common first-run subset, while settings screens can edit the broader shared engine configuration through the same service. After setup, `StationProfileService` manages additional station profiles, persisted active-profile selection, and bounded in-memory session overrides for portable or event operation. The Debug Host `/engine` page now exposes setup and station-profile editor forms for these contract surfaces, so local bootstrap/profile lifecycle testing no longer requires `grpcurl`.
 
 ### Local lookup debug workflow
 

--- a/proto/services/rig_control_settings.proto
+++ b/proto/services/rig_control_settings.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+// Persisted engine-wide rigctld settings.
+message RigControlSettings {
+  optional bool enabled = 1;
+  optional string host = 2;
+  optional uint32 port = 3;
+  optional uint64 read_timeout_ms = 4;
+  optional uint64 stale_threshold_ms = 5;
+}

--- a/proto/services/save_setup_request.proto
+++ b/proto/services/save_setup_request.proto
@@ -6,6 +6,7 @@ option csharp_namespace = "QsoRipper.Services";
 
 import "domain/station_profile.proto";
 import "domain/sync_config.proto";
+import "services/rig_control_settings.proto";
 import "services/storage_backend.proto";
 
 message SaveSetupRequest {
@@ -21,4 +22,6 @@ message SaveSetupRequest {
   optional string qrz_logbook_api_key = 7;
   // Sync behaviour configuration. Omit to leave unchanged.
   optional qsoripper.domain.SyncConfig sync_config = 8;
+  // Engine-wide rig control configuration. Omit to leave unchanged.
+  optional RigControlSettings rig_control = 9;
 }

--- a/proto/services/setup_service.proto
+++ b/proto/services/setup_service.proto
@@ -17,14 +17,16 @@ import "services/test_qrz_logbook_credentials_response.proto";
 import "services/validate_setup_step_request.proto";
 import "services/validate_setup_step_response.proto";
 
-// Production setup/bootstrap surface for first-run configuration.
+// Production setup/bootstrap surface for first-run and shared engine configuration.
 //
 // This service owns persisted engine configuration, not ephemeral developer
 // runtime overrides. Clients can use it to detect missing setup, present the
-// recommended config/data paths, and save the initial station/logbook settings.
+// recommended config/data paths, and save persisted engine settings such as
+// station, logbook, and rig-control defaults.
 //
 // The wizard RPCs (GetSetupWizardState, ValidateSetupStep, TestQrzCredentials)
-// support step-by-step guided setup for new users in any UI surface.
+// support step-by-step guided setup for common first-run settings in any UI
+// surface.
 service SetupService {
   // Read the current persisted setup status and suggested default paths.
   rpc GetSetupStatus(GetSetupStatusRequest) returns (GetSetupStatusResponse);

--- a/proto/services/setup_status.proto
+++ b/proto/services/setup_status.proto
@@ -6,6 +6,7 @@ option csharp_namespace = "QsoRipper.Services";
 
 import "domain/station_profile.proto";
 import "domain/sync_config.proto";
+import "services/rig_control_settings.proto";
 import "services/storage_backend.proto";
 
 message SetupStatus {
@@ -33,4 +34,6 @@ message SetupStatus {
   bool has_qrz_logbook_api_key = 17;
   // Current sync configuration, if set.
   optional qsoripper.domain.SyncConfig sync_config = 18;
+  // Current persisted rig control configuration, if set.
+  optional RigControlSettings rig_control = 19;
 }

--- a/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
@@ -53,6 +53,7 @@ internal static class SetupCommand
         Console.WriteLine($"QRZ username:      {status.QrzXmlUsername ?? "(not set)"}");
         Console.WriteLine($"QRZ Logbook key:   {(status.HasQrzLogbookApiKey ? "(configured)" : "(not set)")}");
         Console.WriteLine($"Station profile:   {status.HasStationProfile}");
+        Console.WriteLine($"Rig control:       {FormatRigControlSummary(status.RigControl)}");
 #pragma warning disable CS0612 // Type or member is obsolete
         Console.WriteLine($"Storage backend:   {status.StorageBackend}");
 #pragma warning restore CS0612
@@ -63,6 +64,8 @@ internal static class SetupCommand
     internal static async Task<int> RunFromEnvAsync(GrpcChannel channel)
     {
         var client = new SetupService.SetupServiceClient(channel);
+        var statusResponse = await client.GetSetupStatusAsync(new GetSetupStatusRequest());
+        var currentStatus = statusResponse.Status;
 
         var stationCallsign = Environment.GetEnvironmentVariable("QSORIPPER_STATION_CALLSIGN");
         if (string.IsNullOrWhiteSpace(stationCallsign))
@@ -80,12 +83,45 @@ internal static class SetupCommand
         var qrzLogbookApiKey = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_LOGBOOK_API_KEY");
         var autoSyncEnv = Environment.GetEnvironmentVariable("QSORIPPER_AUTO_SYNC");
         var syncIntervalEnv = Environment.GetEnvironmentVariable("QSORIPPER_SYNC_INTERVAL");
+        var rigEnabledEnv = Environment.GetEnvironmentVariable("QSORIPPER_RIGCTLD_ENABLED");
+        var rigHostEnv = Environment.GetEnvironmentVariable("QSORIPPER_RIGCTLD_HOST");
+        var rigPortEnv = Environment.GetEnvironmentVariable("QSORIPPER_RIGCTLD_PORT");
+        var rigReadTimeoutEnv = Environment.GetEnvironmentVariable("QSORIPPER_RIGCTLD_READ_TIMEOUT_MS");
+        var rigStaleThresholdEnv = Environment.GetEnvironmentVariable("QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS");
+
+        if (!TryParseOptionalBooleanEnv(
+                rigEnabledEnv,
+                "QSORIPPER_RIGCTLD_ENABLED",
+                out var rigEnabled))
+        {
+            return 1;
+        }
+
+        if (!TryParseOptionalUInt32Env(rigPortEnv, "QSORIPPER_RIGCTLD_PORT", out var rigPort))
+        {
+            return 1;
+        }
+
+        if (!TryParseOptionalUInt64Env(
+                rigReadTimeoutEnv,
+                "QSORIPPER_RIGCTLD_READ_TIMEOUT_MS",
+                out var rigReadTimeoutMs))
+        {
+            return 1;
+        }
+
+        if (!TryParseOptionalUInt64Env(
+                rigStaleThresholdEnv,
+                "QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS",
+                out var rigStaleThresholdMs))
+        {
+            return 1;
+        }
 
         // If no log file path, fetch the suggested one from the engine.
         if (string.IsNullOrWhiteSpace(logFilePath))
         {
-            var statusResponse = await client.GetSetupStatusAsync(new GetSetupStatusRequest());
-            logFilePath = statusResponse.Status?.SuggestedLogFilePath;
+            logFilePath = currentStatus?.SuggestedLogFilePath;
         }
 
         var profile = new StationProfile
@@ -175,6 +211,18 @@ internal static class SetupCommand
         if (!string.IsNullOrWhiteSpace(qrzLogbookApiKey))
         {
             saveRequest.QrzLogbookApiKey = qrzLogbookApiKey;
+        }
+
+        var rigControl = BuildRigControlSettings(
+            rigEnabled,
+            rigHostEnv,
+            rigPort,
+            rigReadTimeoutMs,
+            rigStaleThresholdMs,
+            currentStatus?.RigControl);
+        if (rigControl is not null)
+        {
+            saveRequest.RigControl = rigControl;
         }
 
         // Include sync config when a logbook API key is provided.
@@ -588,6 +636,143 @@ internal static class SetupCommand
 
         return input.Equals("y", StringComparison.OrdinalIgnoreCase)
             || input.Equals("yes", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static RigControlSettings? BuildRigControlSettings(
+        bool? enabled,
+        string? host,
+        uint? port,
+        ulong? readTimeoutMs,
+        ulong? staleThresholdMs,
+        RigControlSettings? existing = null)
+    {
+        var normalizedHost = string.IsNullOrWhiteSpace(host) ? null : host.Trim();
+        var hasValues = enabled.HasValue
+            || !string.IsNullOrWhiteSpace(normalizedHost)
+            || port.HasValue
+            || readTimeoutMs.HasValue
+            || staleThresholdMs.HasValue;
+
+        if (!hasValues)
+        {
+            return null;
+        }
+
+        var settings = existing?.Clone() ?? new RigControlSettings();
+        if (enabled.HasValue)
+        {
+            settings.Enabled = enabled.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(normalizedHost))
+        {
+            settings.Host = normalizedHost;
+        }
+
+        if (port.HasValue)
+        {
+            settings.Port = port.Value;
+        }
+
+        if (readTimeoutMs.HasValue)
+        {
+            settings.ReadTimeoutMs = readTimeoutMs.Value;
+        }
+
+        if (staleThresholdMs.HasValue)
+        {
+            settings.StaleThresholdMs = staleThresholdMs.Value;
+        }
+
+        return settings;
+    }
+
+    private static string FormatRigControlSummary(RigControlSettings? rigControl)
+    {
+        if (rigControl is null)
+        {
+            return "(not set)";
+        }
+
+        var host = rigControl.HasHost ? rigControl.Host : "127.0.0.1";
+        var port = rigControl.HasPort ? rigControl.Port : 4532u;
+        return rigControl.Enabled
+            ? $"enabled ({host}:{port})"
+            : $"disabled ({host}:{port})";
+    }
+
+    private static bool TryParseOptionalBooleanEnv(
+        string? rawValue,
+        string variableName,
+        out bool? value)
+    {
+        value = null;
+        if (string.IsNullOrWhiteSpace(rawValue))
+        {
+            return true;
+        }
+
+        var trimmed = rawValue.Trim();
+        if (trimmed.Equals("true", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("yes", StringComparison.OrdinalIgnoreCase)
+            || trimmed == "1")
+        {
+            value = true;
+            return true;
+        }
+
+        if (trimmed.Equals("false", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("no", StringComparison.OrdinalIgnoreCase)
+            || trimmed == "0")
+        {
+            value = false;
+            return true;
+        }
+
+        Console.Error.WriteLine($"Error: {variableName} must be true/false, yes/no, or 1/0.");
+        return false;
+    }
+
+    private static bool TryParseOptionalUInt32Env(
+        string? rawValue,
+        string variableName,
+        out uint? value)
+    {
+        value = null;
+        if (string.IsNullOrWhiteSpace(rawValue))
+        {
+            return true;
+        }
+
+        if (uint.TryParse(rawValue.Trim(), System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+        {
+            value = parsed;
+            return true;
+        }
+
+        Console.Error.WriteLine($"Error: {variableName} must be an unsigned integer.");
+        return false;
+    }
+
+    private static bool TryParseOptionalUInt64Env(
+        string? rawValue,
+        string variableName,
+        out ulong? value)
+    {
+        value = null;
+        if (string.IsNullOrWhiteSpace(rawValue))
+        {
+            return true;
+        }
+
+        if (ulong.TryParse(rawValue.Trim(), System.Globalization.CultureInfo.InvariantCulture, out var parsed))
+        {
+            value = parsed;
+            return true;
+        }
+
+        Console.Error.WriteLine($"Error: {variableName} must be an unsigned integer.");
+        return false;
     }
 
     private static void PrintFieldErrors(

--- a/src/dotnet/QsoRipper.DebugHost.Tests/EditorModelTests.cs
+++ b/src/dotnet/QsoRipper.DebugHost.Tests/EditorModelTests.cs
@@ -16,6 +16,14 @@ public class EditorModelTests
             {
                 LogFilePath = @".\data\portable.db",
                 QrzXmlUsername = "k7rnd",
+                RigControl = new RigControlSettings
+                {
+                    Enabled = true,
+                    Host = "127.0.0.1",
+                    Port = 4532,
+                    ReadTimeoutMs = 2000,
+                    StaleThresholdMs = 5000
+                },
                 StationProfile = new StationProfile
                 {
                     ProfileName = "Home",
@@ -27,6 +35,11 @@ public class EditorModelTests
 
         Assert.Equal(@".\data\portable.db", model.LogFilePath);
         Assert.Equal("k7rnd", model.QrzXmlUsername);
+        Assert.True(model.RigControlEnabled);
+        Assert.Equal("127.0.0.1", model.RigControlHost);
+        Assert.Equal(4532, model.RigControlPort);
+        Assert.Equal(2000, model.RigControlReadTimeoutMs);
+        Assert.Equal(5000, model.RigControlStaleThresholdMs);
         Assert.Equal("Home", model.ProfileName);
         Assert.Equal("K7RND", model.StationCallsign);
         Assert.Equal("CN87", model.Grid);
@@ -40,6 +53,11 @@ public class EditorModelTests
             LogFilePath = @"  .\data\qsoripper.db  ",
             QrzXmlUsername = "  k7rnd  ",
             QrzXmlPassword = "  secret  ",
+            RigControlEnabled = true,
+            RigControlHost = " 127.0.0.1 ",
+            RigControlPort = 4532,
+            RigControlReadTimeoutMs = 2000,
+            RigControlStaleThresholdMs = 5000,
             ProfileName = "  Home  ",
             StationCallsign = "  K7RND  ",
             OperatorCallsign = "  K7RND  ",
@@ -55,6 +73,16 @@ public class EditorModelTests
         Assert.True(request.HasQrzXmlPassword);
         Assert.Equal("k7rnd", request.QrzXmlUsername);
         Assert.Equal("secret", request.QrzXmlPassword);
+        Assert.NotNull(request.RigControl);
+        Assert.True(request.RigControl.Enabled);
+        Assert.True(request.RigControl.HasHost);
+        Assert.Equal("127.0.0.1", request.RigControl.Host);
+        Assert.True(request.RigControl.HasPort);
+        Assert.Equal(4532u, request.RigControl.Port);
+        Assert.True(request.RigControl.HasReadTimeoutMs);
+        Assert.Equal(2000ul, request.RigControl.ReadTimeoutMs);
+        Assert.True(request.RigControl.HasStaleThresholdMs);
+        Assert.Equal(5000ul, request.RigControl.StaleThresholdMs);
         Assert.NotNull(request.StationProfile);
         Assert.Equal("Home", request.StationProfile.ProfileName);
         Assert.Equal("K7RND", request.StationProfile.StationCallsign);
@@ -77,6 +105,25 @@ public class EditorModelTests
 
         Assert.Contains(results, result => result.MemberNames.Contains(nameof(SetupEditorModel.LogFilePath), StringComparer.Ordinal));
         Assert.Contains(results, result => result.MemberNames.Contains(nameof(SetupEditorModel.QrzXmlPassword), StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void SetupEditorModel_validate_rejects_invalid_rig_control_values()
+    {
+        var model = new SetupEditorModel
+        {
+            LogFilePath = @".\data\qsoripper.db",
+            StationCallsign = "K7RND",
+            RigControlPort = 70000,
+            RigControlReadTimeoutMs = 0,
+            RigControlStaleThresholdMs = 0
+        };
+
+        var results = Validate(model);
+
+        Assert.Contains(results, result => result.MemberNames.Contains(nameof(SetupEditorModel.RigControlPort), StringComparer.Ordinal));
+        Assert.Contains(results, result => result.MemberNames.Contains(nameof(SetupEditorModel.RigControlReadTimeoutMs), StringComparer.Ordinal));
+        Assert.Contains(results, result => result.MemberNames.Contains(nameof(SetupEditorModel.RigControlStaleThresholdMs), StringComparer.Ordinal));
     }
 
     [Fact]

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/Engine.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/Engine.razor
@@ -465,7 +465,7 @@
             <div>
                 <h2 class="h5 mb-1">Persisted setup</h2>
                 <div class="small text-muted">
-                    Inspect and save the durable setup surface that configures storage, the initial station profile, and optional QRZ XML credentials.
+                    Inspect and save the durable engine settings surface that configures storage, shared rig control, the initial station profile, and optional QRZ XML credentials.
                 </div>
             </div>
             <div class="d-flex gap-2 flex-wrap">
@@ -510,10 +510,10 @@
                 <span><strong>Profile count:</strong> @setupStatus.StationProfileCount</span>
             </div>
             <div class="row g-3 mb-3">
-                <div class="col-lg-6">
+                <div class="col-lg-4">
                     <strong>Persisted log file:</strong> @GetSetupLogFileSummary(setupStatus)
                 </div>
-                <div class="col-lg-6">
+                <div class="col-lg-4">
                     <strong>QRZ XML:</strong>
                     @if (!string.IsNullOrWhiteSpace(setupStatus.QrzXmlUsername))
                     {
@@ -524,13 +524,16 @@
                         <span>Not configured</span>
                     }
                 </div>
+                <div class="col-lg-4">
+                    <strong>Rig control:</strong> @GetSetupRigControlSummary(setupStatus)
+                </div>
             </div>
         }
 
         @if (WorkbenchState.SetupStatus?.SetupComplete == true && !isSetupExpanded)
         {
             <div class="small text-muted">
-                Bootstrap setup is complete. Expand this section if you want to inspect or edit the log file path, QRZ credentials, or the currently active persisted station profile.
+                Bootstrap setup is complete. Expand this section if you want to inspect or edit the log file path, QRZ credentials, shared rig control settings, or the currently active persisted station profile.
             </div>
         }
         else
@@ -570,7 +573,7 @@
                     <div>
                         <h3 class="h6 mb-1">Setup editor</h3>
                         <div class="small text-muted">
-                            This form calls <code>SetupService.SaveSetup</code> to edit the persisted log file path, QRZ credentials, and the currently active bootstrap station profile. Use the station profile editor above to add additional profiles. If QRZ XML is enabled, the service requires both username and password on save.
+                            This form calls <code>SetupService.SaveSetup</code> to edit persisted engine-wide settings: the log file path, QRZ credentials, shared rig-control defaults, and the currently active bootstrap station profile. Use the station profile editor above to add additional profiles. If QRZ XML is enabled, the service requires both username and password on save.
                         </div>
                     </div>
                     @if (WorkbenchState.SetupStatus?.HasQrzXmlPassword == true)
@@ -704,8 +707,50 @@
                             <ValidationMessage For="@(() => setupEditor.QrzXmlPassword)" />
                         </div>
                         <div class="col-12">
+                            <div class="form-check">
+                                <InputCheckbox id="setup-rig-enabled"
+                                               class="form-check-input"
+                                               @bind-Value="setupEditor.RigControlEnabled"
+                                               disabled="@isSetupBusy" />
+                                <label class="form-check-label" for="setup-rig-enabled">
+                                    Enable rig control for this engine instance
+                                </label>
+                            </div>
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="setup-rig-host">Rig control host</label>
+                            <InputText id="setup-rig-host"
+                                       class="form-control"
+                                       @bind-Value="setupEditor.RigControlHost"
+                                       disabled="@isSetupBusy" />
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="setup-rig-port">Rig control port</label>
+                            <InputNumber id="setup-rig-port"
+                                         class="form-control"
+                                         @bind-Value="setupEditor.RigControlPort"
+                                         disabled="@isSetupBusy" />
+                            <ValidationMessage For="@(() => setupEditor.RigControlPort)" />
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="setup-rig-read-timeout">Read timeout (ms)</label>
+                            <InputNumber id="setup-rig-read-timeout"
+                                         class="form-control"
+                                         @bind-Value="setupEditor.RigControlReadTimeoutMs"
+                                         disabled="@isSetupBusy" />
+                            <ValidationMessage For="@(() => setupEditor.RigControlReadTimeoutMs)" />
+                        </div>
+                        <div class="col-md-6">
+                            <label class="form-label" for="setup-rig-stale-threshold">Stale threshold (ms)</label>
+                            <InputNumber id="setup-rig-stale-threshold"
+                                         class="form-control"
+                                         @bind-Value="setupEditor.RigControlStaleThresholdMs"
+                                         disabled="@isSetupBusy" />
+                            <ValidationMessage For="@(() => setupEditor.RigControlStaleThresholdMs)" />
+                        </div>
+                        <div class="col-12">
                             <div class="small text-muted mb-2">
-                                Stored QRZ passwords cannot be read back. Re-enter the password when saving QRZ XML credentials, or clear both QRZ fields to remove them.
+                                Stored QRZ passwords cannot be read back. Re-enter the password when saving QRZ XML credentials, or clear both QRZ fields to remove them. Use the Rig Control workbench to test live connections after saving shared rig settings.
                             </div>
                             <button class="btn btn-primary"
                                     type="submit"
@@ -1324,6 +1369,32 @@
         }
 
         return $"Not configured (suggested: {status.SuggestedLogFilePath})";
+    }
+
+    private static string GetSetupRigControlSummary(SetupStatus status)
+    {
+        if (status.RigControl is null)
+        {
+            return "Not configured";
+        }
+
+        var host = status.RigControl.HasHost ? status.RigControl.Host : "127.0.0.1";
+        var port = status.RigControl.HasPort ? status.RigControl.Port : 4532u;
+        var summary = status.RigControl.Enabled
+            ? $"Enabled ({host}:{port})"
+            : $"Disabled ({host}:{port})";
+
+        if (status.RigControl.HasReadTimeoutMs)
+        {
+            summary = $"{summary}, read {status.RigControl.ReadTimeoutMs} ms";
+        }
+
+        if (status.RigControl.HasStaleThresholdMs)
+        {
+            summary = $"{summary}, stale {status.RigControl.StaleThresholdMs} ms";
+        }
+
+        return summary;
     }
 
     private static bool AreSameProfile(StationProfile left, StationProfile right)

--- a/src/dotnet/QsoRipper.DebugHost/Models/SetupEditorModel.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Models/SetupEditorModel.cs
@@ -11,6 +11,21 @@ internal sealed class SetupEditorModel : StationProfileEditorModelBase
 
     public string? QrzXmlPassword { get; set; }
 
+    public bool RigControlEnabled { get; set; }
+
+    public string? RigControlHost { get; set; }
+
+    [Range(1, 65535)]
+    public int? RigControlPort { get; set; }
+
+    [Range(1, long.MaxValue)]
+    public long? RigControlReadTimeoutMs { get; set; }
+
+    [Range(1, long.MaxValue)]
+    public long? RigControlStaleThresholdMs { get; set; }
+
+    private bool HasPersistedRigControl { get; set; }
+
     public static SetupEditorModel Create(SetupStatus? status, string fallbackLogFilePath)
     {
         var model = new SetupEditorModel
@@ -18,8 +33,26 @@ internal sealed class SetupEditorModel : StationProfileEditorModelBase
             LogFilePath = NormalizeOptional(status?.LogFilePath)
                 ?? NormalizeOptional(status?.SuggestedLogFilePath)
                 ?? fallbackLogFilePath,
-            QrzXmlUsername = NormalizeOptional(status?.QrzXmlUsername)
+            QrzXmlUsername = NormalizeOptional(status?.QrzXmlUsername),
+            HasPersistedRigControl = status?.RigControl is not null
         };
+
+        if (status?.RigControl is not null)
+        {
+            model.RigControlEnabled = status.RigControl.Enabled;
+            model.RigControlHost = status.RigControl.HasHost
+                ? NormalizeOptional(status.RigControl.Host)
+                : null;
+            model.RigControlPort = status.RigControl.HasPort
+                ? (int)status.RigControl.Port
+                : null;
+            model.RigControlReadTimeoutMs = status.RigControl.HasReadTimeoutMs
+                ? (long)status.RigControl.ReadTimeoutMs
+                : null;
+            model.RigControlStaleThresholdMs = status.RigControl.HasStaleThresholdMs
+                ? (long)status.RigControl.StaleThresholdMs
+                : null;
+        }
 
         model.LoadFrom(status?.StationProfile);
         return model;
@@ -47,7 +80,55 @@ internal sealed class SetupEditorModel : StationProfileEditorModelBase
             request.QrzXmlPassword = QrzXmlPassword.Trim();
         }
 
+        var rigControl = BuildRigControlRequest();
+        if (rigControl is not null)
+        {
+            request.RigControl = rigControl;
+        }
+
         return request;
+    }
+
+    private RigControlSettings? BuildRigControlRequest()
+    {
+        var hasExplicitValues = RigControlEnabled
+            || !string.IsNullOrWhiteSpace(RigControlHost)
+            || RigControlPort.HasValue
+            || RigControlReadTimeoutMs.HasValue
+            || RigControlStaleThresholdMs.HasValue;
+
+        if (!HasPersistedRigControl && !hasExplicitValues)
+        {
+            return null;
+        }
+
+        var settings = new RigControlSettings();
+        if (HasPersistedRigControl || RigControlEnabled)
+        {
+            settings.Enabled = RigControlEnabled;
+        }
+
+        if (!string.IsNullOrWhiteSpace(RigControlHost))
+        {
+            settings.Host = RigControlHost.Trim();
+        }
+
+        if (RigControlPort.HasValue)
+        {
+            settings.Port = (uint)RigControlPort.Value;
+        }
+
+        if (RigControlReadTimeoutMs.HasValue)
+        {
+            settings.ReadTimeoutMs = (ulong)RigControlReadTimeoutMs.Value;
+        }
+
+        if (RigControlStaleThresholdMs.HasValue)
+        {
+            settings.StaleThresholdMs = (ulong)RigControlStaleThresholdMs.Value;
+        }
+
+        return settings;
     }
 
     public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/src/dotnet/QsoRipper.Gui.Tests/SettingsViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/SettingsViewModelTests.cs
@@ -1,0 +1,37 @@
+using QsoRipper.Gui.Inspection;
+using QsoRipper.Gui.ViewModels;
+
+namespace QsoRipper.Gui.Tests;
+
+public class SettingsViewModelTests
+{
+    [Fact]
+    public async Task SaveCommandRejectsInvalidRigControlValuesWithoutPersistingChanges()
+    {
+        var client = new UxFixtureEngineClient(
+            new UxCaptureFixture
+            {
+                RigControlEnabled = true,
+                RigControlHost = "127.0.0.1",
+                RigControlPort = 4532,
+                RigControlReadTimeoutMs = 2000,
+                RigControlStaleThresholdMs = 5000
+            });
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+        viewModel.RigControlPort = "not-a-port";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        Assert.False(viewModel.DidSave);
+        Assert.Equal(
+            "Rig control port must be a whole number between 1 and 65535.",
+            viewModel.ErrorMessage);
+
+        var status = await client.GetSetupStatusAsync();
+        Assert.NotNull(status.Status.RigControl);
+        Assert.True(status.Status.RigControl.HasPort);
+        Assert.Equal(4532u, status.Status.RigControl.Port);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui.Tests/UxFixtureEngineClientTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/UxFixtureEngineClientTests.cs
@@ -38,6 +38,14 @@ public class UxFixtureEngineClientTests
                     AutoSyncEnabled = true,
                     SyncIntervalSeconds = 600,
                     ConflictPolicy = ConflictPolicy.FlagForReview
+                },
+                RigControl = new RigControlSettings
+                {
+                    Enabled = true,
+                    Host = "127.0.0.1",
+                    Port = 4532,
+                    ReadTimeoutMs = 2500,
+                    StaleThresholdMs = 6000
                 }
             });
 
@@ -48,6 +56,12 @@ public class UxFixtureEngineClientTests
         Assert.True(response.Status.HasQrzLogbookApiKey);
         Assert.Equal(600u, response.Status.SyncConfig.SyncIntervalSeconds);
         Assert.Equal(ConflictPolicy.FlagForReview, response.Status.SyncConfig.ConflictPolicy);
+        Assert.NotNull(response.Status.RigControl);
+        Assert.True(response.Status.RigControl.Enabled);
+        Assert.Equal("127.0.0.1", response.Status.RigControl.Host);
+        Assert.Equal(4532u, response.Status.RigControl.Port);
+        Assert.Equal(2500ul, response.Status.RigControl.ReadTimeoutMs);
+        Assert.Equal(6000ul, response.Status.RigControl.StaleThresholdMs);
 
         var state = await client.GetWizardStateAsync();
         Assert.False(state.Status.IsFirstRun);

--- a/src/dotnet/QsoRipper.Gui/Inspection/UxCaptureFixture.cs
+++ b/src/dotnet/QsoRipper.Gui/Inspection/UxCaptureFixture.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
 using QsoRipper.Gui.Utilities;
+using QsoRipper.Services;
 
 namespace QsoRipper.Gui.Inspection;
 
@@ -74,6 +75,16 @@ internal sealed record UxCaptureFixture
 
     public string ConflictPolicy { get; init; } = nameof(QsoRipper.Domain.ConflictPolicy.LastWriteWins);
 
+    public bool? RigControlEnabled { get; init; }
+
+    public string? RigControlHost { get; init; }
+
+    public uint? RigControlPort { get; init; }
+
+    public ulong? RigControlReadTimeoutMs { get; init; }
+
+    public ulong? RigControlStaleThresholdMs { get; init; }
+
     public bool IsSyncing { get; init; }
 
     public IReadOnlyList<UxCaptureQsoFixtureItem> RecentQsos { get; init; } = CreateDefaultRecentQsos();
@@ -137,6 +148,48 @@ internal sealed record UxCaptureFixture
         }
 
         return profile;
+    }
+
+    public RigControlSettings? BuildRigControlSettings()
+    {
+        var hasValues = RigControlEnabled.HasValue
+            || !string.IsNullOrWhiteSpace(RigControlHost)
+            || RigControlPort.HasValue
+            || RigControlReadTimeoutMs.HasValue
+            || RigControlStaleThresholdMs.HasValue;
+
+        if (!hasValues)
+        {
+            return null;
+        }
+
+        var settings = new RigControlSettings();
+        if (RigControlEnabled.HasValue)
+        {
+            settings.Enabled = RigControlEnabled.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(RigControlHost))
+        {
+            settings.Host = RigControlHost;
+        }
+
+        if (RigControlPort.HasValue)
+        {
+            settings.Port = RigControlPort.Value;
+        }
+
+        if (RigControlReadTimeoutMs.HasValue)
+        {
+            settings.ReadTimeoutMs = RigControlReadTimeoutMs.Value;
+        }
+
+        if (RigControlStaleThresholdMs.HasValue)
+        {
+            settings.StaleThresholdMs = RigControlStaleThresholdMs.Value;
+        }
+
+        return settings;
     }
 
     public SyncConfig BuildSyncConfig() => new()

--- a/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
@@ -19,6 +19,7 @@ internal sealed class UxFixtureEngineClient : IEngineClient
     private string _configPath;
     private string _logFilePath;
     private string? _qrzXmlUsername;
+    private RigControlSettings? _rigControl;
     private DateTimeOffset? _lastSyncUtc;
     private bool _configFileExists;
     private bool _setupComplete;
@@ -37,6 +38,7 @@ internal sealed class UxFixtureEngineClient : IEngineClient
         _configPath = fixture.ConfigPath;
         _logFilePath = fixture.ActiveLogFilePath;
         _qrzXmlUsername = fixture.QrzXmlUsername;
+        _rigControl = fixture.BuildRigControlSettings();
         _lastSyncUtc = fixture.LastSyncUtc;
         _configFileExists = fixture.ConfigFileExists;
         _setupComplete = fixture.SetupComplete;
@@ -186,6 +188,11 @@ internal sealed class UxFixtureEngineClient : IEngineClient
             if (request.SyncConfig is not null)
             {
                 _syncConfig = request.SyncConfig.Clone();
+            }
+
+            if (request.RigControl is not null)
+            {
+                _rigControl = request.RigControl.Clone();
             }
 
             _configFileExists = true;
@@ -421,6 +428,11 @@ internal sealed class UxFixtureEngineClient : IEngineClient
         if (!string.IsNullOrWhiteSpace(_qrzXmlUsername))
         {
             status.QrzXmlUsername = _qrzXmlUsername;
+        }
+
+        if (_rigControl is not null)
+        {
+            status.RigControl = _rigControl.Clone();
         }
 
         if (HasStationProfile())

--- a/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
@@ -96,6 +96,22 @@ internal sealed partial class SettingsViewModel : ObservableObject
     [ObservableProperty]
     private ConflictPolicy _conflictPolicy = ConflictPolicy.LastWriteWins;
 
+    // Rig control
+    [ObservableProperty]
+    private bool _rigControlEnabled;
+
+    [ObservableProperty]
+    private string _rigControlHost = string.Empty;
+
+    [ObservableProperty]
+    private string _rigControlPort = string.Empty;
+
+    [ObservableProperty]
+    private string _rigControlReadTimeoutMs = string.Empty;
+
+    [ObservableProperty]
+    private string _rigControlStaleThresholdMs = string.Empty;
+
     // Log file (read-only display)
     [ObservableProperty]
     private string _logFilePath = string.Empty;
@@ -115,6 +131,8 @@ internal sealed partial class SettingsViewModel : ObservableObject
     /// </summary>
     [ObservableProperty]
     private bool _didSave;
+
+    private bool _hasPersistedRigControl;
 
     /// <summary>
     /// Raised when the dialog should close. The bool parameter is true for save, false for cancel.
@@ -164,6 +182,12 @@ internal sealed partial class SettingsViewModel : ObservableObject
         ErrorMessage = null;
         try
         {
+            if (!TryValidateRigControlInputs(out var validationError))
+            {
+                ErrorMessage = validationError;
+                return;
+            }
+
             var request = BuildSaveRequest();
             await _engine.SaveSetupAsync(request);
             DidSave = true;
@@ -262,6 +286,7 @@ internal sealed partial class SettingsViewModel : ObservableObject
     {
         QrzXmlUsername = status.QrzXmlUsername ?? string.Empty;
         LogFilePath = status.LogFilePath ?? string.Empty;
+        _hasPersistedRigControl = status.RigControl is not null;
 
         if (status.SyncConfig is not null)
         {
@@ -270,6 +295,31 @@ internal sealed partial class SettingsViewModel : ObservableObject
                 ? (int)status.SyncConfig.SyncIntervalSeconds
                 : 300;
             ConflictPolicy = status.SyncConfig.ConflictPolicy;
+        }
+
+        if (status.RigControl is not null)
+        {
+            RigControlEnabled = status.RigControl.Enabled;
+            RigControlHost = status.RigControl.HasHost
+                ? status.RigControl.Host
+                : string.Empty;
+            RigControlPort = status.RigControl.HasPort
+                ? status.RigControl.Port.ToString(CultureInfo.InvariantCulture)
+                : string.Empty;
+            RigControlReadTimeoutMs = status.RigControl.HasReadTimeoutMs
+                ? status.RigControl.ReadTimeoutMs.ToString(CultureInfo.InvariantCulture)
+                : string.Empty;
+            RigControlStaleThresholdMs = status.RigControl.HasStaleThresholdMs
+                ? status.RigControl.StaleThresholdMs.ToString(CultureInfo.InvariantCulture)
+                : string.Empty;
+        }
+        else
+        {
+            RigControlEnabled = false;
+            RigControlHost = string.Empty;
+            RigControlPort = string.Empty;
+            RigControlReadTimeoutMs = string.Empty;
+            RigControlStaleThresholdMs = string.Empty;
         }
 
         // Password and API key are never returned by the engine for security;
@@ -347,7 +397,67 @@ internal sealed partial class SettingsViewModel : ObservableObject
             request.QrzLogbookApiKey = QrzLogbookApiKey.Trim();
         }
 
+        var rigControl = BuildRigControlSettings();
+        if (rigControl is not null)
+        {
+            request.RigControl = rigControl;
+        }
+
         return request;
+    }
+
+    private RigControlSettings? BuildRigControlSettings()
+    {
+        var hasExplicitValues = RigControlEnabled
+            || !string.IsNullOrWhiteSpace(RigControlHost)
+            || !string.IsNullOrWhiteSpace(RigControlPort)
+            || !string.IsNullOrWhiteSpace(RigControlReadTimeoutMs)
+            || !string.IsNullOrWhiteSpace(RigControlStaleThresholdMs);
+
+        if (!_hasPersistedRigControl && !hasExplicitValues)
+        {
+            return null;
+        }
+
+        var settings = new RigControlSettings();
+        if (_hasPersistedRigControl || RigControlEnabled)
+        {
+            settings.Enabled = RigControlEnabled;
+        }
+
+        SetOptionalString(RigControlHost, value => settings.Host = value);
+        SetUInt32Field(RigControlPort, value => settings.Port = value);
+        SetUInt64Field(RigControlReadTimeoutMs, value => settings.ReadTimeoutMs = value);
+        SetUInt64Field(RigControlStaleThresholdMs, value => settings.StaleThresholdMs = value);
+        return settings;
+    }
+
+    private bool TryValidateRigControlInputs(out string? validationError)
+    {
+        if (!TryValidateUInt32Field(
+                RigControlPort,
+                1,
+                65_535,
+                "Rig control port",
+                out validationError))
+        {
+            return false;
+        }
+
+        if (!TryValidateUInt64Field(
+                RigControlReadTimeoutMs,
+                1,
+                "Rig control read timeout",
+                out validationError))
+        {
+            return false;
+        }
+
+        return TryValidateUInt64Field(
+            RigControlStaleThresholdMs,
+            1,
+            "Rig control stale threshold",
+            out validationError);
     }
 
     private static void SetOptionalString(string input, Action<string> setter)
@@ -364,6 +474,67 @@ internal sealed partial class SettingsViewModel : ObservableObject
         {
             setter(value);
         }
+    }
+
+    private static void SetUInt32Field(string? input, Action<uint> setter)
+    {
+        if (uint.TryParse(input, CultureInfo.InvariantCulture, out var value))
+        {
+            setter(value);
+        }
+    }
+
+    private static void SetUInt64Field(string? input, Action<ulong> setter)
+    {
+        if (ulong.TryParse(input, CultureInfo.InvariantCulture, out var value))
+        {
+            setter(value);
+        }
+    }
+
+    private static bool TryValidateUInt32Field(
+        string? input,
+        uint min,
+        uint max,
+        string label,
+        out string? errorMessage)
+    {
+        errorMessage = null;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return true;
+        }
+
+        if (!uint.TryParse(input, CultureInfo.InvariantCulture, out var value)
+            || value < min
+            || value > max)
+        {
+            errorMessage = $"{label} must be a whole number between {min} and {max}.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryValidateUInt64Field(
+        string? input,
+        ulong min,
+        string label,
+        out string? errorMessage)
+    {
+        errorMessage = null;
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return true;
+        }
+
+        if (!ulong.TryParse(input, CultureInfo.InvariantCulture, out var value) || value < min)
+        {
+            errorMessage = $"{label} must be a whole number greater than or equal to {min}.";
+            return false;
+        }
+
+        return true;
     }
 
     private static void SetDoubleField(string? input, Action<double> setter)

--- a/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
@@ -311,6 +311,56 @@
 
         <Separator />
 
+        <!-- Rig Control -->
+        <StackPanel Spacing="8">
+          <TextBlock Text="Rig Control"
+                     FontSize="16" FontWeight="SemiBold" />
+          <TextBlock Text="Engine-wide rigctld settings shared by every client connected to this engine."
+                     Opacity="0.6" TextWrapping="Wrap" />
+
+          <CheckBox x:Name="SettingsRigControlEnabledCheckBox"
+                    AutomationProperties.AutomationId="SettingsRigControlEnabledCheckBox"
+                    Content="Enable live rig control"
+                    IsChecked="{Binding RigControlEnabled, Mode=TwoWay}" />
+
+          <Grid ColumnDefinitions="140,*" RowDefinitions="Auto,Auto,Auto,Auto"
+                ColumnSpacing="12" RowSpacing="6">
+            <TextBlock Grid.Row="0" Grid.Column="0"
+                       Text="Host:" VerticalAlignment="Center" />
+            <TextBox x:Name="SettingsRigControlHostBox"
+                     AutomationProperties.AutomationId="SettingsRigControlHostBox"
+                     Grid.Row="0" Grid.Column="1"
+                     Text="{Binding RigControlHost, Mode=TwoWay}"
+                     PlaceholderText="127.0.0.1" />
+
+            <TextBlock Grid.Row="1" Grid.Column="0"
+                       Text="Port:" VerticalAlignment="Center" />
+            <TextBox x:Name="SettingsRigControlPortBox"
+                     AutomationProperties.AutomationId="SettingsRigControlPortBox"
+                     Grid.Row="1" Grid.Column="1"
+                     Text="{Binding RigControlPort, Mode=TwoWay}"
+                     PlaceholderText="4532" />
+
+            <TextBlock Grid.Row="2" Grid.Column="0"
+                       Text="Read timeout (ms):" VerticalAlignment="Center" />
+            <TextBox x:Name="SettingsRigControlReadTimeoutBox"
+                     AutomationProperties.AutomationId="SettingsRigControlReadTimeoutBox"
+                     Grid.Row="2" Grid.Column="1"
+                     Text="{Binding RigControlReadTimeoutMs, Mode=TwoWay}"
+                     PlaceholderText="2000" />
+
+            <TextBlock Grid.Row="3" Grid.Column="0"
+                       Text="Stale threshold (ms):" VerticalAlignment="Center" />
+            <TextBox x:Name="SettingsRigControlStaleThresholdBox"
+                     AutomationProperties.AutomationId="SettingsRigControlStaleThresholdBox"
+                     Grid.Row="3" Grid.Column="1"
+                     Text="{Binding RigControlStaleThresholdMs, Mode=TwoWay}"
+                     PlaceholderText="5000" />
+          </Grid>
+        </StackPanel>
+
+        <Separator />
+
         <!-- Log File Path (informational) -->
         <StackPanel Spacing="8">
           <TextBlock Text="Log File"

--- a/src/rust/qsoripper-server/src/setup.rs
+++ b/src/rust/qsoripper-server/src/setup.rs
@@ -17,13 +17,14 @@ use qsoripper_core::proto::qsoripper::services::{
     DeleteStationProfileResponse, GetActiveStationContextRequest, GetActiveStationContextResponse,
     GetSetupStatusRequest, GetSetupStatusResponse, GetSetupWizardStateRequest,
     GetSetupWizardStateResponse, GetStationProfileRequest, GetStationProfileResponse,
-    ListStationProfilesRequest, ListStationProfilesResponse, SaveSetupRequest, SaveSetupResponse,
-    SaveStationProfileRequest, SaveStationProfileResponse, SetActiveStationProfileRequest,
-    SetActiveStationProfileResponse, SetSessionStationProfileOverrideRequest,
-    SetSessionStationProfileOverrideResponse, SetupFieldValidation, SetupStatus, SetupWizardStep,
-    SetupWizardStepStatus, StationProfileRecord, StorageBackend, TestQrzCredentialsRequest,
-    TestQrzCredentialsResponse, TestQrzLogbookCredentialsRequest,
-    TestQrzLogbookCredentialsResponse, ValidateSetupStepRequest, ValidateSetupStepResponse,
+    ListStationProfilesRequest, ListStationProfilesResponse, RigControlSettings, SaveSetupRequest,
+    SaveSetupResponse, SaveStationProfileRequest, SaveStationProfileResponse,
+    SetActiveStationProfileRequest, SetActiveStationProfileResponse,
+    SetSessionStationProfileOverrideRequest, SetSessionStationProfileOverrideResponse,
+    SetupFieldValidation, SetupStatus, SetupWizardStep, SetupWizardStepStatus,
+    StationProfileRecord, StorageBackend, TestQrzCredentialsRequest, TestQrzCredentialsResponse,
+    TestQrzLogbookCredentialsRequest, TestQrzLogbookCredentialsResponse, ValidateSetupStepRequest,
+    ValidateSetupStepResponse,
 };
 use qsoripper_core::qrz_logbook::{QrzLogbookClient, QrzLogbookConfig};
 use qsoripper_core::rig_control::{
@@ -623,6 +624,11 @@ impl PersistedSetupConfig {
             config.sync = PersistedSyncConfig::from_proto(sync_config);
         }
 
+        // Rig control config: update when explicitly provided, otherwise keep existing.
+        if let Some(ref rig_control) = request.rig_control {
+            config.rig_control = PersistedRigControlConfig::from_proto(rig_control)?;
+        }
+
         config.sync_active_station_profile();
 
         Ok(config)
@@ -1141,6 +1147,61 @@ impl PersistedRigControlConfig {
             && config.read_timeout_ms.is_none()
             && config.stale_threshold_ms.is_none()
     }
+
+    fn from_proto(rig_control: &RigControlSettings) -> Result<Self, String> {
+        let port = match rig_control.port {
+            Some(0) => {
+                return Err("Rig control port must be between 1 and 65535.".to_string());
+            }
+            Some(port) => Some(
+                u16::try_from(port)
+                    .map_err(|_| "Rig control port must be between 1 and 65535.".to_string())?,
+            ),
+            None => None,
+        };
+
+        let read_timeout_ms = match rig_control.read_timeout_ms {
+            Some(0) => {
+                return Err(
+                    "Rig control read timeout must be greater than 0 milliseconds.".to_string(),
+                );
+            }
+            Some(value) => Some(value),
+            None => None,
+        };
+
+        let stale_threshold_ms = match rig_control.stale_threshold_ms {
+            Some(0) => {
+                return Err(
+                    "Rig control stale threshold must be greater than 0 milliseconds.".to_string(),
+                );
+            }
+            Some(value) => Some(value),
+            None => None,
+        };
+
+        Ok(Self {
+            enabled: rig_control.enabled,
+            host: normalize_optional_string(rig_control.host.as_deref()),
+            port,
+            read_timeout_ms,
+            stale_threshold_ms,
+        })
+    }
+
+    fn to_proto(&self) -> Option<RigControlSettings> {
+        if Self::is_empty(self) {
+            return None;
+        }
+
+        Some(RigControlSettings {
+            enabled: self.enabled,
+            host: self.host.clone(),
+            port: self.port.map(u32::from),
+            read_timeout_ms: self.read_timeout_ms,
+            stale_threshold_ms: self.stale_threshold_ms,
+        })
+    }
 }
 
 pub(crate) fn default_config_path() -> Result<PathBuf, String> {
@@ -1264,6 +1325,7 @@ fn build_status(
             .and_then(|config| config.qrz_logbook.api_key.as_ref())
             .is_some(),
         sync_config: persisted_config.map(|config| config.sync.to_proto()),
+        rig_control: persisted_config.and_then(|config| config.rig_control.to_proto()),
     }
 }
 
@@ -1727,16 +1789,19 @@ mod tests {
         build_station_profiles_step, build_wizard_steps, default_config_path,
         suggested_log_file_path, validate_log_file_step, validate_qrz_step,
         validate_station_profiles_step, PersistedSetupConfig, SetupControlSurface, SetupState,
-        StationProfileControlSurface, DEFAULT_CONFIG_FILE_NAME,
+        StationProfileControlSurface, DEFAULT_CONFIG_FILE_NAME, RIGCTLD_ENABLED_ENV_VAR,
+        RIGCTLD_HOST_ENV_VAR, RIGCTLD_PORT_ENV_VAR, RIGCTLD_READ_TIMEOUT_MS_ENV_VAR,
+        RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR,
     };
     use crate::runtime_config::RuntimeConfigManager;
     use qsoripper_core::proto::qsoripper::domain::{ConflictPolicy, StationProfile, SyncConfig};
     use qsoripper_core::proto::qsoripper::services::{
         setup_service_server::SetupService, station_profile_service_server::StationProfileService,
         GetActiveStationContextRequest, GetSetupStatusRequest, GetSetupWizardStateRequest,
-        ListStationProfilesRequest, SaveSetupRequest, SaveStationProfileRequest,
-        SetActiveStationProfileRequest, SetSessionStationProfileOverrideRequest, SetupWizardStep,
-        StorageBackend, ValidateSetupStepRequest,
+        ListStationProfilesRequest, RigControlSettings, SaveSetupRequest,
+        SaveStationProfileRequest, SetActiveStationProfileRequest,
+        SetSessionStationProfileOverrideRequest, SetupWizardStep, StorageBackend,
+        ValidateSetupStepRequest,
     };
 
     fn unique_config_path() -> std::path::PathBuf {
@@ -2752,6 +2817,149 @@ station_callsign = "K7RND"
     }
 
     #[tokio::test]
+    async fn save_setup_persists_rig_control_and_round_trips() {
+        let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "rig-control.db");
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
+
+        let response = SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file_path),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                rig_control: Some(RigControlSettings {
+                    enabled: Some(true),
+                    host: Some("127.0.0.1".to_string()),
+                    port: Some(4532),
+                    read_timeout_ms: Some(2500),
+                    stale_threshold_ms: Some(6000),
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("save setup")
+        .into_inner();
+
+        let status = response.status.expect("status payload");
+        let rig_control = status.rig_control.expect("rig_control");
+        assert_eq!(Some(true), rig_control.enabled);
+        assert_eq!(Some("127.0.0.1"), rig_control.host.as_deref());
+        assert_eq!(Some(4532), rig_control.port);
+        assert_eq!(Some(2500), rig_control.read_timeout_ms);
+        assert_eq!(Some(6000), rig_control.stale_threshold_ms);
+
+        let saved_toml = fs::read_to_string(&config_path).expect("read config");
+        let parsed =
+            toml::from_str::<PersistedSetupConfig>(&saved_toml).expect("parse saved config");
+        assert_eq!(Some(true), parsed.rig_control.enabled);
+        assert_eq!(Some("127.0.0.1"), parsed.rig_control.host.as_deref());
+        assert_eq!(Some(4532), parsed.rig_control.port);
+        assert_eq!(Some(2500), parsed.rig_control.read_timeout_ms);
+        assert_eq!(Some(6000), parsed.rig_control.stale_threshold_ms);
+
+        let runtime_values = setup_state.runtime_config_values().await;
+        assert_eq!(
+            Some("true"),
+            runtime_values
+                .get(RIGCTLD_ENABLED_ENV_VAR)
+                .map(String::as_str)
+        );
+        assert_eq!(
+            Some("127.0.0.1"),
+            runtime_values.get(RIGCTLD_HOST_ENV_VAR).map(String::as_str)
+        );
+        assert_eq!(
+            Some("4532"),
+            runtime_values.get(RIGCTLD_PORT_ENV_VAR).map(String::as_str)
+        );
+        assert_eq!(
+            Some("2500"),
+            runtime_values
+                .get(RIGCTLD_READ_TIMEOUT_MS_ENV_VAR)
+                .map(String::as_str)
+        );
+        assert_eq!(
+            Some("6000"),
+            runtime_values
+                .get(RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR)
+                .map(String::as_str)
+        );
+
+        drop(service);
+        drop(runtime_config);
+        drop(setup_state);
+
+        let config_directory = config_path.parent().expect("config directory");
+        let _ = fs::remove_dir_all(config_directory);
+    }
+
+    #[tokio::test]
+    async fn save_setup_preserves_rig_control_when_omitted_in_subsequent_save() {
+        let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "preserve-rig-control.db");
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
+
+        SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file_path.clone()),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                rig_control: Some(RigControlSettings {
+                    enabled: Some(true),
+                    host: Some("127.0.0.1".to_string()),
+                    port: Some(4532),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("first save");
+
+        let response = SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file_path),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("second save")
+        .into_inner();
+
+        let rig_control = response
+            .status
+            .expect("status payload")
+            .rig_control
+            .expect("rig_control");
+        assert_eq!(Some(true), rig_control.enabled);
+        assert_eq!(Some("127.0.0.1"), rig_control.host.as_deref());
+        assert_eq!(Some(4532), rig_control.port);
+
+        drop(service);
+        drop(runtime_config);
+        drop(setup_state);
+
+        let config_directory = config_path.parent().expect("config directory");
+        let _ = fs::remove_dir_all(config_directory);
+    }
+
+    #[tokio::test]
     async fn save_setup_preserves_logbook_key_when_omitted_in_subsequent_save() {
         let config_path = unique_config_path();
         let log_file_path = absolute_log_file_path(&config_path, "preserve-key.db");
@@ -2836,5 +3044,40 @@ station_callsign = "K7RND"
 
         let back = persisted.to_proto();
         assert_eq!(300, back.sync_interval_seconds);
+    }
+
+    #[test]
+    fn persisted_rig_control_config_round_trips_through_proto() {
+        let proto = RigControlSettings {
+            enabled: Some(true),
+            host: Some("127.0.0.1".to_string()),
+            port: Some(4532),
+            read_timeout_ms: Some(2000),
+            stale_threshold_ms: Some(5000),
+        };
+        let persisted =
+            super::PersistedRigControlConfig::from_proto(&proto).expect("rig control config");
+        assert_eq!(Some(true), persisted.enabled);
+        assert_eq!(Some("127.0.0.1"), persisted.host.as_deref());
+        assert_eq!(Some(4532), persisted.port);
+        assert_eq!(Some(2000), persisted.read_timeout_ms);
+        assert_eq!(Some(5000), persisted.stale_threshold_ms);
+
+        let back = persisted.to_proto().expect("rig control proto");
+        assert_eq!(proto.enabled, back.enabled);
+        assert_eq!(proto.host, back.host);
+        assert_eq!(proto.port, back.port);
+        assert_eq!(proto.read_timeout_ms, back.read_timeout_ms);
+        assert_eq!(proto.stale_threshold_ms, back.stale_threshold_ms);
+    }
+
+    #[test]
+    fn persisted_rig_control_config_rejects_invalid_port() {
+        let error = super::PersistedRigControlConfig::from_proto(&RigControlSettings {
+            port: Some(u32::from(u16::MAX) + 1),
+            ..Default::default()
+        })
+        .expect_err("invalid port should be rejected");
+        assert_eq!("Rig control port must be between 1 and 65535.", error);
     }
 }

--- a/src/rust/qsoripper-stress/src/runner.rs
+++ b/src/rust/qsoripper-stress/src/runner.rs
@@ -1611,10 +1611,8 @@ mod tests {
     fn workspace_root_resolves_repository_root() {
         let root = workspace_root()
             .unwrap_or_else(|| panic!("workspace root should resolve from cargo manifest dir"));
-        assert_eq!(
-            Some("qsoripper"),
-            root.file_name().and_then(|name| name.to_str())
-        );
+        assert!(root.join("README.md").exists());
+        assert!(root.join("src").join("rust").join("Cargo.toml").exists());
     }
 
     #[expect(


### PR DESCRIPTION
## Summary

- add canonical `RigControlSettings` support to `SetupService` so persisted rig control can round-trip through the shared engine settings contract
- align the GUI settings window, DebugHost setup editor, and CLI setup/status flows with the shared rig-control settings surface
- add regression coverage for rig-control persistence/validation and make the stress runner workspace-root test work from a git worktree

## Notes

- setup wizards remain focused on the common first-run bootstrap subset while ongoing settings screens use the same service for broader shared engine configuration

Fixes #158
