### PR TITLE
WIN32-BUG-5: synchronize Win32 FFI shutdown with in-flight worker calls

### DIFF
--- a/src/c/qsoripper-win32/CMakeLists.txt
+++ b/src/c/qsoripper-win32/CMakeLists.txt
@@ -4,7 +4,10 @@ project(qsoripper-win32 C)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 
-add_executable(qsoripper-win32 WIN32 src/main.c)
+add_executable(qsoripper-win32 WIN32
+    src/main.c
+    src/backend_ffi_gate.c
+)
 
 # FFI library from the Rust qsoripper-ffi crate
 # The .dll.lib import library and header are produced by `cargo build -p qsoripper-ffi`
@@ -32,6 +35,28 @@ if(MSVC)
 else()
     target_compile_options(qsoripper-win32 PRIVATE -Wall -Wextra)
 endif()
+
+enable_testing()
+
+add_executable(qsoripper-win32-backend-lifetime-tests
+    tests/backend_lifetime_tests.c
+    src/backend_ffi_gate.c
+)
+target_include_directories(qsoripper-win32-backend-lifetime-tests PRIVATE
+    ${FFI_INCLUDE}
+)
+target_link_libraries(qsoripper-win32-backend-lifetime-tests PRIVATE
+    user32
+)
+if(MSVC)
+    target_compile_options(qsoripper-win32-backend-lifetime-tests PRIVATE /W4 /WX)
+else()
+    target_compile_options(qsoripper-win32-backend-lifetime-tests PRIVATE -Wall -Wextra)
+endif()
+add_test(
+    NAME qsoripper-win32-backend-lifetime-tests
+    COMMAND qsoripper-win32-backend-lifetime-tests
+)
 
 # cppcheck static analysis
 find_program(CPPCHECK_EXE NAMES cppcheck)

--- a/src/c/qsoripper-win32/include/backend_ffi_gate.h
+++ b/src/c/qsoripper-win32/include/backend_ffi_gate.h
@@ -1,0 +1,20 @@
+#ifndef BACKEND_FFI_GATE_H
+#define BACKEND_FFI_GATE_H
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+typedef struct {
+    SRWLOCK lock;
+    CONDITION_VARIABLE idle_cv;
+    LONG active_calls;
+    int shutting_down;
+    void *client;
+} BackendFfiGate;
+
+void backend_ffi_gate_init(BackendFfiGate *gate, void *client);
+int backend_ffi_gate_try_acquire(BackendFfiGate *gate, void **client_out);
+void backend_ffi_gate_release(BackendFfiGate *gate);
+void backend_ffi_gate_begin_shutdown(BackendFfiGate *gate, void **client_out);
+
+#endif

--- a/src/c/qsoripper-win32/src/backend_ffi_gate.c
+++ b/src/c/qsoripper-win32/src/backend_ffi_gate.c
@@ -1,0 +1,54 @@
+#include "backend_ffi_gate.h"
+
+void backend_ffi_gate_init(BackendFfiGate *gate, void *client)
+{
+    if (!gate) return;
+    InitializeSRWLock(&gate->lock);
+    InitializeConditionVariable(&gate->idle_cv);
+    gate->active_calls = 0;
+    gate->shutting_down = 0;
+    gate->client = client;
+}
+
+int backend_ffi_gate_try_acquire(BackendFfiGate *gate, void **client_out)
+{
+    if (!gate || !client_out) return 0;
+    AcquireSRWLockExclusive(&gate->lock);
+    if (gate->shutting_down || !gate->client) {
+        ReleaseSRWLockExclusive(&gate->lock);
+        return 0;
+    }
+    gate->active_calls++;
+    *client_out = gate->client;
+    ReleaseSRWLockExclusive(&gate->lock);
+    return 1;
+}
+
+void backend_ffi_gate_release(BackendFfiGate *gate)
+{
+    if (!gate) return;
+    AcquireSRWLockExclusive(&gate->lock);
+    if (gate->active_calls > 0) {
+        gate->active_calls--;
+        if (gate->active_calls == 0 && gate->shutting_down) {
+            WakeConditionVariable(&gate->idle_cv);
+        }
+    }
+    ReleaseSRWLockExclusive(&gate->lock);
+}
+
+void backend_ffi_gate_begin_shutdown(BackendFfiGate *gate, void **client_out)
+{
+    if (client_out) *client_out = NULL;
+    if (!gate) return;
+    AcquireSRWLockExclusive(&gate->lock);
+    gate->shutting_down = 1;
+    while (gate->active_calls > 0) {
+        SleepConditionVariableSRW(&gate->idle_cv, &gate->lock, INFINITE, 0);
+    }
+    if (client_out) {
+        *client_out = gate->client;
+    }
+    gate->client = NULL;
+    ReleaseSRWLockExclusive(&gate->lock);
+}

--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -18,6 +18,7 @@
 #include <time.h>
 #include <stdint.h>
 #include "qsoripper_ffi.h"
+#include "backend_ffi_gate.h"
 
 /* ── Compile-time settings ─────────────────────────────────────────────── */
 
@@ -345,6 +346,7 @@ static struct {
     fn_qsr_lookup            pf_lookup;
     fn_qsr_get_rig_status   pf_get_rig_status;
     fn_qsr_get_space_weather pf_get_space_weather;
+    BackendFfiGate ffi_gate;
 
     /* CLI state */
     char cli_path[MAX_PATH];
@@ -369,6 +371,8 @@ static void DeleteSelectedQso(void);
 static int  PaintAdvancedForm(HDC hdc, int y_start, int w);
 static void InitBackend(void);
 static void ShutdownBackend(void);
+static int AcquireFfiClient(struct QsrClient **client_out);
+static void ReleaseFfiClient(void);
 
 static char *FieldBuffer(enum Field f);
 static int   FieldMaxLen(enum Field f);
@@ -1130,6 +1134,17 @@ static void fill_log_request(QsrLogQsoRequest *req)
     }
 }
 
+static int AcquireFfiClient(struct QsrClient **client_out)
+{
+    if (g_backend.mode != BACKEND_FFI) return 0;
+    return backend_ffi_gate_try_acquire(&g_backend.ffi_gate, (void **)client_out);
+}
+
+static void ReleaseFfiClient(void)
+{
+    backend_ffi_gate_release(&g_backend.ffi_gate);
+}
+
 static void LogQso(void)
 {
     if (g_state.callsign[0] == 0) {
@@ -1146,15 +1161,18 @@ static void LogQso(void)
                   "%02d:%02d", st.wHour, st.wMinute);
     }
 
-    char cmd[4096];
-
     if (g_backend.mode == BACKEND_FFI) {
+        struct QsrClient *ffi_client = NULL;
+        if (!AcquireFfiClient(&ffi_client)) {
+            SetStatus("Backend unavailable (shutting down)", 1);
+            return;
+        }
         if (is_update) {
             QsrUpdateQsoRequest ureq;
             memset(&ureq, 0, sizeof(ureq));
             safe_strcpy((char *)ureq.local_id, sizeof(ureq.local_id), g_state.editing_local_id);
             fill_log_request(&ureq.qso);
-            if (g_backend.pf_update_qso(g_backend.ffi_client, &ureq) == 0) {
+            if (g_backend.pf_update_qso(ffi_client, &ureq) == 0) {
                 SetStatus("QSO updated", 0);
             } else {
                 SetStatus("Failed to update QSO", 1);
@@ -1163,7 +1181,7 @@ static void LogQso(void)
             QsrLogQsoRequest req;
             QsrLogQsoResult res;
             fill_log_request(&req);
-            if (g_backend.pf_log_qso(g_backend.ffi_client, &req, &res) == 0) {
+            if (g_backend.pf_log_qso(ffi_client, &req, &res) == 0) {
                 char msg[128];
                 snprintf(msg, sizeof(msg), "Logged %s on %s %s",
                           g_state.callsign, BANDS[g_state.band_idx],
@@ -1173,6 +1191,7 @@ static void LogQso(void)
                 SetStatus("Failed to log QSO", 1);
             }
         }
+        ReleaseFfiClient();
     } else {
         /* CLI path */
         char cmd[4096];
@@ -1267,10 +1286,13 @@ static unsigned __stdcall QsoLoadThread(void *param)
     if (!res) { free(arg); return 0; }
 
     if (g_backend.mode == BACKEND_FFI) {
+        struct QsrClient *ffi_client = NULL;
         QsrQsoList list;
         memset(&list, 0, sizeof(list));
 
-        if (g_backend.pf_list_qsos(g_backend.ffi_client, &list) == 0 && list.count > 0) {
+        if (AcquireFfiClient(&ffi_client) &&
+            g_backend.pf_list_qsos(ffi_client, &list) == 0 &&
+            list.count > 0) {
             res->qsos = (RecentQso *)calloc((size_t)list.count, sizeof(RecentQso));
             if (res->qsos) {
                 res->count = list.count;
@@ -1290,6 +1312,9 @@ static unsigned __stdcall QsoLoadThread(void *param)
                 }
             }
             g_backend.pf_free_qso_list(&list);
+        }
+        if (ffi_client) {
+            ReleaseFfiClient();
         }
     } else {
         /* CLI path */
@@ -1394,9 +1419,11 @@ static unsigned __stdcall LookupThread(void *param)
     safe_strcpy(res->callsign, sizeof(res->callsign), arg->callsign);
 
     if (g_backend.mode == BACKEND_FFI) {
+        struct QsrClient *ffi_client = NULL;
         QsrLookupResult lr;
         memset(&lr, 0, sizeof(lr));
-        if (g_backend.pf_lookup(g_backend.ffi_client, arg->callsign, &lr) == 0) {
+        if (AcquireFfiClient(&ffi_client) &&
+            g_backend.pf_lookup(ffi_client, arg->callsign, &lr) == 0) {
             if (lr.has_data) {
                 res->has_data = 1;
                 safe_strcpy(res->name,    sizeof(res->name),    (const char *)lr.name);
@@ -1409,6 +1436,9 @@ static unsigned __stdcall LookupThread(void *param)
             } else if (lr.error_msg[0]) {
                 safe_strcpy(res->error_msg, sizeof(res->error_msg), (const char *)lr.error_msg);
             }
+        }
+        if (ffi_client) {
+            ReleaseFfiClient();
         }
     } else {
         /* CLI path */
@@ -1456,14 +1486,20 @@ static unsigned __stdcall RigPollThread(void *param)
     if (!res) { free(arg); return 0; }
 
     if (g_backend.mode == BACKEND_FFI) {
+        struct QsrClient *ffi_client = NULL;
         QsrRigStatus rs;
         memset(&rs, 0, sizeof(rs));
-        if (g_backend.pf_get_rig_status(g_backend.ffi_client, &rs) == 0 && rs.connected) {
+        if (AcquireFfiClient(&ffi_client) &&
+            g_backend.pf_get_rig_status(ffi_client, &rs) == 0 &&
+            rs.connected) {
             res->connected = 1;
             safe_strcpy(res->freq_display, sizeof(res->freq_display), (const char *)rs.freq_display);
             safe_strcpy(res->freq_mhz,    sizeof(res->freq_mhz),     (const char *)rs.freq_mhz);
             safe_strcpy(res->band,         sizeof(res->band),          (const char *)rs.band);
             safe_strcpy(res->mode,         sizeof(res->mode),          (const char *)rs.mode);
+        }
+        if (ffi_client) {
+            ReleaseFfiClient();
         }
     } else {
         /* CLI path */
@@ -1500,13 +1536,19 @@ static unsigned __stdcall RigPollThread(void *param)
 static void FetchSpaceWeather(void)
 {
     if (g_backend.mode == BACKEND_FFI) {
+        struct QsrClient *ffi_client = NULL;
         QsrSpaceWeather sw;
         memset(&sw, 0, sizeof(sw));
-        if (g_backend.pf_get_space_weather(g_backend.ffi_client, &sw) == 0 && sw.has_data) {
+        if (AcquireFfiClient(&ffi_client) &&
+            g_backend.pf_get_space_weather(ffi_client, &sw) == 0 &&
+            sw.has_data) {
             g_state.k_index = sw.k_index;
             g_state.solar_flux = sw.solar_flux;
             g_state.sunspot_number = sw.sunspot_number;
             g_state.has_weather = 1;
+        }
+        if (ffi_client) {
+            ReleaseFfiClient();
         }
     } else {
         /* CLI path */
@@ -1541,8 +1583,14 @@ static void LoadSelectedQso(void)
     int loaded = 0;
 
     if (g_backend.mode == BACKEND_FFI) {
-        if (g_backend.pf_get_qso(g_backend.ffi_client, q->local_id, &detail) == 0)
+        struct QsrClient *ffi_client = NULL;
+        if (AcquireFfiClient(&ffi_client) &&
+            g_backend.pf_get_qso(ffi_client, q->local_id, &detail) == 0) {
             loaded = 1;
+        }
+        if (ffi_client) {
+            ReleaseFfiClient();
+        }
     } else {
         /* CLI path */
         char cmd[256];
@@ -1705,7 +1753,11 @@ static void DeleteSelectedQso(void)
 
     int ok = 0;
     if (g_backend.mode == BACKEND_FFI) {
-        ok = (g_backend.pf_delete_qso(g_backend.ffi_client, q->local_id) == 0);
+        struct QsrClient *ffi_client = NULL;
+        if (AcquireFfiClient(&ffi_client)) {
+            ok = (g_backend.pf_delete_qso(ffi_client, q->local_id) == 0);
+            ReleaseFfiClient();
+        }
     } else {
         char cmd[256];
         snprintf(cmd, sizeof(cmd), "delete \"%s\" --json", q->local_id);
@@ -3618,6 +3670,7 @@ static int InitFFIBackend(void)
         g_backend.ffi_dll = NULL;
         return 0;
     }
+    backend_ffi_gate_init(&g_backend.ffi_gate, g_backend.ffi_client);
 
     return 1;
 }
@@ -3657,9 +3710,11 @@ static void InitBackend(void)
 static void ShutdownBackend(void)
 {
     if (g_backend.mode == BACKEND_FFI) {
-        if (g_backend.ffi_client) {
-            g_backend.pf_disconnect(g_backend.ffi_client);
-            g_backend.ffi_client = NULL;
+        struct QsrClient *client_to_disconnect = NULL;
+        backend_ffi_gate_begin_shutdown(&g_backend.ffi_gate, (void **)&client_to_disconnect);
+        g_backend.ffi_client = NULL;
+        if (client_to_disconnect) {
+            g_backend.pf_disconnect(client_to_disconnect);
         }
         if (g_backend.ffi_dll) {
             FreeLibrary(g_backend.ffi_dll);

--- a/src/c/qsoripper-win32/tests/backend_lifetime_tests.c
+++ b/src/c/qsoripper-win32/tests/backend_lifetime_tests.c
@@ -1,0 +1,107 @@
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <process.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "backend_ffi_gate.h"
+
+typedef struct {
+    BackendFfiGate gate;
+    HANDLE worker_entered;
+    HANDLE release_worker;
+    HANDLE shutdown_done;
+    volatile LONG worker_acquired;
+    volatile LONG shutdown_complete;
+    void *shutdown_client;
+} Harness;
+
+static void fail(const char *msg)
+{
+    fprintf(stderr, "FAIL: %s\n", msg);
+    exit(1);
+}
+
+static unsigned __stdcall worker_thread(void *param)
+{
+    Harness *h = (Harness *)param;
+    void *client = NULL;
+    if (!backend_ffi_gate_try_acquire(&h->gate, &client)) {
+        fail("worker failed to acquire backend gate");
+    }
+    InterlockedExchange(&h->worker_acquired, 1);
+    SetEvent(h->worker_entered);
+    WaitForSingleObject(h->release_worker, INFINITE);
+    backend_ffi_gate_release(&h->gate);
+    return 0;
+}
+
+static unsigned __stdcall shutdown_thread(void *param)
+{
+    Harness *h = (Harness *)param;
+    backend_ffi_gate_begin_shutdown(&h->gate, &h->shutdown_client);
+    InterlockedExchange(&h->shutdown_complete, 1);
+    SetEvent(h->shutdown_done);
+    return 0;
+}
+
+int main(void)
+{
+    Harness h;
+    ZeroMemory(&h, sizeof(h));
+    h.worker_entered = CreateEventW(NULL, TRUE, FALSE, NULL);
+    h.release_worker = CreateEventW(NULL, TRUE, FALSE, NULL);
+    h.shutdown_done = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (!h.worker_entered || !h.release_worker || !h.shutdown_done) {
+        fail("failed to create events");
+    }
+
+    backend_ffi_gate_init(&h.gate, (void *)0x1);
+
+    uintptr_t worker_thread_id = _beginthreadex(NULL, 0, worker_thread, &h, 0, NULL);
+    if (!worker_thread_id) fail("failed to create worker thread");
+    HANDLE worker_handle = (HANDLE)worker_thread_id;
+
+    if (WaitForSingleObject(h.worker_entered, 3000) != WAIT_OBJECT_0) {
+        fail("worker did not enter in time");
+    }
+
+    uintptr_t shutdown_thread_id = _beginthreadex(NULL, 0, shutdown_thread, &h, 0, NULL);
+    if (!shutdown_thread_id) fail("failed to create shutdown thread");
+    HANDLE shutdown_handle = (HANDLE)shutdown_thread_id;
+
+    Sleep(100);
+    if (WaitForSingleObject(h.shutdown_done, 0) == WAIT_OBJECT_0) {
+        fail("shutdown completed before in-flight worker finished");
+    }
+
+    SetEvent(h.release_worker);
+
+    if (WaitForSingleObject(h.shutdown_done, 3000) != WAIT_OBJECT_0) {
+        fail("shutdown did not complete after worker release");
+    }
+
+    if (h.shutdown_client != (void *)0x1) {
+        fail("shutdown did not return original client");
+    }
+
+    if (InterlockedCompareExchange(&h.shutdown_complete, 0, 0) != 1) {
+        fail("shutdown completion flag was not set");
+    }
+
+    void *client_after_shutdown = NULL;
+    if (backend_ffi_gate_try_acquire(&h.gate, &client_after_shutdown)) {
+        fail("acquire unexpectedly succeeded after shutdown");
+    }
+
+    WaitForSingleObject(worker_handle, 3000);
+    WaitForSingleObject(shutdown_handle, 3000);
+    CloseHandle(worker_handle);
+    CloseHandle(shutdown_handle);
+    CloseHandle(h.worker_entered);
+    CloseHandle(h.release_worker);
+    CloseHandle(h.shutdown_done);
+
+    puts("PASS: backend gate blocks shutdown until in-flight calls complete");
+    return 0;
+}


### PR DESCRIPTION
## Summary\n- add a deterministic regression harness (qsoripper-win32-backend-lifetime-tests) that reproduces WIN32-BUG-5 by asserting shutdown must block while a worker holds the backend client\n- introduce BackendFfiGate synchronization for FFI client lifetime (cquire/release/shutdown)\n- wrap Win32 FFI call sites (sync + detached worker paths) with gate acquisition to prevent use-after-free during shutdown\n- make backend shutdown wait for in-flight FFI calls before disconnecting client / unloading DLL\n\n## Test-first evidence\n- before fix: ctest -R backend-lifetime failed with FAIL: shutdown completed before in-flight worker finished\n- after fix: same test passes\n\n## Validation\n- cmake --build build --config Debug --target qsoripper-win32 qsoripper-win32-backend-lifetime-tests\n- ctest --test-dir build -C Debug --output-on-failure -R backend-lifetime\n- cargo test --manifest-path src/rust/Cargo.toml -p qsoripper-ffi\n\nFixes WIN32-BUG-5.