### PR TITLE
Fix FormatRst to fall back to raw field when numeric RST fields are zero

### DIFF
--- a/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
@@ -277,7 +277,8 @@ public sealed class CommandHelperTests
         {
             { null, "" },
             { new RstReport { Readability = 5, Strength = 9 }, "59" },
-            { new RstReport { Readability = 5, Strength = 9, Tone = 9 }, "599" }
+            { new RstReport { Readability = 5, Strength = 9, Tone = 9 }, "599" },
+            { new RstReport { Raw = "599" }, "599" },
         };
 
     [Theory]

--- a/src/dotnet/QsoRipper.Cli/Commands/GetQsoCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/GetQsoCommand.cs
@@ -42,12 +42,12 @@ internal static class GetQsoCommand
 
         if (qso.RstSent is not null)
         {
-            Console.WriteLine($"RST Sent:         {FormatRst(qso.RstSent)}");
+            Console.WriteLine($"RST Sent:         {ListQsosCommand.FormatRst(qso.RstSent)}");
         }
 
         if (qso.RstReceived is not null)
         {
-            Console.WriteLine($"RST Rcvd:         {FormatRst(qso.RstReceived)}");
+            Console.WriteLine($"RST Rcvd:         {ListQsosCommand.FormatRst(qso.RstReceived)}");
         }
 
         if (qso.HasQrzLogid)
@@ -56,15 +56,5 @@ internal static class GetQsoCommand
         }
 
         return 0;
-    }
-
-    private static string FormatRst(RstReport rst)
-    {
-        if (rst.HasTone)
-        {
-            return $"{rst.Readability}{rst.Strength}{rst.Tone}";
-        }
-
-        return $"{rst.Readability}{rst.Strength}";
     }
 }


### PR DESCRIPTION
## Summary

Fixes #84

### Problem
The `list` and `get` CLI commands displayed RST as `00` when the numeric readability/strength/tone fields were zero, even when the `Raw` field contained the correct value (e.g., `599`). This affected all ADIF-imported QSOs.

### Root Cause
`GetQsoCommand` had its own private `FormatRst` method that always formatted from numeric fields, producing `00` when those were zero. Meanwhile, `ListQsosCommand.FormatRst` already had the correct fallback logic.

### Fix
- Removed the duplicate private `FormatRst` from `GetQsoCommand`  
- Changed both call sites to use `ListQsosCommand.FormatRst` which falls back to `Raw` when numeric fields are all zero
- Added regression test: `RstReport { Raw = "599" }` with zero numeric fields returns `599` not `00`

### Verification
- Build: clean
- Tests: all pass
- Format: `dotnet format --verify-no-changes` clean