### PR TITLE
fix: Avalonia GUI field routing, sort keyboard, and grid defaults (#222, #223, #225)

### DIFF
--- a/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
@@ -114,6 +114,43 @@ public sealed class QsoLoggerEnrichmentTests
         Assert.Equal(string.Empty, logger.LookupGrid);
     }
 
+    [Fact]
+    public async Task LogQsoAsyncIncludesNotesAndContestFields()
+    {
+        var engine = new CapturingEngineClient();
+        var logger = new QsoLoggerViewModel(engine);
+        logger.Callsign = "W1AW";
+        logger.Notes = "Worked on 20m dipole";
+        logger.ContestId = "CQWW-CW";
+        logger.ExchangeSent = "599 05";
+        logger.Comment = "Strong signal";
+
+        await logger.LogQsoCommand.ExecuteAsync(null);
+
+        Assert.NotNull(engine.LastLoggedQso);
+        Assert.Equal("W1AW", engine.LastLoggedQso!.WorkedCallsign);
+        Assert.Equal("Worked on 20m dipole", engine.LastLoggedQso.Notes);
+        Assert.Equal("CQWW-CW", engine.LastLoggedQso.ContestId);
+        Assert.Equal("599 05", engine.LastLoggedQso.ExchangeSent);
+        Assert.Equal("Strong signal", engine.LastLoggedQso.Comment);
+    }
+
+    [Fact]
+    public async Task LogQsoAsyncOmitsBlankNotesAndContestFields()
+    {
+        var engine = new CapturingEngineClient();
+        var logger = new QsoLoggerViewModel(engine);
+        logger.Callsign = "VK3ABC";
+        // Leave Notes, ContestId, ExchangeSent at their defaults (empty)
+
+        await logger.LogQsoCommand.ExecuteAsync(null);
+
+        Assert.NotNull(engine.LastLoggedQso);
+        Assert.False(engine.LastLoggedQso!.HasNotes);
+        Assert.False(engine.LastLoggedQso.HasContestId);
+        Assert.False(engine.LastLoggedQso.HasExchangeSent);
+    }
+
     private sealed class FakeEngineClient : IEngineClient
     {
         public Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default) =>
@@ -153,6 +190,62 @@ public sealed class QsoLoggerEnrichmentTests
             throw new NotImplementedException();
 
         public Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetRigSnapshotResponse> GetRigSnapshotAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetRigStatusResponse> GetRigStatusAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+    }
+
+    private sealed class CapturingEngineClient : IEngineClient
+    {
+        public QsoRecord? LastLoggedQso { get; private set; }
+
+        public Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default)
+        {
+            LastLoggedQso = qso;
+            return Task.FromResult(new LogQsoResponse { LocalId = "test-id" });
+        }
+
+        public Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<ValidateSetupStepResponse> ValidateStepAsync(ValidateSetupStepRequest request, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<TestQrzCredentialsResponse> TestQrzCredentialsAsync(string username, string password, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<SaveSetupResponse> SaveSetupAsync(SaveSetupRequest request, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) =>
+            Task.FromResult<IReadOnlyList<QsoRecord>>([]);
+
+        public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<LookupResponse> LookupCallsignAsync(string callsign, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<DeleteQsoResponse> DeleteQsoAsync(string localId, bool deleteFromQrz = false, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
         public Task<GetRigSnapshotResponse> GetRigSnapshotAsync(CancellationToken ct = default) =>

--- a/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
@@ -31,15 +31,6 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject
     [ObservableProperty]
     private string _state = string.Empty;
 
-    [ObservableProperty]
-    private string _contest = string.Empty;
-
-    [ObservableProperty]
-    private string _exchange = string.Empty;
-
-    [ObservableProperty]
-    private string _notes = string.Empty;
-
     public event EventHandler? CloseRequested;
 
     [RelayCommand]

--- a/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
@@ -58,6 +58,15 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
     private string _comment = string.Empty;
 
     [ObservableProperty]
+    private string _notes = string.Empty;
+
+    [ObservableProperty]
+    private string _contestId = string.Empty;
+
+    [ObservableProperty]
+    private string _exchangeSent = string.Empty;
+
+    [ObservableProperty]
     private string _elapsedTimeText = "00:00";
 
     [ObservableProperty]
@@ -242,6 +251,21 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
             qso.Comment = Comment.Trim();
         }
 
+        if (!string.IsNullOrWhiteSpace(Notes))
+        {
+            qso.Notes = Notes.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(ContestId))
+        {
+            qso.ContestId = ContestId.Trim();
+        }
+
+        if (!string.IsNullOrWhiteSpace(ExchangeSent))
+        {
+            qso.ExchangeSent = ExchangeSent.Trim();
+        }
+
         EnrichFromLookup(qso, _lastLookupRecord);
 
         LogStatusText = "Logging\u2026";
@@ -332,6 +356,9 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
         _lookupCts?.Cancel();
         Callsign = string.Empty;
         Comment = string.Empty;
+        Notes = string.Empty;
+        ContestId = string.Empty;
+        ExchangeSent = string.Empty;
         LogStatusText = string.Empty;
         ClearLookupFields();
         _frequencyManuallySet = false;

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -819,7 +819,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Contest, "Contest", true);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Station, "Station", true);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Note, "Note", true);
-        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Comment, "Comment", false);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Comment, "Comment", true);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.UtcEnd, "End", false);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.CqZone, "CQ", false);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.ItuZone, "ITU", false);

--- a/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
@@ -62,7 +62,7 @@
 
           <TextBlock Grid.Row="7" Grid.Column="0" Text="Notes" Opacity="0.6" VerticalAlignment="Center" />
           <TextBox Grid.Row="7" Grid.Column="1"
-                   Text="{Binding Notes, Mode=TwoWay}" AcceptsReturn="True"
+                   Text="{Binding Logger.Notes, Mode=TwoWay}" AcceptsReturn="True"
                    Height="48" TextWrapping="Wrap" />
 
           <!-- Right column -->
@@ -84,11 +84,11 @@
 
           <TextBlock Grid.Row="4" Grid.Column="3" Text="Contest" Opacity="0.6" VerticalAlignment="Center" />
           <TextBox Grid.Row="4" Grid.Column="4"
-                   Text="{Binding Contest, Mode=TwoWay}" />
+                   Text="{Binding Logger.ContestId, Mode=TwoWay}" />
 
           <TextBlock Grid.Row="5" Grid.Column="3" Text="Exchange" Opacity="0.6" VerticalAlignment="Center" />
           <TextBox Grid.Row="5" Grid.Column="4"
-                   Text="{Binding Exchange, Mode=TwoWay}" />
+                   Text="{Binding Logger.ExchangeSent, Mode=TwoWay}" />
         </Grid>
       </ScrollViewer>
     </DockPanel>

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -772,6 +772,7 @@
                   BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
                   BorderThickness="1"
                   IsVisible="{Binding IsSortChooserOpen}">
+            <ScrollViewer MaxHeight="480" VerticalScrollBarVisibility="Auto">
             <StackPanel Spacing="6">
               <TextBlock Text="Sort recent QSOs"
                          FontSize="12.5"
@@ -803,9 +804,33 @@
               <Button Content="9  Note"
                       Command="{Binding RecentQsos.SortByColumnCommand}"
                       CommandParameter="{x:Static vm:RecentQsoSortColumn.Note}" />
+              <Separator Margin="0,2" />
+              <Button Content="A  Comment"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Comment}" />
+              <Button Content="B  Grid"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Grid}" />
+              <Button Content="C  RST Sent"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.RstSent}" />
+              <Button Content="D  RST Rcvd"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.RstReceived}" />
+              <Button Content="E  Name"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Name}" />
+              <Button Content="F  Station"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Station}" />
+              <Button Content="G  Exchange"
+                      Command="{Binding RecentQsos.SortByColumnCommand}"
+                      CommandParameter="{x:Static vm:RecentQsoSortColumn.Exchange}" />
+              <Separator Margin="0,2" />
               <Button Content="0  Reverse direction"
                       Command="{Binding RecentQsos.ReverseSortDirectionCommand}" />
             </StackPanel>
+            </ScrollViewer>
           </Border>
 
           <Border x:Name="ColumnChooserPanel"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -843,6 +843,7 @@ internal sealed partial class MainWindow : Window
         }
 
         // Digit shortcuts: 1-9 select a sort column, 0 reverses direction.
+        // Letter shortcuts A-G select additional columns.
         RecentQsoSortColumn? column = e.Key switch
         {
             Key.D1 or Key.NumPad1 => RecentQsoSortColumn.Utc,
@@ -854,6 +855,13 @@ internal sealed partial class MainWindow : Window
             Key.D7 or Key.NumPad7 => RecentQsoSortColumn.Country,
             Key.D8 or Key.NumPad8 => RecentQsoSortColumn.Contest,
             Key.D9 or Key.NumPad9 => RecentQsoSortColumn.Note,
+            Key.A => RecentQsoSortColumn.Comment,
+            Key.B => RecentQsoSortColumn.Grid,
+            Key.C => RecentQsoSortColumn.RstSent,
+            Key.D => RecentQsoSortColumn.RstReceived,
+            Key.E => RecentQsoSortColumn.Name,
+            Key.F => RecentQsoSortColumn.Station,
+            Key.G => RecentQsoSortColumn.Exchange,
             _ => null
         };
 


### PR DESCRIPTION
## Summary

Fixes three Avalonia GUI bugs:

- **#222**: Comment column shown by default in recent QSO grid (was hidden)
- **#223**: Sort chooser keyboard path works correctly with missing columns
- **#225**: Notes, ContestId, and ExchangeSent fields now route through QsoLoggerViewModel into the logged QsoRecord instead of dead FullQsoCardViewModel properties

## Tests Added

2 new enrichment tests (46 total GUI tests pass).

## Validation

\\\powershell
dotnet build src\dotnet\QsoRipper.slnx   # clean
dotnet test src\dotnet\QsoRipper.slnx    # 46 GUI tests pass
\\\

Closes #222, closes #223, closes #225