### PR TITLE
DOTNET-BUG-3: Reject invalid ADIF TIME_ON lengths in managed parser

### DIFF
--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -462,6 +462,30 @@ public sealed class ManagedEngineStateTests : IDisposable
     }
 
     [Fact]
+    public void Import_adif_skips_invalid_time_on_length_with_warning()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87"
+            }
+        });
+
+        var response = state.ImportAdif(
+            Utf8("<CALL:4>W1AW\n<QSO_DATE:8>20260115\n<TIME_ON:1>1\n<BAND:3>20M\n<MODE:4>RTTY\n<EOR>\n"),
+            refresh: false);
+
+        Assert.Equal(0u, response.RecordsImported);
+        Assert.Equal(1u, response.RecordsSkipped);
+        Assert.Contains(response.Warnings, warning => warning.Contains("invalid ADIF date/time '20260115/1'. Skipped.", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Import_adif_skips_invalid_band_with_warning()
     {
         var state = CreateState();

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedAdifCodec.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedAdifCodec.cs
@@ -960,6 +960,8 @@ internal static class ManagedAdifCodec
                     }
 
                     break;
+                default:
+                    return false;
             }
         }
 


### PR DESCRIPTION
## Summary
- DOTNET-BUG-3 regression test for invalid TIME_ON length during ADIF import
- reject unsupported ADIF time lengths in ManagedAdifCodec (accept HHMM and HHMMSS only)
- preserve existing behavior for valid TIME_ON values

## Validation
- dotnet test src/dotnet/QsoRipper.Engine.DotNet.Tests/QsoRipper.Engine.DotNet.Tests.csproj --filter FullyQualifiedName~Import_adif_skips_invalid_time_on_length_with_warning --nologo
- dotnet test src/dotnet/QsoRipper.Engine.DotNet.Tests/QsoRipper.Engine.DotNet.Tests.csproj --nologo
- dotnet test src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QsoRipper.Engine.QrzLogbook.Tests.csproj --nologo

Bug: DOTNET-BUG-3