### PR TITLE
DOTNET-BUG-1: prevent CLI crash on oversized relative times

### DIFF
--- a/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
@@ -258,6 +258,7 @@ public sealed class CommandHelperTests
         {
             { ["--limit", "oops"], "Invalid value for --limit: oops" },
             { ["--after", "yesterdayish"], "Invalid --after value. Use relative (2.days, 3.hours) or absolute (2026-04-10)." },
+            { ["--after", "2147483647.months"], "Invalid --after value. Use relative (2.days, 3.hours) or absolute (2026-04-10)." },
             { ["--callsign"], "Missing value for --callsign." },
             { ["--unknown"], "Unknown option: --unknown" }
         };
@@ -391,6 +392,18 @@ public sealed class CommandHelperTests
         var enrich = false;
 
         var success = UpdateQsoCommand.TryApplyUpdates(["--at", "not-a-time"], qso, ref enrich, out var error);
+
+        Assert.False(success);
+        Assert.Contains("Invalid --at value", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryApplyUpdates_rejects_oversized_relative_at_value()
+    {
+        var qso = new QsoRecord { WorkedCallsign = "W1AW" };
+        var enrich = false;
+
+        var success = UpdateQsoCommand.TryApplyUpdates(["--at", "2147483647.months"], qso, ref enrich, out var error);
 
         Assert.False(success);
         Assert.Contains("Invalid --at value", error, StringComparison.Ordinal);

--- a/src/dotnet/QsoRipper.Cli/TimeParser.cs
+++ b/src/dotnet/QsoRipper.Cli/TimeParser.cs
@@ -32,16 +32,27 @@ internal static class TimeParser
         var unit = parts[1].ToLowerInvariant();
         var now = DateTime.UtcNow;
 
-        result = unit switch
+        try
         {
-            "minutes" or "minute" or "min" => now.AddMinutes(-count),
-            "hours" or "hour" or "hr" => now.AddHours(-count),
-            "days" or "day" => now.AddDays(-count),
-            "weeks" or "week" => now.AddDays(-count * 7),
-            "months" or "month" => now.AddMonths(-count),
-            "years" or "year" => now.AddYears(-count),
-            _ => default,
-        };
+            result = unit switch
+            {
+                "minutes" or "minute" or "min" => now.AddMinutes(-count),
+                "hours" or "hour" or "hr" => now.AddHours(-count),
+                "days" or "day" => now.AddDays(-count),
+                "weeks" or "week" => now.AddDays(-7d * count),
+                "months" or "month" => now.AddMonths(-count),
+                "years" or "year" => now.AddYears(-count),
+                _ => default,
+            };
+        }
+        catch (ArgumentOutOfRangeException)
+        {
+            return false;
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
 
         return result != default;
     }


### PR DESCRIPTION
## Summary
- add regression coverage for oversized relative time inputs in CLI argument parsing
- reproduce crash path for --at 2147483647.months and assert validation error behavior
- guard TimeParser.TryParseRelative against overflow/out-of-range DateTime arithmetic and return parse failure instead of throwing

## Validation
- dotnet test src/dotnet/QsoRipper.Cli.Tests/QsoRipper.Cli.Tests.csproj --filter "TryApplyUpdates_rejects_oversized_relative_at_value" (failed before fix)
- dotnet test src/dotnet/QsoRipper.Cli.Tests/QsoRipper.Cli.Tests.csproj --filter "TryApplyUpdates_rejects_oversized_relative_at_value|TryParseArgs_rejects_invalid_args"
- dotnet test src/dotnet/QsoRipper.Cli.Tests/QsoRipper.Cli.Tests.csproj

Fixes DOTNET-BUG-1.