### PR TITLE
WIN32-BUG-1: Fix LogQso cmd shadowing compile failure

### DIFF
--- a/tests/Build.Tests.ps1
+++ b/tests/Build.Tests.ps1
@@ -23,6 +23,17 @@ function Get-FunctionBody([string]$Content, [string]$FunctionName) {
 $checkRustBody = Get-FunctionBody $scriptContent 'Check-Rust'
 $checkDotnetBody = Get-FunctionBody $scriptContent 'Check-Dotnet'
 
+function Get-CFunctionBody([string]$Content, [string]$FunctionSignature) {
+    $escaped = [regex]::Escape($FunctionSignature)
+    $pattern = "(?ms)$escaped\s*\{(.+?)^\}"
+    if ($Content -match $pattern) { return $Matches[1] }
+    return ''
+}
+
+$win32MainPath = Join-Path $repoRoot 'src' 'c' 'qsoripper-win32' 'src' 'main.c'
+$win32MainContent = Get-Content $win32MainPath -Raw
+$logQsoBody = Get-CFunctionBody $win32MainContent 'static void LogQso(void)'
+
 Describe 'build.ps1 Check-Rust CI parity (Bug #202)' {
 
     It 'runs tests with coverage via cargo-llvm-cov when available' {
@@ -72,5 +83,12 @@ Describe 'Win32 CLI publish/discovery path contract (WIN32-BUG-2)' {
     It 'probes the qsoripper-cli directory from FindCliPath candidates' {
         $win32MainContent | Should Match 'qsoripper-cli'
         $win32MainContent | Should Not Match 'QsoRipper\.Cli\\\\%s\\\\(?:net10\.0\\\\)?QsoRipper\.Cli\.exe'
+    }
+}
+
+Describe 'Win32 LogQso shadowing regression (WIN32-BUG-1)' {
+
+    It 'declares exactly one cmd buffer in LogQso' {
+        [regex]::Matches($logQsoBody, 'char\s+cmd\s*\[\s*4096\s*\]\s*;').Count | Should Be 1
     }
 }


### PR DESCRIPTION
## Summary\n- add regression coverage in 	ests/Build.Tests.ps1 for WIN32-BUG-1 to enforce a single cmd buffer declaration in LogQso\n- remove the duplicate outer cmd local in src/c/qsoripper-win32/src/main.c\n- preserve CLI/FFI behavior while eliminating C4456/C4101 warning-as-error break\n\n## Validation\n- pwsh -NoProfile -File tests/Build.Tests.ps1 (new test fails before fix, passes after fix)\n- pwsh -NoProfile -File ./build.ps1 win32 -Configuration Debug\n  - before fix: fails with C4456 + C4101 in LogQso\n  - after fix: those warnings are gone; build currently still fails due existing /analyze C6340 warnings around date/time formatting\n\n## Bug\n- WIN32-BUG-1