### PR TITLE
Fix launcher parse error and support simultaneous engines

### DIFF
--- a/start-qsoripper.ps1
+++ b/start-qsoripper.ps1
@@ -120,12 +120,12 @@ function Get-ProbeTargets([string]$Address) {
     )
 }
 
-function Format-HttpEndpoint([string]$Host, [int]$Port) {
-    if ($Host.Contains(':') -and -not $Host.StartsWith('[')) {
-        return "http://[$Host]:$Port"
+function Format-HttpEndpoint([string]$TargetHost, [int]$Port) {
+    if ($TargetHost.Contains(':') -and -not $TargetHost.StartsWith('[')) {
+        return "http://[${TargetHost}]:${Port}"
     }
 
-    return "http://$Host:$Port"
+    return "http://${TargetHost}:${Port}"
 }
 
 function Test-TcpEndpoint([string]$TargetHost, [int]$Port) {
@@ -535,7 +535,7 @@ while ([DateTime]::UtcNow -lt $deadline) {
     foreach ($probeTarget in $probeTargets) {
         if (Test-TcpEndpoint -TargetHost $probeTarget.Host -Port $probeTarget.Port) {
             Write-Host "$($profile.DisplayName) started in the background (PID $($process.Id))." -ForegroundColor Green
-            Write-Host "Endpoint: $(Format-HttpEndpoint -Host $probeTarget.Host -Port $probeTarget.Port)" -ForegroundColor Green
+            Write-Host "Endpoint: $(Format-HttpEndpoint -TargetHost $probeTarget.Host -Port $probeTarget.Port)" -ForegroundColor Green
             if ($Storage -ne 'memory' -and -not [string]::IsNullOrWhiteSpace($PersistenceLocation)) {
                 Write-Host "Persistence location: $PersistenceLocation" -ForegroundColor Green
             }
@@ -552,4 +552,4 @@ while ([DateTime]::UtcNow -lt $deadline) {
 
 Stop-TrackedProcess -ProcessId $process.Id
 Remove-Item -LiteralPath $statePath -Force -ErrorAction SilentlyContinue
-throw "QsoRipper did not open any expected endpoint ($((@($probeTargets | ForEach-Object { Format-HttpEndpoint -Host $_.Host -Port $_.Port })) -join ', ')) within $StartupTimeoutSeconds seconds."
+throw "QsoRipper did not open any expected endpoint ($((@($probeTargets | ForEach-Object { Format-HttpEndpoint -TargetHost $_.Host -Port $_.Port })) -join ', ')) within $StartupTimeoutSeconds seconds."

--- a/start-qsoripper.ps1
+++ b/start-qsoripper.ps1
@@ -202,7 +202,7 @@ function Get-ProcessCommandLine([int]$ProcessId) {
 function Get-UntrackedEngineProcesses {
     param(
         [pscustomobject]$Profile,
-        [int]$TrackedProcessId = 0
+        [int[]]$ExcludeProcessIds = @()
     )
 
     $fragments = [System.Collections.Generic.List[string]]::new()
@@ -227,6 +227,11 @@ function Get-UntrackedEngineProcesses {
         return @()
     }
 
+    $excludeSet = [System.Collections.Generic.HashSet[int]]::new()
+    foreach ($excludeId in $ExcludeProcessIds) {
+        if ($excludeId -gt 0) { [void]$excludeSet.Add($excludeId) }
+    }
+
     # Batch WMI query: get all processes with command lines in one call
     $allProcs = if ($IsWindows) {
         Get-CimInstance Win32_Process -Property ProcessId, CommandLine -ErrorAction SilentlyContinue
@@ -237,7 +242,7 @@ function Get-UntrackedEngineProcesses {
 
     $matches = [System.Collections.Generic.List[System.Diagnostics.Process]]::new()
     foreach ($proc in $allProcs) {
-        if ($TrackedProcessId -gt 0 -and $proc.ProcessId -eq $TrackedProcessId) {
+        if ($excludeSet.Contains([int]$proc.ProcessId)) {
             continue
         }
 
@@ -260,7 +265,7 @@ function Get-UntrackedEngineProcesses {
     # Linux/macOS fallback: use /proc or ps
     if (-not $IsWindows) {
         foreach ($candidate in Get-Process -ErrorAction SilentlyContinue) {
-            if ($TrackedProcessId -gt 0 -and $candidate.Id -eq $TrackedProcessId) {
+            if ($excludeSet.Contains($candidate.Id)) {
                 continue
             }
 
@@ -477,8 +482,17 @@ if ($null -ne $existing) {
 }
 
 if ($ForceRestart) {
-    $trackedProcessId = if ($null -ne $existing) { $existing.Process.Id } else { 0 }
-    $orphans = Get-UntrackedEngineProcesses -Profile $profile -TrackedProcessId $trackedProcessId
+    # Collect PIDs tracked by ALL profiles so we don't kill other engines
+    $excludePids = @()
+    if ($null -ne $existing) { $excludePids += $existing.Process.Id }
+    foreach ($otherProfile in $profiles) {
+        if ($otherProfile.ProfileId -eq $profile.ProfileId) { continue }
+        $otherStatePath = Get-ProfileStatePath -ProfileId $otherProfile.ProfileId
+        $otherTracked = Get-TrackedProcess -Path $otherStatePath
+        if ($null -ne $otherTracked) { $excludePids += $otherTracked.Process.Id }
+    }
+
+    $orphans = Get-UntrackedEngineProcesses -Profile $profile -ExcludeProcessIds $excludePids
     foreach ($orphan in $orphans) {
         Write-Info "Stopping untracked $($profile.DisplayName) process $($orphan.Id)."
         Stop-TrackedProcess -ProcessId $orphan.Id

--- a/start-qsoripper.ps1
+++ b/start-qsoripper.ps1
@@ -222,21 +222,58 @@ function Get-UntrackedEngineProcesses {
         }
     }
 
+    $uniqueFragments = @($fragments | Select-Object -Unique)
+    if ($uniqueFragments.Count -eq 0) {
+        return @()
+    }
+
+    # Batch WMI query: get all processes with command lines in one call
+    $allProcs = if ($IsWindows) {
+        Get-CimInstance Win32_Process -Property ProcessId, CommandLine -ErrorAction SilentlyContinue
+    }
+    else {
+        @()
+    }
+
     $matches = [System.Collections.Generic.List[System.Diagnostics.Process]]::new()
-    foreach ($candidate in Get-Process -ErrorAction SilentlyContinue) {
-        if ($TrackedProcessId -gt 0 -and $candidate.Id -eq $TrackedProcessId) {
+    foreach ($proc in $allProcs) {
+        if ($TrackedProcessId -gt 0 -and $proc.ProcessId -eq $TrackedProcessId) {
             continue
         }
 
-        $commandLine = Get-ProcessCommandLine -ProcessId $candidate.Id
+        $commandLine = $proc.CommandLine
         if ([string]::IsNullOrWhiteSpace($commandLine)) {
             continue
         }
 
-        foreach ($fragment in $fragments | Select-Object -Unique) {
+        foreach ($fragment in $uniqueFragments) {
             if ($commandLine.Contains($fragment, [System.StringComparison]::OrdinalIgnoreCase)) {
-                $matches.Add($candidate)
+                $process = Get-Process -Id $proc.ProcessId -ErrorAction SilentlyContinue
+                if ($null -ne $process) {
+                    $matches.Add($process)
+                }
                 break
+            }
+        }
+    }
+
+    # Linux/macOS fallback: use /proc or ps
+    if (-not $IsWindows) {
+        foreach ($candidate in Get-Process -ErrorAction SilentlyContinue) {
+            if ($TrackedProcessId -gt 0 -and $candidate.Id -eq $TrackedProcessId) {
+                continue
+            }
+
+            $commandLine = Get-ProcessCommandLine -ProcessId $candidate.Id
+            if ([string]::IsNullOrWhiteSpace($commandLine)) {
+                continue
+            }
+
+            foreach ($fragment in $uniqueFragments) {
+                if ($commandLine.Contains($fragment, [System.StringComparison]::OrdinalIgnoreCase)) {
+                    $matches.Add($candidate)
+                    break
+                }
             }
         }
     }

--- a/start-qsoripper.ps1
+++ b/start-qsoripper.ps1
@@ -23,9 +23,13 @@ param(
 $ErrorActionPreference = 'Stop'
 
 $runtimeDirectory = Join-Path $PSScriptRoot 'artifacts' | Join-Path -ChildPath 'run'
-$statePath = Join-Path $runtimeDirectory 'qsoripper-engine.json'
+$legacyStatePath = Join-Path $runtimeDirectory 'qsoripper-engine.json'
 $dotenvPath = Join-Path $PSScriptRoot '.env'
 $defaultPersistenceLocation = Join-Path (Join-Path '.' 'data') 'qsoripper.db'
+
+function Get-ProfileStatePath([string]$ProfileId) {
+    return Join-Path $runtimeDirectory "qsoripper-$ProfileId.state.json"
+}
 
 function Write-Info([string]$Message) {
     Write-Host $Message -ForegroundColor Cyan
@@ -60,23 +64,23 @@ function Import-DotEnv([string]$Path) {
     }
 }
 
-function Get-State {
-    if (-not (Test-Path -LiteralPath $statePath)) {
+function Get-State([string]$Path) {
+    if (-not (Test-Path -LiteralPath $Path)) {
         return $null
     }
 
-    return Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
 }
 
-function Get-TrackedProcess {
-    $state = Get-State
+function Get-TrackedProcess([string]$Path) {
+    $state = Get-State -Path $Path
     if ($null -eq $state) {
         return $null
     }
 
     $process = Get-Process -Id $state.pid -ErrorAction SilentlyContinue
     if ($null -eq $process) {
-        Remove-Item -LiteralPath $statePath -Force -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $Path -Force -ErrorAction SilentlyContinue
         return $null
     }
 
@@ -412,15 +416,25 @@ if ([string]::IsNullOrWhiteSpace($ConfigPath)) {
     $ConfigPath = $profile.DefaultConfigPath
 }
 
-$existing = Get-TrackedProcess
+$statePath = Get-ProfileStatePath -ProfileId $profile.ProfileId
+
+# Migrate legacy single-engine state file if it exists and matches this profile
+if ((Test-Path -LiteralPath $legacyStatePath) -and -not (Test-Path -LiteralPath $statePath)) {
+    $legacyState = Get-State -Path $legacyStatePath
+    if ($null -ne $legacyState -and $legacyState.engine -eq $profile.ProfileId) {
+        Move-Item -LiteralPath $legacyStatePath -Destination $statePath -Force
+    }
+}
+
+$existing = Get-TrackedProcess -Path $statePath
 if ($null -ne $existing) {
     if (-not $ForceRestart) {
-        Write-Host "QsoRipper is already running (PID $($existing.Process.Id)) at $($existing.State.listenAddress)." -ForegroundColor Yellow
-        Write-Host "Stop it first with .\stop-qsoripper.ps1 or rerun with -ForceRestart." -ForegroundColor Yellow
+        Write-Host "$($profile.DisplayName) is already running (PID $($existing.Process.Id)) at $($existing.State.listenAddress)." -ForegroundColor Yellow
+        Write-Host "Stop it first with .\stop-qsoripper.ps1 -Engine $($profile.ProfileId) or rerun with -ForceRestart." -ForegroundColor Yellow
         exit 0
     }
 
-    Write-Info "Stopping existing QsoRipper process $($existing.Process.Id)."
+    Write-Info "Stopping existing $($profile.DisplayName) process $($existing.Process.Id)."
     Stop-TrackedProcess -ProcessId $existing.Process.Id
     Remove-Item -LiteralPath $statePath -Force -ErrorAction SilentlyContinue
 }

--- a/stop-qsoripper.ps1
+++ b/stop-qsoripper.ps1
@@ -1,59 +1,98 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Stops a background QsoRipper engine started by start-qsoripper.ps1.
+    Stops background QsoRipper engine(s) started by start-qsoripper.ps1.
+
+.DESCRIPTION
+    With -Engine, stops only that engine profile. Without -Engine, stops all
+    running engine profiles found under artifacts/run.
 #>
 
 param(
+    [string]$Engine,
     [int]$TimeoutSeconds = 15
 )
 
 $ErrorActionPreference = 'Stop'
 
 $runtimeDirectory = Join-Path $PSScriptRoot 'artifacts' | Join-Path -ChildPath 'run'
-$statePath = Join-Path $runtimeDirectory 'qsoripper-engine.json'
+$legacyStatePath = Join-Path $runtimeDirectory 'qsoripper-engine.json'
 
-function Get-State {
-    if (-not (Test-Path -LiteralPath $statePath)) {
+function Get-State([string]$Path) {
+    if (-not (Test-Path -LiteralPath $Path)) {
         return $null
     }
 
-    return Get-Content -LiteralPath $statePath -Raw | ConvertFrom-Json
+    return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
 }
 
-$state = Get-State
-if ($null -eq $state) {
-    Write-Host 'QsoRipper is not running through the helper script.' -ForegroundColor Yellow
-    exit 0
+function Stop-EngineFromState([string]$StatePath) {
+    $state = Get-State -Path $StatePath
+    if ($null -eq $state) {
+        return
+    }
+
+    $process = Get-Process -Id $state.pid -ErrorAction SilentlyContinue
+    if ($null -eq $process) {
+        Remove-Item -LiteralPath $StatePath -Force -ErrorAction SilentlyContinue
+        Write-Host 'Removed stale QsoRipper state file.' -ForegroundColor Yellow
+        return
+    }
+
+    Stop-Process -Id $process.Id
+
+    $deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
+    while ([DateTime]::UtcNow -lt $deadline) {
+        Start-Sleep -Milliseconds 200
+        if ($null -eq (Get-Process -Id $process.Id -ErrorAction SilentlyContinue)) {
+            Remove-Item -LiteralPath $StatePath -Force -ErrorAction SilentlyContinue
+            $engineLabel = if (-not [string]::IsNullOrWhiteSpace($state.displayName)) {
+                $state.displayName
+            }
+            elseif (-not [string]::IsNullOrWhiteSpace($state.engine)) {
+                "$($state.engine) engine"
+            }
+            else {
+                'engine'
+            }
+            Write-Host "Stopped $engineLabel (PID $($process.Id))." -ForegroundColor Green
+            return
+        }
+    }
+
+    throw "Timed out waiting for QsoRipper process $($process.Id) to stop."
 }
 
-$process = Get-Process -Id $state.pid -ErrorAction SilentlyContinue
-if ($null -eq $process) {
-    Remove-Item -LiteralPath $statePath -Force -ErrorAction SilentlyContinue
-    Write-Host 'Removed stale QsoRipper state file.' -ForegroundColor Yellow
-    exit 0
-}
-
-Stop-Process -Id $process.Id
-
-$deadline = [DateTime]::UtcNow.AddSeconds($TimeoutSeconds)
-while ([DateTime]::UtcNow -lt $deadline) {
-    Start-Sleep -Milliseconds 200
-    if ($null -eq (Get-Process -Id $process.Id -ErrorAction SilentlyContinue)) {
-        Remove-Item -LiteralPath $statePath -Force -ErrorAction SilentlyContinue
-        $engineLabel = if (-not [string]::IsNullOrWhiteSpace($state.displayName)) {
-            $state.displayName
-        }
-        elseif (-not [string]::IsNullOrWhiteSpace($state.engine)) {
-            "$($state.engine) engine"
-        }
-        else {
-            'engine'
-        }
-        Write-Host "Stopped $engineLabel (PID $($process.Id))." -ForegroundColor Green
-        Write-Host "Logs retained under $runtimeDirectory." -ForegroundColor Green
+if (-not [string]::IsNullOrWhiteSpace($Engine)) {
+    # Stop a specific engine profile
+    $statePath = Join-Path $runtimeDirectory "qsoripper-$Engine.state.json"
+    if (-not (Test-Path -LiteralPath $statePath)) {
+        Write-Host "No running $Engine engine found." -ForegroundColor Yellow
         exit 0
+    }
+
+    Stop-EngineFromState -StatePath $statePath
+}
+else {
+    # Stop all running engines (per-profile state files + legacy single file)
+    $stateFiles = @()
+    if (Test-Path -LiteralPath $runtimeDirectory) {
+        $stateFiles = @(Get-ChildItem -LiteralPath $runtimeDirectory -Filter 'qsoripper-*.state.json' -File)
+    }
+
+    # Also check legacy single-engine state file
+    if (Test-Path -LiteralPath $legacyStatePath) {
+        $stateFiles += @(Get-Item -LiteralPath $legacyStatePath)
+    }
+
+    if ($stateFiles.Count -eq 0) {
+        Write-Host 'QsoRipper is not running through the helper script.' -ForegroundColor Yellow
+        exit 0
+    }
+
+    foreach ($stateFile in $stateFiles) {
+        Stop-EngineFromState -StatePath $stateFile.FullName
     }
 }
 
-throw "Timed out waiting for QsoRipper process $($process.Id) to stop."
+Write-Host "Logs retained under $runtimeDirectory." -ForegroundColor Green


### PR DESCRIPTION
## Fix launcher scripts for multi-engine use

### Parse error fix

`start-qsoripper.ps1` failed to parse due to `$Host:$Port` being interpreted
as a scope-qualified variable reference. Renamed the parameter from `$Host`
to `$TargetHost` and added `${}` delimiters in string interpolation.

### Multi-engine simultaneous launch

Previously the launcher tracked a single engine process in one state file,
blocking the second engine from starting. Now each profile gets its own
state file (`qsoripper-{profile}.state.json`) so both engines can run
simultaneously on different ports.

### Updated stop script

`stop-qsoripper.ps1` now accepts `-Engine <profile>` to stop a specific
engine, or stops all running engines when no engine is specified.

### Testing

```powershell
.\start-qsoripper.ps1 -Engine rust     # starts on :50051
.\start-qsoripper.ps1 -Engine dotnet   # starts on :50052
.\stop-qsoripper.ps1 -Engine local-dotnet  # stops just .NET
.\stop-qsoripper.ps1                       # stops all remaining
```