### PR TITLE
WIN32-BUG-4: Treat non-zero CLI exit as failure in Win32 proxy

### DIFF
--- a/src/c/qsoripper-win32/CMakeLists.txt
+++ b/src/c/qsoripper-win32/CMakeLists.txt
@@ -50,3 +50,33 @@ if(CPPCHECK_EXE)
 else()
     message(STATUS "cppcheck not found — install it to enable static analysis")
 endif()
+
+include(CTest)
+if(BUILD_TESTING)
+    add_executable(qsoripper-win32-cli-exitcode-regression
+        tests/cli_exit_code_regression.c
+        src/main.c
+    )
+
+    target_include_directories(qsoripper-win32-cli-exitcode-regression PRIVATE ${FFI_INCLUDE})
+    target_link_libraries(qsoripper-win32-cli-exitcode-regression PRIVATE
+        user32 gdi32 shell32 comctl32
+    )
+    target_compile_definitions(qsoripper-win32-cli-exitcode-regression PRIVATE
+        UNICODE _UNICODE QSORIPPER_WIN32_TESTING
+    )
+
+    if(MSVC)
+        target_compile_options(qsoripper-win32-cli-exitcode-regression PRIVATE
+            /W4
+            /analyze
+        )
+    else()
+        target_compile_options(qsoripper-win32-cli-exitcode-regression PRIVATE -Wall -Wextra)
+    endif()
+
+    add_test(
+        NAME win32-cli-exitcode-regression
+        COMMAND qsoripper-win32-cli-exitcode-regression
+    )
+endif()

--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -659,13 +659,37 @@ static char *RunQrCommand(const char *args)
     }
     output[totalRead] = 0;
 
-    WaitForSingleObject(pi.hProcess, 5000);
+    DWORD wait_result = WaitForSingleObject(pi.hProcess, 5000);
+    DWORD exit_code = 1;
+    BOOL got_exit_code = (wait_result == WAIT_OBJECT_0) &&
+                         GetExitCodeProcess(pi.hProcess, &exit_code);
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
     CloseHandle(hReadPipe);
 
+    if (!got_exit_code || exit_code != 0) {
+        free(output);
+        return NULL;
+    }
+
     return output;
 }
+
+#ifdef QSORIPPER_WIN32_TESTING
+void qsr_test_set_cli_path(const WCHAR *path)
+{
+    if (!path) {
+        g_cli_path[0] = L'\0';
+        return;
+    }
+    wcsncpy_s(g_cli_path, MAX_PATH, path, _TRUNCATE);
+}
+
+char *qsr_test_run_qr_command(const char *args)
+{
+    return RunQrCommand(args);
+}
+#endif
 
 /* Append a properly quoted Windows command-line argument to cmd.
    Follows the Microsoft C/C++ argument parsing rules:

--- a/src/c/qsoripper-win32/tests/cli_exit_code_regression.c
+++ b/src/c/qsoripper-win32/tests/cli_exit_code_regression.c
@@ -1,0 +1,62 @@
+#include <windows.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void qsr_test_set_cli_path(const WCHAR *path);
+char *qsr_test_run_qr_command(const char *args);
+
+static int find_powershell_path(WCHAR *buffer, size_t buffer_len)
+{
+    DWORD n = GetEnvironmentVariableW(L"SystemRoot", buffer, (DWORD)buffer_len);
+    if (n == 0 || n >= buffer_len) {
+        return 0;
+    }
+
+    if (wcscat_s(buffer, buffer_len, L"\\System32\\WindowsPowerShell\\v1.0\\powershell.exe") != 0) {
+        return 0;
+    }
+
+    return GetFileAttributesW(buffer) != INVALID_FILE_ATTRIBUTES;
+}
+
+int main(void)
+{
+    WCHAR powershell_path[MAX_PATH] = {0};
+    if (!find_powershell_path(powershell_path, MAX_PATH)) {
+        fprintf(stderr, "failed to locate powershell.exe\n");
+        return 2;
+    }
+
+    qsr_test_set_cli_path(powershell_path);
+
+    /* Regression for WIN32-BUG-4:
+       non-zero exit with output must be treated as failure. */
+    {
+        char *out = qsr_test_run_qr_command(
+            "-NoProfile -NonInteractive -Command \"Write-Output 'synthetic failure'; exit 17\"");
+        if (out != NULL) {
+            fprintf(stderr, "expected failure (NULL), got output: %s\n", out);
+            free(out);
+            return 1;
+        }
+    }
+
+    /* Success path remains unchanged. */
+    {
+        char *out = qsr_test_run_qr_command(
+            "-NoProfile -NonInteractive -Command \"Write-Output 'ok'; exit 0\"");
+        if (out == NULL) {
+            fprintf(stderr, "expected output for successful command\n");
+            return 1;
+        }
+        if (strstr(out, "ok") == NULL) {
+            fprintf(stderr, "expected successful output payload, got: %s\n", out);
+            free(out);
+            return 1;
+        }
+        free(out);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary\n- add regression check for WIN32-BUG-4 that reproduces a CLI child process returning exit 17 while still writing output\n- update RunQrCommand to inspect process exit code and return failure (NULL) when exit code is non-zero or unavailable\n- keep successful command behavior unchanged (exit 0 + output still succeeds)\n\n## Test-first evidence\n1. Before fix: ctest -R win32-cli-exitcode-regression failed with xpected failure (NULL), got output: synthetic failure.\n2. After fix: same test passes.\n\n## Validation\n- cmake --build build-test --config Debug --target qsoripper-win32 qsoripper-win32-cli-exitcode-regression\n- ctest --test-dir build-test -C Debug -R win32-cli-exitcode-regression --output-on-failure\n