### PR TITLE
WIN32-BUG-2: fix Win32 CLI fallback discovery path mismatch

### DIFF
--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -529,10 +529,10 @@ static int TryCliCandidate(const WCHAR *base, const WCHAR *config, int versioned
 {
     if (versioned)
         _snwprintf(g_cli_path, MAX_PATH,
-                   L"%s\\QsoRipper.Cli\\%s\\net10.0\\QsoRipper.Cli.exe", base, config);
+                   L"%s\\qsoripper-cli\\%s\\net10.0\\QsoRipper.Cli.exe", base, config);
     else
         _snwprintf(g_cli_path, MAX_PATH,
-                   L"%s\\QsoRipper.Cli\\%s\\QsoRipper.Cli.exe", base, config);
+                   L"%s\\qsoripper-cli\\%s\\QsoRipper.Cli.exe", base, config);
     g_cli_path[MAX_PATH - 1] = L'\0';
     return GetFileAttributesW(g_cli_path) != INVALID_FILE_ATTRIBUTES;
 }
@@ -541,7 +541,7 @@ static void FindCliPath(void)
 {
     /* Try to find QsoRipper.Cli.exe relative to our own exe:
        We're at: .../artifacts/publish/qsoripper-win32/Release/qsoripper-win32.exe
-       CLI is at: .../artifacts/publish/QsoRipper.Cli/{Debug|Release}[/net10.0]/QsoRipper.Cli.exe */
+       CLI is at: .../artifacts/publish/qsoripper-cli/{Debug|Release}[/net10.0]/QsoRipper.Cli.exe */
     WCHAR module[MAX_PATH];
     GetModuleFileNameW(NULL, module, MAX_PATH);
 

--- a/tests/Build.Tests.ps1
+++ b/tests/Build.Tests.ps1
@@ -10,6 +10,8 @@
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $scriptPath = Join-Path $repoRoot 'build.ps1'
 $scriptContent = Get-Content $scriptPath -Raw
+$win32MainPath = Join-Path $repoRoot 'src' 'c' 'qsoripper-win32' 'src' 'main.c'
+$win32MainContent = Get-Content $win32MainPath -Raw
 
 # Extract function bodies for targeted checks
 function Get-FunctionBody([string]$Content, [string]$FunctionName) {
@@ -58,5 +60,17 @@ Describe 'build.ps1 Check-Dotnet CI parity (Bug #202)' {
     It 'runs vulnerable package check' {
         # Must reference --vulnerable for package vulnerability scanning
         $checkDotnetBody | Should Match '--vulnerable'
+    }
+}
+
+Describe 'Win32 CLI publish/discovery path contract (WIN32-BUG-2)' {
+
+    It 'publishes CLI to artifacts\publish\qsoripper-cli\<Configuration>' {
+        $scriptContent | Should Match "'qsoripper-cli'"
+    }
+
+    It 'probes the qsoripper-cli directory from FindCliPath candidates' {
+        $win32MainContent | Should Match 'qsoripper-cli'
+        $win32MainContent | Should Not Match 'QsoRipper\.Cli\\\\%s\\\\(?:net10\.0\\\\)?QsoRipper\.Cli\.exe'
     }
 }


### PR DESCRIPTION
## Summary
- add a regression test in 	ests/Build.Tests.ps1 for the Win32 CLI publish/discovery path contract (WIN32-BUG-2)
- align FindCliPath candidate probing in src/c/qsoripper-win32/src/main.c with uild.ps1 publish output (rtifacts/publish/qsoripper-cli/<Configuration>)
- keep QSORIPPER_CLI_PATH override behavior unchanged

## Test-first workflow evidence
- pre-fix: Invoke-Pester -Path .\\tests\\Build.Tests.ps1 reported Passed: 8 Failed: 1 on the new WIN32-BUG-2 regression
- post-fix: Invoke-Pester -Path .\\tests\\Build.Tests.ps1 reported Passed: 9 Failed: 0

## Validation
- Invoke-Pester -Path .\\tests\\Build.Tests.ps1
- .\\build.ps1 win32 -Configuration Debug (currently fails on an existing /WX warning in unrelated code around main.c(1154): C4456/C4101)

Fixes WIN32-BUG-2.