### PR TITLE
fix(dotnet-engine): harden protobuf optional-field responses

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,8 +23,10 @@ Primary goals:
 - No specific UI technology is required or privileged.
 - Keep third-party integrations isolated behind interfaces.
 - Make offline logging resilient, even when network integrations fail.
-- Rust owns the core engine, QRZ providers, and gRPC server.
+- The architecture is explicitly multi-engine: both Rust and .NET are fully-featured, production-grade engine implementations. Any conformant implementation in any language can serve as the engine.
 - Components communicate via gRPC with Protocol Buffer messages.
+- See `docs/architecture/engine-specification.md` for the authoritative engine contract.
+- When adding new engine features, RPCs, integrations, or behavioral changes, update the engine specification in the same change so it stays current.
 
 ## Data Model Conventions
 

--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -213,10 +213,16 @@ Treat protobuf 1-1-1 as an architectural rule:
 
 ### Language Split
 
-- **Rust** = Core engine, TUI, QRZ providers, gRPC server (tonic)
-- **C# / .NET** = GUI (Avalonia), reporting, analytics, gRPC client
+- **Rust** = Engine implementation (qsoripper-server), TUI, core library
+- **C# / .NET** = Engine implementation (QsoRipper.Engine.DotNet), GUI (Avalonia), CLI, DebugHost
 
-The Rust process is the engine. The .NET process is the rich client. They communicate via gRPC.
+Both engines are fully-featured, production-grade implementations of the same gRPC service contracts. They are interchangeable — any client can connect to either engine with zero loss of functionality.
+
+### Engine Specification
+
+The authoritative blueprint for implementing a QsoRipper engine lives at `docs/architecture/engine-specification.md`. It documents every gRPC service, RPC, storage contract, integration, and behavioral requirement.
+
+**When adding new features to the engine core — new RPCs, new integrations, new behavioral contracts, or changes to existing ones — update the engine specification in the same change.** The spec must stay current so that a developer could implement a new engine in any language from the spec and proto files alone.
 
 ### ADIF Is an Edge Concern
 

--- a/.github/instructions/integrations.instructions.md
+++ b/.github/instructions/integrations.instructions.md
@@ -9,6 +9,8 @@ External services should enrich local workflows without becoming hard dependenci
 - Normalize provider-specific fields into internal models.
 - Keep provider auth/session lifecycle out of UI code.
 - Log actionable errors without leaking credentials.
+- New integrations must be implemented in both the Rust and .NET engines for full parity.
+- When adding or changing an integration, update `docs/architecture/engine-specification.md` in the same change.
 
 ## QRZ Notes
 

--- a/.github/instructions/proto-contract.instructions.md
+++ b/.github/instructions/proto-contract.instructions.md
@@ -30,11 +30,16 @@ These instructions govern schema and gRPC contract work in `proto/` and any Rust
 ## Rust/.NET Contract Rules
 
 - Rust server traits and generated message types come from `src/rust/qsoripper-core/build.rs` generation.
-- .NET clients consume the same contracts through generated gRPC client code under `src/dotnet/`.
-- If a proto change affects logbook or lookup semantics, update both Rust server-side handling and the .NET debugging/client surfaces in the same change when practical.
+- .NET engine and client projects consume the same contracts through generated gRPC code under `src/dotnet/`.
+- If a proto change affects logbook or lookup semantics, update both Rust and .NET engine implementations in the same change when practical.
 - Shared contract visibility in `src/dotnet/QsoRipper.DebugHost` is part of the .NET client surface. Keep `/protobuf-lab` able to inspect generated message shapes for shared proto messages, and prefer automatic discovery over hand-maintained message lists.
 - Treat generated enum/member names as transport artifacts, not UI labels. In .NET UI and DebugHost code, do not derive band/mode/enum display text from raw generated `ToString()` output; route it through shared helpers such as `src/dotnet/QsoRipper.DebugHost/Utilities/ProtoEnumDisplay.cs`.
 - When a new shared message needs richer example data than the default constructor provides, extend the custom builder path in `src/dotnet/QsoRipper.DebugHost/Services/SampleProtoFactory.cs` instead of adding another manual UI registry.
+
+## Engine Specification
+
+- When adding or changing RPCs, services, storage contracts, integration contracts, or behavioral requirements, update `docs/architecture/engine-specification.md` in the same change.
+- The engine specification is the authoritative blueprint for implementing a conformant QsoRipper engine. It must stay current with every proto or behavioral change.
 
 ## Validation
 

--- a/.github/skills/logging-workflow/SKILL.md
+++ b/.github/skills/logging-workflow/SKILL.md
@@ -17,4 +17,5 @@ description: Designing and implementing efficient QSO logging flows for rapid op
 2. Keep validation immediate and low-friction.
 3. Protect data integrity without interrupting flow.
 4. Keep interaction behavior consistent across TUI and GUI.
+5. When changing QSO logging behavior or adding new logging features, update `docs/architecture/engine-specification.md` to keep the behavioral contract current.
 

--- a/.github/skills/qrz-lookup/SKILL.md
+++ b/.github/skills/qrz-lookup/SKILL.md
@@ -17,6 +17,7 @@ description: Implementing or extending QRZ lookup flows, including auth/session 
 2. Handle auth/session lifecycle explicitly.
 3. Use bounded retries and timeouts.
 4. Degrade gracefully when QRZ is unavailable.
+5. When changing lookup behavior or adding new lookup features, update `docs/architecture/engine-specification.md` to keep the integration contract current.
 
 ## Project references
 

--- a/.github/skills/rust-engine-workflow/SKILL.md
+++ b/.github/skills/rust-engine-workflow/SKILL.md
@@ -23,6 +23,7 @@ description: >-
 3. Do not hand-edit generated proto code; change `proto/` and regenerate.
 4. Keep ADIF and provider-specific formats at the edge, normalized into project-owned types.
 5. Favor current stable Rust semantics over workarounds for outdated compiler behavior.
+6. When adding new RPCs, services, or behavioral changes, update `docs/architecture/engine-specification.md` in the same change so both engines stay aligned.
 
 ## Validation Loop
 

--- a/.github/skills/tonic-proto-contracts/SKILL.md
+++ b/.github/skills/tonic-proto-contracts/SKILL.md
@@ -27,6 +27,7 @@ description: >-
 7. If multiple RPCs need the same payload, extract a separate message and wrap it instead of reusing an RPC response envelope as nested data.
 8. Prefer additive schema changes over breaking changes.
 9. ADIF is not an internal IPC format; protobuf remains the internal contract.
+10. When adding or changing RPCs, services, or contract behavior, update `docs/architecture/engine-specification.md` in the same change.
 
 ## Repo-Specific Contract Surfaces
 
@@ -34,8 +35,10 @@ description: >-
 - `proto/services/*.proto`
 - `src/rust/qsoripper-core/build.rs`
 - `src/rust/qsoripper-server/`
+- `src/dotnet/QsoRipper.Engine.DotNet/`
 - `src/dotnet/QsoRipper.Cli/`
 - `src/dotnet/QsoRipper.DebugHost/`
+- `docs/architecture/engine-specification.md`
 
 ## Validation
 

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -87,6 +87,8 @@ The 1-1-1 rule applies: one top-level message, enum, or service per `.proto` fil
 
 An engine must implement all services in this section except where marked **optional**. Each subsection documents every RPC with its exact types, streaming mode, expected behavior, and error semantics.
 
+For generated protobuf runtimes, absent optional scalar fields must be **omitted**, not assigned `null`. A successful handler must never fail while materializing a response just because an optional string/error field is not present.
+
 ### 3.1 EngineService
 
 **Proto file:** `proto/services/engine_service.proto`
@@ -1199,17 +1201,18 @@ A conformant engine must pass all of the following scenarios:
 6. `ListQsos` returns exactly the expected QSOs with correct ordering.
 7. `UpdateQso` modifies the specified fields and updates `updated_at`.
 8. `DeleteQso` removes the QSO; subsequent `GetQso` returns `NOT_FOUND`.
+9. Unary success and failure responses with optional scalar fields serialize cleanly at the service boundary without handler exceptions.
 
 #### ADIF Round-Trip
 
-9. `ExportAdif` produces valid ADIF output containing all logged QSOs.
-10. `ImportAdif` with previously exported ADIF creates equivalent records.
-11. `extra_fields` survive a full import → export → import round-trip.
+10. `ExportAdif` produces valid ADIF output containing all logged QSOs.
+11. `ImportAdif` with previously exported ADIF creates equivalent records.
+12. `extra_fields` survive a full import → export → import round-trip.
 
 #### Cross-Engine Parity
 
-12. Given the same sequence of operations, the Rust and .NET engines produce field-identical `GetQso`, `ListQsos`, and `ExportAdif` results.
-13. Both engines report `localQsoCount == 1` after logging one QSO.
+13. Given the same sequence of operations, the Rust and .NET engines produce field-identical `GetQso`, `ListQsos`, and `ExportAdif` results.
+14. Both engines report `localQsoCount == 1` after logging one QSO.
 
 #### Lookup (if credentials available)
 

--- a/src/dotnet/QsoRipper.DebugHost/Components/Layout/MainLayout.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Layout/MainLayout.razor
@@ -1,5 +1,6 @@
 @inherits LayoutComponentBase
 @inject RepositoryPaths RepositoryPaths
+@inject DebugWorkbenchState WorkbenchState
 
 <div class="page">
     <div class="sidebar">
@@ -12,7 +13,11 @@
                 <strong>QsoRipper Debug Workbench</strong>
                 <span class="text-muted ms-2">Developer-only tooling for engine inspection and debugging.</span>
             </div>
-            <code>@RepositoryPaths.RepoRoot</code>
+            <div class="engine-indicator">
+                <span class="engine-dot @ProbeStatusCss" title="@ProbeTooltip"></span>
+                <span class="engine-label">@WorkbenchState.EngineProfile.DisplayName</span>
+                <span class="engine-endpoint">@WorkbenchState.EngineEndpoint</span>
+            </div>
         </div>
 
         <article class="content px-4">
@@ -26,3 +31,19 @@
     <a href="." class="reload">Reload</a>
     <span class="dismiss">🗙</span>
 </div>
+
+@code {
+    private string ProbeStatusCss => WorkbenchState.LastProbe switch
+    {
+        { IsSuccess: true } => "dot-connected",
+        { IsSuccess: false } => "dot-error",
+        _ => "dot-unknown",
+    };
+
+    private string ProbeTooltip => WorkbenchState.LastProbe switch
+    {
+        { IsSuccess: true } => $"Connected — {WorkbenchState.ReportedEngineInfo?.DisplayName ?? "unknown"}",
+        { IsSuccess: false } => $"Probe failed — {WorkbenchState.LastProbe.Summary}",
+        _ => "Not probed yet — visit Engine Session to connect",
+    };
+}

--- a/src/dotnet/QsoRipper.DebugHost/Components/Layout/MainLayout.razor.css
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Layout/MainLayout.razor.css
@@ -30,6 +30,51 @@ main {
     white-space: nowrap;
 }
 
+.engine-indicator {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.3rem 0.75rem;
+    border-radius: 6px;
+    background: #f0f4fa;
+    border: 1px solid #d9e2f0;
+    font-size: 0.82rem;
+    white-space: nowrap;
+}
+
+.engine-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.engine-dot.dot-connected {
+    background: #22c55e;
+    box-shadow: 0 0 4px rgba(34, 197, 94, 0.5);
+}
+
+.engine-dot.dot-error {
+    background: #ef4444;
+    box-shadow: 0 0 4px rgba(239, 68, 68, 0.5);
+}
+
+.engine-dot.dot-unknown {
+    background: #f59e0b;
+    box-shadow: 0 0 4px rgba(245, 158, 11, 0.4);
+}
+
+.engine-label {
+    font-weight: 600;
+    color: #1e293b;
+}
+
+.engine-endpoint {
+    color: #64748b;
+    font-family: monospace;
+    font-size: 0.78rem;
+}
+
 .content {
     padding-top: 1.5rem;
     padding-bottom: 2rem;

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -3,6 +3,7 @@ using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
 using QsoRipper.Engine.DotNet;
 using QsoRipper.Engine.QrzLogbook;
+using QsoRipper.Engine.RigControl;
 using QsoRipper.Engine.Storage.Memory;
 using QsoRipper.EngineSelection;
 using QsoRipper.Services;
@@ -154,6 +155,94 @@ public sealed class ManagedEngineStateTests : IDisposable
         ]));
 
         Assert.Equal("The managed .NET engine currently supports only memory storage.", exception.Message);
+    }
+
+    [Fact]
+    public async Task Delete_qso_grpc_success_omits_optional_error_fields()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87"
+            }
+        });
+
+        var logged = state.LogQso(new LogQsoRequest
+        {
+            SyncToQrz = false,
+            Qso = new QsoRecord
+            {
+                WorkedCallsign = "W1AW",
+                Band = Band._20M,
+                Mode = Mode.Ft8,
+                UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-04-16T22:48:00Z", System.Globalization.CultureInfo.InvariantCulture))
+            }
+        });
+
+        var service = new ManagedLogbookGrpcService(state);
+        var response = await service.DeleteQso(
+            new DeleteQsoRequest
+            {
+                LocalId = logged.LocalId,
+                DeleteFromQrz = false
+            },
+            null!);
+
+        Assert.True(response.Success);
+        Assert.True(string.IsNullOrEmpty(response.Error));
+        Assert.True(string.IsNullOrEmpty(response.QrzDeleteError));
+    }
+
+    [Fact]
+    public void Test_rig_connection_connected_omits_error_message()
+    {
+        var state = CreateStateWithRigSnapshot(new RigSnapshot
+        {
+            FrequencyHz = 14_074_000,
+            Band = Band._20M,
+            Mode = Mode.Ft8
+        });
+
+        var response = state.TestRigConnection();
+
+        Assert.True(response.Success);
+        Assert.True(string.IsNullOrEmpty(response.ErrorMessage));
+        Assert.NotNull(response.Snapshot);
+        Assert.Equal(14_074_000UL, response.Snapshot.FrequencyHz);
+        Assert.Equal(RigConnectionStatus.Connected, response.Snapshot.Status);
+    }
+
+    [Fact]
+    public void Build_rig_snapshot_connected_omits_error_message_without_monitor()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87"
+            },
+            RigControl = new RigControlSettings
+            {
+                Enabled = true,
+                Host = "127.0.0.1",
+                Port = 4532
+            }
+        });
+
+        var snapshot = state.BuildRigSnapshot();
+
+        Assert.Equal(RigConnectionStatus.Connected, snapshot.Status);
+        Assert.False(snapshot.HasErrorMessage);
+        Assert.Equal(14_074_000UL, snapshot.FrequencyHz);
     }
 
     [Fact]
@@ -365,9 +454,29 @@ public sealed class ManagedEngineStateTests : IDisposable
             syncEngine: syncEngine);
     }
 
+    private ManagedEngineState CreateStateWithRigSnapshot(RigSnapshot snapshot)
+    {
+        var storage = new MemoryStorage();
+        var monitor = new RigControlMonitor(
+            new FakeRigControlProvider(() => snapshot.Clone()),
+            TimeSpan.Zero);
+        return new ManagedEngineState(
+            Path.Combine(_tempDirectory, "managed-engine.json"),
+            storage,
+            lookupCoordinator: null,
+            rigControlMonitor: monitor,
+            spaceWeatherMonitor: null,
+            syncEngine: null);
+    }
+
     private static byte[] Utf8(string value)
     {
         return Encoding.UTF8.GetBytes(value);
+    }
+
+    private sealed class FakeRigControlProvider(Func<RigSnapshot> factory) : IRigControlProvider
+    {
+        public RigSnapshot GetSnapshot() => factory();
     }
 
     /// <summary>

--- a/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
@@ -265,13 +265,23 @@ internal sealed class ManagedLogbookGrpcService(ManagedEngineState state)
     public override Task<DeleteQsoResponse> DeleteQso(DeleteQsoRequest request, ServerCallContext context)
     {
         var deleted = state.DeleteQso(request.LocalId);
-        return Task.FromResult(new DeleteQsoResponse
+        var response = new DeleteQsoResponse
         {
             Success = deleted,
-            Error = deleted ? null : $"QSO '{request.LocalId}' was not found.",
             QrzDeleteSuccess = false,
-            QrzDeleteError = request.DeleteFromQrz ? "Managed engine does not delete remote QRZ records." : null,
-        });
+        };
+
+        if (!deleted)
+        {
+            response.Error = $"QSO '{request.LocalId}' was not found.";
+        }
+
+        if (request.DeleteFromQrz)
+        {
+            response.QrzDeleteError = "Managed engine does not delete remote QRZ records.";
+        }
+
+        return Task.FromResult(response);
     }
 
     public override Task<GetQsoResponse> GetQso(GetQsoRequest request, ServerCallContext context)

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -776,15 +776,21 @@ internal sealed class ManagedEngineState
         }
 
         var status = CreateRigStatusResponse();
-        return new RigSnapshot
+        var snapshot = new RigSnapshot
         {
             FrequencyHz = status.Status == RigConnectionStatus.Connected ? 14_074_000UL : 0UL,
             Band = status.Status == RigConnectionStatus.Connected ? Band._20M : Band.Unspecified,
             Mode = status.Status == RigConnectionStatus.Connected ? Mode.Ft8 : Mode.Unspecified,
             Status = status.Status,
-            ErrorMessage = status.HasErrorMessage ? status.ErrorMessage : null,
             SampledAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
         };
+
+        if (status.HasErrorMessage)
+        {
+            snapshot.ErrorMessage = status.ErrorMessage;
+        }
+
+        return snapshot;
     }
 
     public TestRigConnectionResponse TestRigConnection()
@@ -792,21 +798,40 @@ internal sealed class ManagedEngineState
         if (_rigControlMonitor is not null)
         {
             var refreshed = _rigControlMonitor.RefreshSnapshot();
-            return new TestRigConnectionResponse
+            var response = new TestRigConnectionResponse
             {
                 Success = refreshed.Status == RigConnectionStatus.Connected,
-                ErrorMessage = refreshed.HasErrorMessage ? refreshed.ErrorMessage : null,
-                Snapshot = refreshed.Status == RigConnectionStatus.Connected ? refreshed : null,
             };
+
+            if (refreshed.HasErrorMessage)
+            {
+                response.ErrorMessage = refreshed.ErrorMessage;
+            }
+
+            if (refreshed.Status == RigConnectionStatus.Connected)
+            {
+                response.Snapshot = refreshed;
+            }
+
+            return response;
         }
 
         var snapshot = BuildRigSnapshot();
-        return new TestRigConnectionResponse
+        var fallbackResponse = new TestRigConnectionResponse
         {
             Success = snapshot.Status == RigConnectionStatus.Connected,
-            ErrorMessage = snapshot.Status == RigConnectionStatus.Connected ? null : "Rig control is disabled in the managed engine.",
-            Snapshot = snapshot.Status == RigConnectionStatus.Connected ? snapshot : null,
         };
+
+        if (snapshot.Status == RigConnectionStatus.Connected)
+        {
+            fallbackResponse.Snapshot = snapshot;
+        }
+        else
+        {
+            fallbackResponse.ErrorMessage = "Rig control is disabled in the managed engine.";
+        }
+
+        return fallbackResponse;
     }
 
     public SpaceWeatherSnapshot BuildSpaceWeatherSnapshot(bool refreshed)

--- a/stop-qsoripper.ps1
+++ b/stop-qsoripper.ps1
@@ -115,27 +115,29 @@ function Wait-ForProcessStop([int]$ProcessId, [int]$TimeoutSeconds) {
 }
 
 function Resolve-Targets([pscustomobject[]]$Entries) {
-    if ($Entries.Count -eq 0) {
+    $normalizedEntries = @($Entries)
+
+    if ($normalizedEntries.Count -eq 0) {
         return @()
     }
 
     if ($All) {
-        return $Entries
+        return $normalizedEntries
     }
 
     if (-not [string]::IsNullOrWhiteSpace($Engine)) {
         return @(
-            $Entries |
+            $normalizedEntries |
                 Where-Object { Test-EngineMatch -State $_.State -RequestedEngine $Engine }
         )
     }
 
-    $legacyEntry = $Entries | Where-Object { $_.IsLegacy } | Select-Object -First 1
+    $legacyEntry = $normalizedEntries | Where-Object { $_.IsLegacy } | Select-Object -First 1
     if ($null -ne $legacyEntry) {
         return @($legacyEntry)
     }
 
-    $latestEntry = $Entries |
+    $latestEntry = $normalizedEntries |
         Sort-Object {
             try {
                 [DateTime]::Parse($_.State.startedAtUtc, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::RoundtripKind)
@@ -153,7 +155,7 @@ function Resolve-Targets([pscustomobject[]]$Entries) {
     return @()
 }
 
-$stateEntries = Get-StateEntries
+$stateEntries = @(Get-StateEntries)
 if ($stateEntries.Count -eq 0) {
     Write-Host 'QsoRipper is not running through the helper script.' -ForegroundColor Yellow
     exit 0

--- a/tests/Run-EngineConformance.ps1
+++ b/tests/Run-EngineConformance.ps1
@@ -367,6 +367,21 @@ function Invoke-ConformanceScenario {
         throw "$EngineProfile export expected exactly one ADIF record but saw $($exportRecords.Count)."
     }
 
+    $deleteResult = Invoke-Cli -Arguments @('--engine', $EngineProfile, 'delete', $localId)
+    Assert-CommandSucceeded -Result $deleteResult -Description "$EngineProfile delete"
+
+    $listAfterDeleteResult = Invoke-Cli -Arguments @('--engine', $EngineProfile, 'list', '--json', '--limit', '5')
+    Assert-CommandSucceeded -Result $listAfterDeleteResult -Description "$EngineProfile list after delete --json"
+    $listAfterDeleteJson = @($listAfterDeleteResult.StdOut | ConvertFrom-Json)
+    if ($listAfterDeleteJson.Count -ne 0) {
+        throw "$EngineProfile expected zero QSOs after delete but saw $($listAfterDeleteJson.Count)."
+    }
+
+    $getAfterDeleteResult = Invoke-Cli -Arguments @('--engine', $EngineProfile, 'get', $localId, '--json')
+    if ($getAfterDeleteResult.ExitCode -eq 0) {
+        throw "$EngineProfile get unexpectedly succeeded after delete for local id '$localId'."
+    }
+
     return [pscustomobject]@{
         EngineProfile = $EngineProfile
         EngineId = $expectedEngineId


### PR DESCRIPTION
## .NET engine protobuf response hardening

Follow-up to the merged multi-engine UI/spec work after a real DebugHost storage smoke test exposed a .NET engine gRPC bug.

### What failed

The DebugHost Storage Workbench could fail during cleanup with:
- `Cleanup: Delete verification failed`
- `Exception was thrown by handler`

Root cause: the .NET engine `DeleteQso` gRPC handler was assigning `null` to generated protobuf string fields on the success path. In generated C# protobuf types that throws `ArgumentNullException` during response materialization.

### Fixes

- **DeleteQso** now omits absent optional string fields instead of assigning `null`
- Hardened the same optional-field pattern in a related rig snapshot/test response path
- Added .NET tests that exercise the service-boundary success path for these responses
- Extended `tests\Run-EngineConformance.ps1` to actually execute **delete** and verify `get` returns `NotFound`
- Hardened `stop-qsoripper.ps1` around singleton/scalar state handling used by the conformance harness
- Updated `docs\architecture\engine-specification.md` to explicitly require omission of absent optional scalar proto fields instead of assigning `null`

### Why this matters

The spec already required delete semantics, but the process gap was real:
1. state-level unit tests did not cover protobuf response construction at the gRPC handler boundary
2. the conformance harness claimed CRUD coverage but never exercised `DeleteQso`

This PR closes both gaps.

### Validation

- `dotnet build src\dotnet\QsoRipper.slnx -c Release --nologo -v minimal --tl:off`
- `dotnet test src\dotnet\QsoRipper.slnx -c Release --no-build --nologo -v minimal --tl:off`
- `dotnet format src\dotnet\QsoRipper.slnx --verify-no-changes --verbosity minimal`
- `.\tests\Run-EngineConformance.ps1 -SkipBuild`
