### PR TITLE
Define a shared durable setup/config model across engines and clients

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -976,7 +976,7 @@ The engine must start and function even when external integrations are unavailab
 
 ### 6.3 Configuration Persistence
 
-- Configuration is persisted as a TOML or JSON file in `QSORIPPER_CONFIG_PATH`.
+- Configuration is persisted as a shared TOML file in `QSORIPPER_CONFIG_PATH`.
 - The `SaveSetup` RPC writes configuration to this path.
 - On startup, the engine loads persisted configuration and overlays environment variable overrides (env vars take precedence).
 - Runtime config mutations (via `DeveloperControlService`) are ephemeral and do not persist across restarts unless explicitly saved.

--- a/src/dotnet/Directory.Packages.props
+++ b/src/dotnet/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
+    <PackageVersion Include="Tomlyn" Version="0.17.0" />
     <PackageVersion Include="ToListinator" Version="0.0.10" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
@@ -180,5 +180,16 @@ public sealed class CliUtilityTests
 
         Assert.Contains("space-weather [--refresh]", help, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void GetCommandHelp_setup_uses_qrz_xml_environment_names()
+    {
+        var help = CliHelpText.GetCommandHelp("setup");
+
+        Assert.Contains("QSORIPPER_QRZ_XML_USERNAME", help, StringComparison.Ordinal);
+        Assert.Contains("QSORIPPER_QRZ_XML_PASSWORD", help, StringComparison.Ordinal);
+        Assert.DoesNotContain("QSORIPPER_QRZ_USERNAME", help, StringComparison.Ordinal);
+        Assert.DoesNotContain("QSORIPPER_QRZ_PASSWORD", help, StringComparison.Ordinal);
+    }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -182,8 +182,8 @@ internal static class CliHelpText
                   QSORIPPER_OPERATOR_CALLSIGN     Operator callsign (defaults to station)
                   QSORIPPER_PROFILE_NAME          Profile name (defaults to "Default")
                   QSORIPPER_GRID                  Grid square
-                  QSORIPPER_QRZ_USERNAME          QRZ XML username (optional)
-                  QSORIPPER_QRZ_PASSWORD          QRZ XML password (optional)
+                  QSORIPPER_QRZ_XML_USERNAME      QRZ XML username (optional)
+                  QSORIPPER_QRZ_XML_PASSWORD      QRZ XML password (optional)
 
                 Examples:
                   setup                           Start the interactive wizard

--- a/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
@@ -78,8 +78,8 @@ internal static class SetupCommand
         var operatorCallsign = Environment.GetEnvironmentVariable("QSORIPPER_OPERATOR_CALLSIGN") ?? stationCallsign;
         var profileName = Environment.GetEnvironmentVariable("QSORIPPER_PROFILE_NAME") ?? "Default";
         var grid = Environment.GetEnvironmentVariable("QSORIPPER_GRID");
-        var qrzUsername = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_USERNAME");
-        var qrzPassword = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_PASSWORD");
+        var qrzUsername = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_XML_USERNAME");
+        var qrzPassword = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_XML_PASSWORD");
         var qrzLogbookApiKey = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_LOGBOOK_API_KEY");
         var autoSyncEnv = Environment.GetEnvironmentVariable("QSORIPPER_AUTO_SYNC");
         var syncIntervalEnv = Environment.GetEnvironmentVariable("QSORIPPER_SYNC_INTERVAL");

--- a/src/dotnet/QsoRipper.DebugHost.Tests/DebugWorkbenchStateTests.cs
+++ b/src/dotnet/QsoRipper.DebugHost.Tests/DebugWorkbenchStateTests.cs
@@ -30,6 +30,23 @@ public class DebugWorkbenchStateTests
     }
 
     [Fact]
+    public void Initializes_default_launcher_preview_without_storage_overrides()
+    {
+        var state = new DebugWorkbenchState(Options.Create(new DebugWorkbenchOptions
+        {
+            DefaultEngineEndpoint = "http://localhost:60051"
+        }));
+
+        Assert.Equal("http://localhost:60051", state.EngineEndpoint);
+        Assert.True(string.IsNullOrWhiteSpace(state.EngineStorageBackend));
+        Assert.Equal(Path.Combine(".", "data", "qsoripper.db"), state.EnginePersistenceLocation);
+        Assert.Contains("start-qsoripper.ps1", state.BuildEngineLaunchCommand(), StringComparison.Ordinal);
+        Assert.DoesNotContain("-Storage", state.BuildEngineLaunchCommand(), StringComparison.Ordinal);
+        Assert.DoesNotContain("-PersistenceLocation", state.BuildEngineLaunchCommand(), StringComparison.Ordinal);
+        Assert.Empty(state.GetEngineEnvironmentOverrides());
+    }
+
+    [Fact]
     public void Update_storage_options_switches_back_to_memory()
     {
         var state = new DebugWorkbenchState(Options.Create(new DebugWorkbenchOptions()));
@@ -71,6 +88,8 @@ public class DebugWorkbenchStateTests
         Assert.Contains("start-qsoripper.ps1", state.BuildEngineLaunchCommand(), StringComparison.Ordinal);
         Assert.Contains("-Engine local-dotnet", state.BuildEngineLaunchCommand(), StringComparison.Ordinal);
         Assert.Contains("-ListenAddress 127.0.0.1:50052", state.BuildEngineLaunchCommand(), StringComparison.Ordinal);
+        Assert.DoesNotContain("-Storage", state.BuildEngineLaunchCommand(), StringComparison.Ordinal);
+        Assert.Empty(state.GetEngineEnvironmentOverrides());
     }
 
     [Fact]
@@ -194,7 +213,7 @@ public class DebugWorkbenchStateTests
 
         Assert.NotNull(state.SetupStatus);
         Assert.Null(state.SetupErrorMessage);
-        Assert.Equal("memory", state.EngineStorageBackend);
+        Assert.True(string.IsNullOrWhiteSpace(state.EngineStorageBackend));
         Assert.Equal(@".\data\portable-qsoripper.db", state.EnginePersistenceLocation);
     }
 

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/Engine.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/Engine.razor
@@ -984,7 +984,7 @@
     <div class="card-body">
         <h2 class="h5">Local launcher preview</h2>
         <div class="small text-muted mb-2">
-            The command below uses the repo launcher helper for the selected engine profile. Profiles that support storage-session overrides reflect the storage state configured on this page.
+            The command below uses the repo launcher helper for the selected engine profile. The environment block only includes explicit overrides, so the shared config file remains the default source of durable storage selection.
         </div>
         <pre class="payload-view">@WorkbenchState.BuildEngineLaunchCommand()</pre>
         <div class="small text-muted mt-2 mb-1">Equivalent environment</div>

--- a/src/dotnet/QsoRipper.DebugHost/Models/DebugWorkbenchOptions.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Models/DebugWorkbenchOptions.cs
@@ -12,7 +12,7 @@ internal sealed class DebugWorkbenchOptions
 
     public string DefaultEngineEndpoint { get; set; } = string.Empty;
 
-    public string DefaultEngineStorageBackend { get; set; } = "memory";
+    public string DefaultEngineStorageBackend { get; set; } = string.Empty;
 
     public string DefaultEnginePersistenceLocation { get; set; } = PersistenceSetup.DefaultRelativePersistencePath;
 

--- a/src/dotnet/QsoRipper.DebugHost/Services/DebugWorkbenchState.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Services/DebugWorkbenchState.cs
@@ -423,7 +423,7 @@ internal sealed class DebugWorkbenchState
     private static string NormalizeStorageBackend(string? configuredBackend)
     {
         return string.IsNullOrWhiteSpace(configuredBackend)
-            ? "memory"
+            ? string.Empty
             : configuredBackend.Trim();
     }
 
@@ -465,7 +465,8 @@ internal sealed class DebugWorkbenchState
             ? string.Empty
             : recipe.DefaultConfigPath;
         var persistenceLocation = EnginePersistenceLocation;
-        var enginePersistenceLocation = string.Equals(EngineStorageBackend, "memory", StringComparison.OrdinalIgnoreCase)
+        var enginePersistenceLocation = string.IsNullOrWhiteSpace(EngineStorageBackend)
+            || string.Equals(EngineStorageBackend, "memory", StringComparison.OrdinalIgnoreCase)
             ? string.Empty
             : EnginePersistenceLocation;
 

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -1,3 +1,5 @@
+using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
@@ -69,7 +71,7 @@ public sealed class ManagedEngineStateTests : IDisposable
 
         var runtime = state.GetRuntimeConfigSnapshot();
         var profiles = state.ListStationProfiles();
-        var persistedJson = File.ReadAllText(Path.Combine(_tempDirectory, "managed-engine.json"));
+        var persistedConfig = File.ReadAllText(Path.Combine(_tempDirectory, "config.toml"));
 
         Assert.True(response.Status.SetupComplete);
         Assert.True(response.Status.ConfigFileExists);
@@ -90,7 +92,7 @@ public sealed class ManagedEngineStateTests : IDisposable
         Assert.Equal("***", passwordValue.DisplayValue);
         Assert.True(passwordValue.Secret);
         Assert.True(passwordValue.Redacted);
-        Assert.DoesNotContain("\"logFilePath\"", persistedJson, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("log_file_path", persistedConfig, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -154,7 +156,134 @@ public sealed class ManagedEngineStateTests : IDisposable
             }
         ]));
 
-        Assert.Equal("The managed .NET engine currently supports only memory storage.", exception.Message);
+        Assert.Equal("The managed .NET engine storage backend is fixed at startup. Restart the engine to use 'sqlite'.", exception.Message);
+    }
+
+    [Fact]
+    public void Runtime_overrides_and_session_override_do_not_persist_across_restart()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            QrzXmlUsername = "k7rnd",
+            QrzXmlPassword = "secret",
+            QrzLogbookApiKey = "api-key",
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87"
+            }
+        });
+
+        state.ApplyRuntimeConfig(
+        [
+            new RuntimeConfigMutation
+            {
+                Key = "QSORIPPER_QRZ_XML_USERNAME",
+                Kind = RuntimeConfigMutationKind.Set,
+                Value = "runtime-user"
+            },
+            new RuntimeConfigMutation
+            {
+                Key = "QSORIPPER_QRZ_XML_PASSWORD",
+                Kind = RuntimeConfigMutationKind.Set,
+                Value = "runtime-secret"
+            },
+            new RuntimeConfigMutation
+            {
+                Key = "QSORIPPER_QRZ_LOGBOOK_API_KEY",
+                Kind = RuntimeConfigMutationKind.Clear
+            }
+        ]);
+
+        state.SetSessionStationProfileOverride(new StationProfile
+        {
+            ProfileName = "Field Day",
+            StationCallsign = "W7FD",
+            OperatorCallsign = "W7FD",
+            Grid = "CN85"
+        });
+
+        var restarted = CreateState();
+        var status = restarted.GetSetupStatus();
+        var runtime = restarted.GetRuntimeConfigSnapshot();
+        var context = restarted.GetActiveStationContext();
+
+        Assert.Equal("k7rnd", status.QrzXmlUsername);
+        Assert.True(status.HasQrzXmlPassword);
+        Assert.True(status.HasQrzLogbookApiKey);
+        Assert.False(context.HasSessionOverride);
+        Assert.Equal("K7RND", context.EffectiveActiveProfile.StationCallsign);
+        Assert.Equal(
+            "k7rnd",
+            runtime.Values.Single(value => value.Key == "QSORIPPER_QRZ_XML_USERNAME").DisplayValue);
+        Assert.True(
+            runtime.Values.Single(value => value.Key == "QSORIPPER_QRZ_LOGBOOK_API_KEY").HasValue);
+    }
+
+    [Fact]
+    public void Save_setup_rebuilds_owned_sync_client_without_leaking_previous_http_client()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            QrzLogbookApiKey = "api-key"
+        });
+
+        var originalSyncEngine = GetRequiredPrivateField<QrzSyncEngine>(state, "_syncEngine");
+        var originalHttpClient = GetOwnedSyncHttpClient(originalSyncEngine);
+        Assert.False(IsHttpClientDisposed(originalHttpClient));
+
+        state.SaveSetup(new SaveSetupRequest
+        {
+            QrzLogbookApiKey = "replacement-key"
+        });
+
+        Assert.True(IsHttpClientDisposed(originalHttpClient));
+    }
+
+    [Fact]
+    public void Migrates_legacy_json_config_to_shared_toml()
+    {
+        var legacyPath = Path.Combine(_tempDirectory, "dotnet-engine.json");
+        var configPath = Path.Combine(_tempDirectory, "config.toml");
+        File.WriteAllText(
+            legacyPath,
+            """
+            {
+              "qrzXmlUsername": "k7rnd",
+              "qrzXmlPassword": "secret",
+              "hasQrzXmlPassword": true,
+              "activeProfileId": "home",
+              "stationProfiles": [
+                {
+                  "profileId": "home",
+                  "profileJson": "{ \"profileName\": \"Home\", \"stationCallsign\": \"K7RND\", \"operatorCallsign\": \"K7RND\", \"grid\": \"CN87\" }"
+                }
+              ],
+              "runtimeOverrides": {
+                "QSORIPPER_QRZ_XML_USERNAME": "runtime-user"
+              },
+              "sessionOverrideProfileJson": "{ \"profileName\": \"Field\", \"stationCallsign\": \"W7FD\", \"operatorCallsign\": \"W7FD\", \"grid\": \"CN85\" }"
+            }
+            """);
+
+        var state = CreateState();
+        var status = state.GetSetupStatus();
+        var context = state.GetActiveStationContext();
+        var persistedConfig = File.ReadAllText(configPath);
+
+        Assert.True(File.Exists(configPath));
+        Assert.Contains("active_profile_id = \"home\"", persistedConfig, StringComparison.Ordinal);
+        Assert.Contains("station_callsign = \"K7RND\"", persistedConfig, StringComparison.Ordinal);
+        Assert.DoesNotContain("runtimeOverrides", persistedConfig, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("sessionOverrideProfileJson", persistedConfig, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("k7rnd", status.QrzXmlUsername);
+        Assert.True(status.HasQrzXmlPassword);
+        Assert.Equal("K7RND", status.StationProfile.StationCallsign);
+        Assert.False(context.HasSessionOverride);
     }
 
     [Fact]
@@ -437,7 +566,7 @@ public sealed class ManagedEngineStateTests : IDisposable
 
     private ManagedEngineState CreateState()
     {
-        return new ManagedEngineState(Path.Combine(_tempDirectory, "managed-engine.json"), new MemoryStorage());
+        return new ManagedEngineState(Path.Combine(_tempDirectory, "config.toml"), new MemoryStorage());
     }
 
     private ManagedEngineState CreateStateWithSync()
@@ -446,7 +575,7 @@ public sealed class ManagedEngineStateTests : IDisposable
         var fakeApi = new FakeQrzLogbookApi();
         var syncEngine = new QrzSyncEngine(fakeApi);
         return new ManagedEngineState(
-            Path.Combine(_tempDirectory, "managed-engine.json"),
+            Path.Combine(_tempDirectory, "config.toml"),
             storage,
             lookupCoordinator: null,
             rigControlMonitor: null,
@@ -461,7 +590,7 @@ public sealed class ManagedEngineStateTests : IDisposable
             new FakeRigControlProvider(() => snapshot.Clone()),
             TimeSpan.Zero);
         return new ManagedEngineState(
-            Path.Combine(_tempDirectory, "managed-engine.json"),
+            Path.Combine(_tempDirectory, "config.toml"),
             storage,
             lookupCoordinator: null,
             rigControlMonitor: monitor,
@@ -472,6 +601,40 @@ public sealed class ManagedEngineStateTests : IDisposable
     private static byte[] Utf8(string value)
     {
         return Encoding.UTF8.GetBytes(value);
+    }
+
+    private static HttpClient GetOwnedSyncHttpClient(QrzSyncEngine syncEngine)
+    {
+        var api = GetRequiredPrivateFieldValue(syncEngine, "_client");
+        return GetRequiredPrivateField<HttpClient>(api, "_httpClient");
+    }
+
+    private static bool IsHttpClientDisposed(HttpClient client)
+    {
+        var disposedField = typeof(HttpMessageInvoker).GetField("_disposed", BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("Could not locate HttpMessageInvoker._disposed.");
+
+        return disposedField.GetValue(client) is true;
+    }
+
+    private static T GetRequiredPrivateField<T>(object instance, string fieldName)
+        where T : class
+    {
+        return Assert.IsType<T>(GetRequiredPrivateFieldValue(instance, fieldName));
+    }
+
+    private static object GetRequiredPrivateFieldValue(object instance, string fieldName)
+    {
+        ArgumentNullException.ThrowIfNull(instance);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fieldName);
+
+        var field = instance.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException(
+                $"Could not locate field '{fieldName}' on {instance.GetType().FullName}.");
+
+        return field.GetValue(instance)
+            ?? throw new InvalidOperationException(
+                $"Field '{fieldName}' on {instance.GetType().FullName} was null.");
     }
 
     private sealed class FakeRigControlProvider(Func<RigSnapshot> factory) : IRigControlProvider

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -1,5 +1,3 @@
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -18,25 +16,19 @@ namespace QsoRipper.Engine.DotNet;
 internal sealed class ManagedEngineState
 {
     private const string PersistenceStepDescription = "The managed .NET engine keeps its logbook in memory. No persistence input is required during setup.";
-    private const string PersistenceStepDescriptionSqlite = "The managed .NET engine stores its logbook in a local SQLite database.";
+    private const string PersistenceStepDescriptionSqlite = "The managed .NET engine stores its logbook in a local SQLite database backed by shared setup.";
     private const string PersistenceStepLabel = "Storage";
-    private const string PersistenceSummary = "In-memory logbook";
+    private const string InMemoryPersistenceSummary = "In-memory logbook";
+    private const string SqlitePersistenceSummary = "SQLite logbook";
 
     private const string StorageBackendKey = "QSORIPPER_STORAGE_BACKEND";
     private const string QrzXmlUsernameKey = "QSORIPPER_QRZ_XML_USERNAME";
     private const string QrzXmlPasswordKey = "QSORIPPER_QRZ_XML_PASSWORD";
+    private const string QrzUserAgentKey = "QSORIPPER_QRZ_USER_AGENT";
     private const string QrzLogbookApiKeyKey = "QSORIPPER_QRZ_LOGBOOK_API_KEY";
     private const string RigEnabledKey = "QSORIPPER_RIGCTLD_ENABLED";
 
     private const string ManagedLookupProviderSummary = "Managed sample provider";
-    private const string ManagedStorageBackend = "memory";
-
-    private static readonly JsonSerializerOptions SerializerOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-    };
 
     private static readonly JsonFormatter ProtoJsonFormatter = new(JsonFormatter.Settings.Default.WithFormatDefaultValues(true));
     private static readonly JsonParser ProtoJsonParser = new(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
@@ -47,9 +39,12 @@ internal sealed class ManagedEngineState
     private readonly RigControlMonitor? _rigControlMonitor;
     private readonly SpaceWeatherMonitor? _spaceWeatherMonitor;
     private readonly string _configPath;
+    private readonly SharedPersistedSetupConfig _persistedSetup;
+    private readonly string? _currentPersistenceLocation;
     private string? _qrzXmlUsername;
     private string? _qrzXmlPassword;
     private bool _hasQrzXmlPassword;
+    private string? _qrzLogbookApiKey;
     private bool _hasQrzLogbookApiKey;
     private SyncConfig _syncConfig;
     private RigControlSettings? _rigControl;
@@ -57,7 +52,9 @@ internal sealed class ManagedEngineState
     private string? _activeProfileId;
     private StationProfile? _sessionOverrideProfile;
     private readonly Dictionary<string, string> _runtimeOverrides;
-    private readonly QrzSyncEngine? _syncEngine;
+    private readonly bool _ownsSyncEngine;
+    private QrzLogbookClient? _ownedSyncClient;
+    private QrzSyncEngine? _syncEngine;
 
     public ManagedEngineState(string configPath)
         : this(configPath, new MemoryStorage(), null, null, null, null)
@@ -80,11 +77,16 @@ internal sealed class ManagedEngineState
     }
 
     public ManagedEngineState(string configPath, IEngineStorage storage, ILookupCoordinator? lookupCoordinator, RigControlMonitor? rigControlMonitor, SpaceWeatherMonitor? spaceWeatherMonitor)
-        : this(configPath, storage, lookupCoordinator, rigControlMonitor, spaceWeatherMonitor, null)
+        : this(configPath, storage, lookupCoordinator, rigControlMonitor, spaceWeatherMonitor, null, null, null)
     {
     }
 
     public ManagedEngineState(string configPath, IEngineStorage storage, ILookupCoordinator? lookupCoordinator, RigControlMonitor? rigControlMonitor, SpaceWeatherMonitor? spaceWeatherMonitor, QrzSyncEngine? syncEngine)
+        : this(configPath, storage, lookupCoordinator, rigControlMonitor, spaceWeatherMonitor, syncEngine, null, null)
+    {
+    }
+
+    public ManagedEngineState(string configPath, IEngineStorage storage, ILookupCoordinator? lookupCoordinator, RigControlMonitor? rigControlMonitor, SpaceWeatherMonitor? spaceWeatherMonitor, QrzSyncEngine? syncEngine, string? currentPersistenceLocation, LoadedSharedSetupConfig? loadedPersistedSetup)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
         ArgumentNullException.ThrowIfNull(storage);
@@ -94,20 +96,43 @@ internal sealed class ManagedEngineState
         _lookupCoordinator = lookupCoordinator ?? CreateDefaultCoordinator(storage);
         _rigControlMonitor = rigControlMonitor;
         _spaceWeatherMonitor = spaceWeatherMonitor;
+        _ownsSyncEngine = syncEngine is null;
         _syncEngine = syncEngine;
-        var persisted = LoadPersistedState(_configPath);
-        _qrzXmlUsername = NormalizeOptional(persisted.QrzXmlUsername);
-        _qrzXmlPassword = NormalizeOptional(persisted.QrzXmlPassword);
-        _hasQrzXmlPassword = persisted.HasQrzXmlPassword;
-        _hasQrzLogbookApiKey = persisted.HasQrzLogbookApiKey;
-        _syncConfig = ParseProtoOrDefault<SyncConfig>(persisted.SyncConfigJson);
-        _rigControl = ParseOptionalProto<RigControlSettings>(persisted.RigControlJson);
-        _stationProfiles = persisted.StationProfiles.ToList();
-        _activeProfileId = NormalizeOptional(persisted.ActiveProfileId);
-        _sessionOverrideProfile = ParseOptionalProto<StationProfile>(persisted.SessionOverrideProfileJson);
-        _runtimeOverrides = new Dictionary<string, string>(persisted.RuntimeOverrides, StringComparer.OrdinalIgnoreCase);
+        var loadedSetup = loadedPersistedSetup ?? SharedSetupConfigPersistence.Load(_configPath);
+        _persistedSetup = loadedSetup.Config;
+        _currentPersistenceLocation = NormalizeOptional(currentPersistenceLocation)
+            ?? (_storage.BackendName.Equals("sqlite", StringComparison.OrdinalIgnoreCase)
+                ? NormalizeOptional(_persistedSetup.GetPersistedLogFilePath())
+                : null);
+        _qrzXmlUsername = NormalizeOptional(_persistedSetup.QrzXmlUsername);
+        _qrzXmlPassword = NormalizeOptional(_persistedSetup.QrzXmlPassword);
+        _hasQrzXmlPassword = _qrzXmlPassword is not null;
+        _qrzLogbookApiKey = NormalizeOptional(_persistedSetup.QrzLogbookApiKey);
+        _hasQrzLogbookApiKey = _qrzLogbookApiKey is not null;
+        _syncConfig = _persistedSetup.SyncConfig.Clone();
+        _rigControl = _persistedSetup.RigControl?.Clone();
+        _stationProfiles = _persistedSetup.StationProfiles
+            .Select(static entry => new ManagedPersistedStationProfile
+            {
+                ProfileId = entry.ProfileId,
+                ProfileJson = entry.ProfileJson,
+            })
+            .ToList();
+        _activeProfileId = NormalizeOptional(_persistedSetup.ActiveProfileId);
+        _sessionOverrideProfile = null;
+        _runtimeOverrides = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
-        if (persisted.LastSyncUtc is { } lastSync)
+        if (lookupCoordinator is null)
+        {
+            RebuildLookupCoordinatorNoLock();
+        }
+
+        if (_ownsSyncEngine)
+        {
+            RebuildSyncEngineNoLock();
+        }
+
+        if (loadedSetup.LastSyncUtc is { } lastSync)
         {
             Sync(_storage.Logbook.UpsertSyncMetadataAsync(new SyncMetadata { LastSync = lastSync }));
         }
@@ -265,37 +290,47 @@ internal sealed class ManagedEngineState
             if (!string.IsNullOrWhiteSpace(request.QrzXmlUsername))
             {
                 _qrzXmlUsername = request.QrzXmlUsername.Trim();
+                _persistedSetup.QrzXmlUsername = _qrzXmlUsername;
+                _runtimeOverrides.Remove(QrzXmlUsernameKey);
+                RebuildLookupCoordinatorNoLock();
             }
 
             if (!string.IsNullOrWhiteSpace(request.QrzXmlPassword))
             {
                 _qrzXmlPassword = request.QrzXmlPassword.Trim();
                 _hasQrzXmlPassword = true;
-                _runtimeOverrides[QrzXmlPasswordKey] = "***";
+                _persistedSetup.QrzXmlPassword = _qrzXmlPassword;
+                _runtimeOverrides.Remove(QrzXmlPasswordKey);
                 RebuildLookupCoordinatorNoLock();
             }
 
             if (!string.IsNullOrWhiteSpace(request.QrzLogbookApiKey))
             {
+                _qrzLogbookApiKey = request.QrzLogbookApiKey.Trim();
                 _hasQrzLogbookApiKey = true;
-                _runtimeOverrides[QrzLogbookApiKeyKey] = "***";
+                _persistedSetup.QrzLogbookApiKey = _qrzLogbookApiKey;
+                _runtimeOverrides.Remove(QrzLogbookApiKeyKey);
+                if (_ownsSyncEngine)
+                {
+                    RebuildSyncEngineNoLock();
+                }
             }
 
             if (request.SyncConfig is not null)
             {
                 _syncConfig = request.SyncConfig.Clone();
+                _persistedSetup.SyncConfig = _syncConfig.Clone();
             }
 
             if (request.RigControl is not null)
             {
                 _rigControl = request.RigControl.Clone();
+                _persistedSetup.RigControl = _rigControl.Clone();
             }
 
-            _runtimeOverrides[StorageBackendKey] = ManagedStorageBackend;
-            if (!string.IsNullOrWhiteSpace(_qrzXmlUsername))
-            {
-                _runtimeOverrides[QrzXmlUsernameKey] = _qrzXmlUsername;
-            }
+            UpdatePersistedStorageSettingsNoLock(request);
+            SyncPersistedProfilesNoLock();
+            _runtimeOverrides.Remove(StorageBackendKey);
 
             PersistNoLock();
             return new SaveSetupResponse
@@ -345,6 +380,7 @@ internal sealed class ManagedEngineState
             var profile = request.Profile ?? throw new InvalidOperationException("profile is required.");
             var profileId = NormalizeProfileIdOrDefault(request.ProfileId, profile.ProfileName, profile.StationCallsign);
             var record = SaveStationProfileNoLock(profileId, profile, request.MakeActive);
+            SyncPersistedProfilesNoLock();
             PersistNoLock();
 
             var response = new SaveStationProfileResponse
@@ -373,6 +409,7 @@ internal sealed class ManagedEngineState
             }
 
             _activeProfileId = stored.ProfileId;
+            SyncPersistedProfilesNoLock();
             PersistNoLock();
             return BuildStationProfileRecordNoLock(stored);
         }
@@ -392,6 +429,7 @@ internal sealed class ManagedEngineState
             var removed = _stationProfiles.RemoveAll(entry => string.Equals(entry.ProfileId, profileId.Trim(), StringComparison.Ordinal));
             if (removed > 0)
             {
+                SyncPersistedProfilesNoLock();
                 PersistNoLock();
                 return true;
             }
@@ -415,7 +453,6 @@ internal sealed class ManagedEngineState
         lock (_gate)
         {
             _sessionOverrideProfile = profile.Clone();
-            PersistNoLock();
             return BuildActiveStationContextNoLock();
         }
     }
@@ -425,7 +462,6 @@ internal sealed class ManagedEngineState
         lock (_gate)
         {
             _sessionOverrideProfile = null;
-            PersistNoLock();
             return BuildActiveStationContextNoLock();
         }
     }
@@ -875,22 +911,24 @@ internal sealed class ManagedEngineState
                 {
                     case StorageBackendKey:
                         if (mutation.Kind == RuntimeConfigMutationKind.Set
-                            && !string.Equals(mutation.Value, ManagedStorageBackend, StringComparison.OrdinalIgnoreCase))
+                            && !string.Equals(mutation.Value, _storage.BackendName, StringComparison.OrdinalIgnoreCase))
                         {
-                            throw new InvalidOperationException("The managed .NET engine currently supports only memory storage.");
+                            throw new InvalidOperationException(
+                                $"The managed .NET engine storage backend is fixed at startup. Restart the engine to use '{mutation.Value}'.");
                         }
 
-                        _runtimeOverrides[StorageBackendKey] = ManagedStorageBackend;
+                        _runtimeOverrides.Remove(StorageBackendKey);
                         break;
                     case QrzXmlUsernameKey:
                         ApplyStringOverrideNoLock(QrzXmlUsernameKey, mutation, value => _qrzXmlUsername = NormalizeOptional(value));
+                        RebuildLookupCoordinatorNoLock();
                         break;
                     case QrzXmlPasswordKey:
                         if (mutation.Kind == RuntimeConfigMutationKind.Clear)
                         {
                             _qrzXmlPassword = null;
                             _hasQrzXmlPassword = false;
-                            _runtimeOverrides.Remove(QrzXmlPasswordKey);
+                            _runtimeOverrides[QrzXmlPasswordKey] = string.Empty;
                             RebuildLookupCoordinatorNoLock();
                         }
                         else
@@ -910,22 +948,28 @@ internal sealed class ManagedEngineState
                     case QrzLogbookApiKeyKey:
                         if (mutation.Kind == RuntimeConfigMutationKind.Clear)
                         {
+                            _qrzLogbookApiKey = null;
                             _hasQrzLogbookApiKey = false;
-                            _runtimeOverrides.Remove(QrzLogbookApiKeyKey);
+                            _runtimeOverrides[QrzLogbookApiKeyKey] = string.Empty;
                         }
                         else
                         {
-                            _hasQrzLogbookApiKey = !string.IsNullOrWhiteSpace(mutation.Value);
-                            _runtimeOverrides[QrzLogbookApiKeyKey] = "***";
+                            _qrzLogbookApiKey = string.IsNullOrWhiteSpace(mutation.Value) ? null : mutation.Value.Trim();
+                            _hasQrzLogbookApiKey = _qrzLogbookApiKey is not null;
+                            _runtimeOverrides[QrzLogbookApiKeyKey] = _hasQrzLogbookApiKey ? "***" : string.Empty;
                         }
 
+                        if (_ownsSyncEngine)
+                        {
+                            RebuildSyncEngineNoLock();
+                        }
                         break;
                     case RigEnabledKey:
                         if (mutation.Kind == RuntimeConfigMutationKind.Clear)
                         {
                             _rigControl ??= new RigControlSettings();
                             _rigControl.Enabled = false;
-                            _runtimeOverrides.Remove(RigEnabledKey);
+                            _runtimeOverrides[RigEnabledKey] = string.Empty;
                         }
                         else if (bool.TryParse(mutation.Value, out var enabled))
                         {
@@ -944,7 +988,6 @@ internal sealed class ManagedEngineState
                 }
             }
 
-            PersistNoLock();
             return BuildRuntimeConfigSnapshotNoLock();
         }
     }
@@ -959,16 +1002,17 @@ internal sealed class ManagedEngineState
             if (normalizedKeys.Length == 0)
             {
                 _runtimeOverrides.Clear();
-                _qrzXmlUsername = null;
-                _qrzXmlPassword = null;
-                _hasQrzXmlPassword = false;
-                _hasQrzLogbookApiKey = false;
-                if (_rigControl is not null)
-                {
-                    _rigControl.Enabled = false;
-                }
-
+                _qrzXmlUsername = NormalizeOptional(_persistedSetup.QrzXmlUsername);
+                _qrzXmlPassword = NormalizeOptional(_persistedSetup.QrzXmlPassword);
+                _hasQrzXmlPassword = _qrzXmlPassword is not null;
+                _qrzLogbookApiKey = NormalizeOptional(_persistedSetup.QrzLogbookApiKey);
+                _hasQrzLogbookApiKey = _qrzLogbookApiKey is not null;
+                _rigControl = _persistedSetup.RigControl?.Clone();
                 RebuildLookupCoordinatorNoLock();
+                if (_ownsSyncEngine)
+                {
+                    RebuildSyncEngineNoLock();
+                }
             }
             else
             {
@@ -977,25 +1021,30 @@ internal sealed class ManagedEngineState
                     switch (key)
                     {
                         case StorageBackendKey:
-                            _runtimeOverrides[StorageBackendKey] = ManagedStorageBackend;
+                            _runtimeOverrides.Remove(StorageBackendKey);
                             break;
                         case QrzXmlUsernameKey:
-                            _qrzXmlUsername = null;
+                            _qrzXmlUsername = NormalizeOptional(_persistedSetup.QrzXmlUsername);
                             _runtimeOverrides.Remove(QrzXmlUsernameKey);
+                            RebuildLookupCoordinatorNoLock();
                             break;
                         case QrzXmlPasswordKey:
-                            _qrzXmlPassword = null;
-                            _hasQrzXmlPassword = false;
+                            _qrzXmlPassword = NormalizeOptional(_persistedSetup.QrzXmlPassword);
+                            _hasQrzXmlPassword = _qrzXmlPassword is not null;
                             _runtimeOverrides.Remove(QrzXmlPasswordKey);
                             RebuildLookupCoordinatorNoLock();
                             break;
                         case QrzLogbookApiKeyKey:
-                            _hasQrzLogbookApiKey = false;
+                            _qrzLogbookApiKey = NormalizeOptional(_persistedSetup.QrzLogbookApiKey);
+                            _hasQrzLogbookApiKey = _qrzLogbookApiKey is not null;
                             _runtimeOverrides.Remove(QrzLogbookApiKeyKey);
+                            if (_ownsSyncEngine)
+                            {
+                                RebuildSyncEngineNoLock();
+                            }
                             break;
                         case RigEnabledKey:
-                            _rigControl ??= new RigControlSettings();
-                            _rigControl.Enabled = false;
+                            _rigControl = _persistedSetup.RigControl?.Clone();
                             _runtimeOverrides.Remove(RigEnabledKey);
                             break;
                         default:
@@ -1004,107 +1053,81 @@ internal sealed class ManagedEngineState
                 }
             }
 
-            PersistNoLock();
             return BuildRuntimeConfigSnapshotNoLock();
         }
     }
 
-    private static ManagedEnginePersistedState LoadPersistedState(string configPath)
-    {
-        if (!File.Exists(configPath))
-        {
-            return new ManagedEnginePersistedState
-            {
-                SyncConfigJson = ProtoJsonFormatter.Format(new SyncConfig
-                {
-                    AutoSyncEnabled = false,
-                    SyncIntervalSeconds = 300,
-                    ConflictPolicy = ConflictPolicy.LastWriteWins,
-                })
-            };
-        }
-
-        var json = File.ReadAllText(configPath);
-        return JsonSerializer.Deserialize<ManagedEnginePersistedState>(json, SerializerOptions)
-            ?? new ManagedEnginePersistedState();
-    }
-
     private void PersistNoLock()
     {
-        var directory = Path.GetDirectoryName(_configPath);
-        if (!string.IsNullOrWhiteSpace(directory))
-        {
-            Directory.CreateDirectory(directory);
-        }
-
-        var syncMeta = Sync(_storage.Logbook.GetSyncMetadataAsync());
-        var persisted = new ManagedEnginePersistedState
-        {
-            QrzXmlUsername = _qrzXmlUsername,
-            QrzXmlPassword = _qrzXmlPassword,
-            HasQrzXmlPassword = _hasQrzXmlPassword,
-            HasQrzLogbookApiKey = _hasQrzLogbookApiKey,
-            SyncConfigJson = ProtoJsonFormatter.Format(_syncConfig),
-            RigControlJson = _rigControl is null ? null : ProtoJsonFormatter.Format(_rigControl),
-            ActiveProfileId = _activeProfileId,
-            SessionOverrideProfileJson = _sessionOverrideProfile is null ? null : ProtoJsonFormatter.Format(_sessionOverrideProfile),
-            LastSyncUtc = syncMeta.LastSync,
-        };
-
-        foreach (var entry in _stationProfiles)
-        {
-            persisted.StationProfiles.Add(new ManagedPersistedStationProfile
-            {
-                ProfileId = entry.ProfileId,
-                ProfileJson = entry.ProfileJson,
-            });
-        }
-
-        foreach (var entry in _runtimeOverrides)
-        {
-            persisted.RuntimeOverrides[entry.Key] = entry.Value;
-        }
-
-        File.WriteAllText(_configPath, JsonSerializer.Serialize(persisted, SerializerOptions));
+        SharedSetupConfigPersistence.Save(_configPath, _persistedSetup);
     }
 
     private SetupStatus BuildSetupStatusNoLock()
     {
-        var isSqlite = string.Equals(_storage.BackendName, "sqlite", StringComparison.OrdinalIgnoreCase);
+        var isSqlite = IsSqliteBackendNoLock();
+        var persistedProfile = GetPersistedActiveProfileNoLock() ?? new StationProfile();
+        var persistedPath = NormalizeOptional(_persistedSetup.GetPersistedLogFilePath())
+            ?? (isSqlite ? NormalizeOptional(_currentPersistenceLocation) : null);
         var status = new SetupStatus
         {
             ConfigFileExists = File.Exists(_configPath),
             SetupComplete = IsSetupCompleteNoLock(),
             ConfigPath = _configPath,
             HasStationProfile = _stationProfiles.Count > 0,
-            StationProfile = GetEffectiveActiveProfileNoLock() ?? new StationProfile(),
+            StationProfile = persistedProfile,
             StationProfileCount = (uint)_stationProfiles.Count,
             IsFirstRun = !File.Exists(_configPath),
-            HasQrzXmlPassword = _hasQrzXmlPassword,
-            HasQrzLogbookApiKey = _hasQrzLogbookApiKey,
+            HasQrzXmlPassword = !string.IsNullOrWhiteSpace(_persistedSetup.QrzXmlPassword),
+            HasQrzLogbookApiKey = !string.IsNullOrWhiteSpace(_persistedSetup.QrzLogbookApiKey),
             PersistenceDescription = isSqlite ? PersistenceStepDescriptionSqlite : PersistenceStepDescription,
             PersistenceLabel = PersistenceStepLabel,
             PersistenceContractExplicit = true,
-            SyncConfig = _syncConfig.Clone(),
+            SyncConfig = _persistedSetup.SyncConfig.Clone(),
         };
 #pragma warning disable CS0612
         status.StorageBackend = isSqlite ? StorageBackend.Sqlite : StorageBackend.Memory;
 #pragma warning restore CS0612
         status.PersistenceStepEnabled = isSqlite;
 
-        if (!string.IsNullOrWhiteSpace(_qrzXmlUsername))
+        if (!string.IsNullOrWhiteSpace(_persistedSetup.QrzXmlUsername))
         {
-            status.QrzXmlUsername = _qrzXmlUsername;
+            status.QrzXmlUsername = _persistedSetup.QrzXmlUsername;
         }
 
-        if (!string.IsNullOrWhiteSpace(_activeProfileId))
+        if (!string.IsNullOrWhiteSpace(_persistedSetup.ActiveProfileId))
         {
-            status.ActiveStationProfileId = _activeProfileId;
+            status.ActiveStationProfileId = _persistedSetup.ActiveProfileId;
         }
 
-        if (_rigControl is not null)
+        if (_persistedSetup.RigControl is not null)
         {
-            status.RigControl = _rigControl.Clone();
+            status.RigControl = _persistedSetup.RigControl.Clone();
+        }
+
+        if (isSqlite)
+        {
+            status.PersistenceDefinitions.Add(
+                new RuntimeConfigDefinition
+                {
+                    Key = PersistenceSetup.PathKey,
+                    Label = PersistenceStepLabel,
+                    Description = "SQLite logbook path for the shared durable setup.",
+                    Kind = RuntimeConfigValueKind.Path,
+                    Required = true,
+                });
+
+            if (!string.IsNullOrWhiteSpace(persistedPath))
+            {
+                status.LogFilePath = persistedPath;
+                status.SuggestedLogFilePath = persistedPath;
+                status.PersistenceValues.Add(
+                    new RuntimeConfigValue
+                    {
+                        Key = PersistenceSetup.PathKey,
+                        HasValue = true,
+                        DisplayValue = persistedPath,
+                    });
+            }
         }
 
         if (!isSqlite)
@@ -1122,17 +1145,18 @@ internal sealed class ManagedEngineState
             new SetupWizardStepStatus
             {
                 Step = SetupWizardStep.LogFile,
-                Complete = true,
+                Complete = !IsSqliteBackendNoLock() || !string.IsNullOrWhiteSpace(_persistedSetup.GetPersistedLogFilePath()) || !string.IsNullOrWhiteSpace(_currentPersistenceLocation),
             },
             new SetupWizardStepStatus
             {
                 Step = SetupWizardStep.StationProfiles,
-                Complete = GetEffectiveActiveProfileNoLock() is { } active && IsStationProfileComplete(active),
+                Complete = GetPersistedActiveProfileNoLock() is { } active && IsStationProfileComplete(active),
             },
             new SetupWizardStepStatus
             {
                 Step = SetupWizardStep.QrzIntegration,
-                Complete = !string.IsNullOrWhiteSpace(_qrzXmlUsername) && _hasQrzXmlPassword,
+                Complete = !string.IsNullOrWhiteSpace(_persistedSetup.QrzXmlUsername)
+                    && !string.IsNullOrWhiteSpace(_persistedSetup.QrzXmlPassword),
             },
             new SetupWizardStepStatus
             {
@@ -1219,6 +1243,57 @@ internal sealed class ManagedEngineState
     private StationProfile? GetEffectiveActiveProfileNoLock()
     {
         return _sessionOverrideProfile?.Clone() ?? GetPersistedActiveProfileNoLock();
+    }
+
+    private void SyncPersistedProfilesNoLock()
+    {
+        _persistedSetup.ActiveProfileId = _activeProfileId;
+        _persistedSetup.StationProfiles.Clear();
+
+        foreach (var entry in _stationProfiles)
+        {
+            _persistedSetup.StationProfiles.Add(
+                new ManagedPersistedStationProfile
+                {
+                    ProfileId = entry.ProfileId,
+                    ProfileJson = entry.ProfileJson,
+                });
+        }
+    }
+
+    private void UpdatePersistedStorageSettingsNoLock(SaveSetupRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var requestedPath = request.PersistenceValues
+            .FirstOrDefault(static value => PersistenceSetup.IsPathKey(value.Key))
+            ?.Value;
+
+        requestedPath = NormalizeOptional(requestedPath)
+            ?? NormalizeOptional(request.LogFilePath);
+
+#pragma warning disable CS0612
+        requestedPath ??= NormalizeOptional(request.SqlitePath);
+#pragma warning restore CS0612
+
+        if (IsSqliteBackendNoLock())
+        {
+            _persistedSetup.LogbookFilePath = requestedPath
+                ?? NormalizeOptional(_currentPersistenceLocation)
+                ?? NormalizeOptional(_persistedSetup.GetPersistedLogFilePath());
+            _persistedSetup.StorageBackend = null;
+            _persistedSetup.StorageSqlitePath = null;
+            return;
+        }
+
+        _persistedSetup.LogbookFilePath = null;
+        _persistedSetup.StorageBackend = "memory";
+        _persistedSetup.StorageSqlitePath = null;
+    }
+
+    private bool IsSqliteBackendNoLock()
+    {
+        return string.Equals(_storage.BackendName, "sqlite", StringComparison.OrdinalIgnoreCase);
     }
 
     private void ApplyStationContextNoLock(QsoRecord qso, QsoRecord? existing = null)
@@ -1318,6 +1393,8 @@ internal sealed class ManagedEngineState
             ?? _qrzXmlUsername;
         var password = Environment.GetEnvironmentVariable(QrzXmlPasswordKey)?.Trim()
             ?? _qrzXmlPassword;
+        var userAgent = Environment.GetEnvironmentVariable(QrzUserAgentKey)?.Trim()
+            ?? NormalizeOptional(_persistedSetup.QrzXmlUserAgent);
 
         if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
         {
@@ -1326,7 +1403,7 @@ internal sealed class ManagedEngineState
             var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(8) };
 #pragma warning restore CA2000
             _lookupCoordinator = new LookupCoordinator(
-                new Lookup.Qrz.QrzXmlProvider(httpClient, username, password),
+                new Lookup.Qrz.QrzXmlProvider(httpClient, username, password, userAgent: userAgent),
                 _storage.LookupSnapshots);
         }
         else
@@ -1337,11 +1414,48 @@ internal sealed class ManagedEngineState
         }
     }
 
+    private void RebuildSyncEngineNoLock()
+    {
+        var apiKey = Environment.GetEnvironmentVariable(QrzLogbookApiKeyKey)?.Trim()
+            ?? _qrzLogbookApiKey;
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            DisposeOwnedSyncResourcesNoLock();
+            return;
+        }
+
+        var baseUrl = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_LOGBOOK_BASE_URL")?.Trim()
+            ?? NormalizeOptional(_persistedSetup.QrzLogbookBaseUrl);
+        Uri? apiUri = null;
+        if (!string.IsNullOrWhiteSpace(baseUrl))
+        {
+            apiUri = Uri.TryCreate(baseUrl, UriKind.Absolute, out var parsedUri)
+                ? parsedUri
+                : throw new InvalidOperationException($"Invalid QRZ logbook base URL '{baseUrl}'.");
+        }
+
+        var nextClient = apiUri is null
+            ? new QrzLogbookClient(apiKey)
+            : new QrzLogbookClient(apiKey, apiUri);
+        var previousOwnedSyncClient = _ownedSyncClient;
+        _ownedSyncClient = nextClient;
+        _syncEngine = new QrzSyncEngine(nextClient);
+        previousOwnedSyncClient?.Dispose();
+    }
+
+    private void DisposeOwnedSyncResourcesNoLock()
+    {
+        _ownedSyncClient?.Dispose();
+        _ownedSyncClient = null;
+        _syncEngine = null;
+    }
+
     private static LookupCoordinator CreateDefaultCoordinator(IEngineStorage storage)
     {
         ICallsignProvider provider;
         var username = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_XML_USERNAME")?.Trim();
         var password = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_XML_PASSWORD")?.Trim();
+        var userAgent = Environment.GetEnvironmentVariable(QrzUserAgentKey)?.Trim();
 
         if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
         {
@@ -1349,7 +1463,7 @@ internal sealed class ManagedEngineState
 #pragma warning disable CA2000 // Dispose objects before losing scope
             var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(8) };
 #pragma warning restore CA2000
-            provider = new Lookup.Qrz.QrzXmlProvider(httpClient, username, password);
+            provider = new Lookup.Qrz.QrzXmlProvider(httpClient, username, password, userAgent: userAgent);
         }
         else
         {
@@ -1367,9 +1481,9 @@ internal sealed class ManagedEngineState
             {
                 Key = StorageBackendKey,
                 Label = "Storage backend",
-                Description = "Managed engine storage backend. The current implementation supports only memory.",
+                Description = "Active storage backend for this engine process. Change it through startup configuration rather than runtime mutations.",
                 Kind = RuntimeConfigValueKind.String,
-                AllowedValues = { ManagedStorageBackend },
+                AllowedValues = { "memory", "sqlite" },
             },
             new RuntimeConfigDefinition
             {
@@ -1407,11 +1521,12 @@ internal sealed class ManagedEngineState
 
     private RuntimeConfigSnapshot BuildRuntimeConfigSnapshotNoLock()
     {
+        var isSqlite = IsSqliteBackendNoLock();
         var snapshot = new RuntimeConfigSnapshot
         {
-            ActiveStorageBackend = ManagedStorageBackend,
+            ActiveStorageBackend = _storage.BackendName,
             LookupProviderSummary = ManagedLookupProviderSummary,
-            PersistenceSummary = PersistenceSummary,
+            PersistenceSummary = isSqlite ? SqlitePersistenceSummary : InMemoryPersistenceSummary,
         };
 
         if (GetEffectiveActiveProfileNoLock() is { } activeProfile)
@@ -1419,7 +1534,16 @@ internal sealed class ManagedEngineState
             snapshot.ActiveStationProfile = activeProfile.Clone();
         }
 
-        snapshot.Warnings.Add("Managed .NET engine currently uses an in-memory logbook.");
+        if (isSqlite && !string.IsNullOrWhiteSpace(_currentPersistenceLocation))
+        {
+            snapshot.PersistenceLocation = _currentPersistenceLocation;
+        }
+
+        if (!isSqlite)
+        {
+            snapshot.Warnings.Add("Managed .NET engine currently uses an in-memory logbook.");
+        }
+
         snapshot.Definitions.AddRange(BuildRuntimeConfigDefinitionsNoLock());
         snapshot.Values.AddRange(BuildRuntimeConfigValuesNoLock());
         return snapshot;
@@ -1429,7 +1553,7 @@ internal sealed class ManagedEngineState
     {
         return
         [
-            BuildRuntimeValue(StorageBackendKey, ManagedStorageBackend, overridden: true, secret: false, redacted: false),
+            BuildRuntimeValue(StorageBackendKey, _storage.BackendName, overridden: _runtimeOverrides.ContainsKey(StorageBackendKey), secret: false, redacted: false),
             BuildRuntimeValue(QrzXmlUsernameKey, _qrzXmlUsername, overridden: _runtimeOverrides.ContainsKey(QrzXmlUsernameKey), secret: false, redacted: false),
             BuildRuntimeValue(QrzXmlPasswordKey, _hasQrzXmlPassword ? "***" : null, overridden: _runtimeOverrides.ContainsKey(QrzXmlPasswordKey), secret: true, redacted: _hasQrzXmlPassword),
             BuildRuntimeValue(QrzLogbookApiKeyKey, _hasQrzLogbookApiKey ? "***" : null, overridden: _runtimeOverrides.ContainsKey(QrzLogbookApiKeyKey), secret: true, redacted: _hasQrzLogbookApiKey),
@@ -1455,7 +1579,7 @@ internal sealed class ManagedEngineState
         if (mutation.Kind == RuntimeConfigMutationKind.Clear)
         {
             setter(null);
-            _runtimeOverrides.Remove(key);
+            _runtimeOverrides[key] = string.Empty;
             return;
         }
 
@@ -1473,7 +1597,7 @@ internal sealed class ManagedEngineState
 
     private bool IsSetupCompleteNoLock()
     {
-        var active = GetEffectiveActiveProfileNoLock();
+        var active = GetPersistedActiveProfileNoLock();
         return active is not null && IsStationProfileComplete(active);
     }
 
@@ -1533,7 +1657,9 @@ internal sealed class ManagedEngineState
                 continue;
             }
 
-            var normalized = Regex.Replace(candidate.Trim().ToUpperInvariant(), "[^A-Z0-9]+", "-").Trim('-');
+#pragma warning disable CA1308 // Profile IDs intentionally match Rust's lowercase normalization.
+            var normalized = Regex.Replace(candidate.Trim().ToLowerInvariant(), "[^a-z0-9]+", "-").Trim('-');
+#pragma warning restore CA1308
             if (!string.IsNullOrWhiteSpace(normalized))
             {
                 return normalized;

--- a/src/dotnet/QsoRipper.Engine.DotNet/Program.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/Program.cs
@@ -1,31 +1,30 @@
 using System.Net;
-using System.Text.Json;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using QsoRipper.Engine.DotNet;
 using QsoRipper.Engine.Lookup;
 using QsoRipper.Engine.Lookup.Qrz;
-using QsoRipper.Engine.QrzLogbook;
 using QsoRipper.Engine.RigControl;
 using QsoRipper.Engine.SpaceWeather;
 using QsoRipper.Engine.Storage;
 using QsoRipper.Engine.Storage.Memory;
 using QsoRipper.Engine.Storage.Sqlite;
+using QsoRipper.EngineSelection;
 
 var options = ManagedEngineHostOptions.Parse(args);
+var persistedSetup = SharedSetupConfigPersistence.Load(options.ConfigPath);
 
 var builder = WebApplication.CreateBuilder(args);
 builder.WebHost.ConfigureKestrel(kestrel => ConfigureListenEndpoint(kestrel, options.ListenAddress));
 builder.Services.AddGrpc();
 
-var storage = CreateStorage();
-builder.Services.AddSingleton(storage);
+var resolvedStorage = CreateStorage(persistedSetup.Config);
+builder.Services.AddSingleton(resolvedStorage.Storage);
 
-var lookupCoordinator = CreateLookupCoordinator(storage, options.ConfigPath);
+var lookupCoordinator = CreateLookupCoordinator(resolvedStorage.Storage, persistedSetup.Config);
 builder.Services.AddSingleton(lookupCoordinator);
 
 var rigControlMonitor = CreateRigControlMonitor();
 var spaceWeatherMonitor = CreateSpaceWeatherMonitor();
-var syncEngine = CreateSyncEngine();
 
 builder.Services.AddSingleton(provider => new ManagedEngineState(
     options.ConfigPath,
@@ -33,7 +32,9 @@ builder.Services.AddSingleton(provider => new ManagedEngineState(
     provider.GetRequiredService<ILookupCoordinator>(),
     rigControlMonitor,
     spaceWeatherMonitor,
-    syncEngine));
+    null,
+    resolvedStorage.PersistenceLocation,
+    persistedSetup));
 
 var app = builder.Build();
 app.MapGrpcService<ManagedEngineInfoGrpcService>();
@@ -46,64 +47,59 @@ app.MapGrpcService<ManagedRigControlGrpcService>();
 app.MapGrpcService<ManagedSpaceWeatherGrpcService>();
 app.MapGet("/", () => "QsoRipper .NET engine host. Use a gRPC client.");
 
-Console.WriteLine($"Starting QsoRipper .NET engine on {options.ListenAddress} using config {options.ConfigPath} (storage: {storage.BackendName})");
+Console.WriteLine($"Starting QsoRipper .NET engine on {options.ListenAddress} using config {options.ConfigPath} (storage: {resolvedStorage.Storage.BackendName})");
 await app.RunAsync();
 
-static QrzSyncEngine? CreateSyncEngine()
-{
-    var apiKey = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_LOGBOOK_API_KEY")?.Trim();
-    if (string.IsNullOrWhiteSpace(apiKey))
-    {
-        Console.WriteLine("QRZ Logbook sync: disabled (QSORIPPER_QRZ_LOGBOOK_API_KEY not set)");
-        return null;
-    }
-
-    // HttpClient is intentionally not disposed — it is a singleton owned by the client for the app lifetime.
-#pragma warning disable CA2000 // Dispose objects before losing scope
-    var client = new QrzLogbookClient(new HttpClient { Timeout = TimeSpan.FromSeconds(30) }, apiKey);
-#pragma warning restore CA2000
-    Console.WriteLine("QRZ Logbook sync: enabled");
-    return new QrzSyncEngine(client);
-}
-
-static IEngineStorage CreateStorage()
+static ResolvedStorageSettings CreateStorage(SharedPersistedSetupConfig persistedSetup)
 {
     var backend = Environment.GetEnvironmentVariable("QSORIPPER_STORAGE_BACKEND")?.Trim();
-    if (string.Equals(backend, "sqlite", StringComparison.OrdinalIgnoreCase))
+    var path = Environment.GetEnvironmentVariable("QSORIPPER_STORAGE_PATH")?.Trim();
+    if (string.IsNullOrWhiteSpace(backend) && !string.IsNullOrWhiteSpace(path))
     {
-        var path = Environment.GetEnvironmentVariable("QSORIPPER_STORAGE_PATH")?.Trim();
-        var storageBuilder = new SqliteStorageBuilder();
-        if (!string.IsNullOrWhiteSpace(path))
-        {
-            storageBuilder.Path(path);
-        }
-
-        return storageBuilder.Build();
+        backend = "sqlite";
     }
 
-    return new MemoryStorage();
+    var persistedPath = persistedSetup.GetPersistedLogFilePath();
+    backend = string.IsNullOrWhiteSpace(backend)
+        ? (string.IsNullOrWhiteSpace(persistedPath) ? persistedSetup.StorageBackend?.Trim() : "sqlite")
+        : backend;
+
+    if (string.Equals(backend, "sqlite", StringComparison.OrdinalIgnoreCase))
+    {
+        var storageBuilder = new SqliteStorageBuilder();
+        var resolvedPath = string.IsNullOrWhiteSpace(path) ? persistedPath : path;
+        if (!string.IsNullOrWhiteSpace(resolvedPath))
+        {
+            storageBuilder.Path(resolvedPath);
+        }
+
+        return new ResolvedStorageSettings(
+            storageBuilder.Build(),
+            string.IsNullOrWhiteSpace(resolvedPath) ? null : Path.GetFullPath(resolvedPath));
+    }
+
+    return new ResolvedStorageSettings(new MemoryStorage(), null);
 }
 
-static ILookupCoordinator CreateLookupCoordinator(IEngineStorage storage, string? configPath = null)
+static ILookupCoordinator CreateLookupCoordinator(IEngineStorage storage, SharedPersistedSetupConfig persistedSetup)
 {
     var username = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_XML_USERNAME")?.Trim();
     var password = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_XML_PASSWORD")?.Trim();
+    var userAgent = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_USER_AGENT")?.Trim();
 
-    if ((string.IsNullOrWhiteSpace(username) || string.IsNullOrWhiteSpace(password)) && configPath is not null)
+    if (string.IsNullOrWhiteSpace(username))
     {
-        var persisted = TryLoadPersistedConfig(configPath);
-        if (persisted is not null)
-        {
-            if (string.IsNullOrWhiteSpace(username))
-            {
-                username = persisted.QrzXmlUsername?.Trim();
-            }
+        username = persistedSetup.QrzXmlUsername?.Trim();
+    }
 
-            if (string.IsNullOrWhiteSpace(password))
-            {
-                password = persisted.QrzXmlPassword?.Trim();
-            }
-        }
+    if (string.IsNullOrWhiteSpace(password))
+    {
+        password = persistedSetup.QrzXmlPassword?.Trim();
+    }
+
+    if (string.IsNullOrWhiteSpace(userAgent))
+    {
+        userAgent = persistedSetup.QrzXmlUserAgent?.Trim();
     }
 
     ICallsignProvider provider;
@@ -113,7 +109,7 @@ static ILookupCoordinator CreateLookupCoordinator(IEngineStorage storage, string
 #pragma warning disable CA2000 // Dispose objects before losing scope
         var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(8) };
 #pragma warning restore CA2000
-        provider = new QrzXmlProvider(httpClient, username, password);
+        provider = new QrzXmlProvider(httpClient, username, password, userAgent: userAgent);
     }
     else
     {
@@ -202,29 +198,6 @@ static void ConfigureListenEndpoint(KestrelServerOptions options, string listenA
     options.ListenAnyIP(port, configure => configure.Protocols = HttpProtocols.Http2);
 }
 
-static ManagedEnginePersistedState? TryLoadPersistedConfig(string configPath)
-{
-    try
-    {
-        if (!File.Exists(configPath))
-        {
-            return null;
-        }
-
-        var json = File.ReadAllText(configPath);
-        return JsonSerializer.Deserialize<ManagedEnginePersistedState>(json, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        });
-    }
-#pragma warning disable CA1031 // Do not catch general exception types
-    catch
-#pragma warning restore CA1031
-    {
-        return null;
-    }
-}
-
 internal sealed record ManagedEngineHostOptions(string ListenAddress, string ConfigPath)
 {
     public const string DefaultListenAddress = "127.0.0.1:50052";
@@ -271,22 +244,23 @@ internal sealed record ManagedEngineHostOptions(string ListenAddress, string Con
 
     private static string GetDefaultConfigPath()
     {
-        var baseDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return Path.Combine(baseDirectory, "QsoRipper", "dotnet-engine.json");
+        return SharedSetupPaths.GetDefaultConfigPath();
     }
 
     private static void PrintHelp()
     {
         Console.WriteLine(
             """
-            QsoRipper .NET engine host
+              QsoRipper .NET engine host
 
-            Usage:
-              dotnet run --project src\dotnet\QsoRipper.Engine.DotNet -- [--listen 127.0.0.1:50052] [--config path\to\dotnet-engine.json]
+             Usage:
+              dotnet run --project src\dotnet\QsoRipper.Engine.DotNet -- [--listen 127.0.0.1:50052] [--config path\to\config.toml]
 
-            Environment:
+             Environment:
               QSORIPPER_SERVER_ADDR   Overrides the bind address
-              QSORIPPER_CONFIG_PATH   Overrides the managed-engine config path
-            """);
+              QSORIPPER_CONFIG_PATH   Overrides the shared engine config path
+             """);
     }
 }
+
+internal sealed record ResolvedStorageSettings(IEngineStorage Storage, string? PersistenceLocation);

--- a/src/dotnet/QsoRipper.Engine.DotNet/QsoRipper.Engine.DotNet.csproj
+++ b/src/dotnet/QsoRipper.Engine.DotNet/QsoRipper.Engine.DotNet.csproj
@@ -11,6 +11,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Tomlyn" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/QsoRipper.Engine.DotNet/SharedSetupConfigPersistence.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/SharedSetupConfigPersistence.cs
@@ -1,0 +1,925 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Google.Protobuf;
+using QsoRipper.Domain;
+using QsoRipper.EngineSelection;
+using QsoRipper.Services;
+using Tomlyn;
+using Tomlyn.Model;
+
+namespace QsoRipper.Engine.DotNet;
+
+internal static class SharedSetupConfigPersistence
+{
+    private static readonly JsonFormatter ProtoJsonFormatter = new(JsonFormatter.Settings.Default.WithFormatDefaultValues(true));
+    private static readonly JsonParser ProtoJsonParser = new(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+    private static readonly JsonSerializerOptions LegacyJsonSerializerOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+    private static readonly UTF8Encoding Utf8WithoutBom = new(encoderShouldEmitUTF8Identifier: false);
+
+    public static LoadedSharedSetupConfig Load(string configPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
+
+        var normalizedPath = Path.GetFullPath(configPath.Trim());
+        if (File.Exists(normalizedPath))
+        {
+            return LoadFromExistingPath(normalizedPath);
+        }
+
+        foreach (var legacyCandidate in GetLegacyMigrationCandidates(normalizedPath))
+        {
+            if (!File.Exists(legacyCandidate.Path))
+            {
+                continue;
+            }
+
+            var migrated = LoadLegacyJson(legacyCandidate.Path, legacyCandidate.PreserveSensitiveValues);
+            Save(normalizedPath, migrated.Config);
+            return migrated;
+        }
+
+        return new LoadedSharedSetupConfig
+        {
+            Config = SharedPersistedSetupConfig.CreateDefault(),
+        };
+    }
+
+    public static void Save(string configPath, SharedPersistedSetupConfig config)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
+        ArgumentNullException.ThrowIfNull(config);
+
+        var normalizedPath = Path.GetFullPath(configPath.Trim());
+        var directory = Path.GetDirectoryName(normalizedPath);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+            if (!OperatingSystem.IsWindows())
+            {
+                File.SetUnixFileMode(
+                    directory,
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            }
+        }
+
+        var content = Toml.FromModel(BuildModel(config));
+        if (OperatingSystem.IsWindows())
+        {
+            File.WriteAllText(normalizedPath, content, Utf8WithoutBom);
+            return;
+        }
+
+        using var stream = new FileStream(
+            normalizedPath,
+            new FileStreamOptions
+            {
+                Access = FileAccess.Write,
+                Mode = FileMode.Create,
+                Share = FileShare.None,
+                Options = FileOptions.None,
+                UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite,
+            });
+        using var writer = new StreamWriter(stream, Utf8WithoutBom);
+        writer.Write(content);
+        writer.Flush();
+
+        File.SetUnixFileMode(normalizedPath, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+    }
+
+    private static LoadedSharedSetupConfig LoadFromExistingPath(string configPath)
+    {
+        var content = File.ReadAllText(configPath);
+        try
+        {
+            var model = Toml.ToModel(content);
+            if (model is not TomlTable table)
+            {
+                if (LooksLikeJson(content))
+                {
+                    var migrated = LoadLegacyJsonContent(content, preserveSensitiveValues: true);
+                    Save(configPath, migrated.Config);
+                    return migrated;
+                }
+
+                throw new InvalidOperationException($"Config '{configPath}' did not deserialize into a TOML table.");
+            }
+
+            return new LoadedSharedSetupConfig
+            {
+                Config = ParseToml(table),
+            };
+        }
+        catch (TomlException) when (LooksLikeJson(content))
+        {
+            var migrated = LoadLegacyJsonContent(content, preserveSensitiveValues: true);
+            Save(configPath, migrated.Config);
+            return migrated;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or FormatException or TomlException)
+        {
+            throw new InvalidOperationException($"Failed to parse shared setup config '{configPath}': {ex.Message}", ex);
+        }
+    }
+
+    private static LoadedSharedSetupConfig LoadLegacyJson(string configPath, bool preserveSensitiveValues)
+    {
+        var content = File.ReadAllText(configPath);
+        return LoadLegacyJsonContent(content, preserveSensitiveValues);
+    }
+
+    private static LoadedSharedSetupConfig LoadLegacyJsonContent(string content, bool preserveSensitiveValues)
+    {
+        var legacy = JsonSerializer.Deserialize<ManagedEnginePersistedState>(
+                         content,
+                         LegacyJsonSerializerOptions)
+                     ?? new ManagedEnginePersistedState();
+
+        return new LoadedSharedSetupConfig
+        {
+            Config = ConvertLegacyState(legacy, preserveSensitiveValues),
+            LastSyncUtc = legacy.LastSyncUtc,
+        };
+    }
+
+    private static IEnumerable<LegacyMigrationCandidate> GetLegacyMigrationCandidates(string configPath)
+    {
+        var siblingDirectory = Path.GetDirectoryName(configPath);
+        if (!string.IsNullOrWhiteSpace(siblingDirectory))
+        {
+            yield return new LegacyMigrationCandidate(
+                Path.Combine(siblingDirectory, "dotnet-engine.json"),
+                PreserveSensitiveValues: true);
+        }
+
+        if (string.Equals(configPath, SharedSetupPaths.GetDefaultConfigPath(), StringComparison.OrdinalIgnoreCase))
+        {
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (!string.IsNullOrWhiteSpace(localAppData))
+            {
+                yield return new LegacyMigrationCandidate(
+                    Path.Combine(localAppData, "QsoRipper", "dotnet-engine.json"),
+                    PreserveSensitiveValues: false);
+            }
+        }
+    }
+
+    private static SharedPersistedSetupConfig ConvertLegacyState(
+        ManagedEnginePersistedState legacy,
+        bool preserveSensitiveValues)
+    {
+        ArgumentNullException.ThrowIfNull(legacy);
+
+        var config = SharedPersistedSetupConfig.CreateDefault();
+        config.StorageBackend = "memory";
+        config.QrzXmlUsername = NormalizeOptional(legacy.QrzXmlUsername);
+        config.QrzXmlPassword = preserveSensitiveValues && legacy.HasQrzXmlPassword
+            ? NormalizeOptional(legacy.QrzXmlPassword)
+            : null;
+        config.SyncConfig = ParseProtoOrDefault<SyncConfig>(legacy.SyncConfigJson, CreateDefaultSyncConfig);
+        config.RigControl = ParseOptionalProto<RigControlSettings>(legacy.RigControlJson);
+        config.ActiveProfileId = NormalizeOptional(legacy.ActiveProfileId);
+
+        foreach (var entry in legacy.StationProfiles)
+        {
+            if (string.IsNullOrWhiteSpace(entry.ProfileId) || string.IsNullOrWhiteSpace(entry.ProfileJson))
+            {
+                continue;
+            }
+
+            config.StationProfiles.Add(
+                new ManagedPersistedStationProfile
+                {
+                    ProfileId = NormalizeProfileIdOrDefault(entry.ProfileId),
+                    ProfileJson = entry.ProfileJson,
+                });
+        }
+
+        if (config.StationProfiles.Count == 0 && !string.IsNullOrWhiteSpace(legacy.SessionOverrideProfileJson))
+        {
+            var profile = ParseOptionalProto<StationProfile>(legacy.SessionOverrideProfileJson);
+            if (profile is not null && StationProfileHasValues(profile))
+            {
+                var profileId = NormalizeProfileIdOrDefault(profile.ProfileName, profile.StationCallsign);
+                config.StationProfiles.Add(
+                    new ManagedPersistedStationProfile
+                    {
+                        ProfileId = profileId,
+                        ProfileJson = ProtoJsonFormatter.Format(profile),
+                    });
+                config.ActiveProfileId = profileId;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(config.ActiveProfileId) && config.StationProfiles.Count > 0)
+        {
+            config.ActiveProfileId = config.StationProfiles[0].ProfileId;
+        }
+
+        return config;
+    }
+
+    private readonly record struct LegacyMigrationCandidate(string Path, bool PreserveSensitiveValues);
+
+    private static SharedPersistedSetupConfig ParseToml(TomlTable root)
+    {
+        var config = SharedPersistedSetupConfig.CreateDefault();
+
+        var logbook = GetTable(root, "logbook");
+        var storage = GetTable(root, "storage");
+        var qrzXml = GetTable(root, "qrz_xml");
+        var qrzLogbook = GetTable(root, "qrz_logbook");
+        var sync = GetTable(root, "sync");
+        var rigControl = GetTable(root, "rig_control");
+        var stationProfile = GetTable(root, "station_profile");
+        var stationProfiles = GetTable(root, "station_profiles");
+
+        config.LogbookFilePath = GetString(logbook, "file_path");
+        config.StorageBackend = GetString(storage, "backend");
+        config.StorageSqlitePath = GetString(storage, "sqlite_path");
+        config.QrzXmlUsername = GetString(qrzXml, "username");
+        config.QrzXmlPassword = GetString(qrzXml, "password");
+        config.QrzXmlUserAgent = GetString(qrzXml, "user_agent");
+        config.QrzLogbookApiKey = GetString(qrzLogbook, "api_key");
+        config.QrzLogbookBaseUrl = GetString(qrzLogbook, "base_url");
+        config.SyncConfig = ParseSyncConfig(sync);
+        config.RigControl = ParseRigControl(rigControl);
+        config.ActiveProfileId = NormalizeOptional(GetString(stationProfiles, "active_profile_id"));
+
+        var entries = GetTableArray(stationProfiles, "entries");
+        if (entries is not null)
+        {
+            foreach (var entry in entries.OfType<TomlTable>())
+            {
+                var profileId = NormalizeProfileIdOrDefault(GetString(entry, "profile_id"));
+                var profile = ParseStationProfile(entry);
+                if (!StationProfileHasValues(profile))
+                {
+                    continue;
+                }
+
+                config.StationProfiles.Add(
+                    new ManagedPersistedStationProfile
+                    {
+                        ProfileId = profileId,
+                        ProfileJson = ProtoJsonFormatter.Format(profile),
+                    });
+            }
+        }
+
+        if (config.StationProfiles.Count == 0)
+        {
+            var legacyProfile = ParseStationProfile(stationProfile);
+            if (StationProfileHasValues(legacyProfile))
+            {
+                var profileId = NormalizeProfileIdOrDefault(
+                    config.ActiveProfileId,
+                    legacyProfile.ProfileName,
+                    legacyProfile.StationCallsign);
+                config.StationProfiles.Add(
+                    new ManagedPersistedStationProfile
+                    {
+                        ProfileId = profileId,
+                        ProfileJson = ProtoJsonFormatter.Format(legacyProfile),
+                    });
+                config.ActiveProfileId ??= profileId;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(config.ActiveProfileId) && config.StationProfiles.Count > 0)
+        {
+            config.ActiveProfileId = config.StationProfiles[0].ProfileId;
+        }
+
+        return config;
+    }
+
+    private static TomlTable BuildModel(SharedPersistedSetupConfig config)
+    {
+        var root = new TomlTable();
+
+        var logbook = new TomlTable();
+        AddIfValue(logbook, "file_path", NormalizeOptional(config.LogbookFilePath));
+        AddTableIfNotEmpty(root, "logbook", logbook);
+
+        var storage = new TomlTable();
+        if (string.IsNullOrWhiteSpace(config.GetPersistedLogFilePath()) && string.Equals(config.StorageBackend, "memory", StringComparison.OrdinalIgnoreCase))
+        {
+            storage["backend"] = "memory";
+        }
+
+        AddTableIfNotEmpty(root, "storage", storage);
+
+        var activeProfile = config.GetPersistedActiveProfile();
+        if (activeProfile is not null && StationProfileHasValues(activeProfile))
+        {
+            var legacyProfile = BuildStationProfileTable(activeProfile);
+            AddTableIfNotEmpty(root, "station_profile", legacyProfile);
+        }
+
+        if (config.StationProfiles.Count > 0 || !string.IsNullOrWhiteSpace(config.ActiveProfileId))
+        {
+            var stationProfiles = new TomlTable();
+            AddIfValue(stationProfiles, "active_profile_id", NormalizeOptional(config.ActiveProfileId));
+
+            if (config.StationProfiles.Count > 0)
+            {
+                var entries = new TomlTableArray();
+                foreach (var entry in config.StationProfiles)
+                {
+                    if (string.IsNullOrWhiteSpace(entry.ProfileId) || string.IsNullOrWhiteSpace(entry.ProfileJson))
+                    {
+                        continue;
+                    }
+
+                    var profile = ParseProtoOrDefault<StationProfile>(entry.ProfileJson, static () => new StationProfile());
+                    if (!StationProfileHasValues(profile))
+                    {
+                        continue;
+                    }
+
+                    var table = BuildStationProfileTable(profile);
+                    table["profile_id"] = entry.ProfileId;
+                    entries.Add(table);
+                }
+
+                if (entries.Count > 0)
+                {
+                    stationProfiles["entries"] = entries;
+                }
+            }
+
+            AddTableIfNotEmpty(root, "station_profiles", stationProfiles);
+        }
+
+        var qrzXml = new TomlTable();
+        AddIfValue(qrzXml, "username", NormalizeOptional(config.QrzXmlUsername));
+        AddIfValue(qrzXml, "password", NormalizeOptional(config.QrzXmlPassword));
+        AddIfValue(qrzXml, "user_agent", NormalizeOptional(config.QrzXmlUserAgent));
+        AddTableIfNotEmpty(root, "qrz_xml", qrzXml);
+
+        var qrzLogbook = new TomlTable();
+        AddIfValue(qrzLogbook, "api_key", NormalizeOptional(config.QrzLogbookApiKey));
+        AddIfValue(qrzLogbook, "base_url", NormalizeOptional(config.QrzLogbookBaseUrl));
+        AddTableIfNotEmpty(root, "qrz_logbook", qrzLogbook);
+
+        var sync = BuildSyncTable(config.SyncConfig);
+        AddTableIfNotEmpty(root, "sync", sync);
+
+        var rigControl = BuildRigControlTable(config.RigControl);
+        AddTableIfNotEmpty(root, "rig_control", rigControl);
+
+        return root;
+    }
+
+    private static SyncConfig ParseSyncConfig(TomlTable? table)
+    {
+        var config = CreateDefaultSyncConfig();
+        if (table is null)
+        {
+            return config;
+        }
+
+        config.AutoSyncEnabled = GetBoolean(table, "auto_sync_enabled") ?? false;
+        config.SyncIntervalSeconds = GetUInt32(table, "sync_interval_seconds") ?? 300u;
+        config.ConflictPolicy = GetString(table, "conflict_policy") switch
+        {
+            "flag_for_review" => ConflictPolicy.FlagForReview,
+            _ => ConflictPolicy.LastWriteWins,
+        };
+        return config;
+    }
+
+    private static TomlTable BuildSyncTable(SyncConfig config)
+    {
+        var table = new TomlTable();
+        if (config.AutoSyncEnabled)
+        {
+            table["auto_sync_enabled"] = true;
+        }
+
+        var interval = config.SyncIntervalSeconds == 0 ? 300u : config.SyncIntervalSeconds;
+        if (interval != 300u)
+        {
+            table["sync_interval_seconds"] = interval;
+        }
+
+        if (config.ConflictPolicy == ConflictPolicy.FlagForReview)
+        {
+            table["conflict_policy"] = "flag_for_review";
+        }
+
+        return table;
+    }
+
+    private static RigControlSettings? ParseRigControl(TomlTable? table)
+    {
+        if (table is null)
+        {
+            return null;
+        }
+
+        var settings = new RigControlSettings();
+        var enabled = GetBoolean(table, "enabled");
+        if (enabled is not null)
+        {
+            settings.Enabled = enabled.Value;
+        }
+
+        var host = GetString(table, "host");
+        if (!string.IsNullOrWhiteSpace(host))
+        {
+            settings.Host = host;
+        }
+
+        var port = GetUInt32(table, "port");
+        if (port is not null)
+        {
+            settings.Port = port.Value;
+        }
+
+        var readTimeoutMs = GetUInt64(table, "read_timeout_ms");
+        if (readTimeoutMs is not null)
+        {
+            settings.ReadTimeoutMs = readTimeoutMs.Value;
+        }
+
+        var staleThresholdMs = GetUInt64(table, "stale_threshold_ms");
+        if (staleThresholdMs is not null)
+        {
+            settings.StaleThresholdMs = staleThresholdMs.Value;
+        }
+
+        return RigControlHasValues(settings) ? settings : null;
+    }
+
+    private static TomlTable BuildRigControlTable(RigControlSettings? settings)
+    {
+        var table = new TomlTable();
+        if (settings is null)
+        {
+            return table;
+        }
+
+        if (settings.HasEnabled)
+        {
+            table["enabled"] = settings.Enabled;
+        }
+
+        if (settings.HasHost)
+        {
+            AddIfValue(table, "host", NormalizeOptional(settings.Host));
+        }
+
+        if (settings.HasPort)
+        {
+            table["port"] = settings.Port;
+        }
+
+        if (settings.HasReadTimeoutMs)
+        {
+            table["read_timeout_ms"] = settings.ReadTimeoutMs;
+        }
+
+        if (settings.HasStaleThresholdMs)
+        {
+            table["stale_threshold_ms"] = settings.StaleThresholdMs;
+        }
+
+        return table;
+    }
+
+    private static StationProfile ParseStationProfile(TomlTable? table)
+    {
+        if (table is null)
+        {
+            return new StationProfile();
+        }
+
+        var profile = new StationProfile
+        {
+            StationCallsign = GetString(table, "station_callsign") ?? string.Empty,
+        };
+
+        var profileName = GetString(table, "profile_name");
+        if (!string.IsNullOrWhiteSpace(profileName))
+        {
+            profile.ProfileName = profileName;
+        }
+
+        var operatorCallsign = GetString(table, "operator_callsign");
+        if (!string.IsNullOrWhiteSpace(operatorCallsign))
+        {
+            profile.OperatorCallsign = operatorCallsign;
+        }
+
+        var operatorName = GetString(table, "operator_name");
+        if (!string.IsNullOrWhiteSpace(operatorName))
+        {
+            profile.OperatorName = operatorName;
+        }
+
+        var grid = GetString(table, "grid");
+        if (!string.IsNullOrWhiteSpace(grid))
+        {
+            profile.Grid = grid;
+        }
+
+        var county = GetString(table, "county");
+        if (!string.IsNullOrWhiteSpace(county))
+        {
+            profile.County = county;
+        }
+
+        var state = GetString(table, "state");
+        if (!string.IsNullOrWhiteSpace(state))
+        {
+            profile.State = state;
+        }
+
+        var country = GetString(table, "country");
+        if (!string.IsNullOrWhiteSpace(country))
+        {
+            profile.Country = country;
+        }
+
+        var arrlSection = GetString(table, "arrl_section");
+        if (!string.IsNullOrWhiteSpace(arrlSection))
+        {
+            profile.ArrlSection = arrlSection;
+        }
+
+        var dxcc = GetUInt32(table, "dxcc");
+        if (dxcc is not null)
+        {
+            profile.Dxcc = dxcc.Value;
+        }
+
+        var cqZone = GetUInt32(table, "cq_zone");
+        if (cqZone is not null)
+        {
+            profile.CqZone = cqZone.Value;
+        }
+
+        var ituZone = GetUInt32(table, "itu_zone");
+        if (ituZone is not null)
+        {
+            profile.ItuZone = ituZone.Value;
+        }
+
+        var latitude = GetDouble(table, "latitude");
+        if (latitude is not null)
+        {
+            profile.Latitude = latitude.Value;
+        }
+
+        var longitude = GetDouble(table, "longitude");
+        if (longitude is not null)
+        {
+            profile.Longitude = longitude.Value;
+        }
+
+        return profile;
+    }
+
+    private static TomlTable BuildStationProfileTable(StationProfile profile)
+    {
+        var table = new TomlTable();
+        AddIfValue(table, "profile_name", NormalizeOptional(profile.ProfileName));
+        AddIfValue(table, "station_callsign", NormalizeOptional(profile.StationCallsign));
+        AddIfValue(table, "operator_callsign", NormalizeOptional(profile.OperatorCallsign));
+        AddIfValue(table, "operator_name", NormalizeOptional(profile.OperatorName));
+        AddIfValue(table, "grid", NormalizeOptional(profile.Grid));
+        AddIfValue(table, "county", NormalizeOptional(profile.County));
+        AddIfValue(table, "state", NormalizeOptional(profile.State));
+        AddIfValue(table, "country", NormalizeOptional(profile.Country));
+        AddIfValue(table, "arrl_section", NormalizeOptional(profile.ArrlSection));
+        if (profile.HasDxcc)
+        {
+            table["dxcc"] = profile.Dxcc;
+        }
+
+        if (profile.HasCqZone)
+        {
+            table["cq_zone"] = profile.CqZone;
+        }
+
+        if (profile.HasItuZone)
+        {
+            table["itu_zone"] = profile.ItuZone;
+        }
+
+        if (profile.HasLatitude)
+        {
+            table["latitude"] = profile.Latitude;
+        }
+
+        if (profile.HasLongitude)
+        {
+            table["longitude"] = profile.Longitude;
+        }
+
+        return table;
+    }
+
+    private static T ParseProtoOrDefault<T>(string? json, Func<T> defaultFactory)
+        where T : class, IMessage<T>, new()
+    {
+        return string.IsNullOrWhiteSpace(json) ? defaultFactory() : ProtoJsonParser.Parse<T>(json);
+    }
+
+    private static T? ParseOptionalProto<T>(string? json)
+        where T : class, IMessage<T>, new()
+    {
+        return string.IsNullOrWhiteSpace(json) ? null : ProtoJsonParser.Parse<T>(json);
+    }
+
+    private static SyncConfig CreateDefaultSyncConfig()
+    {
+        return new SyncConfig
+        {
+            AutoSyncEnabled = false,
+            SyncIntervalSeconds = 300,
+            ConflictPolicy = ConflictPolicy.LastWriteWins,
+        };
+    }
+
+    private static bool StationProfileHasValues(StationProfile profile)
+    {
+        return !string.IsNullOrWhiteSpace(profile.ProfileName)
+            || !string.IsNullOrWhiteSpace(profile.StationCallsign)
+            || !string.IsNullOrWhiteSpace(profile.OperatorCallsign)
+            || !string.IsNullOrWhiteSpace(profile.OperatorName)
+            || !string.IsNullOrWhiteSpace(profile.Grid)
+            || !string.IsNullOrWhiteSpace(profile.County)
+            || !string.IsNullOrWhiteSpace(profile.State)
+            || !string.IsNullOrWhiteSpace(profile.Country)
+            || !string.IsNullOrWhiteSpace(profile.ArrlSection)
+            || profile.HasDxcc
+            || profile.HasCqZone
+            || profile.HasItuZone
+            || profile.HasLatitude
+            || profile.HasLongitude;
+    }
+
+    private static bool RigControlHasValues(RigControlSettings settings)
+    {
+        return settings.HasEnabled
+            || settings.HasHost
+            || settings.HasPort
+            || settings.HasReadTimeoutMs
+            || settings.HasStaleThresholdMs;
+    }
+
+    private static bool LooksLikeJson(string content)
+    {
+        foreach (var character in content)
+        {
+            if (char.IsWhiteSpace(character))
+            {
+                continue;
+            }
+
+            return character is '{' or '[';
+        }
+
+        return false;
+    }
+
+    private static void AddIfValue(TomlTable table, string key, string? value)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            table[key] = value;
+        }
+    }
+
+    private static void AddIfValue(TomlTable table, string key, bool? value)
+    {
+        if (value is not null)
+        {
+            table[key] = value.Value;
+        }
+    }
+
+    private static void AddIfValue(TomlTable table, string key, uint? value)
+    {
+        if (value is not null)
+        {
+            table[key] = value.Value;
+        }
+    }
+
+    private static void AddIfValue(TomlTable table, string key, ulong? value)
+    {
+        if (value is not null)
+        {
+            table[key] = value.Value;
+        }
+    }
+
+    private static void AddIfValue(TomlTable table, string key, double? value)
+    {
+        if (value is not null)
+        {
+            table[key] = value.Value;
+        }
+    }
+
+    private static void AddTableIfNotEmpty(TomlTable root, string key, TomlTable table)
+    {
+        if (table.Count > 0)
+        {
+            root[key] = table;
+        }
+    }
+
+    private static TomlTable? GetTable(TomlTable? table, string key)
+    {
+        if (table is null)
+        {
+            return null;
+        }
+
+        return table.TryGetValue(key, out var value) ? value as TomlTable : null;
+    }
+
+    private static TomlTableArray? GetTableArray(TomlTable? table, string key)
+    {
+        if (table is null)
+        {
+            return null;
+        }
+
+        return table.TryGetValue(key, out var value) ? value as TomlTableArray : null;
+    }
+
+    private static string? GetString(TomlTable? table, string key)
+    {
+        if (table is null || !table.TryGetValue(key, out var value))
+        {
+            return null;
+        }
+
+        return NormalizeOptional(value as string);
+    }
+
+    private static bool? GetBoolean(TomlTable? table, string key)
+    {
+        if (table is null || !table.TryGetValue(key, out var value))
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            bool booleanValue => booleanValue,
+            _ => null,
+        };
+    }
+
+    private static uint? GetUInt32(TomlTable? table, string key)
+    {
+        if (table is null || !table.TryGetValue(key, out var value))
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            long longValue when longValue >= 0 && longValue <= uint.MaxValue => (uint)longValue,
+            int intValue when intValue >= 0 => (uint)intValue,
+            uint uintValue => uintValue,
+            _ => null,
+        };
+    }
+
+    private static ulong? GetUInt64(TomlTable? table, string key)
+    {
+        if (table is null || !table.TryGetValue(key, out var value))
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            long longValue when longValue >= 0 => (ulong)longValue,
+            int intValue when intValue >= 0 => (ulong)intValue,
+            uint uintValue => uintValue,
+            ulong ulongValue => ulongValue,
+            _ => null,
+        };
+    }
+
+    private static double? GetDouble(TomlTable? table, string key)
+    {
+        if (table is null || !table.TryGetValue(key, out var value))
+        {
+            return null;
+        }
+
+        return value switch
+        {
+            double doubleValue => doubleValue,
+            float floatValue => floatValue,
+            long longValue => longValue,
+            int intValue => intValue,
+            _ => null,
+        };
+    }
+
+    private static string? NormalizeOptional(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+    }
+
+    private static string NormalizeProfileIdOrDefault(params string?[] candidates)
+    {
+        foreach (var candidate in candidates)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+            {
+                continue;
+            }
+
+#pragma warning disable CA1308 // Profile IDs intentionally match Rust's lowercase normalization.
+            var normalized = Regex.Replace(candidate.Trim().ToLowerInvariant(), "[^a-z0-9]+", "-").Trim('-');
+#pragma warning restore CA1308
+            if (!string.IsNullOrWhiteSpace(normalized))
+            {
+                return normalized;
+            }
+        }
+
+        return "default";
+    }
+}
+
+internal sealed class LoadedSharedSetupConfig
+{
+    public required SharedPersistedSetupConfig Config { get; init; }
+
+    public DateTimeOffset? LastSyncUtc { get; init; }
+}
+
+internal sealed class SharedPersistedSetupConfig
+{
+    public string? LogbookFilePath { get; set; }
+
+    public string? StorageBackend { get; set; }
+
+    public string? StorageSqlitePath { get; set; }
+
+    public string? ActiveProfileId { get; set; }
+
+    public List<ManagedPersistedStationProfile> StationProfiles { get; } = [];
+
+    public string? QrzXmlUsername { get; set; }
+
+    public string? QrzXmlPassword { get; set; }
+
+    public string? QrzXmlUserAgent { get; set; }
+
+    public string? QrzLogbookApiKey { get; set; }
+
+    public string? QrzLogbookBaseUrl { get; set; }
+
+    public SyncConfig SyncConfig { get; set; } = new();
+
+    public RigControlSettings? RigControl { get; set; }
+
+    public static SharedPersistedSetupConfig CreateDefault()
+    {
+        return new SharedPersistedSetupConfig
+        {
+            SyncConfig = new SyncConfig
+            {
+                AutoSyncEnabled = false,
+                SyncIntervalSeconds = 300,
+                ConflictPolicy = ConflictPolicy.LastWriteWins,
+            }
+        };
+    }
+
+    public string? GetPersistedLogFilePath()
+    {
+        return string.IsNullOrWhiteSpace(LogbookFilePath)
+            ? (string.IsNullOrWhiteSpace(StorageSqlitePath) ? null : StorageSqlitePath.Trim())
+            : LogbookFilePath.Trim();
+    }
+
+    public StationProfile? GetPersistedActiveProfile()
+    {
+        var profileJson = StationProfiles
+            .FirstOrDefault(entry => string.Equals(entry.ProfileId, ActiveProfileId, StringComparison.Ordinal))
+            ?.ProfileJson
+            ?? StationProfiles.FirstOrDefault()?.ProfileJson;
+
+        return string.IsNullOrWhiteSpace(profileJson)
+            ? null
+            : new JsonParser(JsonParser.Settings.Default.WithIgnoreUnknownFields(true)).Parse<StationProfile>(profileJson);
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.Lookup.Qrz/QrzXmlProvider.cs
+++ b/src/dotnet/QsoRipper.Engine.Lookup.Qrz/QrzXmlProvider.cs
@@ -11,12 +11,13 @@ namespace QsoRipper.Engine.Lookup.Qrz;
 public sealed class QrzXmlProvider : ICallsignProvider
 {
     private const string DefaultBaseUrl = "https://xmldata.qrz.com/xml/current/";
-    private const string AgentName = "qsoripper-dotnet";
+    private const string DefaultAgentName = "qsoripper-dotnet";
 
     private readonly HttpClient _httpClient;
     private readonly string _username;
     private readonly string _password;
     private readonly string _baseUrl;
+    private readonly string _userAgent;
     private readonly Lock _sessionLock = new();
     private string? _sessionKey;
 
@@ -24,7 +25,7 @@ public sealed class QrzXmlProvider : ICallsignProvider
 
     /// <summary>Create a new QRZ XML provider.</summary>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1054:URI parameters should not be strings", Justification = "URL is built from env config, not user-facing API")]
-    public QrzXmlProvider(HttpClient httpClient, string username, string password, string? baseUrl = null)
+    public QrzXmlProvider(HttpClient httpClient, string username, string password, string? baseUrl = null, string? userAgent = null)
     {
         ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentException.ThrowIfNullOrWhiteSpace(username);
@@ -34,6 +35,7 @@ public sealed class QrzXmlProvider : ICallsignProvider
         _username = username;
         _password = password;
         _baseUrl = NormalizeBaseUrl(baseUrl ?? DefaultBaseUrl);
+        _userAgent = NormalizeUserAgent(userAgent);
     }
 
     /// <inheritdoc/>
@@ -187,7 +189,7 @@ public sealed class QrzXmlProvider : ICallsignProvider
 
     private async Task<string?> LoginAsync(CancellationToken ct)
     {
-        var url = new Uri($"{_baseUrl}?username={Uri.EscapeDataString(_username)}&password={Uri.EscapeDataString(_password)}&agent={Uri.EscapeDataString(AgentName)}");
+        var url = new Uri($"{_baseUrl}?username={Uri.EscapeDataString(_username)}&password={Uri.EscapeDataString(_password)}&agent={Uri.EscapeDataString(_userAgent)}");
 
         string body;
         try
@@ -544,5 +546,12 @@ public sealed class QrzXmlProvider : ICallsignProvider
     private static string NormalizeBaseUrl(string baseUrl)
     {
         return baseUrl.EndsWith('/') ? baseUrl : baseUrl + '/';
+    }
+
+    private static string NormalizeUserAgent(string? userAgent)
+    {
+        return string.IsNullOrWhiteSpace(userAgent)
+            ? DefaultAgentName
+            : userAgent.Trim();
     }
 }

--- a/src/dotnet/QsoRipper.Engine.Lookup.Tests/QrzXmlProviderTests.cs
+++ b/src/dotnet/QsoRipper.Engine.Lookup.Tests/QrzXmlProviderTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using System.Net.Http;
+using QsoRipper.Engine.Lookup;
+using QsoRipper.Engine.Lookup.Qrz;
+
+namespace QsoRipper.Engine.Lookup.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+public sealed class QrzXmlProviderTests
+{
+    [Fact]
+    public async Task LookupAsync_UsesConfiguredUserAgentForLogin()
+    {
+        using var handler = new RecordingHandler(
+            CreateXmlResponse(
+                """
+                <?xml version="1.0" encoding="utf-8" ?>
+                <QRZDatabase version="1.34" xmlns="http://xmldata.qrz.com">
+                    <Session>
+                        <Key>abc123</Key>
+                    </Session>
+                </QRZDatabase>
+                """),
+            CreateXmlResponse(
+                """
+                <?xml version="1.0" encoding="utf-8" ?>
+                <QRZDatabase version="1.34" xmlns="http://xmldata.qrz.com">
+                    <Callsign>
+                        <call>W1AW</call>
+                    </Callsign>
+                    <Session>
+                        <Key>abc123</Key>
+                    </Session>
+                </QRZDatabase>
+                """));
+        using var httpClient = new HttpClient(handler);
+        var provider = new QrzXmlProvider(httpClient, "demo-user", "demo-password", userAgent: "Managed Agent/1.0");
+
+        var result = await provider.LookupAsync("W1AW");
+
+        Assert.Equal(ProviderLookupState.Found, result.State);
+        Assert.Equal(2, handler.RequestUris.Count);
+
+        var loginQuery = ParseQuery(handler.RequestUris[0]);
+        Assert.Equal("demo-user", loginQuery["username"]);
+        Assert.Equal("demo-password", loginQuery["password"]);
+        Assert.Equal("Managed Agent/1.0", loginQuery["agent"]);
+    }
+
+    private static HttpResponseMessage CreateXmlResponse(string body)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body),
+        };
+    }
+
+    private static Dictionary<string, string> ParseQuery(Uri uri)
+    {
+        return uri.Query
+            .TrimStart('?')
+            .Split('&', StringSplitOptions.RemoveEmptyEntries)
+            .Select(static entry => entry.Split('=', 2))
+            .ToDictionary(
+                static parts => Uri.UnescapeDataString(parts[0]),
+                static parts => parts.Length == 2 ? Uri.UnescapeDataString(parts[1]) : string.Empty,
+                StringComparer.Ordinal);
+    }
+
+    private sealed class RecordingHandler(params HttpResponseMessage[] responses) : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses = new(responses);
+
+        public List<Uri> RequestUris { get; } = [];
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Assert.NotNull(request.RequestUri);
+            RequestUris.Add(request.RequestUri!);
+            Assert.NotEmpty(_responses);
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
@@ -25,6 +25,14 @@ public sealed class QrzLogbookClient : IQrzLogbookApi, IDisposable
     }
 
     /// <summary>
+    /// Create a client using the provided API key and explicit QRZ API URL.
+    /// </summary>
+    public QrzLogbookClient(string apiKey, Uri apiUri)
+        : this(new HttpClient { Timeout = TimeSpan.FromSeconds(30) }, apiKey, apiUri, ownsHttpClient: true)
+    {
+    }
+
+    /// <summary>
     /// Create a client with a caller-supplied <see cref="HttpClient"/> and optional API URL override (for testing).
     /// </summary>
     public QrzLogbookClient(HttpClient httpClient, string apiKey, Uri? apiUri = null)

--- a/src/dotnet/QsoRipper.EngineSelection/EngineCatalog.cs
+++ b/src/dotnet/QsoRipper.EngineSelection/EngineCatalog.cs
@@ -11,6 +11,7 @@ public static class EngineCatalog
     public const string EndpointEnvironmentVariable = "QSORIPPER_ENDPOINT";
 
     private static readonly string StartScriptPath = Path.Combine(".", "start-qsoripper.ps1");
+    private static readonly string DefaultConfigPath = SharedSetupPaths.GetDefaultConfigPath();
 
     private static readonly IReadOnlyList<EngineTargetProfile> BuiltInProfiles =
     [
@@ -21,7 +22,7 @@ public static class EngineCatalog
             "http://127.0.0.1:50051",
             [KnownEngineProfiles.LocalRust, "rust", "rust-tonic"],
             new EngineLaunchRecipe(
-                Path.Combine(".", "artifacts", "run", "rust-engine.json"),
+                DefaultConfigPath,
                 SupportsStorageSession: true,
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
@@ -37,10 +38,6 @@ public static class EngineCatalog
                         KnownEngineProfiles.LocalRust,
                         "-ListenAddress",
                         "{listenAddress}",
-                        "-Storage",
-                        "{storageBackend}",
-                        "-PersistenceLocation",
-                        "{persistenceLocation}",
                         "-ConfigPath",
                         "{configPath}"
                     ]))),
@@ -51,7 +48,7 @@ public static class EngineCatalog
             "http://127.0.0.1:50052",
             [KnownEngineProfiles.LocalDotNet, "dotnet", "dotnet-aspnet", "managed"],
             new EngineLaunchRecipe(
-                Path.Combine(".", "artifacts", "run", "dotnet-engine.json"),
+                DefaultConfigPath,
                 SupportsStorageSession: true,
                 new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
                 {
@@ -67,10 +64,6 @@ public static class EngineCatalog
                         KnownEngineProfiles.LocalDotNet,
                         "-ListenAddress",
                         "{listenAddress}",
-                        "-Storage",
-                        "{storageBackend}",
-                        "-PersistenceLocation",
-                        "{persistenceLocation}",
                         "-ConfigPath",
                         "{configPath}"
                     ]))),

--- a/src/dotnet/QsoRipper.EngineSelection/SharedSetupPaths.cs
+++ b/src/dotnet/QsoRipper.EngineSelection/SharedSetupPaths.cs
@@ -1,0 +1,34 @@
+namespace QsoRipper.EngineSelection;
+
+public static class SharedSetupPaths
+{
+    public const string DefaultConfigFileName = "config.toml";
+
+    public static string GetDefaultConfigPath()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            if (string.IsNullOrWhiteSpace(appData))
+            {
+                throw new InvalidOperationException("APPDATA is not set; cannot resolve the default config path.");
+            }
+
+            return Path.GetFullPath(Path.Combine(appData, "qsoripper", DefaultConfigFileName));
+        }
+
+        var xdgConfigHome = Environment.GetEnvironmentVariable("XDG_CONFIG_HOME");
+        if (!string.IsNullOrWhiteSpace(xdgConfigHome))
+        {
+            return Path.GetFullPath(Path.Combine(xdgConfigHome, "qsoripper", DefaultConfigFileName));
+        }
+
+        var home = Environment.GetEnvironmentVariable("HOME");
+        if (string.IsNullOrWhiteSpace(home))
+        {
+            throw new InvalidOperationException("HOME is not set; cannot resolve the default config path.");
+        }
+
+        return Path.GetFullPath(Path.Combine(home, ".config", "qsoripper", DefaultConfigFileName));
+    }
+}

--- a/start-qsoripper.ps1
+++ b/start-qsoripper.ps1
@@ -61,6 +61,26 @@ function Import-DotEnv([string]$Path) {
     }
 }
 
+function Get-DefaultSharedConfigPath {
+    if ($IsWindows) {
+        if ([string]::IsNullOrWhiteSpace($env:APPDATA)) {
+            throw 'APPDATA is not set; cannot resolve the default shared config path.'
+        }
+
+        return Join-Path (Join-Path $env:APPDATA 'qsoripper') 'config.toml'
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($env:XDG_CONFIG_HOME)) {
+        return Join-Path (Join-Path $env:XDG_CONFIG_HOME 'qsoripper') 'config.toml'
+    }
+
+    if ([string]::IsNullOrWhiteSpace($env:HOME)) {
+        throw 'HOME is not set; cannot resolve the default shared config path.'
+    }
+
+    return Join-Path (Join-Path (Join-Path $env:HOME '.config') 'qsoripper') 'config.toml'
+}
+
 function Get-StatePathForProfile([string]$ProfileId) {
     if ([string]::IsNullOrWhiteSpace($ProfileId)) {
         throw 'ProfileId is required.'
@@ -453,6 +473,7 @@ function Invoke-WithTemporaryEnvironment([hashtable]$EnvironmentOverrides, [scri
 }
 
 function Get-EngineProfiles {
+    $defaultConfigPath = Get-DefaultSharedConfigPath
     $rustManifestPath = Join-Path $PSScriptRoot 'src' | Join-Path -ChildPath 'rust' | Join-Path -ChildPath 'Cargo.toml'
     $dotnetProjectPath = Join-Path $PSScriptRoot 'src' | Join-Path -ChildPath 'dotnet' | Join-Path -ChildPath 'QsoRipper.Engine.DotNet' | Join-Path -ChildPath 'QsoRipper.Engine.DotNet.csproj'
     $dotnetDebugDllPath = Join-Path $PSScriptRoot 'src' | Join-Path -ChildPath 'dotnet' | Join-Path -ChildPath 'QsoRipper.Engine.DotNet' | Join-Path -ChildPath 'bin' | Join-Path -ChildPath 'Debug' | Join-Path -ChildPath 'net10.0' | Join-Path -ChildPath 'QsoRipper.Engine.DotNet.dll'
@@ -478,7 +499,7 @@ function Get-EngineProfiles {
             DefaultListenAddress = '127.0.0.1:50051'
             DefaultStorage = 'sqlite'
             DefaultPersistenceLocation = $defaultPersistenceLocation
-            DefaultConfigPath = Join-Path $runtimeDirectory 'rust-engine.json'
+            DefaultConfigPath = $defaultConfigPath
             EnvironmentTemplates = @{
                 QSORIPPER_STORAGE_BACKEND = '{storageBackend}'
                 QSORIPPER_SQLITE_PATH = '{persistenceLocation}'
@@ -497,7 +518,7 @@ function Get-EngineProfiles {
             DefaultListenAddress = '127.0.0.1:50052'
             DefaultStorage = 'memory'
             DefaultPersistenceLocation = $defaultPersistenceLocation
-            DefaultConfigPath = Join-Path $runtimeDirectory 'dotnet-engine.json'
+            DefaultConfigPath = $defaultConfigPath
             EnvironmentTemplates = @{
                 QSORIPPER_STORAGE_BACKEND = '{storageBackend}'
                 QSORIPPER_STORAGE_PATH = '{persistenceLocation}'
@@ -557,20 +578,47 @@ if ([string]::IsNullOrWhiteSpace($ListenAddress)) {
     $ListenAddress = $profile.DefaultListenAddress
 }
 
-if ([string]::IsNullOrWhiteSpace($Storage)) {
+$resolvedConfigPath = if ([string]::IsNullOrWhiteSpace($ConfigPath)) {
+    $profile.DefaultConfigPath
+}
+else {
+    $ConfigPath
+}
+
+$storageSpecified = $PSBoundParameters.ContainsKey('Storage')
+$persistenceSpecified = $PSBoundParameters.ContainsKey('PersistenceLocation') -or $PSBoundParameters.ContainsKey('SqlitePath')
+
+if (-not $storageSpecified -and $persistenceSpecified) {
+    $Storage = 'sqlite'
+    $storageSpecified = $true
+}
+
+if ($storageSpecified) {
+    if ([string]::IsNullOrWhiteSpace($Storage)) {
+        $Storage = $profile.DefaultStorage
+    }
+
+    if (-not $profile.SupportsStorageSession -and $Storage -ne $profile.DefaultStorage) {
+        throw "$($profile.DisplayName) only supports its default storage backend '$($profile.DefaultStorage)' through the launcher helper."
+    }
+
+    if ($Storage -ne 'memory' -and [string]::IsNullOrWhiteSpace($PersistenceLocation)) {
+        $PersistenceLocation = $profile.DefaultPersistenceLocation
+    }
+}
+elseif (-not (Test-Path -LiteralPath $resolvedConfigPath)) {
     $Storage = $profile.DefaultStorage
+    if ($Storage -ne 'memory' -and [string]::IsNullOrWhiteSpace($PersistenceLocation)) {
+        $PersistenceLocation = $profile.DefaultPersistenceLocation
+    }
 }
-
-if (-not $profile.SupportsStorageSession -and $Storage -ne $profile.DefaultStorage) {
-    throw "$($profile.DisplayName) only supports its default storage backend '$($profile.DefaultStorage)' through the launcher helper."
-}
-
-if ([string]::IsNullOrWhiteSpace($PersistenceLocation)) {
-    $PersistenceLocation = $profile.DefaultPersistenceLocation
+else {
+    $Storage = ''
+    $PersistenceLocation = ''
 }
 
 if ([string]::IsNullOrWhiteSpace($ConfigPath)) {
-    $ConfigPath = $profile.DefaultConfigPath
+    $ConfigPath = $resolvedConfigPath
 }
 
 $existing = Get-TrackedProcess -Path $statePath
@@ -676,7 +724,7 @@ if (-not $SkipBuild) {
 $tokens = @{
     configPath = $ConfigPath
     listenAddress = $ListenAddress
-    persistenceLocation = if ($Storage -eq 'memory') { '' } else { $PersistenceLocation }
+    persistenceLocation = if ($Storage -eq 'memory' -or [string]::IsNullOrWhiteSpace($Storage)) { '' } else { $PersistenceLocation }
     storageBackend = $Storage
 }
 
@@ -728,7 +776,7 @@ $state = [pscustomobject]@{
     startedAtUtc = [DateTime]::UtcNow.ToString('O')
     stderrPath = $stderrPath
     stdoutPath = $stdoutPath
-    storage = $Storage
+    storage = if ([string]::IsNullOrWhiteSpace($Storage)) { $null } else { $Storage }
 }
 $state | ConvertTo-Json | Set-Content -LiteralPath $statePath
 $state | ConvertTo-Json | Set-Content -LiteralPath $legacyStatePath

--- a/tests/Run-EngineConformance.ps1
+++ b/tests/Run-EngineConformance.ps1
@@ -67,6 +67,18 @@ function Invoke-Cli {
     $startInfo.RedirectStandardError = $true
     $startInfo.UseShellExecute = $false
     $startInfo.ArgumentList.Add($cliDll)
+
+    foreach ($name in @(
+            'QSORIPPER_QRZ_XML_USERNAME',
+            'QSORIPPER_QRZ_XML_PASSWORD',
+            'QSORIPPER_QRZ_USER_AGENT',
+            'QSORIPPER_QRZ_XML_BASE_URL',
+            'QSORIPPER_QRZ_LOGBOOK_API_KEY',
+            'QSORIPPER_QRZ_LOGBOOK_BASE_URL'
+        )) {
+        $null = $startInfo.Environment.Remove($name)
+    }
+
     foreach ($argument in $Arguments) {
         $startInfo.ArgumentList.Add($argument)
     }
@@ -250,9 +262,12 @@ function Start-TestEngine {
         ForceRestart = $true
     }
 
-    if ($EngineProfile -eq 'rust') {
+    if (-not [string]::IsNullOrWhiteSpace($Storage)) {
         $parameters.Storage = $Storage
-        $parameters.SqlitePath = $SqlitePath
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($SqlitePath)) {
+        $parameters.PersistenceLocation = $SqlitePath
     }
 
     if ($SkipBuild) {
@@ -393,6 +408,67 @@ function Invoke-ConformanceScenario {
     }
 }
 
+function Assert-SharedSetupRoundTrip {
+    param(
+        [string]$FirstEngineProfile,
+        [string]$SecondEngineProfile,
+        [string]$ScenarioId
+    )
+
+    $scenarioDirectory = Join-Path $runDirectory $ScenarioId
+    $null = New-Item -ItemType Directory -Path $scenarioDirectory -Force
+    $configPath = Join-Path $scenarioDirectory 'config.toml'
+    $persistencePath = Join-Path $scenarioDirectory 'shared-setup.db'
+    $environment = @{
+        QSORIPPER_LOG_FILE = $persistencePath
+        QSORIPPER_STATION_CALLSIGN = $stationCallsign
+        QSORIPPER_OPERATOR_CALLSIGN = $stationCallsign
+        QSORIPPER_PROFILE_NAME = $profileName
+        QSORIPPER_GRID = $grid
+    }
+
+    Write-Step "Seeding shared setup with $FirstEngineProfile"
+    $null = Start-TestEngine -EngineProfile $FirstEngineProfile -ConfigPath $configPath -Storage 'sqlite' -SqlitePath $persistencePath
+    $seedSetup = Invoke-Cli -Arguments @('--engine', $FirstEngineProfile, 'setup', '--from-env') -Environment $environment
+    Assert-CommandSucceeded -Result $seedSetup -Description "$FirstEngineProfile setup round-trip seed"
+    Stop-TestEngine
+
+    Write-Step "Verifying shared setup on $SecondEngineProfile"
+    $null = Start-TestEngine -EngineProfile $SecondEngineProfile -ConfigPath $configPath -Storage '' -SqlitePath ''
+    $statusResult = Invoke-Cli -Arguments @('--engine', $SecondEngineProfile, 'setup', '--status', '--json')
+    Assert-CommandSucceeded -Result $statusResult -Description "$SecondEngineProfile setup --status round-trip"
+    $statusJson = $statusResult.StdOut | ConvertFrom-Json
+    $runtimeResult = Invoke-Cli -Arguments @('--engine', $SecondEngineProfile, 'config', '--json')
+    Assert-CommandSucceeded -Result $runtimeResult -Description "$SecondEngineProfile config --json round-trip"
+    $runtimeJson = $runtimeResult.StdOut | ConvertFrom-Json
+
+    if (-not $statusJson.status.setupComplete) {
+        throw "$ScenarioId did not preserve setup completeness when switching from $FirstEngineProfile to $SecondEngineProfile."
+    }
+
+    if ($statusJson.status.stationProfile.stationCallsign -ne $stationCallsign) {
+        throw "$ScenarioId did not preserve the station profile when switching from $FirstEngineProfile to $SecondEngineProfile."
+    }
+
+    if ([string]::IsNullOrWhiteSpace($statusJson.status.activeStationProfileId)) {
+        throw "$ScenarioId did not preserve the active station profile id when switching from $FirstEngineProfile to $SecondEngineProfile."
+    }
+
+    if ($runtimeJson.activeStorageBackend -ne 'sqlite') {
+        throw "$ScenarioId did not reload sqlite storage from shared config when switching from $FirstEngineProfile to $SecondEngineProfile."
+    }
+
+    if ([string]::IsNullOrWhiteSpace($runtimeJson.persistenceLocation)) {
+        throw "$ScenarioId did not report a persistence path after switching from $FirstEngineProfile to $SecondEngineProfile."
+    }
+
+    if ([System.IO.Path]::GetFullPath($runtimeJson.persistenceLocation) -ne [System.IO.Path]::GetFullPath($persistencePath)) {
+        throw "$ScenarioId did not preserve the shared persistence path when switching from $FirstEngineProfile to $SecondEngineProfile."
+    }
+
+    Stop-TestEngine
+}
+
 function Assert-EquivalentRecords {
     param(
         [System.Collections.IDictionary]$Left,
@@ -452,17 +528,19 @@ try {
         }
     }
 
-    $rustConfigPath = Join-Path $runDirectory 'rust-engine.json'
-    $dotnetConfigPath = Join-Path $runDirectory 'dotnet-engine.json'
+    $sharedConfigPath = Join-Path $runDirectory 'config.toml'
     $persistencePath = Join-Path $runDirectory 'conformance-log.db'
 
-    $rustScenarioOutput = @(Invoke-ConformanceScenario -EngineProfile 'rust' -ConfigPath $rustConfigPath -PersistencePath $persistencePath -Storage 'sqlite')
+    $rustScenarioOutput = @(Invoke-ConformanceScenario -EngineProfile 'rust' -ConfigPath $sharedConfigPath -PersistencePath $persistencePath -Storage 'sqlite')
     $rustResult = Select-ScenarioResult -Results $rustScenarioOutput -EngineProfile 'rust'
     Stop-TestEngine
 
-    $dotnetScenarioOutput = @(Invoke-ConformanceScenario -EngineProfile 'dotnet' -ConfigPath $dotnetConfigPath -PersistencePath $persistencePath -Storage 'memory')
+    $dotnetScenarioOutput = @(Invoke-ConformanceScenario -EngineProfile 'dotnet' -ConfigPath $sharedConfigPath -PersistencePath $persistencePath -Storage 'sqlite')
     $dotnetResult = Select-ScenarioResult -Results $dotnetScenarioOutput -EngineProfile 'dotnet'
     Stop-TestEngine
+
+    Assert-SharedSetupRoundTrip -FirstEngineProfile 'rust' -SecondEngineProfile 'dotnet' -ScenarioId 'rust-to-dotnet'
+    Assert-SharedSetupRoundTrip -FirstEngineProfile 'dotnet' -SecondEngineProfile 'rust' -ScenarioId 'dotnet-to-rust'
 
     Assert-EquivalentRecords -Left $rustResult.Qso -Right $dotnetResult.Qso -Description 'GetQso'
     Assert-EquivalentRecords -Left $rustResult.ListQso -Right $dotnetResult.ListQso -Description 'ListQsos'


### PR DESCRIPTION
## Summary
- define a shared TOML-backed durable setup model used by the Rust and .NET hosts through one canonical shared config path
- keep runtime overrides and session station-profile overrides ephemeral while persisting engine-neutral setup like storage, station profiles, QRZ XML/logbook config, sync settings, and rig-control defaults
- align the launcher, CLI, DebugHost, and engine catalog so clients can swap between engines without Rust-specific storage assumptions or forced local overrides
- harden the remaining gaps by honoring shared QRZ XML user-agent in the managed engine, restoring first-run Rust sqlite bootstrap, tightening Unix config permissions, avoiding secret migration from LocalAppData into roaming config, and scrubbing ambient QRZ credentials from conformance runs

## Validation
- .\build.ps1 check-dotnet
- .\build.ps1 check-rust
- .\tests\Run-EngineConformance.ps1

Closes #187.