### PR TITLE
Fix QRZ sync inserting ghost QSO records from ADIF artefacts

### DIFF
--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -305,6 +305,13 @@ async fn parse_adif_records_tolerantly(payload: &str) -> Vec<QsoRecord> {
     parsed
 }
 
+/// A remotely fetched QSO must have at minimum a callsign and timestamp to be
+/// usable for matching and storage. Records that fail this check are artefacts
+/// of ADIF header/trailer fragments and should be silently dropped.
+fn is_syncable_qso(qso: &QsoRecord) -> bool {
+    !qso.worked_callsign.trim().is_empty() && qso.utc_timestamp.is_some()
+}
+
 async fn parse_fetch_adif_payload(
     adif_payload: &str,
     expected_count: Option<usize>,
@@ -316,10 +323,14 @@ async fn parse_fetch_adif_payload(
     let strict_result = adif::parse_adi_qsos(normalized_adif.as_bytes()).await;
     let strict_parse_error = match strict_result {
         Ok(qsos) if !qsos.is_empty() => {
+            // Filter out ghost records (empty callsign / missing timestamp)
+            // *before* comparing against the expected count so that trailing
+            // ADIF artefacts don't needlessly trigger the tolerant fallback.
+            let valid: Vec<QsoRecord> = qsos.into_iter().filter(is_syncable_qso).collect();
             let over_parsed =
-                expected_count.is_some_and(|expected| expected > 0 && qsos.len() > expected);
-            if !over_parsed {
-                return Ok(qsos);
+                expected_count.is_some_and(|expected| expected > 0 && valid.len() > expected);
+            if !valid.is_empty() && !over_parsed {
+                return Ok(valid);
             }
             None
         }
@@ -328,8 +339,9 @@ async fn parse_fetch_adif_payload(
     };
 
     let tolerant = parse_adif_records_tolerantly(&normalized_adif).await;
-    if !tolerant.is_empty() {
-        return Ok(tolerant);
+    let valid_tolerant: Vec<QsoRecord> = tolerant.into_iter().filter(is_syncable_qso).collect();
+    if !valid_tolerant.is_empty() {
+        return Ok(valid_tolerant);
     }
 
     if let Some(err) = strict_parse_error {
@@ -1070,6 +1082,72 @@ mod tests {
         let payload = "<CALL:4>W1AW <eor>\n<eoh>\n";
         let normalized = normalize_adif_record_markers(payload);
         assert_eq!(normalized, "<CALL:4>W1AW <EOR>\n<EOH>\n");
+    }
+
+    // -- is_syncable_qso / ghost filtering -----------------------------------
+
+    #[test]
+    fn is_syncable_qso_rejects_empty_callsign() {
+        let ghost = QsoRecord::default();
+        assert!(!is_syncable_qso(&ghost));
+    }
+
+    #[test]
+    fn is_syncable_qso_rejects_missing_timestamp() {
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            utc_timestamp: None,
+            ..Default::default()
+        };
+        assert!(!is_syncable_qso(&qso));
+    }
+
+    #[test]
+    fn is_syncable_qso_accepts_valid_record() {
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            utc_timestamp: Some(prost_types::Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            }),
+            ..Default::default()
+        };
+        assert!(is_syncable_qso(&qso));
+    }
+
+    #[tokio::test]
+    async fn parse_fetch_adif_drops_ghost_records_from_trailing_content() {
+        // Simulate QRZ response with 2 real records + trailing junk after last <EOR>
+        let adif = "<CALL:4>W1AW <BAND:3>20M <MODE:3>SSB \
+                    <QSO_DATE:8>20250101 <TIME_ON:4>1200 <EOR>\n\
+                    <CALL:6>N0CALL <BAND:3>40M <MODE:2>CW \
+                    <QSO_DATE:8>20250102 <TIME_ON:4>1300 <EOR>\n\
+                    some trailing garbage\n";
+
+        let result = parse_fetch_adif_payload(adif, Some(2))
+            .await
+            .expect("parse");
+
+        assert_eq!(result.len(), 2, "ghost records should be filtered out");
+        assert_eq!(result[0].worked_callsign, "W1AW");
+        assert_eq!(result[1].worked_callsign, "N0CALL");
+    }
+
+    #[tokio::test]
+    async fn parse_fetch_adif_count_mismatch_does_not_trigger_tolerant_after_filtering() {
+        // Strict parser may produce 3 records (2 real + 1 ghost), but after
+        // filtering, the 2 real records match COUNT=2 and should be returned
+        // without falling through to the tolerant path.
+        let adif = "<CALL:4>W1AW <BAND:3>20M <MODE:3>SSB \
+                    <QSO_DATE:8>20250101 <TIME_ON:4>1200 <EOR>\n\
+                    <CALL:6>N0CALL <BAND:3>40M <MODE:2>CW \
+                    <QSO_DATE:8>20250102 <TIME_ON:4>1300 <EOR>\n";
+
+        let result = parse_fetch_adif_payload(adif, Some(2))
+            .await
+            .expect("parse");
+
+        assert_eq!(result.len(), 2);
     }
 
     // -- upload_qso integration ---------------------------------------------

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -224,6 +224,13 @@ async fn download_phase(
 
     // Process each remote QSO.
     for remote in &remote_qsos {
+        // Defense-in-depth: skip records that lack the minimum fields needed
+        // for matching and storage. These are artefacts of ADIF
+        // header/trailer fragments that slip through the parser.
+        if remote.worked_callsign.trim().is_empty() || remote.utc_timestamp.is_none() {
+            continue;
+        }
+
         let remote_logid = extract_qrz_logid(remote);
 
         let local_match = remote_logid
@@ -1339,5 +1346,59 @@ mod tests {
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].sync_status, SyncStatus::Synced as i32);
         assert_eq!(all[0].notes.as_deref(), Some("remote tie"));
+    }
+
+    #[tokio::test]
+    async fn download_skips_ghost_records_with_empty_callsign() {
+        let store = MemoryStorage::new();
+
+        // One valid remote QSO and one ghost (empty callsign, no timestamp).
+        let valid = {
+            let mut q = make_qso("W1AW", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+            q.qrz_logid = Some("QRZ001".into());
+            q
+        };
+        let ghost = QsoRecord::default();
+
+        let api = MockQrzApi::new(Ok(vec![valid, ghost]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.downloaded_records, 1, "ghost should be skipped");
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1, "only the valid QSO should be stored");
+        assert_eq!(all[0].worked_callsign, "K7ABC");
+    }
+
+    #[tokio::test]
+    async fn download_skips_records_with_callsign_but_no_timestamp() {
+        let store = MemoryStorage::new();
+
+        let no_ts = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            utc_timestamp: None,
+            ..Default::default()
+        };
+
+        let api = MockQrzApi::new(Ok(vec![no_ts]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(
+            final_msg.downloaded_records, 0,
+            "record without timestamp should be skipped"
+        );
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert!(all.is_empty());
     }
 }


### PR DESCRIPTION
## Problem

QRZ sync was inserting ~767 ghost QSO records alongside ~766 real QSOs, resulting in 1533 total rows in the database where only 766 were legitimate.

The ghost records had:
- Empty `worked_callsign`
- No `utc_timestamp` (null/zero)
- Zero `band` and `mode`
- `sync_status = Synced`

## Root Cause

The ADIF parser produces empty `QsoRecord` objects from header/trailer fragments in QRZ FETCH response payloads. These ghost records caused two cascading issues:

1. **`parse_fetch_adif_payload` over-parsed detection**: The strict parser produced N+1 records (N real + 1 ghost from trailing content). Since `N+1 > COUNT(N)`, the `over_parsed` check triggered, needlessly falling through to the lossy tolerant parser which produced additional ghost records.

2. **Sync `download_phase` inserted ghosts**: `fuzzy_match()` early-returns `None` for records without `utc_timestamp` (via `?` operator), so every ghost record appeared as a new unmatched QSO and got inserted.

## Fix

Two-level defense:

### Level 1: Parse filtering (`qsoripper-core`)
- Added `is_syncable_qso()` predicate requiring non-empty `worked_callsign` AND present `utc_timestamp`
- Filter ghost records from strict parser output **before** the `over_parsed` comparison, so the strict path succeeds when real QSO count matches COUNT
- Also filter tolerant parser output for defense in depth

### Level 2: Sync guard (`qsoripper-server`)
- Skip records with empty callsign or missing timestamp in `download_phase` before matching/insertion

## Tests

- `is_syncable_qso` unit tests: rejects empty callsign, rejects missing timestamp, accepts valid records
- `parse_fetch_adif_drops_ghost_records_from_trailing_content`: verifies trailing garbage doesn't produce ghost QSOs
- `parse_fetch_adif_count_mismatch_does_not_trigger_tolerant_after_filtering`: verifies ghost filtering prevents unnecessary tolerant fallback
- `download_skips_ghost_records_with_empty_callsign`: sync skips ghost records
- `download_skips_records_with_callsign_but_no_timestamp`: sync skips records without timestamp

## Data Repair

The 767 ghost records in the local SQLite database were cleaned up manually:

```
DELETE FROM qsos
WHERE (worked_callsign IS NULL OR worked_callsign = '')
  AND (utc_timestamp_ms IS NULL OR utc_timestamp_ms = 0);
```

After cleanup: 766 total rows (all legitimate QSOs).