### PR TITLE
feat: engine indicator badge + spec enforcement instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,8 +23,10 @@ Primary goals:
 - No specific UI technology is required or privileged.
 - Keep third-party integrations isolated behind interfaces.
 - Make offline logging resilient, even when network integrations fail.
-- Rust owns the core engine, QRZ providers, and gRPC server.
+- The architecture is explicitly multi-engine: both Rust and .NET are fully-featured, production-grade engine implementations. Any conformant implementation in any language can serve as the engine.
 - Components communicate via gRPC with Protocol Buffer messages.
+- See `docs/architecture/engine-specification.md` for the authoritative engine contract.
+- When adding new engine features, RPCs, integrations, or behavioral changes, update the engine specification in the same change so it stays current.
 
 ## Data Model Conventions
 

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -213,10 +213,16 @@ Treat protobuf 1-1-1 as an architectural rule:
 
 ### Language Split
 
-- **Rust** = Core engine, TUI, QRZ providers, gRPC server (tonic)
-- **C# / .NET** = GUI (Avalonia), reporting, analytics, gRPC client
+- **Rust** = Engine implementation (qsoripper-server), TUI, core library
+- **C# / .NET** = Engine implementation (QsoRipper.Engine.DotNet), GUI (Avalonia), CLI, DebugHost
 
-The Rust process is the engine. The .NET process is the rich client. They communicate via gRPC.
+Both engines are fully-featured, production-grade implementations of the same gRPC service contracts. They are interchangeable — any client can connect to either engine with zero loss of functionality.
+
+### Engine Specification
+
+The authoritative blueprint for implementing a QsoRipper engine lives at `docs/architecture/engine-specification.md`. It documents every gRPC service, RPC, storage contract, integration, and behavioral requirement.
+
+**When adding new features to the engine core — new RPCs, new integrations, new behavioral contracts, or changes to existing ones — update the engine specification in the same change.** The spec must stay current so that a developer could implement a new engine in any language from the spec and proto files alone.
 
 ### ADIF Is an Edge Concern
 

--- a/.github/instructions/integrations.instructions.md
+++ b/.github/instructions/integrations.instructions.md
@@ -9,6 +9,8 @@ External services should enrich local workflows without becoming hard dependenci
 - Normalize provider-specific fields into internal models.
 - Keep provider auth/session lifecycle out of UI code.
 - Log actionable errors without leaking credentials.
+- New integrations must be implemented in both the Rust and .NET engines for full parity.
+- When adding or changing an integration, update `docs/architecture/engine-specification.md` in the same change.
 
 ## QRZ Notes
 

--- a/.github/instructions/proto-contract.instructions.md
+++ b/.github/instructions/proto-contract.instructions.md
@@ -30,11 +30,16 @@ These instructions govern schema and gRPC contract work in `proto/` and any Rust
 ## Rust/.NET Contract Rules
 
 - Rust server traits and generated message types come from `src/rust/qsoripper-core/build.rs` generation.
-- .NET clients consume the same contracts through generated gRPC client code under `src/dotnet/`.
-- If a proto change affects logbook or lookup semantics, update both Rust server-side handling and the .NET debugging/client surfaces in the same change when practical.
+- .NET engine and client projects consume the same contracts through generated gRPC code under `src/dotnet/`.
+- If a proto change affects logbook or lookup semantics, update both Rust and .NET engine implementations in the same change when practical.
 - Shared contract visibility in `src/dotnet/QsoRipper.DebugHost` is part of the .NET client surface. Keep `/protobuf-lab` able to inspect generated message shapes for shared proto messages, and prefer automatic discovery over hand-maintained message lists.
 - Treat generated enum/member names as transport artifacts, not UI labels. In .NET UI and DebugHost code, do not derive band/mode/enum display text from raw generated `ToString()` output; route it through shared helpers such as `src/dotnet/QsoRipper.DebugHost/Utilities/ProtoEnumDisplay.cs`.
 - When a new shared message needs richer example data than the default constructor provides, extend the custom builder path in `src/dotnet/QsoRipper.DebugHost/Services/SampleProtoFactory.cs` instead of adding another manual UI registry.
+
+## Engine Specification
+
+- When adding or changing RPCs, services, storage contracts, integration contracts, or behavioral requirements, update `docs/architecture/engine-specification.md` in the same change.
+- The engine specification is the authoritative blueprint for implementing a conformant QsoRipper engine. It must stay current with every proto or behavioral change.
 
 ## Validation
 

--- a/.github/skills/logging-workflow/SKILL.md
+++ b/.github/skills/logging-workflow/SKILL.md
@@ -17,4 +17,5 @@ description: Designing and implementing efficient QSO logging flows for rapid op
 2. Keep validation immediate and low-friction.
 3. Protect data integrity without interrupting flow.
 4. Keep interaction behavior consistent across TUI and GUI.
+5. When changing QSO logging behavior or adding new logging features, update `docs/architecture/engine-specification.md` to keep the behavioral contract current.
 

--- a/.github/skills/qrz-lookup/SKILL.md
+++ b/.github/skills/qrz-lookup/SKILL.md
@@ -17,6 +17,7 @@ description: Implementing or extending QRZ lookup flows, including auth/session 
 2. Handle auth/session lifecycle explicitly.
 3. Use bounded retries and timeouts.
 4. Degrade gracefully when QRZ is unavailable.
+5. When changing lookup behavior or adding new lookup features, update `docs/architecture/engine-specification.md` to keep the integration contract current.
 
 ## Project references
 

--- a/.github/skills/rust-engine-workflow/SKILL.md
+++ b/.github/skills/rust-engine-workflow/SKILL.md
@@ -23,6 +23,7 @@ description: >-
 3. Do not hand-edit generated proto code; change `proto/` and regenerate.
 4. Keep ADIF and provider-specific formats at the edge, normalized into project-owned types.
 5. Favor current stable Rust semantics over workarounds for outdated compiler behavior.
+6. When adding new RPCs, services, or behavioral changes, update `docs/architecture/engine-specification.md` in the same change so both engines stay aligned.
 
 ## Validation Loop
 

--- a/.github/skills/tonic-proto-contracts/SKILL.md
+++ b/.github/skills/tonic-proto-contracts/SKILL.md
@@ -27,6 +27,7 @@ description: >-
 7. If multiple RPCs need the same payload, extract a separate message and wrap it instead of reusing an RPC response envelope as nested data.
 8. Prefer additive schema changes over breaking changes.
 9. ADIF is not an internal IPC format; protobuf remains the internal contract.
+10. When adding or changing RPCs, services, or contract behavior, update `docs/architecture/engine-specification.md` in the same change.
 
 ## Repo-Specific Contract Surfaces
 
@@ -34,8 +35,10 @@ description: >-
 - `proto/services/*.proto`
 - `src/rust/qsoripper-core/build.rs`
 - `src/rust/qsoripper-server/`
+- `src/dotnet/QsoRipper.Engine.DotNet/`
 - `src/dotnet/QsoRipper.Cli/`
 - `src/dotnet/QsoRipper.DebugHost/`
+- `docs/architecture/engine-specification.md`
 
 ## Validation
 

--- a/src/dotnet/QsoRipper.DebugHost/Components/Layout/MainLayout.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 @inject RepositoryPaths RepositoryPaths
+@inject DebugWorkbenchState WorkbenchState
 
 <div class="page">
     <div class="sidebar">
@@ -12,7 +13,11 @@
                 <strong>QsoRipper Debug Workbench</strong>
                 <span class="text-muted ms-2">Developer-only tooling for engine inspection and debugging.</span>
             </div>
-            <code>@RepositoryPaths.RepoRoot</code>
+            <div class="engine-indicator">
+                <span class="engine-dot @ProbeStatusCss" title="@ProbeTooltip"></span>
+                <span class="engine-label">@WorkbenchState.EngineProfile.DisplayName</span>
+                <span class="engine-endpoint">@WorkbenchState.EngineEndpoint</span>
+            </div>
         </div>
 
         <article class="content px-4">
@@ -26,3 +31,19 @@
     <a href="." class="reload">Reload</a>
     <span class="dismiss">🗙</span>
 </div>
+
+@code {
+    private string ProbeStatusCss => WorkbenchState.LastProbe switch
+    {
+        { IsSuccess: true } => "dot-connected",
+        { IsSuccess: false } => "dot-error",
+        _ => "dot-unknown",
+    };
+
+    private string ProbeTooltip => WorkbenchState.LastProbe switch
+    {
+        { IsSuccess: true } => $"Connected — {WorkbenchState.ReportedEngineInfo?.DisplayName ?? "unknown"}",
+        { IsSuccess: false } => $"Probe failed — {WorkbenchState.LastProbe.Summary}",
+        _ => "Not probed yet — visit Engine Session to connect",
+    };
+}

--- a/src/dotnet/QsoRipper.DebugHost/Components/Layout/MainLayout.razor.css
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Layout/MainLayout.razor.css
@@ -30,6 +30,51 @@ main {
     white-space: nowrap;
 }
 
+.engine-indicator {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.75rem;
+    border-radius: 6px;
+    background: #f0f4fa;
+    border: 1px solid #d9e2f0;
+    font-size: 0.82rem;
+    white-space: nowrap;
+}
+
+.engine-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.engine-dot.dot-connected {
+    background: #22c55e;
+    box-shadow: 0 0 4px rgba(34, 197, 94, 0.5);
+}
+
+.engine-dot.dot-error {
+    background: #ef4444;
+    box-shadow: 0 0 4px rgba(239, 68, 68, 0.5);
+}
+
+.engine-dot.dot-unknown {
+    background: #f59e0b;
+    box-shadow: 0 0 4px rgba(245, 158, 11, 0.4);
+}
+
+.engine-label {
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.engine-endpoint {
+    color: #64748b;
+    font-family: monospace;
+    font-size: 0.78rem;
+}
+
 .content {
     padding-top: 1.5rem;
     padding-bottom: 2rem;


### PR DESCRIPTION
## Engine Indicator Badge + Spec Enforcement

Two related improvements that strengthen the multi-engine development experience.

### 1. Persistent Engine Indicator in DebugHost Top Bar

Adds a compact badge to the DebugHost layout that shows:
- **Active engine name** (e.g., "QsoRipper Rust Engine (rust-tonic)")
- **Endpoint** (e.g., `http://127.0.0.1:50051`)
- **Connection status dot** — green (connected), red (probe failed), yellow (not yet probed)

The badge appears on every page so operators always know which engine they're targeting without navigating to Engine Session. Hovering the dot shows detailed status.

**Files changed:**
- `MainLayout.razor` — badge markup + `@code` block for status logic
- `MainLayout.razor.css` — scoped styles for the indicator

### 2. Engine Specification Enforcement in Copilot Instructions

Updates 8 instruction/skill files to require engine specification updates whenever engine features change:

- `.github/copilot-instructions.md` — Architecture Direction now says multi-engine (was Rust-centric)
- `.github/instructions/architecture.instructions.md` — Language Split corrected; Engine Specification section added
- `.github/instructions/proto-contract.instructions.md` — Engine specification rule + .NET engine surface added
- `.github/instructions/integrations.instructions.md` — Parity requirement + spec update rule
- `.github/skills/rust-engine-workflow/SKILL.md` — Rule 6: update engine spec
- `.github/skills/tonic-proto-contracts/SKILL.md` — Rule 10 + .NET engine surface
- `.github/skills/logging-workflow/SKILL.md` — Engine spec update rule
- `.github/skills/qrz-lookup/SKILL.md` — Engine spec update rule

### Testing

All 570 .NET tests pass. Build clean with zero warnings.
