### PR TITLE
fix: QRZ sync REPLACE, proto doc alignment, and capability vocabulary (#213, #214, #215, #216)

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -107,8 +107,12 @@ Returns metadata about the running engine.
 
 **Behavior:**
 - Must always succeed if the engine is running.
-- Returns the engine's name (e.g., `"qsoripper-server"`), version string, implementation language (e.g., `"rust"`, `"csharp"`), and a list of supported capability flags.
-- The response must include the storage backend currently in use (see `StorageBackend` enum).
+- Returns the engine's identity (`engine_id`, `display_name`), version string, and a list of supported capability strings.
+- The response is an `EngineInfo` message (see `proto/services/engine_info.proto`) containing:
+  - `engine_id` — stable identifier (e.g., `"rust-tonic"`, `"dotnet-managed"`)
+  - `display_name` — human-readable label
+  - `version` — semver string
+  - `capabilities` — repeated list of capability names (see §8)
 
 **Error semantics:**
 - This RPC should never fail under normal operation.
@@ -1148,15 +1152,16 @@ Every engine must implement `GetEngineInfo` to report its identity and capabilit
 
 **Required response fields:**
 
-| Field | Example (Rust) | Example (.NET) |
+| Proto field | Example (Rust) | Example (.NET) |
 |---|---|---|
-| Engine name | `qsoripper-server` | `qsoripper-engine-dotnet` |
-| Version | `0.1.0` | `0.1.0` |
-| Language | `rust` | `csharp` |
-| Storage backend | `sqlite` | `memory` |
-| Capabilities | List of supported feature flags | List of supported feature flags |
+| `engine_id` | `rust-tonic` | `dotnet-managed` |
+| `display_name` | `QsoRipper Rust Engine` | `QsoRipper .NET Engine` |
+| `version` | `0.1.0` | `0.1.0` |
+| `capabilities` | List of supported capability strings | List of supported capability strings |
 
-**Capability flags** indicate which optional features the engine supports. Clients use these to enable or disable UI features. Examples:
+> **Note:** Earlier drafts of this spec referenced `engine_language` and `storage_backend` fields. These were never added to the `EngineInfo` proto message. Use `engine_id` to infer the implementation language if needed.
+
+**Capability strings** indicate which optional features the engine supports. Clients use these to enable or disable UI features. Examples:
 
 - `logbook` — core QSO CRUD
 - `lookup` — callsign lookup

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -1161,18 +1161,26 @@ Every engine must implement `GetEngineInfo` to report its identity and capabilit
 
 > **Note:** Earlier drafts of this spec referenced `engine_language` and `storage_backend` fields. These were never added to the `EngineInfo` proto message. Use `engine_id` to infer the implementation language if needed.
 
-**Capability strings** indicate which optional features the engine supports. Clients use these to enable or disable UI features. Examples:
+**Capability strings** indicate which optional features the engine supports. Clients use these to enable or disable UI features.
 
-- `logbook` — core QSO CRUD
-- `lookup` — callsign lookup
-- `sync` — QRZ logbook sync
-- `rig_control` — rigctld integration
-- `space_weather` — NOAA space weather
-- `stress` — stress testing control plane
-- `adif_import` — ADIF file import
-- `adif_export` — ADIF file export
+Both engines currently report the following capabilities:
 
-Engines should report capabilities accurately based on their current configuration. An engine with no QRZ credentials should not report `lookup` as a capability.
+| Capability | Description |
+|---|---|
+| `engine-info` | Engine metadata / health check |
+| `logbook` | Core QSO CRUD |
+| `lookup-cache` | Cached callsign lookup |
+| `lookup-callsign` | Live callsign lookup |
+| `lookup-stream` | Streaming callsign lookup |
+| `setup` | First-run setup wizard |
+| `station-profiles` | Station profile management |
+| `runtime-config` | Runtime configuration updates |
+| `rig-control` | rigctld integration |
+| `space-weather` | NOAA space weather data |
+
+> **Note:** Earlier drafts listed aspirational names (`sync`, `rig_control`, `stress`, `adif_import`, `adif_export`) that were never adopted. The canonical names above use kebab-case and match what both engines actually report. New capabilities should follow this convention.
+
+Engines currently report a static set of capabilities. Configuration-gated capability reporting (e.g., hiding `lookup-callsign` when no QRZ credentials are configured) is a planned enhancement.
 
 ---
 

--- a/proto/services/logbook_service.proto
+++ b/proto/services/logbook_service.proto
@@ -31,10 +31,10 @@ import "services/update_qso_response.proto";
 //   DeleteQso     — implemented for local storage; QRZ delete supported when delete_from_qrz=true
 //   GetQso        — implemented for local storage
 //   ListQsos      — implemented for local storage
-//   SyncWithQrz  — planned (returns UNIMPLEMENTED)
-//   GetSyncStatus — implemented for local storage counts; QRZ metadata remains absent until sync lands
-//   ImportAdif   — implemented for local ADIF migration import with duplicate/warning reporting
-//   ExportAdif   — implemented for filtered ADIF export
+//   SyncWithQrz   — implemented (both engines)
+//   GetSyncStatus — implemented for local storage counts
+//   ImportAdif    — implemented for local ADIF migration import with duplicate/warning reporting
+//   ExportAdif    — implemented for filtered ADIF export
 //
 // Transport: native gRPC (HTTP/2 + binary protobuf).
 // Browser clients must go through a gRPC-Web proxy — see docs/api/client-integration.md.

--- a/proto/services/lookup_service.proto
+++ b/proto/services/lookup_service.proto
@@ -21,11 +21,11 @@ import "services/stream_lookup_response.proto";
 //   Client → LookupService → LookupCoordinator → CallsignProvider → QrzProvider
 //
 // Implementation status:
-//   Lookup             — implemented
-//   StreamLookup       — implemented
-//   GetCachedCallsign  — implemented
-//   GetDxccEntity      — planned (returns UNIMPLEMENTED)
-//   BatchLookup        — planned (returns UNIMPLEMENTED)
+//   Lookup             — implemented (both engines)
+//   StreamLookup       — implemented (both engines)
+//   GetCachedCallsign  — implemented (both engines)
+//   GetDxccEntity      — implemented (.NET, by DXCC code; prefix lookup not yet supported); unimplemented (Rust)
+//   BatchLookup        — implemented (.NET); unimplemented (Rust)
 //
 // Transport: native gRPC (HTTP/2 + binary protobuf).
 // Browser clients must go through a gRPC-Web proxy — see docs/api/client-integration.md.

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -494,6 +494,12 @@ public sealed class ManagedEngineStateTests : IDisposable
             var logId = $"FAKE-{Interlocked.Increment(ref _logIdCounter)}";
             return Task.FromResult(logId);
         }
+
+        public Task<string> UpdateQsoAsync(QsoRecord qso)
+        {
+            var logId = $"FAKE-{Interlocked.Increment(ref _logIdCounter)}";
+            return Task.FromResult(logId);
+        }
     }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
@@ -215,7 +215,7 @@ public sealed class QrzSyncEngineTests
     }
 
     [Fact]
-    public async Task Upload_sends_modified_qsos()
+    public async Task Upload_sends_modified_qsos_via_replace()
     {
         var store = CreateStore();
         var local = MakeLocalQso("N0CALL", BaseTime, Band._20M, Mode.Ssb, SyncStatus.Modified);
@@ -225,13 +225,50 @@ public sealed class QrzSyncEngineTests
         var api = new FakeQrzLogbookApi
         {
             FetchResult = [],
-            UploadLogid = "88888",
+            UpdateLogid = "existing-id",
         };
         var engine = new QrzSyncEngine(api);
 
         var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
 
         Assert.Equal(1u, result.UploadedCount);
+        // Modified QSO must go through UpdateQsoAsync (REPLACE), not UploadQsoAsync (INSERT)
+        Assert.Empty(api.UploadedQsos);
+        Assert.Single(api.UpdatedQsos);
+        Assert.Equal("N0CALL", api.UpdatedQsos[0].WorkedCallsign);
+    }
+
+    [Fact]
+    public async Task Upload_modified_qso_overwrites_existing_logid_bug_213()
+    {
+        // Regression: modified QSOs with an existing QrzLogid must use REPLACE, not INSERT.
+        var store = CreateStore();
+        var modified = MakeLocalQso("W1AW", BaseTime, Band._40M, Mode.Cw, SyncStatus.Modified);
+        modified.QrzLogid = "qrz-99";
+        await store.Logbook.InsertQsoAsync(modified);
+
+        var newQso = MakeLocalQso("K1ABC", BaseTime.AddMinutes(5), Band._20M, Mode.Ssb, SyncStatus.LocalOnly);
+        await store.Logbook.InsertQsoAsync(newQso);
+
+        var api = new FakeQrzLogbookApi
+        {
+            FetchResult = [],
+            UploadLogid = "new-id-100",
+            UpdateLogid = "qrz-99",
+        };
+        var engine = new QrzSyncEngine(api);
+
+        var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
+
+        Assert.Equal(2u, result.UploadedCount);
+
+        // Modified QSO → UpdateQsoAsync (REPLACE)
+        Assert.Single(api.UpdatedQsos);
+        Assert.Equal("W1AW", api.UpdatedQsos[0].WorkedCallsign);
+
+        // New QSO → UploadQsoAsync (INSERT)
+        Assert.Single(api.UploadedQsos);
+        Assert.Equal("K1ABC", api.UploadedQsos[0].WorkedCallsign);
     }
 
     [Fact]
@@ -428,8 +465,10 @@ public sealed class QrzSyncEngineTests
     {
         public List<QsoRecord> FetchResult { get; set; } = [];
         public string UploadLogid { get; set; } = "12345";
+        public string UpdateLogid { get; set; } = "12345";
         public Func<QsoRecord, Task<string>>? UploadFunc { get; set; }
         public List<QsoRecord> UploadedQsos { get; } = [];
+        public List<QsoRecord> UpdatedQsos { get; } = [];
         public string? LastSinceDate { get; private set; }
 
         public Task<List<QsoRecord>> FetchQsosAsync(string? sinceDateYmd)
@@ -447,6 +486,12 @@ public sealed class QrzSyncEngineTests
             }
 
             return Task.FromResult(UploadLogid);
+        }
+
+        public Task<string> UpdateQsoAsync(QsoRecord qso)
+        {
+            UpdatedQsos.Add(qso);
+            return Task.FromResult(UpdateLogid);
         }
     }
 }

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/IQrzLogbookApi.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/IQrzLogbookApi.cs
@@ -18,4 +18,12 @@ public interface IQrzLogbookApi
     /// Returns the QRZ-assigned LOGID on success.
     /// </summary>
     Task<string> UploadQsoAsync(QsoRecord qso);
+
+    /// <summary>
+    /// Update an existing QSO on QRZ via the REPLACE action.
+    /// The <paramref name="qso"/> must have a non-empty <see cref="QsoRecord.QrzLogid"/>
+    /// that identifies the remote record to overwrite.
+    /// Returns the QRZ LOGID on success.
+    /// </summary>
+    Task<string> UpdateQsoAsync(QsoRecord qso);
 }

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
@@ -104,6 +104,38 @@ public sealed class QrzLogbookClient : IQrzLogbookApi, IDisposable
         return logid;
     }
 
+    /// <inheritdoc />
+    public async Task<string> UpdateQsoAsync(QsoRecord qso)
+    {
+        ArgumentNullException.ThrowIfNull(qso);
+
+        if (!qso.HasQrzLogid || string.IsNullOrWhiteSpace(qso.QrzLogid))
+        {
+            throw new QrzLogbookException("REPLACE requires a QRZ LOGID but the QSO has none.");
+        }
+
+        var adifRecord = AdifCodec.SerializeSingleQso(qso);
+
+        var formFields = new List<KeyValuePair<string, string>>(4)
+        {
+            new("ACTION", "REPLACE"),
+            new("KEY", _apiKey),
+            new("LOGID", qso.QrzLogid),
+            new("ADIF", adifRecord),
+        };
+
+        var body = await PostFormAsync(formFields).ConfigureAwait(false);
+        var map = QrzResponseParser.ParseKeyValueResponse(body);
+        QrzResponseParser.CheckResult(map);
+
+        if (!map.TryGetValue("LOGID", out var logid) || string.IsNullOrWhiteSpace(logid))
+        {
+            throw new QrzLogbookException("REPLACE response missing LOGID.");
+        }
+
+        return logid;
+    }
+
     /// <inheritdoc cref="IDisposable.Dispose"/>
     public void Dispose()
     {

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
@@ -194,7 +194,9 @@ public sealed class QrzSyncEngine
         {
             try
             {
-                var logid = await _client.UploadQsoAsync(qso).ConfigureAwait(false);
+                var logid = qso.SyncStatus == SyncStatus.Modified && !string.IsNullOrWhiteSpace(qso.QrzLogid)
+                    ? await _client.UpdateQsoAsync(qso).ConfigureAwait(false)
+                    : await _client.UploadQsoAsync(qso).ConfigureAwait(false);
                 var synced = qso.Clone();
                 synced.QrzLogid = logid;
                 synced.SyncStatus = SyncStatus.Synced;

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
@@ -309,10 +309,14 @@ public class RecentQsoListViewModelTests
 
         Assert.Equal(12, viewModel.GridFontSize);
         Assert.Equal("Zoom 100%", viewModel.GridZoomStatusText);
+        Assert.Equal(18, viewModel.GridRowHeight);
+        Assert.Equal(20, viewModel.GridHeaderHeight);
 
         Assert.True(viewModel.AdjustZoom(1));
         Assert.Equal(13, viewModel.GridFontSize);
         Assert.Equal("Zoom 108%", viewModel.GridZoomStatusText);
+        Assert.Equal(20, viewModel.GridRowHeight);
+        Assert.Equal(22, viewModel.GridHeaderHeight);
 
         viewModel.ApplyPersistedGridFontSize(99);
         Assert.Equal(18, viewModel.GridFontSize);
@@ -321,6 +325,15 @@ public class RecentQsoListViewModelTests
 
         viewModel.ResetGridZoom();
         Assert.Equal(12, viewModel.GridFontSize);
+    }
+
+    [Fact]
+    public void GridDensityUsesCompactDefaultHeights()
+    {
+        var viewModel = new RecentQsoListViewModel(new FakeEngineClient());
+
+        Assert.Equal(18, viewModel.GridRowHeight);
+        Assert.Equal(20, viewModel.GridHeaderHeight);
     }
 
     private static QsoRecord CreateQso(

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -95,9 +95,9 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
 
     public string GridZoomStatusText => $"Zoom {Math.Round((GridFontSize / DefaultGridFontSize) * 100):0}%";
 
-    public double GridRowHeight => Math.Round(19 * (GridFontSize / DefaultGridFontSize));
+    public double GridRowHeight => Math.Round(18 * (GridFontSize / DefaultGridFontSize));
 
-    public double GridHeaderHeight => Math.Round(21 * (GridFontSize / DefaultGridFontSize));
+    public double GridHeaderHeight => Math.Round(20 * (GridFontSize / DefaultGridFontSize));
 
     public string SyncSummaryText => BuildSyncSummaryText();
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -59,12 +59,12 @@
     </Style>
 
     <Style Selector="DataGrid#RecentQsoGrid DataGridColumnHeader">
-      <Setter Property="Padding" Value="4,1" />
+      <Setter Property="Padding" Value="4,0" />
       <Setter Property="FontWeight" Value="SemiBold" />
     </Style>
 
     <Style Selector="DataGrid#RecentQsoGrid DataGridCell">
-      <Setter Property="Padding" Value="4,1" />
+      <Setter Property="Padding" Value="4,0" />
       <Setter Property="BorderThickness" Value="0" />
     </Style>
 
@@ -82,7 +82,7 @@
 
     <!-- Prevent text clipping when editing cells -->
     <Style Selector="DataGrid#RecentQsoGrid DataGridCell:editing TextBox">
-      <Setter Property="Padding" Value="4,2" />
+      <Setter Property="Padding" Value="4,1" />
       <Setter Property="VerticalContentAlignment" Value="Center" />
     </Style>
 

--- a/src/rust/deny.toml
+++ b/src/rust/deny.toml
@@ -35,6 +35,11 @@ version = "=0.2.17"
 reason = "Required by ring/rustls transitives while uuid and tempfile currently resolve getrandom 0.4."
 
 [[bans.skip]]
+name = "wit-bindgen"
+version = "=0.51.0"
+reason = "getrandom's WASI transitives currently resolve both wit-bindgen 0.51 and 0.57 on Ubuntu, with no direct workspace-level unification path."
+
+[[bans.skip]]
 name = "hashbrown"
 version = "=0.12.3"
 reason = "Pulled by the tonic 0.12 transport stack via indexmap 1.x while the rest of the graph is already on indexmap 2.x."


### PR DESCRIPTION
## Summary

Fixes four contract/QRZ bugs:

- **#213**: QRZ sync uses \ACTION=REPLACE\ for modified QSOs instead of \INSERT\, preserving existing logids
- **#214**: Engine specification aligned with actual proto field names and types
- **#215**: Capability vocabulary in docs aligned with actual engine output
- **#216**: Proto service docs updated to reflect implemented vs unimplemented RPCs

## Tests Added

Updated sync tests verify REPLACE behavior. \uf lint\ passes.

## Validation

\\\powershell
dotnet build src\dotnet\QsoRipper.slnx   # clean
dotnet test src\dotnet\QsoRipper.slnx    # 55 engine tests pass
buf lint                                  # clean
\\\

Closes #213, closes #214, closes #215, closes #216