### PR TITLE
fix: CLI UTC time parsing and DebugHost ArrlSection round-trip (#226, #227)

### DIFF
--- a/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
@@ -149,6 +149,30 @@ public sealed class CliUtilityTests
     }
 
     [Fact]
+    public void TimeParser_treats_offsetless_timestamp_as_utc()
+    {
+        var parsed = TimeParser.Parse("2024-06-15 14:30:00");
+
+        Assert.NotNull(parsed);
+        Assert.Equal(new DateTime(2024, 6, 15, 14, 30, 0, DateTimeKind.Utc), parsed!.ToDateTime());
+    }
+
+    [Theory]
+    [InlineData("2024-06-15T14:30:00")]
+    [InlineData("2024-06-15 14:30:00")]
+    [InlineData("06/15/2024 14:30:00")]
+    public void TimeParser_offsetless_timestamps_are_not_shifted_by_local_timezone(string input)
+    {
+        var parsed = TimeParser.Parse(input);
+
+        Assert.NotNull(parsed);
+        var dt = parsed!.ToDateTime();
+        Assert.Equal(DateTimeKind.Utc, dt.Kind);
+        Assert.Equal(14, dt.Hour);
+        Assert.Equal(30, dt.Minute);
+    }
+
+    [Fact]
     public void JsonOutput_Print_writes_indented_json()
     {
         var output = ConsoleCapture.Out(() => JsonOutput.Print(new GetSyncStatusResponse { LocalQsoCount = 3 }));

--- a/src/dotnet/QsoRipper.Cli/TimeParser.cs
+++ b/src/dotnet/QsoRipper.Cli/TimeParser.cs
@@ -11,7 +11,7 @@ internal static class TimeParser
             return Timestamp.FromDateTime(dt);
         }
 
-        if (DateTime.TryParse(input, null, System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsed))
+        if (DateTime.TryParse(input, null, System.Globalization.DateTimeStyles.AssumeUniversal | System.Globalization.DateTimeStyles.AdjustToUniversal, out var parsed))
         {
             return Timestamp.FromDateTime(DateTime.SpecifyKind(parsed, DateTimeKind.Utc));
         }

--- a/src/dotnet/QsoRipper.DebugHost.Tests/EditorModelTests.cs
+++ b/src/dotnet/QsoRipper.DebugHost.Tests/EditorModelTests.cs
@@ -279,6 +279,40 @@ public class EditorModelTests
     }
 
     [Fact]
+    public void StationProfileEditorModel_roundtrips_arrl_section()
+    {
+        var original = new StationProfile
+        {
+            StationCallsign = "K7RND",
+            ArrlSection = "WWA"
+        };
+
+        var model = new StationProfileEditorModel();
+        model.LoadFrom("test-id", original);
+
+        Assert.Equal("WWA", model.ArrlSection);
+
+        var roundTripped = model.ToStationProfile();
+
+        Assert.True(roundTripped.HasArrlSection);
+        Assert.Equal("WWA", roundTripped.ArrlSection);
+    }
+
+    [Fact]
+    public void StationProfileEditorModel_clears_arrl_section_when_blank()
+    {
+        var model = new StationProfileEditorModel
+        {
+            StationCallsign = "K7RND",
+            ArrlSection = "   "
+        };
+
+        var roundTripped = model.ToStationProfile();
+
+        Assert.False(roundTripped.HasArrlSection);
+    }
+
+    [Fact]
     public void AdifExportEditorModel_to_request_trims_values_and_parses_utc_filters()
     {
         var model = new AdifExportEditorModel

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/Engine.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/Engine.razor
@@ -365,6 +365,13 @@
                                        disabled="@isStationProfilesBusy" />
                         </div>
                         <div class="col-md-4">
+                            <label class="form-label" for="station-arrl-section">ARRL section</label>
+                            <InputText id="station-arrl-section"
+                                       class="form-control"
+                                       @bind-Value="stationProfileEditor.ArrlSection"
+                                       disabled="@isStationProfilesBusy" />
+                        </div>
+                        <div class="col-md-4">
                             <label class="form-label" for="station-dxcc">DXCC</label>
                             <InputNumber id="station-dxcc"
                                          class="form-control"

--- a/src/dotnet/QsoRipper.DebugHost/Models/StationProfileEditorModelBase.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Models/StationProfileEditorModelBase.cs
@@ -31,6 +31,8 @@ internal abstract class StationProfileEditorModelBase : IValidatableObject
 
     public double? Longitude { get; set; }
 
+    public string? ArrlSection { get; set; }
+
     public void LoadFrom(StationProfile? profile)
     {
         if (profile is null)
@@ -52,6 +54,7 @@ internal abstract class StationProfileEditorModelBase : IValidatableObject
         ItuZone = profile.HasItuZone ? checked((int)profile.ItuZone) : null;
         Latitude = profile.HasLatitude ? profile.Latitude : null;
         Longitude = profile.HasLongitude ? profile.Longitude : null;
+        ArrlSection = NormalizeOptional(profile.ArrlSection);
     }
 
     public StationProfile ToStationProfile()
@@ -94,6 +97,10 @@ internal abstract class StationProfileEditorModelBase : IValidatableObject
         SetOptionalValue(ItuZone, value => profile.ItuZone = checked((uint)value), profile.ClearItuZone);
         SetOptionalValue(Latitude, value => profile.Latitude = value, profile.ClearLatitude);
         SetOptionalValue(Longitude, value => profile.Longitude = value, profile.ClearLongitude);
+        SetOptionalString(
+            NormalizeOptional(ArrlSection),
+            value => profile.ArrlSection = value,
+            profile.ClearArrlSection);
 
         return profile;
     }
@@ -158,6 +165,7 @@ internal abstract class StationProfileEditorModelBase : IValidatableObject
         ItuZone = null;
         Latitude = null;
         Longitude = null;
+        ArrlSection = null;
     }
 
     protected static string? NormalizeOptional(string? value)


### PR DESCRIPTION
## Summary

Fixes two .NET miscellaneous bugs:

- **#226**: DebugHost station profile editor now round-trips ArrlSection field correctly
- **#227**: CLI time parser treats offsetless timestamps as UTC (using \AssumeUniversal|AdjustToUniversal\) instead of silently converting to local time

## Tests Added

4 new tests verifying UTC parsing and ArrlSection persistence.

## Validation

\\\powershell
dotnet build src\dotnet\QsoRipper.slnx   # clean
dotnet test src\dotnet\QsoRipper.slnx    # all pass
\\\

Closes #226, closes #227