### PR TITLE
fix: set time_off when logging QSOs

### DIFF
--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -902,8 +902,16 @@ static void LogQso(void)
         return;
     }
 
-    char cmd[4096];
+    /* Auto-fill time_off with current UTC when logging a new QSO */
     int is_update = g_state.editing_local_id[0] != 0;
+    if (!is_update && !g_state.time_off[0]) {
+        SYSTEMTIME st;
+        GetSystemTime(&st);
+        snprintf(g_state.time_off, sizeof(g_state.time_off),
+                  "%02d:%02d", st.wHour, st.wMinute);
+    }
+
+    char cmd[4096];
 
     if (is_update) {
         snprintf(cmd, sizeof(cmd),

--- a/src/rust/qsoripper-tui/src/grpc.rs
+++ b/src/rust/qsoripper-tui/src/grpc.rs
@@ -49,6 +49,11 @@ pub(crate) async fn log_qso(
     let (mode, submode) = resolve_mode(mode_str);
 
     let utc_timestamp = parse_timestamp(&form.date, &form.time).ok();
+    let utc_end_timestamp = if form.time_off.is_empty() {
+        None
+    } else {
+        parse_timestamp(&form.date, &form.time_off).ok()
+    };
 
     let frequency_khz = form.frequency_mhz.parse::<f64>().ok().map(mhz_to_khz);
 
@@ -60,6 +65,7 @@ pub(crate) async fn log_qso(
         band: i32::from(band),
         mode: i32::from(mode),
         utc_timestamp,
+        utc_end_timestamp,
         frequency_khz,
         submode: if form.submode_override.is_empty() {
             submode.map(str::to_string)
@@ -306,6 +312,11 @@ pub(crate) async fn update_qso(
     let (mode, submode) = resolve_mode(mode_str);
 
     let utc_timestamp = parse_timestamp(&form.date, &form.time).ok();
+    let utc_end_timestamp = if form.time_off.is_empty() {
+        None
+    } else {
+        parse_timestamp(&form.date, &form.time_off).ok()
+    };
     let frequency_khz = form.frequency_mhz.parse::<f64>().ok().map(mhz_to_khz);
 
     let (worked_grid, worked_country, worked_cq_zone, worked_dxcc) =
@@ -317,6 +328,7 @@ pub(crate) async fn update_qso(
         band: i32::from(band),
         mode: i32::from(mode),
         utc_timestamp,
+        utc_end_timestamp,
         frequency_khz,
         submode: if form.submode_override.is_empty() {
             submode.map(str::to_string)


### PR DESCRIPTION
## Summary

Fixes #174 — the `time_off` (end time) was not being recorded when logging QSOs in either the Win32 or TUI apps.

## Changes

### Win32 app (`main.c`)
- Auto-fills `time_off` with current UTC (`HH:MM`) at the moment a new QSO is logged (F10 / Shift+Enter)
- Does not overwrite on updates, preserving the original end time

### TUI app (`grpc.rs`)
- Maps `form.time_off` → `QsoRecord.utc_end_timestamp` in both `log_qso()` and `update_qso()`
- The form was already being populated with `time_off` (via `chrono::Utc::now()`) but the value was never sent to the server in the gRPC request

## Testing
- Win32 app builds cleanly (`build.ps1 win32`)
- TUI compiles cleanly (`cargo check -p qsoripper-tui`)