### PR TITLE
fix(dotnet-engine): harden protobuf optional-field responses

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -87,6 +87,8 @@ The 1-1-1 rule applies: one top-level message, enum, or service per `.proto` fil
 
 An engine must implement all services in this section except where marked **optional**. Each subsection documents every RPC with its exact types, streaming mode, expected behavior, and error semantics.
 
+For generated protobuf runtimes, absent optional scalar fields must be **omitted**, not assigned `null`. A successful handler must never fail while materializing a response just because an optional string/error field is not present.
+
 ### 3.1 EngineService
 
 **Proto file:** `proto/services/engine_service.proto`
@@ -1199,17 +1201,18 @@ A conformant engine must pass all of the following scenarios:
 6. `ListQsos` returns exactly the expected QSOs with correct ordering.
 7. `UpdateQso` modifies the specified fields and updates `updated_at`.
 8. `DeleteQso` removes the QSO; subsequent `GetQso` returns `NOT_FOUND`.
+9. Unary success and failure responses with optional scalar fields serialize cleanly at the service boundary without handler exceptions.
 
 #### ADIF Round-Trip
 
-9. `ExportAdif` produces valid ADIF output containing all logged QSOs.
-10. `ImportAdif` with previously exported ADIF creates equivalent records.
-11. `extra_fields` survive a full import → export → import round-trip.
+10. `ExportAdif` produces valid ADIF output containing all logged QSOs.
+11. `ImportAdif` with previously exported ADIF creates equivalent records.
+12. `extra_fields` survive a full import → export → import round-trip.
 
 #### Cross-Engine Parity
 
-12. Given the same sequence of operations, the Rust and .NET engines produce field-identical `GetQso`, `ListQsos`, and `ExportAdif` results.
-13. Both engines report `localQsoCount == 1` after logging one QSO.
+13. Given the same sequence of operations, the Rust and .NET engines produce field-identical `GetQso`, `ListQsos`, and `ExportAdif` results.
+14. Both engines report `localQsoCount == 1` after logging one QSO.
 
 #### Lookup (if credentials available)
 

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -3,6 +3,7 @@ using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
 using QsoRipper.Engine.DotNet;
 using QsoRipper.Engine.QrzLogbook;
+using QsoRipper.Engine.RigControl;
 using QsoRipper.Engine.Storage.Memory;
 using QsoRipper.EngineSelection;
 using QsoRipper.Services;
@@ -154,6 +155,94 @@ public sealed class ManagedEngineStateTests : IDisposable
         ]));
 
         Assert.Equal("The managed .NET engine currently supports only memory storage.", exception.Message);
+    }
+
+    [Fact]
+    public async Task Delete_qso_grpc_success_omits_optional_error_fields()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87"
+            }
+        });
+
+        var logged = state.LogQso(new LogQsoRequest
+        {
+            SyncToQrz = false,
+            Qso = new QsoRecord
+            {
+                WorkedCallsign = "W1AW",
+                Band = Band._20M,
+                Mode = Mode.Ft8,
+                UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-04-16T22:48:00Z", System.Globalization.CultureInfo.InvariantCulture))
+            }
+        });
+
+        var service = new ManagedLogbookGrpcService(state);
+        var response = await service.DeleteQso(
+            new DeleteQsoRequest
+            {
+                LocalId = logged.LocalId,
+                DeleteFromQrz = false
+            },
+            null!);
+
+        Assert.True(response.Success);
+        Assert.True(string.IsNullOrEmpty(response.Error));
+        Assert.True(string.IsNullOrEmpty(response.QrzDeleteError));
+    }
+
+    [Fact]
+    public void Test_rig_connection_connected_omits_error_message()
+    {
+        var state = CreateStateWithRigSnapshot(new RigSnapshot
+        {
+            FrequencyHz = 14_074_000,
+            Band = Band._20M,
+            Mode = Mode.Ft8
+        });
+
+        var response = state.TestRigConnection();
+
+        Assert.True(response.Success);
+        Assert.True(string.IsNullOrEmpty(response.ErrorMessage));
+        Assert.NotNull(response.Snapshot);
+        Assert.Equal(14_074_000UL, response.Snapshot.FrequencyHz);
+        Assert.Equal(RigConnectionStatus.Connected, response.Snapshot.Status);
+    }
+
+    [Fact]
+    public void Build_rig_snapshot_connected_omits_error_message_without_monitor()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87"
+            },
+            RigControl = new RigControlSettings
+            {
+                Enabled = true,
+                Host = "127.0.0.1",
+                Port = 4532
+            }
+        });
+
+        var snapshot = state.BuildRigSnapshot();
+
+        Assert.Equal(RigConnectionStatus.Connected, snapshot.Status);
+        Assert.False(snapshot.HasErrorMessage);
+        Assert.Equal(14_074_000UL, snapshot.FrequencyHz);
     }
 
     [Fact]
@@ -365,9 +454,29 @@ public sealed class ManagedEngineStateTests : IDisposable
             syncEngine: syncEngine);
     }
 
+    private ManagedEngineState CreateStateWithRigSnapshot(RigSnapshot snapshot)
+    {
+        var storage = new MemoryStorage();
+        var monitor = new RigControlMonitor(
+            new FakeRigControlProvider(() => snapshot.Clone()),
+            TimeSpan.Zero);
+        return new ManagedEngineState(
+            Path.Combine(_tempDirectory, "managed-engine.json"),
+            storage,
+            lookupCoordinator: null,
+            rigControlMonitor: monitor,
+            spaceWeatherMonitor: null,
+            syncEngine: null);
+    }
+
     private static byte[] Utf8(string value)
     {
         return Encoding.UTF8.GetBytes(value);
+    }
+
+    private sealed class FakeRigControlProvider(Func<RigSnapshot> factory) : IRigControlProvider
+    {
+        public RigSnapshot GetSnapshot() => factory();
     }
 
     /// <summary>

--- a/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
@@ -265,13 +265,23 @@ internal sealed class ManagedLogbookGrpcService(ManagedEngineState state)
     public override Task<DeleteQsoResponse> DeleteQso(DeleteQsoRequest request, ServerCallContext context)
     {
         var deleted = state.DeleteQso(request.LocalId);
-        return Task.FromResult(new DeleteQsoResponse
+        var response = new DeleteQsoResponse
         {
             Success = deleted,
-            Error = deleted ? null : $"QSO '{request.LocalId}' was not found.",
             QrzDeleteSuccess = false,
-            QrzDeleteError = request.DeleteFromQrz ? "Managed engine does not delete remote QRZ records." : null,
-        });
+        };
+
+        if (!deleted)
+        {
+            response.Error = $"QSO '{request.LocalId}' was not found.";
+        }
+
+        if (request.DeleteFromQrz)
+        {
+            response.QrzDeleteError = "Managed engine does not delete remote QRZ records.";
+        }
+
+        return Task.FromResult(response);
     }
 
     public override Task<GetQsoResponse> GetQso(GetQsoRequest request, ServerCallContext context)

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -776,15 +776,21 @@ internal sealed class ManagedEngineState
         }
 
         var status = CreateRigStatusResponse();
-        return new RigSnapshot
+        var snapshot = new RigSnapshot
         {
             FrequencyHz = status.Status == RigConnectionStatus.Connected ? 14_074_000UL : 0UL,
             Band = status.Status == RigConnectionStatus.Connected ? Band._20M : Band.Unspecified,
             Mode = status.Status == RigConnectionStatus.Connected ? Mode.Ft8 : Mode.Unspecified,
             Status = status.Status,
-            ErrorMessage = status.HasErrorMessage ? status.ErrorMessage : null,
             SampledAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
         };
+
+        if (status.HasErrorMessage)
+        {
+            snapshot.ErrorMessage = status.ErrorMessage;
+        }
+
+        return snapshot;
     }
 
     public TestRigConnectionResponse TestRigConnection()
@@ -792,21 +798,40 @@ internal sealed class ManagedEngineState
         if (_rigControlMonitor is not null)
         {
             var refreshed = _rigControlMonitor.RefreshSnapshot();
-            return new TestRigConnectionResponse
+            var response = new TestRigConnectionResponse
             {
                 Success = refreshed.Status == RigConnectionStatus.Connected,
-                ErrorMessage = refreshed.HasErrorMessage ? refreshed.ErrorMessage : null,
-                Snapshot = refreshed.Status == RigConnectionStatus.Connected ? refreshed : null,
             };
+
+            if (refreshed.HasErrorMessage)
+            {
+                response.ErrorMessage = refreshed.ErrorMessage;
+            }
+
+            if (refreshed.Status == RigConnectionStatus.Connected)
+            {
+                response.Snapshot = refreshed;
+            }
+
+            return response;
         }
 
         var snapshot = BuildRigSnapshot();
-        return new TestRigConnectionResponse
+        var fallbackResponse = new TestRigConnectionResponse
         {
             Success = snapshot.Status == RigConnectionStatus.Connected,
-            ErrorMessage = snapshot.Status == RigConnectionStatus.Connected ? null : "Rig control is disabled in the managed engine.",
-            Snapshot = snapshot.Status == RigConnectionStatus.Connected ? snapshot : null,
         };
+
+        if (snapshot.Status == RigConnectionStatus.Connected)
+        {
+            fallbackResponse.Snapshot = snapshot;
+        }
+        else
+        {
+            fallbackResponse.ErrorMessage = "Rig control is disabled in the managed engine.";
+        }
+
+        return fallbackResponse;
     }
 
     public SpaceWeatherSnapshot BuildSpaceWeatherSnapshot(bool refreshed)

--- a/stop-qsoripper.ps1
+++ b/stop-qsoripper.ps1
@@ -115,27 +115,29 @@ function Wait-ForProcessStop([int]$ProcessId, [int]$TimeoutSeconds) {
 }
 
 function Resolve-Targets([pscustomobject[]]$Entries) {
-    if ($Entries.Count -eq 0) {
+    $normalizedEntries = @($Entries)
+
+    if ($normalizedEntries.Count -eq 0) {
         return @()
     }
 
     if ($All) {
-        return $Entries
+        return $normalizedEntries
     }
 
     if (-not [string]::IsNullOrWhiteSpace($Engine)) {
         return @(
-            $Entries |
+            $normalizedEntries |
                 Where-Object { Test-EngineMatch -State $_.State -RequestedEngine $Engine }
         )
     }
 
-    $legacyEntry = $Entries | Where-Object { $_.IsLegacy } | Select-Object -First 1
+    $legacyEntry = $normalizedEntries | Where-Object { $_.IsLegacy } | Select-Object -First 1
     if ($null -ne $legacyEntry) {
         return @($legacyEntry)
     }
 
-    $latestEntry = $Entries |
+    $latestEntry = $normalizedEntries |
         Sort-Object {
             try {
                 [DateTime]::Parse($_.State.startedAtUtc, [System.Globalization.CultureInfo]::InvariantCulture, [System.Globalization.DateTimeStyles]::RoundtripKind)
@@ -153,7 +155,7 @@ function Resolve-Targets([pscustomobject[]]$Entries) {
     return @()
 }
 
-$stateEntries = Get-StateEntries
+$stateEntries = @(Get-StateEntries)
 if ($stateEntries.Count -eq 0) {
     Write-Host 'QsoRipper is not running through the helper script.' -ForegroundColor Yellow
     exit 0

--- a/tests/Run-EngineConformance.ps1
+++ b/tests/Run-EngineConformance.ps1
@@ -367,6 +367,21 @@ function Invoke-ConformanceScenario {
         throw "$EngineProfile export expected exactly one ADIF record but saw $($exportRecords.Count)."
     }
 
+    $deleteResult = Invoke-Cli -Arguments @('--engine', $EngineProfile, 'delete', $localId)
+    Assert-CommandSucceeded -Result $deleteResult -Description "$EngineProfile delete"
+
+    $listAfterDeleteResult = Invoke-Cli -Arguments @('--engine', $EngineProfile, 'list', '--json', '--limit', '5')
+    Assert-CommandSucceeded -Result $listAfterDeleteResult -Description "$EngineProfile list after delete --json"
+    $listAfterDeleteJson = @($listAfterDeleteResult.StdOut | ConvertFrom-Json)
+    if ($listAfterDeleteJson.Count -ne 0) {
+        throw "$EngineProfile expected zero QSOs after delete but saw $($listAfterDeleteJson.Count)."
+    }
+
+    $getAfterDeleteResult = Invoke-Cli -Arguments @('--engine', $EngineProfile, 'get', $localId, '--json')
+    if ($getAfterDeleteResult.ExitCode -eq 0) {
+        throw "$EngineProfile get unexpectedly succeeded after delete for local id '$localId'."
+    }
+
     return [pscustomobject]@{
         EngineProfile = $EngineProfile
         EngineId = $expectedEngineId


### PR DESCRIPTION
## .NET engine protobuf response hardening

Follow-up to the merged multi-engine UI/spec work after a real DebugHost storage smoke test exposed a .NET engine gRPC bug.

### What failed

The DebugHost Storage Workbench could fail during cleanup with:
- `Cleanup: Delete verification failed`
- `Exception was thrown by handler`

Root cause: the .NET engine `DeleteQso` gRPC handler was assigning `null` to generated protobuf string fields on the success path. In generated C# protobuf types that throws `ArgumentNullException` during response materialization.

### Fixes

- **DeleteQso** now omits absent optional string fields instead of assigning `null`
- Hardened the same optional-field pattern in a related rig snapshot/test response path
- Added .NET tests that exercise the service-boundary success path for these responses
- Extended `tests\Run-EngineConformance.ps1` to actually execute **delete** and verify `get` returns `NotFound`
- Hardened `stop-qsoripper.ps1` around singleton/scalar state handling used by the conformance harness
- Updated `docs\architecture\engine-specification.md` to explicitly require omission of absent optional scalar proto fields instead of assigning `null`

### Why this matters

The spec already required delete semantics, but the process gap was real:
1. state-level unit tests did not cover protobuf response construction at the gRPC handler boundary
2. the conformance harness claimed CRUD coverage but never exercised `DeleteQso`

This PR closes both gaps.

### Validation

- `dotnet build src\dotnet\QsoRipper.slnx -c Release --nologo -v minimal --tl:off`
- `dotnet test src\dotnet\QsoRipper.slnx -c Release --no-build --nologo -v minimal --tl:off`
- `dotnet format src\dotnet\QsoRipper.slnx --verify-no-changes --verbosity minimal`
- `.\tests\Run-EngineConformance.ps1 -SkipBuild`
