### PR TITLE
fix(dotnet-engine): persist QRZ XML password so callsign lookup works after restart

### DIFF
--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEnginePersistedState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEnginePersistedState.cs
@@ -7,6 +7,8 @@ internal sealed class ManagedEnginePersistedState
 {
     public string? QrzXmlUsername { get; set; }
 
+    public string? QrzXmlPassword { get; set; }
+
     public bool HasQrzXmlPassword { get; set; }
 
     public bool HasQrzLogbookApiKey { get; set; }

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -43,11 +43,12 @@ internal sealed class ManagedEngineState
 
     private readonly Lock _gate = new();
     private readonly IEngineStorage _storage;
-    private readonly ILookupCoordinator _lookupCoordinator;
+    private ILookupCoordinator _lookupCoordinator;
     private readonly RigControlMonitor? _rigControlMonitor;
     private readonly SpaceWeatherMonitor? _spaceWeatherMonitor;
     private readonly string _configPath;
     private string? _qrzXmlUsername;
+    private string? _qrzXmlPassword;
     private bool _hasQrzXmlPassword;
     private bool _hasQrzLogbookApiKey;
     private SyncConfig _syncConfig;
@@ -96,6 +97,7 @@ internal sealed class ManagedEngineState
         _syncEngine = syncEngine;
         var persisted = LoadPersistedState(_configPath);
         _qrzXmlUsername = NormalizeOptional(persisted.QrzXmlUsername);
+        _qrzXmlPassword = NormalizeOptional(persisted.QrzXmlPassword);
         _hasQrzXmlPassword = persisted.HasQrzXmlPassword;
         _hasQrzLogbookApiKey = persisted.HasQrzLogbookApiKey;
         _syncConfig = ParseProtoOrDefault<SyncConfig>(persisted.SyncConfigJson);
@@ -267,8 +269,10 @@ internal sealed class ManagedEngineState
 
             if (!string.IsNullOrWhiteSpace(request.QrzXmlPassword))
             {
+                _qrzXmlPassword = request.QrzXmlPassword.Trim();
                 _hasQrzXmlPassword = true;
                 _runtimeOverrides[QrzXmlPasswordKey] = "***";
+                RebuildLookupCoordinatorNoLock();
             }
 
             if (!string.IsNullOrWhiteSpace(request.QrzLogbookApiKey))
@@ -884,12 +888,21 @@ internal sealed class ManagedEngineState
                     case QrzXmlPasswordKey:
                         if (mutation.Kind == RuntimeConfigMutationKind.Clear)
                         {
+                            _qrzXmlPassword = null;
                             _hasQrzXmlPassword = false;
                             _runtimeOverrides.Remove(QrzXmlPasswordKey);
+                            RebuildLookupCoordinatorNoLock();
                         }
                         else
                         {
-                            _hasQrzXmlPassword = !string.IsNullOrWhiteSpace(mutation.Value);
+                            var newPassword = string.IsNullOrWhiteSpace(mutation.Value) ? null : mutation.Value.Trim();
+                            if (newPassword is not null && newPassword != "***")
+                            {
+                                _qrzXmlPassword = newPassword;
+                                RebuildLookupCoordinatorNoLock();
+                            }
+
+                            _hasQrzXmlPassword = _qrzXmlPassword is not null;
                             _runtimeOverrides[QrzXmlPasswordKey] = "***";
                         }
 
@@ -947,12 +960,15 @@ internal sealed class ManagedEngineState
             {
                 _runtimeOverrides.Clear();
                 _qrzXmlUsername = null;
+                _qrzXmlPassword = null;
                 _hasQrzXmlPassword = false;
                 _hasQrzLogbookApiKey = false;
                 if (_rigControl is not null)
                 {
                     _rigControl.Enabled = false;
                 }
+
+                RebuildLookupCoordinatorNoLock();
             }
             else
             {
@@ -968,8 +984,10 @@ internal sealed class ManagedEngineState
                             _runtimeOverrides.Remove(QrzXmlUsernameKey);
                             break;
                         case QrzXmlPasswordKey:
+                            _qrzXmlPassword = null;
                             _hasQrzXmlPassword = false;
                             _runtimeOverrides.Remove(QrzXmlPasswordKey);
+                            RebuildLookupCoordinatorNoLock();
                             break;
                         case QrzLogbookApiKeyKey:
                             _hasQrzLogbookApiKey = false;
@@ -1023,6 +1041,7 @@ internal sealed class ManagedEngineState
         var persisted = new ManagedEnginePersistedState
         {
             QrzXmlUsername = _qrzXmlUsername,
+            QrzXmlPassword = _qrzXmlPassword,
             HasQrzXmlPassword = _hasQrzXmlPassword,
             HasQrzLogbookApiKey = _hasQrzLogbookApiKey,
             SyncConfigJson = ProtoJsonFormatter.Format(_syncConfig),
@@ -1291,6 +1310,31 @@ internal sealed class ManagedEngineState
         }
 
         response.SyncSuccess = true;
+    }
+
+    private void RebuildLookupCoordinatorNoLock()
+    {
+        var username = Environment.GetEnvironmentVariable(QrzXmlUsernameKey)?.Trim()
+            ?? _qrzXmlUsername;
+        var password = Environment.GetEnvironmentVariable(QrzXmlPasswordKey)?.Trim()
+            ?? _qrzXmlPassword;
+
+        if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
+        {
+            // HttpClient is intentionally not disposed — it is a singleton owned by the provider for the app lifetime.
+#pragma warning disable CA2000 // Dispose objects before losing scope
+            var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(8) };
+#pragma warning restore CA2000
+            _lookupCoordinator = new LookupCoordinator(
+                new Lookup.Qrz.QrzXmlProvider(httpClient, username, password),
+                _storage.LookupSnapshots);
+        }
+        else
+        {
+            _lookupCoordinator = new LookupCoordinator(
+                new Lookup.Qrz.DisabledCallsignProvider(),
+                _storage.LookupSnapshots);
+        }
     }
 
     private static LookupCoordinator CreateDefaultCoordinator(IEngineStorage storage)

--- a/src/dotnet/QsoRipper.Engine.DotNet/Program.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/Program.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text.Json;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using QsoRipper.Engine.DotNet;
 using QsoRipper.Engine.Lookup;
@@ -19,7 +20,7 @@ builder.Services.AddGrpc();
 var storage = CreateStorage();
 builder.Services.AddSingleton(storage);
 
-var lookupCoordinator = CreateLookupCoordinator(storage);
+var lookupCoordinator = CreateLookupCoordinator(storage, options.ConfigPath);
 builder.Services.AddSingleton(lookupCoordinator);
 
 var rigControlMonitor = CreateRigControlMonitor();
@@ -83,10 +84,27 @@ static IEngineStorage CreateStorage()
     return new MemoryStorage();
 }
 
-static ILookupCoordinator CreateLookupCoordinator(IEngineStorage storage)
+static ILookupCoordinator CreateLookupCoordinator(IEngineStorage storage, string? configPath = null)
 {
     var username = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_XML_USERNAME")?.Trim();
     var password = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_XML_PASSWORD")?.Trim();
+
+    if ((string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password)) && configPath is not null)
+    {
+        var persisted = TryLoadPersistedConfig(configPath);
+        if (persisted is not null)
+        {
+            if (string.IsNullOrWhiteSpace(username))
+            {
+                username = persisted.QrzXmlUsername?.Trim();
+            }
+
+            if (string.IsNullOrWhiteSpace(password))
+            {
+                password = persisted.QrzXmlPassword?.Trim();
+            }
+        }
+    }
 
     ICallsignProvider provider;
     if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
@@ -182,6 +200,29 @@ static void ConfigureListenEndpoint(KestrelServerOptions options, string listenA
     }
 
     options.ListenAnyIP(port, configure => configure.Protocols = HttpProtocols.Http2);
+}
+
+static ManagedEnginePersistedState? TryLoadPersistedConfig(string configPath)
+{
+    try
+    {
+        if (!File.Exists(configPath))
+        {
+            return null;
+        }
+
+        var json = File.ReadAllText(configPath);
+        return JsonSerializer.Deserialize<ManagedEnginePersistedState>(json, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        });
+    }
+#pragma warning disable CA1031 // Do not catch general exception types
+    catch
+#pragma warning restore CA1031
+    {
+        return null;
+    }
 }
 
 internal sealed record ManagedEngineHostOptions(string ListenAddress, string ConfigPath)


### PR DESCRIPTION
Root cause analysis

The .NET engine callsign lookup silently failed on every startup after initial setup. Stream-lookup returned NotFound in 3 ms with no network call because the lookup coordinator was initialized with DisabledCallsignProvider instead of QrzXmlProvider.

The bug had two components:

1. The setup wizard discarded the real password. SaveSetup received the actual QRZ XML password from the client but stored only _hasQrzXmlPassword = true and a sentinel string (***) in the runtime overrides. The real password was never written to disk or held in memory past the end of SaveSetup.

2. Startup credentials came only from environment variables. CreateLookupCoordinator in Program.cs read only QSORIPPER_QRZ_XML_USERNAME and QSORIPPER_QRZ_XML_PASSWORD env vars. When those were absent, it fell through to DisabledCallsignProvider. There was no fallback to persisted config, so credentials entered through the setup wizard had zero effect on the next startup.

The result: every stream-lookup call hit DisabledCallsignProvider which returns NotFound immediately without any network attempt.

Fix

Three files changed:

ManagedEnginePersistedState.cs: add QrzXmlPassword field to the JSON model so the password survives process restarts.

ManagedEngineState.cs:
- Add _qrzXmlPassword field to hold the credential in memory.
- Load QrzXmlPassword from persisted state in the constructor.
- In SaveSetup, store the real password and call RebuildLookupCoordinatorNoLock() so lookup works immediately without a restart.
- Add RebuildLookupCoordinatorNoLock() which constructs QrzXmlProvider when both username and password are available, or falls back to DisabledCallsignProvider.
- Apply the same fix to ApplyRuntimeConfig and ResetRuntimeConfig so runtime credential mutations also take live effect and persist correctly.
- Remove readonly from _lookupCoordinator so it can be replaced at runtime.

Program.cs: extend CreateLookupCoordinator to accept the config path and fall back to the persisted QrzXmlPassword when env vars are absent, so a correctly configured engine always starts with a live QRZ provider.

After this fix, running setup once to provide credentials will persist them to dotnet-engine.json and activate lookup immediately. Subsequent restarts will read the persisted password and start with a live provider.