### PR TITLE
WIN32-BUG-3: Set deterministic qsr_last_error on qsr_connect failure

### DIFF
--- a/src/rust/qsoripper-ffi/src/client.rs
+++ b/src/rust/qsoripper-ffi/src/client.rs
@@ -39,7 +39,7 @@ use crate::types::{
 static LAST_ERROR: Mutex<String> = Mutex::new(String::new());
 
 /// Set the last error message.
-fn set_error(msg: impl Into<String>) {
+pub(crate) fn set_error(msg: impl Into<String>) {
     if let Ok(mut guard) = LAST_ERROR.lock() {
         *guard = msg.into();
     }

--- a/src/rust/qsoripper-ffi/src/lib.rs
+++ b/src/rust/qsoripper-ffi/src/lib.rs
@@ -39,9 +39,11 @@ use client::QsrClient;
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn qsr_connect(endpoint: *const c_char) -> *mut QsrClient {
     let ep = unsafe { client::cstr_to_str(endpoint) };
-    match QsrClient::connect(ep) {
-        Ok(boxed) => Box::into_raw(boxed),
-        Err(_) => std::ptr::null_mut(),
+    if let Ok(boxed) = QsrClient::connect(ep) {
+        Box::into_raw(boxed)
+    } else {
+        client::set_error("WIN32-BUG-3: connect failed");
+        std::ptr::null_mut()
     }
 }
 

--- a/src/rust/qsoripper-ffi/tests/integration.rs
+++ b/src/rust/qsoripper-ffi/tests/integration.rs
@@ -136,6 +136,21 @@ fn connect_and_disconnect() {
 }
 
 #[test]
+fn connect_failure_sets_last_error() {
+    let bad_endpoint = CString::new("not-a-uri").expect("CString::new failed");
+    let client = unsafe { qsr_connect(bad_endpoint.as_ptr()) };
+    assert!(
+        client.is_null(),
+        "expected qsr_connect to fail for invalid URI"
+    );
+    assert_eq!(
+        last_error(),
+        "WIN32-BUG-3: connect failed",
+        "connect failure must set deterministic last_error"
+    );
+}
+
+#[test]
 fn log_list_get_delete_round_trip() {
     skip_if_no_server!();
     let client = connect();


### PR DESCRIPTION
## Summary
- add failing-first FFI integration test for connect failure error propagation
- set deterministic last_error text when qsr_connect fails
- keep connect success path behavior unchanged

## Validation
- cargo test --manifest-path src/rust/Cargo.toml -p qsoripper-ffi --test integration
- cargo fmt --manifest-path src/rust/Cargo.toml --all -- --check
- cargo clippy --manifest-path src/rust/Cargo.toml -p qsoripper-ffi --all-targets -- -D warnings

Fixes WIN32-BUG-3.