### PR TITLE
fix: QRZ lookup broken and rig poll sluggish in Win32 UI

### DIFF
--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -143,6 +143,8 @@ typedef struct {
     char country[64];
     int  cq_zone;
     int  has_data;
+    int  not_found;
+    char error_msg[128];
 } LookupResultMsg;
 
 /* ── Rig poll message structs ──────────────────────────────────────────── */
@@ -250,6 +252,8 @@ typedef struct {
     int  lookup_cq_zone;
     int  has_lookup;
     int  lookup_in_progress;
+    int  lookup_not_found;
+    char lookup_error[128];
 
     /* Recent QSOs (heap-allocated; grows as needed) */
     RecentQso *recent_qsos;
@@ -1129,6 +1133,8 @@ static void ClearLookupDisplay(void)
 {
     g_state.has_lookup = 0;
     g_state.lookup_in_progress = 0;
+    g_state.lookup_not_found = 0;
+    g_state.lookup_error[0] = 0;
     g_state.lookup_name[0] = 0;
     g_state.lookup_qth[0] = 0;
     g_state.lookup_grid[0] = 0;
@@ -1150,6 +1156,23 @@ static unsigned __stdcall LookupThread(void *param)
     char *result = RunQrCommand(cmd);
 
     if (result) {
+        /* Check the lookup state first — error or not_found mean no record */
+        char *state = json_get_string(result, "state");
+        if (state) {
+            if (strstr(state, "NOT_FOUND")) {
+                res->not_found = 1;
+            } else if (strstr(state, "ERROR")) {
+                char *emsg = json_get_string(result, "errorMessage");
+                if (emsg) {
+                    safe_strcpy(res->error_msg, sizeof(res->error_msg), emsg);
+                    free(emsg);
+                } else {
+                    safe_strcpy(res->error_msg, sizeof(res->error_msg), "Lookup error");
+                }
+            }
+            free(state);
+        }
+
         const char *record_pos = strstr(result, "\"record\"");
         if (record_pos) {
             char *v;
@@ -1946,6 +1969,10 @@ static int PaintLookup(HDC hdc, int y_start, int w)
         char line[64];
         snprintf(line, sizeof(line), "Looking up%s", dots[frame]);
         DrawText_A(hdc, pad + cw, y + ch, CLR_CYAN, line);
+    } else if (g_state.lookup_not_found) {
+        DrawText_A(hdc, pad + cw, y + ch, CLR_YELLOW, "Callsign not found");
+    } else if (g_state.lookup_error[0]) {
+        DrawText_A(hdc, pad + cw, y + ch, CLR_RED, g_state.lookup_error);
     } else {
         DrawText_A(hdc, pad + cw, y + ch, CLR_DARKGRAY, "");
     }
@@ -2861,10 +2888,10 @@ static void OnTimer(HWND hwnd)
         }
     }
 
-    /* Rig poll: every 1000ms when enabled and no poll in flight */
+    /* Rig poll: every 500ms when enabled and no poll in flight */
     if (g_state.rig_enabled && !g_state.rig_poll_in_progress) {
         ULONGLONG now = GetTickCount64();
-        if (now - g_state.last_rig_poll >= 1000) {
+        if (now - g_state.last_rig_poll >= 500) {
             g_state.last_rig_poll = now;
             RigPollArg *rarg = (RigPollArg *)malloc(sizeof(RigPollArg));
             if (rarg) {
@@ -3053,17 +3080,27 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
     {
         LookupResultMsg *res = (LookupResultMsg *)lParam;
         if (res) {
-            if (_stricmp(res->callsign, g_state.callsign) == 0 && res->has_data) {
-                safe_strcpy(g_state.lookup_name, sizeof(g_state.lookup_name), res->name);
-                safe_strcpy(g_state.lookup_qth,  sizeof(g_state.lookup_qth),  res->qth);
-                safe_strcpy(g_state.lookup_grid, sizeof(g_state.lookup_grid), res->grid);
-                safe_strcpy(g_state.lookup_country, sizeof(g_state.lookup_country), res->country);
-                g_state.lookup_cq_zone = res->cq_zone;
-                g_state.has_lookup = 1;
-                if (g_state.worked_name[0] == 0)
-                    safe_strcpy(g_state.worked_name, sizeof(g_state.worked_name), res->name);
-                if (g_state.qth[0] == 0)
-                    safe_strcpy(g_state.qth, sizeof(g_state.qth), res->qth);
+            if (_stricmp(res->callsign, g_state.callsign) == 0) {
+                if (res->has_data) {
+                    safe_strcpy(g_state.lookup_name, sizeof(g_state.lookup_name), res->name);
+                    safe_strcpy(g_state.lookup_qth,  sizeof(g_state.lookup_qth),  res->qth);
+                    safe_strcpy(g_state.lookup_grid, sizeof(g_state.lookup_grid), res->grid);
+                    safe_strcpy(g_state.lookup_country, sizeof(g_state.lookup_country), res->country);
+                    g_state.lookup_cq_zone = res->cq_zone;
+                    g_state.has_lookup = 1;
+                    g_state.lookup_not_found = 0;
+                    g_state.lookup_error[0] = 0;
+                    if (g_state.worked_name[0] == 0)
+                        safe_strcpy(g_state.worked_name, sizeof(g_state.worked_name), res->name);
+                    if (g_state.qth[0] == 0)
+                        safe_strcpy(g_state.qth, sizeof(g_state.qth), res->qth);
+                } else if (res->not_found) {
+                    g_state.lookup_not_found = 1;
+                    g_state.lookup_error[0] = 0;
+                } else if (res->error_msg[0]) {
+                    g_state.lookup_not_found = 0;
+                    safe_strcpy(g_state.lookup_error, sizeof(g_state.lookup_error), res->error_msg);
+                }
                 safe_strcpy(g_state.last_looked_up, sizeof(g_state.last_looked_up), res->callsign);
             }
             g_state.lookup_in_progress = 0;

--- a/src/rust/qsoripper-core/src/rig_control/rigctld.rs
+++ b/src/rust/qsoripper-core/src/rig_control/rigctld.rs
@@ -33,7 +33,7 @@ pub const RIGCTLD_READ_TIMEOUT_MS_ENV_VAR: &str = "QSORIPPER_RIGCTLD_READ_TIMEOU
 pub const RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR: &str = "QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS";
 
 /// Default stale threshold in milliseconds.
-pub const DEFAULT_RIGCTLD_STALE_THRESHOLD_MS: u64 = 5_000;
+pub const DEFAULT_RIGCTLD_STALE_THRESHOLD_MS: u64 = 500;
 
 /// Configuration for the rigctld adapter.
 #[derive(Debug, Clone)]

--- a/src/rust/qsoripper-server/src/runtime_config.rs
+++ b/src/rust/qsoripper-server/src/runtime_config.rs
@@ -65,6 +65,7 @@ const DEFAULT_SYNC_CONFLICT_POLICY: &str = "last_write_wins";
 
 const DEFAULT_STORAGE_BACKEND: &str = "memory";
 const DEFAULT_SQLITE_PATH: &str = "qsoripper.db";
+const DEFAULT_QRZ_USER_AGENT: &str = "QsoRipper/1.0";
 const REDACTED_VALUE: &str = "<redacted>";
 
 const CONFLICT_POLICY_ALLOWED_VALUES: &[&str] = &["last_write_wins", "flag_for_review"];
@@ -498,7 +499,7 @@ const SUPPORTED_FIELDS: &[ConfigFieldSpec] = &[
         kind: RuntimeConfigValueKind::String,
         secret: false,
         allowed_values: &[],
-        default_value: None,
+        default_value: Some(DEFAULT_QRZ_USER_AGENT),
     },
     ConfigFieldSpec {
         key: QRZ_XML_BASE_URL_ENV_VAR,
@@ -681,7 +682,7 @@ const SUPPORTED_FIELDS: &[ConfigFieldSpec] = &[
         kind: RuntimeConfigValueKind::Integer,
         secret: false,
         allowed_values: &[],
-        default_value: Some("5000"),
+        default_value: Some("500"),
     },
 ];
 
@@ -1002,7 +1003,22 @@ fn parse_storage_options_from_values(
 }
 
 fn build_lookup_provider(values: &BTreeMap<String, String>) -> (Arc<dyn CallsignProvider>, String) {
-    match QrzXmlConfig::from_value_provider(|name| values.get(name).cloned()) {
+    // Derive a user agent fallback from the username when no explicit value is
+    // configured, matching the pattern used by TestQrzCredentials.
+    let derived_user_agent = values
+        .get(QRZ_XML_USERNAME_ENV_VAR)
+        .filter(|u| !u.trim().is_empty())
+        .map(|u| format!("{DEFAULT_QRZ_USER_AGENT} ({u})"));
+
+    match QrzXmlConfig::from_value_provider(|name| {
+        values.get(name).cloned().or_else(|| {
+            if name == QRZ_USER_AGENT_ENV_VAR {
+                derived_user_agent.clone()
+            } else {
+                None
+            }
+        })
+    }) {
         Ok(config) => match QrzXmlProvider::new(config.clone()) {
             Ok(provider) => {
                 let summary = if config.capture_only() {

--- a/src/rust/qsoripper-server/src/setup.rs
+++ b/src/rust/qsoripper-server/src/setup.rs
@@ -611,6 +611,9 @@ impl PersistedSetupConfig {
         config.qrz_xml = PersistedQrzXmlConfig {
             username: qrz_xml_username,
             password: qrz_xml_password,
+            // Preserve any existing user_agent; the setup wizard does not set it
+            // directly, and runtime derives a default from the username when absent.
+            user_agent: existing.and_then(|c| c.qrz_xml.user_agent.clone()),
         };
 
         // QRZ logbook API key: update when explicitly provided, otherwise keep existing.
@@ -660,6 +663,9 @@ impl PersistedSetupConfig {
         }
         if let Some(password) = self.qrz_xml.password.as_deref() {
             values.insert(QRZ_XML_PASSWORD_ENV_VAR.to_string(), password.to_string());
+        }
+        if let Some(user_agent) = self.qrz_xml.user_agent.as_deref() {
+            values.insert(QRZ_USER_AGENT_ENV_VAR.to_string(), user_agent.to_string());
         }
 
         // QRZ logbook config
@@ -1061,6 +1067,7 @@ impl PersistedStationProfile {
 struct PersistedQrzXmlConfig {
     username: Option<String>,
     password: Option<String>,
+    user_agent: Option<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]


### PR DESCRIPTION
## Summary

Fixes two issues in the Win32 C GUI:

1. **QRZ callsign lookup was silently broken** — flashed "Looking up..." then immediately showed nothing
2. **Rig mode/frequency polling felt sluggish** — updates took up to 5 seconds to appear

## Root Causes

### QRZ Lookup
The QRZ XML provider requires three config values: `username`, `password`, and `user_agent`. The `user_agent` had no default and wasn't persisted in `config.toml`, so unless the `QSORIPPER_QRZ_USER_AGENT` env var was explicitly set, the provider was disabled and all lookups returned `LOOKUP_STATE_ERROR`. The C GUI only checked for a `record` field in the JSON response, so errors were silently swallowed.

### Rig Poll
The server-side `DEFAULT_RIGCTLD_STALE_THRESHOLD_MS` was 5000ms, meaning cached rig data was reused for up to 5 seconds regardless of how frequently the client polled.

## Changes

### Rust server (`runtime_config.rs`, `setup.rs`, `rigctld.rs`)
- `build_lookup_provider()` now derives a fallback user agent (`QsoRipper/1.0 ({username})`) from the configured username when no explicit value is present
- Added `DEFAULT_QRZ_USER_AGENT` constant and updated `ConfigFieldSpec` default
- Added `user_agent: Option<String>` to `PersistedQrzXmlConfig` so it can be persisted in `config.toml`
- Reduced `DEFAULT_RIGCTLD_STALE_THRESHOLD_MS` from 5000 to 500

### Win32 C GUI (`main.c`)
- Now parses `state` and `errorMessage` from lookup JSON response
- Displays yellow "Callsign not found" for `LOOKUP_STATE_NOT_FOUND`
- Displays red error message for `LOOKUP_STATE_ERROR`
- Reduced client-side rig poll interval from 1000ms to 500ms

## Validation
- `cargo fmt` — clean
- `cargo clippy -D warnings` — clean
- `cargo test` — all 196 tests pass
- Win32 C build — compiles cleanly