### PR TITLE
DOTNET-BUG-2: Reject config --set without value

### DIFF
--- a/src/dotnet/QsoRipper.Cli.Tests/CliRegressionTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliRegressionTests.cs
@@ -45,6 +45,16 @@ public class CliRegressionTests
         Assert.DoesNotContain("Could not connect to QsoRipper engine", result.StandardError, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task Entry_point_rejects_config_set_without_key_value_before_connecting()
+    {
+        var result = await CliProcessRunner.RunAsync("config", "--set");
+
+        Assert.Equal(1, result.ExitCode);
+        Assert.Contains("Missing value for --set. Expected KEY=VALUE format.", result.StandardError, StringComparison.Ordinal);
+        Assert.DoesNotContain("Could not connect to QsoRipper engine", result.StandardError, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData(Band._125M, "1.25M")]
     [InlineData(Band._125Cm, "1.25CM")]

--- a/src/dotnet/QsoRipper.Cli/Commands/ConfigCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ConfigCommand.cs
@@ -27,8 +27,14 @@ internal static class ConfigCommand
                 return 0;
             }
 
-            if (args[i] == "--set" && i < args.Length - 1)
+            if (args[i] == "--set")
             {
+                if (i >= args.Length - 1)
+                {
+                    Console.Error.WriteLine("Missing value for --set. Expected KEY=VALUE format.");
+                    return 1;
+                }
+
                 var kvp = args[++i];
                 var eqIndex = kvp.IndexOf('=', StringComparison.Ordinal);
                 if (eqIndex < 1)


### PR DESCRIPTION
## Summary
- add regression test proving config --set without KEY=VALUE is rejected locally
- fail fast in ConfigCommand when --set is provided without a following value
- preserve existing behavior for valid --set key=value input

## Validation
- dotnet test src/dotnet/QsoRipper.Cli.Tests/QsoRipper.Cli.Tests.csproj --filter "Entry_point_rejects_config_set_without_key_value_before_connecting" (fails before fix, passes after)
- dotnet test src/dotnet/QsoRipper.Cli.Tests/QsoRipper.Cli.Tests.csproj

Fixes DOTNET-BUG-2.