### PR TITLE
Fix TUI QTH lookup to include state alongside city

### DIFF
--- a/src/rust/qsoripper-tui/src/grpc.rs
+++ b/src/rust/qsoripper-tui/src/grpc.rs
@@ -207,7 +207,12 @@ pub(crate) async fn lookup_callsign(
     Ok(Some(CallsignInfo {
         callsign: record.callsign,
         name,
-        qth: record.addr2,
+        qth: match (record.addr2.as_deref(), record.state.as_deref()) {
+            (Some(city), Some(st)) if !st.is_empty() => Some(format!("{city}, {st}")),
+            (Some(city), _) => Some(city.to_string()),
+            (None, Some(st)) if !st.is_empty() => Some(st.to_string()),
+            _ => None,
+        },
         grid: record.grid_square,
         country: record.country,
         cq_zone: record.cq_zone,


### PR DESCRIPTION
## Summary

Fixes #236

The TUI lookup panel was showing only the city (`addr2`) for QTH. Now it combines city and state into "City, ST" format (e.g., "Seattle, WA" instead of just "Seattle").

### Change

**`src/rust/qsoripper-tui/src/grpc.rs`** — Updated `CallsignInfo` construction to combine `record.addr2` and `record.state`:
- Both present: "City, ST"
- City only: "City"
- State only: "ST"
- Neither: None (displays "—")

### Verification
- `cargo fmt --check`: clean
- `cargo clippy --all-targets -- -D warnings`: clean
- `cargo test`: 582 tests passed, 0 failed