### PR TITLE
gui: simplify chrome and fix settings path field

### DIFF
--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -149,37 +149,9 @@
         <Grid Grid.Row="0"
               MinHeight="44"
               Margin="10,6,10,6"
-              ColumnDefinitions="Auto,*,Auto"
+              ColumnDefinitions="*,Auto"
               ColumnSpacing="12">
-          <StackPanel Grid.Column="0"
-                      Orientation="Horizontal"
-                      Spacing="10"
-                      MaxWidth="520"
-                      ClipToBounds="True"
-                      VerticalAlignment="Center">
-            <TextBlock Text="QsoRipper"
-                       FontSize="13"
-                       FontWeight="SemiBold"
-                       VerticalAlignment="Center" />
-            <TextBlock Classes="commandCaption"
-                       Text="{Binding ActiveLogText}"
-                       ToolTip.Tip="{Binding ActiveLogText}"
-                       MaxWidth="120" />
-            <TextBlock Classes="commandCaption"
-                       Text="{Binding ActiveProfileText}"
-                       ToolTip.Tip="{Binding ActiveProfileText}"
-                       MaxWidth="120" />
-            <TextBlock Classes="commandCaption"
-                       Text="{Binding ActiveStationText}"
-                       ToolTip.Tip="{Binding ActiveStationText}"
-                       MaxWidth="120" />
-            <TextBlock Classes="commandCaption"
-                       Text="{Binding ActiveEngineText}"
-                       ToolTip.Tip="{Binding ActiveEngineText}"
-                       MaxWidth="220" />
-          </StackPanel>
-
-          <Grid Grid.Column="1"
+          <Grid Grid.Column="0"
                 ColumnDefinitions="Auto,*"
                 ColumnSpacing="8"
                 MinWidth="0"
@@ -217,7 +189,7 @@
             </ScrollViewer>
           </Grid>
 
-          <StackPanel Grid.Column="2"
+          <StackPanel Grid.Column="1"
                       Orientation="Horizontal"
                       Spacing="10"
                       VerticalAlignment="Center">
@@ -229,10 +201,6 @@
                     MinWidth="62"
                     MinHeight="28"
                     IsVisible="{Binding IsSetupIncomplete}" />
-            <TextBlock Classes="commandCaption"
-                       Text="{Binding RecentQsos.RefreshIndicatorText}"
-                       MaxWidth="140"
-                       TextTrimming="CharacterEllipsis" />
             <Button x:Name="SyncNowButton"
                     AutomationProperties.AutomationId="SyncNowButton"
                     Content="⟳ Sync"
@@ -240,13 +208,6 @@
                     MinHeight="28"
                     MinWidth="54"
                     ToolTip.Tip="Sync with QRZ (F6)" />
-            <TextBlock Text="{Binding CurrentUtcTime}"
-                       FontFamily="Cascadia Mono, Consolas, monospace"
-                       FontSize="12.5"
-                       FontWeight="SemiBold"
-                       VerticalAlignment="Center" />
-            <TextBlock Classes="commandCaption"
-                       Text="{Binding CurrentUtcDate}" />
             <Button x:Name="SortButton"
                     AutomationProperties.AutomationId="SortButton"
                     Content="Sort"
@@ -899,53 +860,29 @@
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1,0,0,0"
                 Padding="10,4">
-          <Grid ColumnDefinitions="*,Auto"
-                ColumnSpacing="12">
-            <StackPanel Orientation="Horizontal"
-                        Spacing="10"
-                        VerticalAlignment="Center"
-                        ClipToBounds="True">
-              <TextBlock Text="{Binding RecentQsos.CountStatusText}" FontSize="11.5" />
-              <TextBlock Text="|" Opacity="0.45" />
-              <TextBlock Text="{Binding RecentQsos.FilterStatusText}" FontSize="11.5" TextTrimming="CharacterEllipsis" />
-              <TextBlock Text="|" Opacity="0.45" />
-              <TextBlock Text="{Binding RecentQsos.SortStatusText}" FontSize="11.5" TextTrimming="CharacterEllipsis" />
-              <TextBlock Text="|" Opacity="0.45" />
-              <TextBlock Text="{Binding RecentQsos.EditStatusText}" FontSize="11.5" />
-              <TextBlock Text="|" Opacity="0.45" />
-              <TextBlock Text="{Binding RecentQsos.GridZoomStatusText}" FontSize="11.5" />
-              <TextBlock Text="|" Opacity="0.45" />
-              <TextBlock Text="{Binding ActiveStationText}" FontSize="11.5" TextTrimming="CharacterEllipsis" />
-              <TextBlock Text="|" Opacity="0.45" />
-              <TextBlock Text="{Binding RecentQsos.SyncSummaryText}"
-                         FontSize="11.5"
-                         TextTrimming="CharacterEllipsis"
-                         MaxWidth="200" />
-              <TextBlock Text="|" Opacity="0.45" />
-              <TextBlock Text="{Binding SyncStatusText}"
-                         FontSize="11.5"
-                         TextTrimming="CharacterEllipsis"
-                         MaxWidth="140" />
-              <TextBlock Text="|" Opacity="0.45" />
-              <TextBlock Text="{Binding AvailableEnginesText}"
-                         FontSize="11.5"
-                         TextTrimming="CharacterEllipsis"
-                         MaxWidth="170" />
-              <TextBlock Text="|" Opacity="0.45" />
-              <TextBlock Text="{Binding EngineSwitchStatusText}"
-                         FontSize="11.5"
-                         TextTrimming="CharacterEllipsis"
-                         ToolTip.Tip="{Binding EngineSwitchStatusText}"
-                         MaxWidth="220" />
-            </StackPanel>
-
-            <TextBlock Grid.Column="1"
-                       Text="Ctrl+Enter Log &#x2022; Ctrl+L Expand &#x2022; F1 Help &#x2022; F3 Grid &#x2022; F4 Search &#x2022; Ctrl+N Logger &#x2022; Ctrl+R Rig &#x2022; Ctrl+W Weather"
+          <StackPanel Orientation="Horizontal"
+                      Spacing="10"
+                      VerticalAlignment="Center"
+                      ClipToBounds="True">
+            <TextBlock Text="{Binding RecentQsos.CountStatusText}" FontSize="11.5" />
+            <TextBlock Text="|" Opacity="0.45" />
+            <TextBlock Text="{Binding RecentQsos.FilterStatusText}" FontSize="11.5" TextTrimming="CharacterEllipsis" />
+            <TextBlock Text="|" Opacity="0.45" />
+            <TextBlock Text="{Binding RecentQsos.SortStatusText}" FontSize="11.5" TextTrimming="CharacterEllipsis" />
+            <TextBlock Text="|" Opacity="0.45" />
+            <TextBlock Text="{Binding RecentQsos.EditStatusText}" FontSize="11.5" />
+            <TextBlock Text="|" Opacity="0.45" />
+            <TextBlock Text="{Binding SyncStatusText}"
                        FontSize="11.5"
-                       Opacity="0.68"
-                       VerticalAlignment="Center"
-                       HorizontalAlignment="Right" />
-          </Grid>
+                       TextTrimming="CharacterEllipsis"
+                       MaxWidth="140" />
+            <TextBlock Text="|" Opacity="0.45" />
+            <TextBlock Text="{Binding ActiveStationText}" FontSize="11.5" TextTrimming="CharacterEllipsis" MaxWidth="180" />
+            <TextBlock Text="|" Opacity="0.45" />
+            <TextBlock Text="{Binding ActiveProfileText}" FontSize="11.5" TextTrimming="CharacterEllipsis" MaxWidth="180" />
+            <TextBlock Text="|" Opacity="0.45" />
+            <TextBlock Text="{Binding ActiveEngineText}" FontSize="11.5" TextTrimming="CharacterEllipsis" MaxWidth="260" />
+          </StackPanel>
         </Border>
       </Grid>
 

--- a/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
@@ -386,7 +386,10 @@
                             IsVisible="{Binding HasChoices}" />
                   <TextBox Grid.Column="1"
                            Text="{Binding Value, Mode=TwoWay}"
-                           IsVisible="{Binding !HasChoices}" />
+                           IsVisible="{Binding !HasChoices}"
+                           TextWrapping="NoWrap"
+                           ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                           ToolTip.Tip="{Binding Value}" />
                 </Grid>
               </DataTemplate>
             </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- remove top-row metadata clutter beside search and keep search area left-aligned
- simplify bottom status bar and show station/profile/selected engine there
- remove duplicated sync/shortcut text from status area
- make settings persistence value textbox long-path friendly (no wrap, horizontal scroll, tooltip)

## Notes
- capture-avalonia verification for main window is updated
- settings smoke automation is currently flaky in this environment (CopyFromScreen handle invalid), but the settings tree confirms the Path field remains present and reachable