### PR TITLE
Fix F3/F4 navigation keys not working from QSO logger

### DIFF
--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -117,6 +117,14 @@ internal sealed partial class MainWindow : Window
             return;
         }
 
+        // Global navigation keys — handled explicitly so they work even when
+        // focus is inside a TextBox (e.g. the QSO logger fields) where the
+        // XAML KeyBinding may not fire reliably.
+        if (TryHandleGlobalNavigationKey(e))
+        {
+            return;
+        }
+
         base.OnKeyDown(e);
 
         if (e.Handled || _viewModel is null || _viewModel.IsWizardOpen)
@@ -275,6 +283,28 @@ internal sealed partial class MainWindow : Window
         }
 
         return false;
+    }
+
+    private bool TryHandleGlobalNavigationKey(KeyEventArgs e)
+    {
+        if (_viewModel is null || e.KeyModifiers != KeyModifiers.None)
+        {
+            return false;
+        }
+
+        switch (e.Key)
+        {
+            case Key.F3:
+                _viewModel.FocusGridCommand.Execute(null);
+                e.Handled = true;
+                return true;
+            case Key.F4:
+                _viewModel.FocusSearchCommand.Execute(null);
+                e.Handled = true;
+                return true;
+            default:
+                return false;
+        }
     }
 
     private bool TryHandleRecentQsoZoomKey(KeyEventArgs e)


### PR DESCRIPTION
## Problem

When focus is inside a TextBox in the QSO logger panel (e.g. after pressing Ctrl+N), pressing F3 does not return focus to the QSO grid as expected. F4 (focus search) has the same issue.

The XAML `KeyBinding` declarations on the Window don't fire reliably when focus is inside a TextBox, likely because the key event doesn't reach the Window's KeyBinding processing chain during Avalonia's bubbling phase.

## Fix

Added `TryHandleGlobalNavigationKey()` in `MainWindow.OnKeyDown` that explicitly handles F3 and F4 before `base.OnKeyDown(e)` and the KeyBinding chain. This ensures these navigation shortcuts work regardless of which control currently has focus.

The XAML KeyBindings are kept as a fallback for scenarios where the explicit handler doesn't run (e.g. wizard mode).