### PR TITLE
Reduce QSO grid row density for compact keyboard-first UX

### DIFF
--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -57,7 +57,13 @@
       <Setter Property="IsReadOnly" Value="False" />
     </Style>
 
+    <!-- Compact density: override Fluent theme MinHeight so RowHeight/ColumnHeaderHeight bindings control sizing -->
+    <Style Selector="DataGrid#RecentQsoGrid DataGridRow">
+      <Setter Property="MinHeight" Value="0" />
+    </Style>
+
     <Style Selector="DataGrid#RecentQsoGrid DataGridColumnHeader">
+      <Setter Property="MinHeight" Value="0" />
       <Setter Property="Padding" Value="2,0" />
       <Setter Property="FontWeight" Value="SemiBold" />
     </Style>


### PR DESCRIPTION
## Summary

Fixes #126

### Problem
Grid rows were taller than ideal for a dense, keyboard-first QSO log. The ViewModel already computed compact heights (19px rows, 21px headers), but the Avalonia Fluent theme's default `MinHeight` on `DataGridRow` and `DataGridColumnHeader` was inflating the actual rendered size.

### Fix
Added compact density style overrides in `MainWindow.axaml`:
- `DataGridRow` style: `MinHeight=0` so the `RowHeight` binding (19px) controls sizing
- `DataGridColumnHeader` style: `MinHeight=0` so the `ColumnHeaderHeight` binding (21px) controls sizing

This gives operators the dense grid view needed for keyboard-first contest logging.

### Verification
- Build: 0 errors, 0 warnings
- Tests: 229 passed, 0 failed
- Format: `dotnet format --verify-no-changes` clean