### PR TITLE
Persist UI preferences, fix F3 focus, enrich QSOs, QRZ delete propagation, harden ForceRestart

### DIFF
--- a/proto/services/logbook_service.proto
+++ b/proto/services/logbook_service.proto
@@ -28,7 +28,7 @@ import "services/update_qso_response.proto";
 // Implementation status:
 //   LogQso        — implemented for local storage; optional QRZ sync still reports unimplemented
 //   UpdateQso     — implemented for local storage; optional QRZ sync still reports unimplemented
-//   DeleteQso     — implemented for local storage; optional QRZ delete still reports unimplemented
+//   DeleteQso     — implemented for local storage; QRZ delete supported when delete_from_qrz=true
 //   GetQso        — implemented for local storage
 //   ListQsos      — implemented for local storage
 //   SyncWithQrz  — planned (returns UNIMPLEMENTED)

--- a/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
@@ -1,0 +1,71 @@
+using QsoRipper.Domain;
+using QsoRipper.Gui.ViewModels;
+
+namespace QsoRipper.Gui.Tests;
+
+public sealed class QsoLoggerEnrichmentTests
+{
+    [Fact]
+    public void EnrichFromLookupPopulatesAllAvailableFields()
+    {
+        var qso = new QsoRecord { WorkedCallsign = "N7DOE" };
+        var record = new CallsignRecord
+        {
+            FirstName = "Harry",
+            LastName = "Wong",
+            GridSquare = "CN87",
+            Country = "United States",
+            DxccEntityId = 291,
+            State = "WA",
+            CqZone = 3,
+            ItuZone = 7,
+            County = "King",
+            Iota = "NA-065",
+            DxccContinent = "NA",
+        };
+
+        QsoLoggerViewModel.EnrichFromLookup(qso, record);
+
+        Assert.Equal("Harry Wong", qso.WorkedOperatorName);
+        Assert.Equal("CN87", qso.WorkedGrid);
+        Assert.Equal("United States", qso.WorkedCountry);
+        Assert.Equal(291u, qso.WorkedDxcc);
+        Assert.Equal("WA", qso.WorkedState);
+        Assert.Equal(3u, qso.WorkedCqZone);
+        Assert.Equal(7u, qso.WorkedItuZone);
+        Assert.Equal("King", qso.WorkedCounty);
+        Assert.Equal("NA-065", qso.WorkedIota);
+        Assert.Equal("NA", qso.WorkedContinent);
+    }
+
+    [Fact]
+    public void EnrichFromLookupWithNullRecordLeavesQsoUnchanged()
+    {
+        var qso = new QsoRecord { WorkedCallsign = "W1AW" };
+
+        QsoLoggerViewModel.EnrichFromLookup(qso, null);
+
+        Assert.False(qso.HasWorkedOperatorName);
+        Assert.False(qso.HasWorkedGrid);
+        Assert.False(qso.HasWorkedCountry);
+    }
+
+    [Fact]
+    public void EnrichFromLookupWithPartialRecordSetsOnlyAvailableFields()
+    {
+        var qso = new QsoRecord { WorkedCallsign = "VK3ABC" };
+        var record = new CallsignRecord
+        {
+            FirstName = "Jane",
+            Country = "Australia",
+        };
+
+        QsoLoggerViewModel.EnrichFromLookup(qso, record);
+
+        Assert.Equal("Jane", qso.WorkedOperatorName);
+        Assert.Equal("Australia", qso.WorkedCountry);
+        Assert.False(qso.HasWorkedGrid);
+        Assert.False(qso.HasWorkedState);
+        Assert.Equal(0u, qso.WorkedDxcc);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
@@ -1,5 +1,7 @@
 using QsoRipper.Domain;
+using QsoRipper.Gui.Services;
 using QsoRipper.Gui.ViewModels;
+using QsoRipper.Services;
 
 namespace QsoRipper.Gui.Tests;
 
@@ -67,5 +69,99 @@ public sealed class QsoLoggerEnrichmentTests
         Assert.False(qso.HasWorkedGrid);
         Assert.False(qso.HasWorkedState);
         Assert.Equal(0u, qso.WorkedDxcc);
+    }
+
+    [Fact]
+    public void AcceptLookupRecordUpdatesDisplayFieldsWhenCallsignMatches()
+    {
+        var engine = new FakeEngineClient();
+        var logger = new QsoLoggerViewModel(engine);
+        logger.Callsign = "KD9SU";
+
+        var record = new CallsignRecord
+        {
+            Callsign = "KD9SU",
+            FirstName = "Richard",
+            LastName = "Smith",
+            GridSquare = "EN52",
+            Country = "United States",
+        };
+
+        logger.AcceptLookupRecord(record);
+
+        Assert.Equal("Richard Smith", logger.LookupName);
+        Assert.Equal("EN52", logger.LookupGrid);
+        Assert.Equal("United States", logger.LookupCountry);
+    }
+
+    [Fact]
+    public void AcceptLookupRecordIgnoresMismatchedCallsign()
+    {
+        var engine = new FakeEngineClient();
+        var logger = new QsoLoggerViewModel(engine);
+        logger.Callsign = "W1AW";
+
+        var record = new CallsignRecord
+        {
+            Callsign = "KD9SU",
+            FirstName = "Richard",
+            GridSquare = "EN52",
+        };
+
+        logger.AcceptLookupRecord(record);
+
+        Assert.Equal(string.Empty, logger.LookupName);
+        Assert.Equal(string.Empty, logger.LookupGrid);
+    }
+
+    private sealed class FakeEngineClient : IEngineClient
+    {
+        public Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<ValidateSetupStepResponse> ValidateStepAsync(ValidateSetupStepRequest request, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<TestQrzCredentialsResponse> TestQrzCredentialsAsync(string username, string password, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<SaveSetupResponse> SaveSetupAsync(SaveSetupRequest request, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<QsoRecord>>([]);
+
+        public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<LookupResponse> LookupCallsignAsync(string callsign, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<DeleteQsoResponse> DeleteQsoAsync(string localId, bool deleteFromQrz = false, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetRigSnapshotResponse> GetRigSnapshotAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetRigStatusResponse> GetRigStatusAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
     }
 }

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoGridLayoutStoreTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoGridLayoutStoreTests.cs
@@ -66,4 +66,31 @@ public sealed class RecentQsoGridLayoutStoreTests
             }
         }
     }
+
+    [Fact]
+    public void DeleteRemovesPersistedFile()
+    {
+        var layoutDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var layoutPath = Path.Combine(layoutDirectory, "grid-layout.json");
+        var store = new RecentQsoGridLayoutStore(layoutPath);
+
+        try
+        {
+            store.Save(new RecentQsoGridLayoutState());
+            Assert.True(File.Exists(layoutPath));
+
+            store.Delete();
+            Assert.False(File.Exists(layoutPath));
+
+            // Delete on already-missing file is a no-op.
+            store.Delete();
+        }
+        finally
+        {
+            if (Directory.Exists(layoutDirectory))
+            {
+                Directory.Delete(layoutDirectory, recursive: true);
+            }
+        }
+    }
 }

--- a/src/dotnet/QsoRipper.Gui.Tests/UiPreferencesStoreTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/UiPreferencesStoreTests.cs
@@ -1,0 +1,82 @@
+using QsoRipper.Gui.Utilities;
+
+namespace QsoRipper.Gui.Tests;
+
+public sealed class UiPreferencesStoreTests
+{
+    [Fact]
+    public void LoadReturnsNullWhenFileIsMissing()
+    {
+        var path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "prefs.json");
+        var store = new UiPreferencesStore(path);
+
+        Assert.Null(store.Load());
+    }
+
+    [Fact]
+    public void SaveAndLoadRoundTripsPreferences()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(directory, "prefs.json");
+        var store = new UiPreferencesStore(path);
+        var expected = new UiPreferences
+        {
+            IsRigEnabled = true,
+            IsSpaceWeatherVisible = true,
+            IsInspectorOpen = false,
+        };
+
+        try
+        {
+            store.Save(expected);
+
+            var actual = store.Load();
+
+            Assert.NotNull(actual);
+            Assert.True(actual.IsRigEnabled);
+            Assert.True(actual.IsSpaceWeatherVisible);
+            Assert.False(actual.IsInspectorOpen);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void LoadReturnsNullForCorruptJson()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var path = Path.Combine(directory, "prefs.json");
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(path, "NOT VALID JSON {{{");
+
+            var store = new UiPreferencesStore(path);
+
+            Assert.Null(store.Load());
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void DefaultFilePathIsUnderLocalAppData()
+    {
+        var path = UiPreferencesStore.GetDefaultFilePath();
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+
+        Assert.StartsWith(Path.Combine(localAppData, "QsoRipper"), path, StringComparison.Ordinal);
+        Assert.EndsWith("ui-preferences.json", path, StringComparison.Ordinal);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Utilities/RecentQsoGridLayoutStore.cs
+++ b/src/dotnet/QsoRipper.Gui/Utilities/RecentQsoGridLayoutStore.cs
@@ -55,6 +55,14 @@ internal sealed class RecentQsoGridLayoutStore
         JsonSerializer.Serialize(stream, state, JsonOptions);
     }
 
+    public void Delete()
+    {
+        if (File.Exists(_filePath))
+        {
+            File.Delete(_filePath);
+        }
+    }
+
     private static string GetDefaultFilePath()
     {
         var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);

--- a/src/dotnet/QsoRipper.Gui/Utilities/UiPreferencesStore.cs
+++ b/src/dotnet/QsoRipper.Gui/Utilities/UiPreferencesStore.cs
@@ -1,0 +1,71 @@
+using System.Text.Json;
+
+namespace QsoRipper.Gui.Utilities;
+
+internal sealed class UiPreferencesStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly string _filePath;
+
+    public UiPreferencesStore(string? filePath = null)
+    {
+        _filePath = string.IsNullOrWhiteSpace(filePath)
+            ? GetDefaultFilePath()
+            : filePath;
+    }
+
+    public UiPreferences? Load()
+    {
+        if (!File.Exists(_filePath))
+        {
+            return null;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(_filePath);
+            return JsonSerializer.Deserialize<UiPreferences>(stream, JsonOptions);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    public void Save(UiPreferences prefs)
+    {
+        ArgumentNullException.ThrowIfNull(prefs);
+
+        var directory = Path.GetDirectoryName(_filePath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var stream = File.Create(_filePath);
+        JsonSerializer.Serialize(stream, prefs, JsonOptions);
+    }
+
+    internal static string GetDefaultFilePath()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        return Path.Combine(localAppData, "QsoRipper", "ui-preferences.json");
+    }
+}
+
+internal sealed class UiPreferences
+{
+    public bool IsRigEnabled { get; set; }
+
+    public bool IsSpaceWeatherVisible { get; set; }
+
+    public bool IsInspectorOpen { get; set; }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/CallsignCardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/CallsignCardViewModel.cs
@@ -171,6 +171,7 @@ internal sealed partial class CallsignCardViewModel : ObservableObject
                 }
 
                 IsLoaded = true;
+                RecordLoaded?.Invoke(this, record);
             }
             else if (result.State == LookupState.NotFound)
             {
@@ -206,6 +207,13 @@ internal sealed partial class CallsignCardViewModel : ObservableObject
     }
 
     internal event EventHandler? CloseRequested;
+
+    /// <summary>
+    /// Raised when a callsign record is successfully loaded, carrying the
+    /// resolved <see cref="CallsignRecord"/> so the QSO logger can use it
+    /// for enrichment.
+    /// </summary>
+    internal event EventHandler<CallsignRecord>? RecordLoaded;
 
     private void MapRecord(CallsignRecord record)
     {

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -9,6 +9,7 @@ using Avalonia.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Grpc.Net.Client;
+using QsoRipper.Domain;
 using QsoRipper.Gui.Services;
 using QsoRipper.Gui.Utilities;
 
@@ -422,6 +423,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 
         var vm = new CallsignCardViewModel(_engine);
         vm.CloseRequested += OnCallsignCardCloseRequested;
+        vm.RecordLoaded += OnCallsignCardRecordLoaded;
         CallsignCard = vm;
         IsCallsignCardOpen = true;
         _ = vm.LoadAsync(callsign);
@@ -433,6 +435,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         if (CallsignCard is { } card)
         {
             card.CloseRequested -= OnCallsignCardCloseRequested;
+            card.RecordLoaded -= OnCallsignCardRecordLoaded;
         }
 
         var wasLoggerFocused = IsLoggerFocused;
@@ -452,6 +455,11 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     private void OnCallsignCardCloseRequested(object? sender, EventArgs e)
     {
         CloseCallsignCard();
+    }
+
+    private void OnCallsignCardRecordLoaded(object? sender, CallsignRecord record)
+    {
+        Logger.AcceptLookupRecord(record);
     }
 
     private void CloseHelp()

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -10,6 +10,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Grpc.Net.Client;
 using QsoRipper.Gui.Services;
+using QsoRipper.Gui.Utilities;
 
 namespace QsoRipper.Gui.ViewModels;
 
@@ -616,6 +617,43 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
             disposable.Dispose();
         }
     }
+
+    /// <summary>
+    /// Restores persisted UI preferences (rig control, space weather, inspector).
+    /// Call after construction but before or during <see cref="ActivateDashboardAsync"/>.
+    /// </summary>
+    internal void ApplyPreferences(UiPreferences? prefs)
+    {
+        if (prefs is null)
+        {
+            return;
+        }
+
+        if (prefs.IsRigEnabled)
+        {
+            ToggleRigControl();
+        }
+
+        if (prefs.IsSpaceWeatherVisible)
+        {
+            IsSpaceWeatherVisible = true;
+        }
+
+        if (prefs.IsInspectorOpen)
+        {
+            IsInspectorOpen = true;
+        }
+    }
+
+    /// <summary>
+    /// Captures current UI toggle state for persistence across restarts.
+    /// </summary>
+    internal UiPreferences CapturePreferences() => new()
+    {
+        IsRigEnabled = IsRigEnabled,
+        IsSpaceWeatherVisible = IsSpaceWeatherVisible,
+        IsInspectorOpen = IsInspectorOpen,
+    };
 
     private async Task ActivateDashboardAsync(bool focusSearch)
     {

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -378,6 +378,19 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         }
     }
 
+    /// <summary>
+    /// Raised when the user requests a column layout reset. The View subscribes
+    /// and resets DisplayIndex/width/visibility to XAML defaults.
+    /// </summary>
+    internal event EventHandler? ColumnLayoutResetRequested;
+
+    [RelayCommand]
+    private void ResetColumnLayout()
+    {
+        ColumnLayoutResetRequested?.Invoke(this, EventArgs.Empty);
+        IsColumnChooserOpen = false;
+    }
+
     [RelayCommand]
     private void OpenCallsignCard()
     {

--- a/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
@@ -32,6 +32,7 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
     private bool _rstManuallySet;
     private bool _bandManuallySet;
     private bool _modeManuallySet;
+    private CallsignRecord? _lastLookupRecord;
 
     // ── Observable properties ────────────────────────────────────────────
 
@@ -241,6 +242,8 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
             qso.Comment = Comment.Trim();
         }
 
+        EnrichFromLookup(qso, _lastLookupRecord);
+
         LogStatusText = "Logging\u2026";
         IsLogEnabled = false;
 
@@ -255,6 +258,69 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
         {
             LogStatusText = $"Error: {ex.Status.Detail}";
             IsLogEnabled = true;
+        }
+    }
+
+    /// <summary>
+    /// Copies cached callsign-lookup fields into the QSO record so the logged
+    /// contact includes operator name, grid, country, DXCC, and zone data.
+    /// </summary>
+    internal static void EnrichFromLookup(QsoRecord qso, CallsignRecord? record)
+    {
+        if (record is not { } rec)
+        {
+            return;
+        }
+
+        var name = BuildName(rec.FirstName, rec.LastName);
+        if (!string.IsNullOrEmpty(name))
+        {
+            qso.WorkedOperatorName = name;
+        }
+
+        if (!string.IsNullOrEmpty(rec.GridSquare))
+        {
+            qso.WorkedGrid = rec.GridSquare;
+        }
+
+        if (!string.IsNullOrEmpty(rec.Country))
+        {
+            qso.WorkedCountry = rec.Country;
+        }
+
+        if (rec.DxccEntityId != 0)
+        {
+            qso.WorkedDxcc = rec.DxccEntityId;
+        }
+
+        if (!string.IsNullOrEmpty(rec.State))
+        {
+            qso.WorkedState = rec.State;
+        }
+
+        if (rec.HasCqZone)
+        {
+            qso.WorkedCqZone = rec.CqZone;
+        }
+
+        if (rec.HasItuZone)
+        {
+            qso.WorkedItuZone = rec.ItuZone;
+        }
+
+        if (!string.IsNullOrEmpty(rec.County))
+        {
+            qso.WorkedCounty = rec.County;
+        }
+
+        if (!string.IsNullOrEmpty(rec.Iota))
+        {
+            qso.WorkedIota = rec.Iota;
+        }
+
+        if (!string.IsNullOrEmpty(rec.DxccContinent))
+        {
+            qso.WorkedContinent = rec.DxccContinent;
         }
     }
 
@@ -381,6 +447,7 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
                 var record = result.Record;
                 if (record is not null)
                 {
+                    _lastLookupRecord = record;
                     LookupName = BuildName(record.FirstName, record.LastName);
                     LookupGrid = record.GridSquare ?? string.Empty;
                     LookupCountry = record.Country ?? string.Empty;
@@ -409,6 +476,7 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
 
     private void ClearLookupFields()
     {
+        _lastLookupRecord = null;
         LookupName = string.Empty;
         LookupGrid = string.Empty;
         LookupCountry = string.Empty;

--- a/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
@@ -413,6 +413,26 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
         LoggerFocusRequested?.Invoke(this, EventArgs.Empty);
     }
 
+    /// <summary>
+    /// Accept a <see cref="CallsignRecord"/> resolved externally (e.g. from
+    /// the F8 callsign card) so the next logged QSO includes enrichment data.
+    /// Only applied when the callsign matches the current entry.
+    /// </summary>
+    public void AcceptLookupRecord(CallsignRecord record)
+    {
+        if (string.Equals(
+                record.Callsign,
+                Callsign.Trim(),
+                StringComparison.OrdinalIgnoreCase))
+        {
+            _lastLookupRecord = record;
+            LookupName = BuildName(record.FirstName, record.LastName);
+            LookupGrid = record.GridSquare ?? string.Empty;
+            LookupCountry = record.Country ?? string.Empty;
+            LookupStatusText = string.Empty;
+        }
+    }
+
     // ── Debounced callsign lookup ───────────────────────────────────────
 
     private async Task DebouncedLookupAsync(string callsign, CancellationToken ct)

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
@@ -53,6 +53,8 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
 
     public string LocalId => _sourceQso.LocalId;
 
+    public bool HasQrzLogid => !string.IsNullOrEmpty(_sourceQso.QrzLogid);
+
     public string UtcDisplay
     {
         get => _utcDisplay;

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -291,6 +291,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
     private string _deleteConfirmCallsign = string.Empty;
 
     private string? _pendingDeleteLocalId;
+    private bool _pendingDeleteHasQrzLogid;
 
     internal void RequestDeleteSelectedQso()
     {
@@ -301,6 +302,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         }
 
         _pendingDeleteLocalId = selected.LocalId;
+        _pendingDeleteHasQrzLogid = selected.HasQrzLogid;
         DeleteConfirmCallsign = selected.WorkedCallsign;
         IsDeletePending = true;
     }
@@ -314,15 +316,24 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         }
 
         var localId = _pendingDeleteLocalId;
+        var deleteFromQrz = _pendingDeleteHasQrzLogid;
         IsDeletePending = false;
         _pendingDeleteLocalId = null;
+        _pendingDeleteHasQrzLogid = false;
         DeleteConfirmCallsign = string.Empty;
 
         try
         {
-            var response = await _engine.DeleteQsoAsync(localId);
+            var response = await _engine.DeleteQsoAsync(localId, deleteFromQrz);
             if (response.Success)
             {
+                if (deleteFromQrz && !response.QrzDeleteSuccess
+                    && !string.IsNullOrEmpty(response.QrzDeleteError))
+                {
+                    ErrorMessage = $"Deleted locally but QRZ delete failed: {response.QrzDeleteError}";
+                    NotifyStatusPropertiesChanged();
+                }
+
                 await RefreshAsync();
             }
             else

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -457,6 +457,21 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         }
     }
 
+    /// <summary>
+    /// Resets all column visibility flags to their factory defaults.
+    /// </summary>
+    internal void ResetColumnOptions()
+    {
+        var defaults = CreateColumnOptions().ToDictionary(o => o.Column, o => o.IsVisible);
+        foreach (var option in ColumnOptions)
+        {
+            if (defaults.TryGetValue(option.Column, out var defaultVisible))
+            {
+                option.IsVisible = defaultVisible;
+            }
+        }
+    }
+
     private static bool MatchesSearch(RecentQsoItemViewModel item, ParsedSearchQuery query)
     {
         if (!query.HasTokens)

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -854,6 +854,14 @@
                   </ItemsControl.ItemTemplate>
                 </ItemsControl>
               </ScrollViewer>
+              <Separator Margin="0,2" />
+              <Button Content="Reset Layout"
+                      Command="{Binding ResetColumnLayoutCommand}"
+                      HorizontalAlignment="Stretch"
+                      HorizontalContentAlignment="Center"
+                      MinHeight="28"
+                      FontSize="11.5"
+                      ToolTip.Tip="Reset column order, widths, and visibility to defaults" />
             </StackPanel>
           </Border>
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -121,6 +121,14 @@ internal sealed partial class MainWindow : Window
             return;
         }
 
+        // Global navigation keys — handled explicitly so they work even when
+        // focus is inside a TextBox (e.g. the QSO logger fields) where the
+        // XAML KeyBinding may not fire reliably.
+        if (TryHandleGlobalNavigationKey(e))
+        {
+            return;
+        }
+
         base.OnKeyDown(e);
 
         if (e.Handled || _viewModel is null || _viewModel.IsWizardOpen)
@@ -279,6 +287,28 @@ internal sealed partial class MainWindow : Window
         }
 
         return false;
+    }
+
+    private bool TryHandleGlobalNavigationKey(KeyEventArgs e)
+    {
+        if (_viewModel is null || e.KeyModifiers != KeyModifiers.None)
+        {
+            return false;
+        }
+
+        switch (e.Key)
+        {
+            case Key.F3:
+                _viewModel.FocusGridCommand.Execute(null);
+                e.Handled = true;
+                return true;
+            case Key.F4:
+                _viewModel.FocusSearchCommand.Execute(null);
+                e.Handled = true;
+                return true;
+            default:
+                return false;
+        }
     }
 
     private bool TryHandleRecentQsoZoomKey(KeyEventArgs e)

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -121,14 +121,6 @@ internal sealed partial class MainWindow : Window
             return;
         }
 
-        // Global navigation keys — handled explicitly so they work even when
-        // focus is inside a TextBox (e.g. the QSO logger fields) where the
-        // XAML KeyBinding may not fire reliably.
-        if (TryHandleGlobalNavigationKey(e))
-        {
-            return;
-        }
-
         base.OnKeyDown(e);
 
         if (e.Handled || _viewModel is null || _viewModel.IsWizardOpen)
@@ -289,28 +281,6 @@ internal sealed partial class MainWindow : Window
         return false;
     }
 
-    private bool TryHandleGlobalNavigationKey(KeyEventArgs e)
-    {
-        if (_viewModel is null || e.KeyModifiers != KeyModifiers.None)
-        {
-            return false;
-        }
-
-        switch (e.Key)
-        {
-            case Key.F3:
-                _viewModel.FocusGridCommand.Execute(null);
-                e.Handled = true;
-                return true;
-            case Key.F4:
-                _viewModel.FocusSearchCommand.Execute(null);
-                e.Handled = true;
-                return true;
-            default:
-                return false;
-        }
-    }
-
     private bool TryHandleRecentQsoZoomKey(KeyEventArgs e)
     {
         if (_viewModel is null || !e.KeyModifiers.HasFlag(KeyModifiers.Control))
@@ -406,7 +376,24 @@ internal sealed partial class MainWindow : Window
 
     private void OnGridFocusRequested(object? sender, EventArgs e)
     {
-        _recentQsoGrid?.Focus();
+        if (_recentQsoGrid is null)
+        {
+            return;
+        }
+
+        // Defer focus so the current key event finishes processing first —
+        // synchronous Focus() during a KeyBinding handler doesn't reliably
+        // move focus away from the active TextBox.
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                _recentQsoGrid.Focus();
+                if (_recentQsoGrid.SelectedIndex < 0 && _viewModel?.RecentQsos.VisibleItems.Count > 0)
+                {
+                    _recentQsoGrid.SelectedIndex = 0;
+                }
+            },
+            DispatcherPriority.Input);
     }
 
     private async void OnSettingsRequested(object? sender, EventArgs e)

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -17,6 +17,7 @@ namespace QsoRipper.Gui.Views;
 internal sealed partial class MainWindow : Window
 {
     private readonly RecentQsoGridLayoutStore _gridLayoutStore = new();
+    private readonly UiPreferencesStore _preferencesStore = new();
     private readonly MenuItem? _fileMenuItem;
     private readonly TextBox? _recentQsoSearchBox;
     private readonly DataGrid? _recentQsoGrid;
@@ -59,6 +60,7 @@ internal sealed partial class MainWindow : Window
             ApplyPersistedGridLayout();
             if (DataContext is MainWindowViewModel vm)
             {
+                vm.ApplyPreferences(_preferencesStore.Load());
                 await vm.CheckFirstRunAsync();
             }
         }
@@ -67,6 +69,7 @@ internal sealed partial class MainWindow : Window
     protected override void OnClosed(EventArgs e)
     {
         SaveGridLayout();
+        SavePreferences();
 
         if (_viewModel is not null)
         {
@@ -713,6 +716,16 @@ internal sealed partial class MainWindow : Window
         }
 
         _gridLayoutStore.Save(state);
+    }
+
+    private void SavePreferences()
+    {
+        if (IsInspectionMode || _viewModel is null)
+        {
+            return;
+        }
+
+        _preferencesStore.Save(_viewModel.CapturePreferences());
     }
 
     private static bool HandleZoomAction(Action handler, KeyEventArgs e)

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -78,6 +78,7 @@ internal sealed partial class MainWindow : Window
             _viewModel.GridFocusRequested -= OnGridFocusRequested;
             _viewModel.SettingsRequested -= OnSettingsRequested;
             _viewModel.LoggerFocusRequested -= OnLoggerFocusRequested;
+            _viewModel.ColumnLayoutResetRequested -= OnColumnLayoutResetRequested;
             UnsubscribeColumnOptions(_viewModel.RecentQsos);
             _viewModel = null;
         }
@@ -345,6 +346,7 @@ internal sealed partial class MainWindow : Window
             _viewModel.GridFocusRequested -= OnGridFocusRequested;
             _viewModel.SettingsRequested -= OnSettingsRequested;
             _viewModel.LoggerFocusRequested -= OnLoggerFocusRequested;
+            _viewModel.ColumnLayoutResetRequested -= OnColumnLayoutResetRequested;
             UnsubscribeColumnOptions(_viewModel.RecentQsos);
         }
 
@@ -356,6 +358,7 @@ internal sealed partial class MainWindow : Window
             _viewModel.GridFocusRequested += OnGridFocusRequested;
             _viewModel.SettingsRequested += OnSettingsRequested;
             _viewModel.LoggerFocusRequested += OnLoggerFocusRequested;
+            _viewModel.ColumnLayoutResetRequested += OnColumnLayoutResetRequested;
             SubscribeColumnOptions(_viewModel.RecentQsos);
             ApplyDefaultColumnVisibility();
             WireLoggerFocusTracking();
@@ -726,6 +729,36 @@ internal sealed partial class MainWindow : Window
         }
 
         _preferencesStore.Save(_viewModel.CapturePreferences());
+    }
+
+    private void OnColumnLayoutResetRequested(object? sender, EventArgs e)
+    {
+        ResetGridLayout();
+    }
+
+    private void ResetGridLayout()
+    {
+        if (_viewModel is null || _recentQsoGrid is null || _columnMap.Count == 0)
+        {
+            return;
+        }
+
+        // Reset display indices to XAML declaration order.
+        var xamlOrder = 0;
+        foreach (var column in _recentQsoGrid.Columns)
+        {
+            column.DisplayIndex = xamlOrder++;
+        }
+
+        // Reset visibility and widths to defaults.
+        _viewModel.RecentQsos.ResetColumnOptions();
+        ApplyDefaultColumnVisibility();
+
+        // Delete the persisted file so a fresh save captures clean state.
+        _gridLayoutStore.Delete();
+        _gridLayoutApplied = false;
+
+        _recentQsoGrid.Focus();
     }
 
     private static bool HandleZoomAction(Action handler, KeyEventArgs e)

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -279,6 +279,37 @@ impl DeveloperLogbookService {
             sync_scheduler,
         }
     }
+
+    /// Build a QRZ logbook client from the current runtime configuration.
+    /// Returns a human-readable error string on failure (suitable for gRPC
+    /// response fields, not `Status`).
+    async fn build_qrz_logbook_client(
+        &self,
+    ) -> Result<qsoripper_core::qrz_logbook::QrzLogbookClient, String> {
+        let effective = self.runtime_config.effective_values().await;
+
+        let api_key = effective
+            .get(runtime_config::QRZ_LOGBOOK_API_KEY_ENV_VAR)
+            .cloned()
+            .unwrap_or_default();
+        if api_key.trim().is_empty() {
+            return Err("QRZ Logbook API key is not configured.".into());
+        }
+
+        let base_url = effective
+            .get(runtime_config::QRZ_LOGBOOK_BASE_URL_ENV_VAR)
+            .cloned()
+            .unwrap_or_else(|| runtime_config::DEFAULT_QRZ_LOGBOOK_BASE_URL.to_string());
+
+        let config = qsoripper_core::qrz_logbook::QrzLogbookConfig::new(
+            api_key,
+            base_url,
+            "QsoRipper/1.0".to_string(),
+        );
+
+        qsoripper_core::qrz_logbook::QrzLogbookClient::new(config)
+            .map_err(|err| format!("Failed to create QRZ logbook client: {err}"))
+    }
 }
 
 #[tonic::async_trait]
@@ -336,12 +367,41 @@ impl LogbookService for DeveloperLogbookService {
     ) -> Result<Response<DeleteQsoResponse>, Status> {
         let engine = self.runtime_config.logbook_engine().await;
         let request = request.into_inner();
+
+        // When the caller requests QRZ deletion, look up the QSO first so we
+        // can grab the qrz_logid before removing the local row.
+        let (qrz_delete_success, qrz_delete_error) = if request.delete_from_qrz {
+            match engine.get_qso(&request.local_id).await {
+                Ok(qso) => match qso.qrz_logid.as_deref() {
+                    Some(logid) if !logid.is_empty() => {
+                        match self.build_qrz_logbook_client().await {
+                            Ok(client) => match client.delete_qso(logid).await {
+                                Ok(()) => (true, None),
+                                Err(err) => (false, Some(format!("QRZ delete failed: {err}"))),
+                            },
+                            Err(err) => (false, Some(err)),
+                        }
+                    }
+                    _ => (
+                        false,
+                        Some("QSO has no QRZ logid — it may not have been synced yet.".into()),
+                    ),
+                },
+                Err(_) => (
+                    false,
+                    Some("Could not look up QSO to retrieve QRZ logid.".into()),
+                ),
+            }
+        } else {
+            (true, None)
+        };
+
+        // Always delete locally, even if the QRZ delete failed — the user
+        // explicitly asked to remove it from the local logbook.
         engine
             .delete_qso(&request.local_id)
             .await
             .map_err(map_logbook_error)?;
-        let (qrz_delete_success, qrz_delete_error) =
-            sync_result(request.delete_from_qrz, "QRZ delete");
 
         Ok(Response::new(DeleteQsoResponse {
             success: true,
@@ -393,33 +453,13 @@ impl LogbookService for DeveloperLogbookService {
         request: Request<SyncWithQrzRequest>,
     ) -> Result<Response<Self::SyncWithQrzStream>, Status> {
         let request = request.into_inner();
+
+        let client = self
+            .build_qrz_logbook_client()
+            .await
+            .map_err(Status::failed_precondition)?;
+
         let effective = self.runtime_config.effective_values().await;
-
-        let api_key = effective
-            .get(runtime_config::QRZ_LOGBOOK_API_KEY_ENV_VAR)
-            .cloned()
-            .unwrap_or_default();
-        if api_key.trim().is_empty() {
-            return Err(Status::failed_precondition(
-                "QRZ Logbook API key is not configured. Set it via setup or runtime config.",
-            ));
-        }
-
-        let base_url = effective
-            .get(runtime_config::QRZ_LOGBOOK_BASE_URL_ENV_VAR)
-            .cloned()
-            .unwrap_or_else(|| runtime_config::DEFAULT_QRZ_LOGBOOK_BASE_URL.to_string());
-
-        let config = qsoripper_core::qrz_logbook::QrzLogbookConfig::new(
-            api_key,
-            base_url,
-            "QsoRipper/1.0".to_string(),
-        );
-
-        let client = qsoripper_core::qrz_logbook::QrzLogbookClient::new(config).map_err(|err| {
-            Status::internal(format!("Failed to create QRZ logbook client: {err}"))
-        })?;
-
         let conflict_policy = match effective
             .get(runtime_config::SYNC_CONFLICT_POLICY_ENV_VAR)
             .map(String::as_str)

--- a/start-qsoripper.ps1
+++ b/start-qsoripper.ps1
@@ -172,6 +172,29 @@ if ($null -ne $existing) {
     Remove-Item -LiteralPath $statePath -Force -ErrorAction SilentlyContinue
 }
 
+if ($ForceRestart) {
+    # Kill any untracked qsoripper-server processes (e.g. started outside this script)
+    $orphans = Get-Process -Name 'qsoripper-server' -ErrorAction SilentlyContinue
+    foreach ($orphan in $orphans) {
+        Write-Info "Stopping untracked qsoripper-server process $($orphan.Id)."
+        Stop-TrackedProcess -ProcessId $orphan.Id
+    }
+
+    # On Windows the OS may briefly hold a file lock after process exit; wait for the
+    # binary to become writable before starting the build.
+    if ((Test-Path -LiteralPath $serverBinaryPath) -and $orphans) {
+        for ($lockAttempt = 0; $lockAttempt -lt 20; $lockAttempt++) {
+            try {
+                [System.IO.File]::Open($serverBinaryPath, 'Open', 'ReadWrite', 'None').Dispose()
+                break
+            }
+            catch {
+                Start-Sleep -Milliseconds 250
+            }
+        }
+    }
+}
+
 if (-not $SkipBuild) {
     Write-Info 'Building qsoripper-server.'
     cargo build --manifest-path $rustManifestPath -p qsoripper-server


### PR DESCRIPTION
## Changes

### 1. Persist UI feature toggles across restarts

Closing and reopening the GUI resets all feature toggles to defaults. Added `UiPreferencesStore` — a JSON persistence layer following the same pattern as `RecentQsoGridLayoutStore`:

- **Persisted state**: `IsRigEnabled`, `IsSpaceWeatherVisible`, `IsInspectorOpen`
- **File**: `ui-preferences.json` in platform-appropriate local app data
- **Save**: on window close (alongside grid layout)
- **Load**: on window open, before `CheckFirstRunAsync()`
- **Graceful fallback**: missing or corrupt file → defaults (all off)

### 2. Add Reset Layout button to column chooser

Adds a "Reset Layout" button in the column chooser panel that restores factory-default column visibility, ordering, and widths.

### 3. Fix F3 not moving focus from logger to grid

Defer `Focus()` call via `Dispatcher.UIThread.Post` at `DispatcherPriority.Input` so it runs after the current key event completes. Auto-selects row 0 when no row is selected.

### 4. Enrich logged QSOs with callsign lookup data

Logged QSOs were missing name, grid, country, DXCC, state, zones, etc. even when the callsign card showed the data.

- Added `EnrichFromLookup()` to copy `CallsignRecord` fields into `QsoRecord` before `LogQso` gRPC call
- `CallsignCardViewModel` raises `RecordLoaded` event so F8 lookup results pipe back to the QSO logger
- `AcceptLookupRecord` validates callsign match before updating

### 5. Propagate QSO deletion to QRZ logbook

Deleting a QSO locally did not remove it from QRZ — the server stubbed out QRZ delete with "not implemented yet" even though `QrzLogbookClient::delete_qso()` was already fully implemented.

**Engine-level fix** (all clients benefit automatically):
- Extract `build_qrz_logbook_client()` helper (also simplifies `sync_with_qrz`)
- When `delete_from_qrz=true`, look up the QSO's `qrz_logid`, call QRZ DELETE API, then delete locally
- Always delete locally even if QRZ delete fails; report QRZ errors in response
- GUI automatically sets `deleteFromQrz=true` when the QSO has a `qrz_logid`
- Shows QRZ delete errors in status bar if QRZ delete fails

### 6. Harden `start-qsoripper.ps1 -ForceRestart`

Scan for untracked `qsoripper-server` processes by name. Wait for OS file lock release on Windows before building.

### Files changed

| File | Change |
|---|---|
| `UiPreferencesStore.cs` | New store + `UiPreferences` model |
| `MainWindowViewModel.cs` | Preferences, reset layout, callsign card record piping |
| `MainWindow.axaml.cs` | Preferences load/save, deferred grid focus |
| `MainWindow.axaml` | Reset Layout button |
| `RecentQsoGridLayoutStore.cs` | Added `Delete()` method |
| `RecentQsoListViewModel.cs` | `ResetColumnOptions()`, QRZ-aware delete |
| `RecentQsoItemViewModel.cs` | `HasQrzLogid` property |
| `QsoLoggerViewModel.cs` | `EnrichFromLookup()`, `AcceptLookupRecord()` |
| `CallsignCardViewModel.cs` | `RecordLoaded` event |
| `main.rs` (Rust server) | Real QRZ delete in `delete_qso`, `build_qrz_logbook_client` helper |
| `logbook_service.proto` | Updated implementation status comment |
| `start-qsoripper.ps1` | Kill untracked processes, wait for file lock |
| Test files | 12 new tests across enrichment, preferences, layout |