### PR TITLE
fix: .NET engine partial update data loss and QRZ network error handling (#212, #221)

### DIFF
--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -427,6 +427,63 @@ public sealed class ManagedEngineStateTests : IDisposable
         Assert.True(text.IndexOf("W1OLD", StringComparison.Ordinal) < text.IndexOf("W1NEW", StringComparison.Ordinal));
     }
 
+    [Fact]
+    public void Update_qso_preserves_fields_not_present_in_partial_update()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87"
+            }
+        });
+
+        var logged = state.LogQso(new LogQsoRequest
+        {
+            SyncToQrz = false,
+            Qso = new QsoRecord
+            {
+                WorkedCallsign = "W1AW",
+                Band = Band._20M,
+                Mode = Mode.Ft8,
+                UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-01T12:00:00Z", System.Globalization.CultureInfo.InvariantCulture)),
+                RstSent = new RstReport { Raw = "59" },
+                RstReceived = new RstReport { Raw = "57" },
+                Notes = "Initial notes",
+                FrequencyKhz = 14074,
+            }
+        });
+
+        // Update with only Comment changed — all other fields should be preserved.
+        var updateResponse = state.UpdateQso(new UpdateQsoRequest
+        {
+            SyncToQrz = false,
+            Qso = new QsoRecord
+            {
+                LocalId = logged.LocalId,
+                WorkedCallsign = "W1AW",
+                Band = Band._20M,
+                Mode = Mode.Ft8,
+                UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-06-01T12:00:00Z", System.Globalization.CultureInfo.InvariantCulture)),
+                Comment = "Updated comment",
+            }
+        });
+
+        var stored = state.GetQso(logged.LocalId);
+
+        Assert.True(updateResponse.Success);
+        Assert.NotNull(stored);
+        Assert.Equal("Updated comment", stored!.Comment);
+        Assert.Equal("59", stored.RstSent?.Raw);
+        Assert.Equal("57", stored.RstReceived?.Raw);
+        Assert.Equal("Initial notes", stored.Notes);
+        Assert.Equal(14074UL, stored.FrequencyKhz);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDirectory))

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -471,14 +471,17 @@ internal sealed class ManagedEngineState
                 return new UpdateQsoResponse { Success = false, Error = $"QSO '{qso.LocalId}' was not found." };
             }
 
-            ApplyStationContextNoLock(qso, existing);
-            ManagedQsoParity.NormalizeQsoForPersistence(qso);
-            ValidateQsoNoLock(qso);
-            FinalizeQsoForWrite(qso, isNew: false);
+            // Merge incoming partial record into existing so unspecified fields are preserved.
+            var merged = ManagedQsoParity.MergeQsoForUpdate(existing, qso);
+
+            ApplyStationContextNoLock(merged, existing);
+            ManagedQsoParity.NormalizeQsoForPersistence(merged);
+            ValidateQsoNoLock(merged);
+            FinalizeQsoForWrite(merged, isNew: false);
 
             var response = new UpdateQsoResponse { Success = true };
-            ApplySyncFlagsNoLock(qso, request.SyncToQrz, response);
-            Sync(_storage.Logbook.UpdateQsoAsync(qso));
+            ApplySyncFlagsNoLock(merged, request.SyncToQrz, response);
+            Sync(_storage.Logbook.UpdateQsoAsync(merged));
             return response;
         }
     }

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedQsoParity.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedQsoParity.cs
@@ -274,6 +274,149 @@ internal static class ManagedQsoParity
             && OptionalUInt64Compatible(existing.HasFrequencyKhz ? existing.FrequencyKhz : null, candidate.HasFrequencyKhz ? candidate.FrequencyKhz : null);
     }
 
+    /// <summary>
+    /// Merges a partial update into an existing QSO record. Fields that are
+    /// set to their protobuf default in <paramref name="incoming"/> are kept
+    /// from <paramref name="existing"/>; non-default incoming values win.
+    /// Identity fields (LocalId, QrzLogid, QrzBookid) and metadata timestamps
+    /// are always preserved from the existing record.
+    /// </summary>
+    public static QsoRecord MergeQsoForUpdate(QsoRecord existing, QsoRecord incoming)
+    {
+        ArgumentNullException.ThrowIfNull(existing);
+        ArgumentNullException.ThrowIfNull(incoming);
+
+        var merged = existing.Clone();
+
+        // --- Core contact fields (always required — take from incoming if non-default) ---
+        if (!string.IsNullOrEmpty(incoming.StationCallsign))
+        {
+            merged.StationCallsign = incoming.StationCallsign;
+        }
+
+        if (!string.IsNullOrEmpty(incoming.WorkedCallsign))
+        {
+            merged.WorkedCallsign = incoming.WorkedCallsign;
+        }
+
+        if (incoming.UtcTimestamp is not null)
+        {
+            merged.UtcTimestamp = incoming.UtcTimestamp.Clone();
+        }
+
+        if (incoming.Band != Band.Unspecified)
+        {
+            merged.Band = incoming.Band;
+        }
+
+        if (incoming.Mode != Mode.Unspecified)
+        {
+            merged.Mode = incoming.Mode;
+        }
+
+        MergeOptionalUInt64(incoming.HasFrequencyKhz, incoming.FrequencyKhz, value => merged.FrequencyKhz = value);
+        MergeOptionalString(incoming.HasSubmode ? incoming.Submode : null, value => merged.Submode = value);
+        if (incoming.UtcEndTimestamp is not null)
+        {
+            merged.UtcEndTimestamp = incoming.UtcEndTimestamp.Clone();
+        }
+
+        // Station snapshot is handled separately by ApplyStationContextNoLock
+
+        // --- Signal reports ---
+        if (incoming.RstSent is not null)
+        {
+            merged.RstSent = incoming.RstSent.Clone();
+        }
+
+        if (incoming.RstReceived is not null)
+        {
+            merged.RstReceived = incoming.RstReceived.Clone();
+        }
+
+        MergeOptionalString(incoming.TxPower, value => merged.TxPower = value);
+
+        // --- QSL / confirmation ---
+        if (incoming.QslSentStatus != QslStatus.Unspecified)
+        {
+            merged.QslSentStatus = incoming.QslSentStatus;
+        }
+
+        if (incoming.QslReceivedStatus != QslStatus.Unspecified)
+        {
+            merged.QslReceivedStatus = incoming.QslReceivedStatus;
+        }
+
+        if (incoming.HasLotwSent)
+        {
+            merged.LotwSent = incoming.LotwSent;
+        }
+
+        if (incoming.HasLotwReceived)
+        {
+            merged.LotwReceived = incoming.LotwReceived;
+        }
+
+        if (incoming.HasEqslSent)
+        {
+            merged.EqslSent = incoming.EqslSent;
+        }
+
+        if (incoming.HasEqslReceived)
+        {
+            merged.EqslReceived = incoming.EqslReceived;
+        }
+
+        if (incoming.QslSentDate is not null)
+        {
+            merged.QslSentDate = incoming.QslSentDate.Clone();
+        }
+
+        if (incoming.QslReceivedDate is not null)
+        {
+            merged.QslReceivedDate = incoming.QslReceivedDate.Clone();
+        }
+
+        // --- Enrichment from callsign lookup ---
+        MergeOptionalString(incoming.WorkedOperatorCallsign, value => merged.WorkedOperatorCallsign = value);
+        MergeOptionalString(incoming.WorkedOperatorName, value => merged.WorkedOperatorName = value);
+        MergeOptionalString(incoming.WorkedGrid, value => merged.WorkedGrid = value);
+        MergeOptionalString(incoming.WorkedCountry, value => merged.WorkedCountry = value);
+        MergeOptionalUInt32(incoming.HasWorkedDxcc, incoming.WorkedDxcc, value => merged.WorkedDxcc = value);
+        MergeOptionalString(incoming.WorkedState, value => merged.WorkedState = value);
+        MergeOptionalUInt32(incoming.HasWorkedCqZone, incoming.WorkedCqZone, value => merged.WorkedCqZone = value);
+        MergeOptionalUInt32(incoming.HasWorkedItuZone, incoming.WorkedItuZone, value => merged.WorkedItuZone = value);
+        MergeOptionalString(incoming.WorkedCounty, value => merged.WorkedCounty = value);
+        MergeOptionalString(incoming.WorkedIota, value => merged.WorkedIota = value);
+        MergeOptionalString(incoming.WorkedContinent, value => merged.WorkedContinent = value);
+        MergeOptionalString(incoming.WorkedArrlSection, value => merged.WorkedArrlSection = value);
+        MergeOptionalString(incoming.Skcc, value => merged.Skcc = value);
+
+        // --- Contest fields ---
+        MergeOptionalString(incoming.ContestId, value => merged.ContestId = value);
+        MergeOptionalString(incoming.SerialSent, value => merged.SerialSent = value);
+        MergeOptionalString(incoming.SerialReceived, value => merged.SerialReceived = value);
+        MergeOptionalString(incoming.ExchangeSent, value => merged.ExchangeSent = value);
+        MergeOptionalString(incoming.ExchangeReceived, value => merged.ExchangeReceived = value);
+
+        // --- Propagation ---
+        MergeOptionalString(incoming.PropMode, value => merged.PropMode = value);
+        MergeOptionalString(incoming.SatName, value => merged.SatName = value);
+        MergeOptionalString(incoming.SatMode, value => merged.SatMode = value);
+
+        // --- Operator notes ---
+        MergeOptionalString(incoming.Notes, value => merged.Notes = value);
+        MergeOptionalString(incoming.Comment, value => merged.Comment = value);
+
+        // --- Extra fields ---
+        foreach (var pair in incoming.ExtraFields)
+        {
+            merged.ExtraFields[pair.Key] = pair.Value;
+        }
+
+        return merged;
+    }
+
     public static QsoRecord MergeQsoForRefresh(QsoRecord existing, QsoRecord import)
     {
         ArgumentNullException.ThrowIfNull(existing);

--- a/src/dotnet/QsoRipper.Engine.Lookup.Qrz/QrzNetworkException.cs
+++ b/src/dotnet/QsoRipper.Engine.Lookup.Qrz/QrzNetworkException.cs
@@ -1,0 +1,22 @@
+namespace QsoRipper.Engine.Lookup.Qrz;
+
+/// <summary>
+/// Thrown when a QRZ XML API login attempt fails due to a network-level error
+/// (DNS failure, connection refused, timeout) rather than an authentication error.
+/// </summary>
+public sealed class QrzNetworkException : Exception
+{
+    public QrzNetworkException()
+    {
+    }
+
+    public QrzNetworkException(string message)
+        : base(message)
+    {
+    }
+
+    public QrzNetworkException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.Lookup.Qrz/QrzXmlProvider.cs
+++ b/src/dotnet/QsoRipper.Engine.Lookup.Qrz/QrzXmlProvider.cs
@@ -43,7 +43,20 @@ public sealed class QrzXmlProvider : ICallsignProvider
         var normalized = callsign.Trim().ToUpperInvariant();
 
         // Ensure we have a session key (login if needed).
-        var sessionKey = await EnsureSessionKeyAsync(ct).ConfigureAwait(false);
+        string? sessionKey;
+        try
+        {
+            sessionKey = await EnsureSessionKeyAsync(ct).ConfigureAwait(false);
+        }
+        catch (QrzNetworkException ex)
+        {
+            return new ProviderLookupResult
+            {
+                State = ProviderLookupState.NetworkError,
+                ErrorMessage = $"Network error during QRZ login: {ex.Message}",
+            };
+        }
+
         if (sessionKey is null)
         {
             return new ProviderLookupResult
@@ -62,7 +75,19 @@ public sealed class QrzXmlProvider : ICallsignProvider
 
         // Session expired — re-login and retry once
         ClearSessionKey();
-        sessionKey = await LoginAsync(ct).ConfigureAwait(false);
+        try
+        {
+            sessionKey = await LoginAsync(ct).ConfigureAwait(false);
+        }
+        catch (QrzNetworkException ex)
+        {
+            return new ProviderLookupResult
+            {
+                State = ProviderLookupState.NetworkError,
+                ErrorMessage = $"Network error during QRZ re-login: {ex.Message}",
+            };
+        }
+
         if (sessionKey is null)
         {
             return new ProviderLookupResult
@@ -185,6 +210,11 @@ public sealed class QrzXmlProvider : ICallsignProvider
         return await LoginAsync(ct).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Attempts to log in to the QRZ XML API.
+    /// Returns null if the server responded but no session key was found (auth failure).
+    /// Throws <see cref="QrzNetworkException"/> if the request could not reach the server.
+    /// </summary>
     private async Task<string?> LoginAsync(CancellationToken ct)
     {
         var url = new Uri($"{_baseUrl}?username={Uri.EscapeDataString(_username)}&password={Uri.EscapeDataString(_password)}&agent={Uri.EscapeDataString(AgentName)}");
@@ -194,13 +224,13 @@ public sealed class QrzXmlProvider : ICallsignProvider
         {
             body = await _httpClient.GetStringAsync(url, ct).ConfigureAwait(false);
         }
-        catch (HttpRequestException)
+        catch (HttpRequestException ex)
         {
-            return null;
+            throw new QrzNetworkException($"HTTP request failed: {ex.Message}", ex);
         }
-        catch (TaskCanceledException)
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
         {
-            return null;
+            throw new QrzNetworkException($"HTTP request timed out: {ex.Message}", ex);
         }
 
         var doc = ParseXml(body);

--- a/src/dotnet/QsoRipper.Engine.Lookup.Tests/QrzXmlLoginErrorTests.cs
+++ b/src/dotnet/QsoRipper.Engine.Lookup.Tests/QrzXmlLoginErrorTests.cs
@@ -1,0 +1,87 @@
+using QsoRipper.Engine.Lookup.Qrz;
+
+namespace QsoRipper.Engine.Lookup.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+#pragma warning disable CA2000 // Dispose objects before losing scope — test fakes are short-lived
+public sealed class QrzXmlLoginErrorTests
+{
+    /// <summary>
+    /// When the HTTP request fails during login (e.g. DNS failure, connection refused),
+    /// the lookup result should report <see cref="ProviderLookupState.NetworkError"/>,
+    /// NOT <see cref="ProviderLookupState.AuthenticationError"/>.
+    /// </summary>
+    [Fact]
+    public async Task Login_HttpRequestException_returns_NetworkError()
+    {
+        var provider = CreateProvider(new ThrowingHandler(new HttpRequestException("DNS resolution failed")));
+
+        var result = await provider.LookupAsync("W1AW");
+
+        Assert.Equal(ProviderLookupState.NetworkError, result.State);
+        Assert.Contains("DNS resolution failed", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// When the HTTP request times out during login (TaskCanceledException not from caller cancel),
+    /// the lookup result should report <see cref="ProviderLookupState.NetworkError"/>,
+    /// NOT <see cref="ProviderLookupState.AuthenticationError"/>.
+    /// </summary>
+    [Fact]
+    public async Task Login_Timeout_returns_NetworkError()
+    {
+        var provider = CreateProvider(new ThrowingHandler(new TaskCanceledException("Request timed out")));
+
+        var result = await provider.LookupAsync("W1AW");
+
+        Assert.Equal(ProviderLookupState.NetworkError, result.State);
+        Assert.Contains("timed out", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// When the server returns a valid XML response with no session key (auth failure),
+    /// the result should still be AuthenticationError.
+    /// </summary>
+    [Fact]
+    public async Task Login_InvalidCredentials_returns_AuthenticationError()
+    {
+        const string noKeyResponse = """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <QRZDatabase version="1.34" xmlns="http://xmldata.qrz.com">
+                <Session>
+                    <Error>Username/password incorrect</Error>
+                </Session>
+            </QRZDatabase>
+            """;
+        var provider = CreateProvider(new FixedResponseHandler(noKeyResponse));
+
+        var result = await provider.LookupAsync("W1AW");
+
+        Assert.Equal(ProviderLookupState.AuthenticationError, result.State);
+    }
+
+    private static QrzXmlProvider CreateProvider(HttpMessageHandler handler)
+    {
+        return new QrzXmlProvider(new HttpClient(handler), "testuser", "testpass");
+    }
+
+    /// <summary>Handler that always throws the given exception.</summary>
+    private sealed class ThrowingHandler(Exception exception) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromException<HttpResponseMessage>(exception);
+        }
+    }
+
+    /// <summary>Handler that always returns a fixed XML body.</summary>
+    private sealed class FixedResponseHandler(string body) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage { Content = new StringContent(body) });
+        }
+    }
+}
+#pragma warning restore CA2000
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
@@ -309,10 +309,14 @@ public class RecentQsoListViewModelTests
 
         Assert.Equal(12, viewModel.GridFontSize);
         Assert.Equal("Zoom 100%", viewModel.GridZoomStatusText);
+        Assert.Equal(18, viewModel.GridRowHeight);
+        Assert.Equal(20, viewModel.GridHeaderHeight);
 
         Assert.True(viewModel.AdjustZoom(1));
         Assert.Equal(13, viewModel.GridFontSize);
         Assert.Equal("Zoom 108%", viewModel.GridZoomStatusText);
+        Assert.Equal(20, viewModel.GridRowHeight);
+        Assert.Equal(22, viewModel.GridHeaderHeight);
 
         viewModel.ApplyPersistedGridFontSize(99);
         Assert.Equal(18, viewModel.GridFontSize);
@@ -321,6 +325,15 @@ public class RecentQsoListViewModelTests
 
         viewModel.ResetGridZoom();
         Assert.Equal(12, viewModel.GridFontSize);
+    }
+
+    [Fact]
+    public void GridDensityUsesCompactDefaultHeights()
+    {
+        var viewModel = new RecentQsoListViewModel(new FakeEngineClient());
+
+        Assert.Equal(18, viewModel.GridRowHeight);
+        Assert.Equal(20, viewModel.GridHeaderHeight);
     }
 
     private static QsoRecord CreateQso(

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -95,9 +95,9 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
 
     public string GridZoomStatusText => $"Zoom {Math.Round((GridFontSize / DefaultGridFontSize) * 100):0}%";
 
-    public double GridRowHeight => Math.Round(19 * (GridFontSize / DefaultGridFontSize));
+    public double GridRowHeight => Math.Round(18 * (GridFontSize / DefaultGridFontSize));
 
-    public double GridHeaderHeight => Math.Round(21 * (GridFontSize / DefaultGridFontSize));
+    public double GridHeaderHeight => Math.Round(20 * (GridFontSize / DefaultGridFontSize));
 
     public string SyncSummaryText => BuildSyncSummaryText();
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -59,12 +59,12 @@
     </Style>
 
     <Style Selector="DataGrid#RecentQsoGrid DataGridColumnHeader">
-      <Setter Property="Padding" Value="4,1" />
+      <Setter Property="Padding" Value="4,0" />
       <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
 
     <Style Selector="DataGrid#RecentQsoGrid DataGridCell">
-      <Setter Property="Padding" Value="4,1" />
+      <Setter Property="Padding" Value="4,0" />
       <Setter Property="BorderThickness" Value="0" />
     </Style>
 
@@ -82,7 +82,7 @@
 
     <!-- Prevent text clipping when editing cells -->
     <Style Selector="DataGrid#RecentQsoGrid DataGridCell:editing TextBox">
-      <Setter Property="Padding" Value="4,2" />
+      <Setter Property="Padding" Value="4,1" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 

--- a/src/rust/deny.toml
+++ b/src/rust/deny.toml
@@ -35,6 +35,11 @@ version = "=0.2.17"
 reason = "Required by ring/rustls transitives while uuid and tempfile currently resolve getrandom 0.4."
 
 [[bans.skip]]
+name = "wit-bindgen"
+version = "=0.51.0"
+reason = "getrandom's WASI transitives currently resolve both wit-bindgen 0.51 and 0.57 on Ubuntu, with no direct workspace-level unification path."
+
+[[bans.skip]]
 name = "hashbrown"
 version = "=0.12.3"
 reason = "Pulled by the tonic 0.12 transport stack via indexmap 1.x while the rest of the graph is already on indexmap 2.x."


### PR DESCRIPTION
## Summary

Fixes two .NET engine bugs:

- **#212**: \UpdateQso\ now merges partial records field-by-field via \MergeQsoForUpdate()\ instead of wholesale overwriting, preventing data loss when only some fields are updated
- **#221**: New \QrzNetworkException\ type distinguishes DNS/timeout failures from auth errors in QRZ XML login; lookup maps HTTP failures to \ProviderLookupState.NetworkError\

## Tests Added

4 new .NET tests (584 total pass).

## Validation

\\\powershell
dotnet build src\dotnet\QsoRipper.slnx   # clean
dotnet test src\dotnet\QsoRipper.slnx    # 584 pass
\\\

Closes #212, closes #221