### PR TITLE
Improve dialog Yes/No button contrast for readability

### DIFF
--- a/src/dotnet/QsoRipper.Gui/App.axaml
+++ b/src/dotnet/QsoRipper.Gui/App.axaml
@@ -17,6 +17,12 @@
           <Color x:Key="SystemAccentColorLight1">#33AADD</Color>
           <Color x:Key="SystemAccentColorLight2">#66C0E8</Color>
           <Color x:Key="SystemAccentColorLight3">#99D6F2</Color>
+
+          <!-- Ensure accent-button text is always white against the cyan accent fill -->
+          <SolidColorBrush x:Key="AccentButtonForeground" Color="White" />
+          <SolidColorBrush x:Key="AccentButtonForegroundPointerOver" Color="White" />
+          <SolidColorBrush x:Key="AccentButtonForegroundPressed" Color="#CCFFFFFF" />
+          <SolidColorBrush x:Key="AccentButtonForegroundDisabled" Color="#80FFFFFF" />
         </ResourceDictionary>
       </ResourceDictionary.ThemeDictionaries>
     </ResourceDictionary>

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -956,9 +956,11 @@
                         HorizontalAlignment="Right">
               <Button Content="Cancel"
                       MinWidth="80"
+                      Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
                       Command="{Binding RecentQsos.CancelDeleteCommand}" />
               <Button Content="Delete"
                       MinWidth="80"
+                      Foreground="White"
                       Classes="accent"
                       Command="{Binding RecentQsos.ConfirmDeleteCommand}" />
             </StackPanel>


### PR DESCRIPTION
## Summary

Fixes #156

### Problem
The Yes/No (Cancel/Delete) buttons in the confirmation dialog were hard to read because the button text lacked sufficient contrast against the button background in the dark theme with the custom cyan accent color.

### Root Cause
The Fluent theme's accent button foreground resources weren't explicitly overridden in the dark theme dictionary. When combining a custom `SystemAccentColor` with the Fluent dark theme, the default text-on-accent color didn't provide adequate contrast.

### Fix
**`App.axaml`** — Added four `AccentButtonForeground*` brush overrides to the dark theme ResourceDictionary:
- `AccentButtonForeground` → White (normal)
- `AccentButtonForegroundPointerOver` → White (hover)
- `AccentButtonForegroundPressed` → 80%% white (pressed)
- `AccentButtonForegroundDisabled` → 50%% white (disabled)

**`MainWindow.axaml`** — Added explicit `Foreground` to both dialog buttons:
- Cancel: theme-aware light text
- Delete: explicit white on accent background

### Verification
- Build: 0 errors, 0 warnings
- Tests: 229 passed, 0 failed
- Format: `dotnet format --verify-no-changes` clean