### PR TITLE
Add Win32 CI quality workflow and fix build

### DIFF
--- a/.github/workflows/full-stack-quality.yml
+++ b/.github/workflows/full-stack-quality.yml
@@ -16,3 +16,7 @@ jobs:
   dotnet:
     name: .NET Quality
     uses: ./.github/workflows/dotnet-quality.yml
+
+  win32:
+    name: Win32 Quality
+    uses: ./.github/workflows/win32-quality.yml

--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -7,7 +7,6 @@ on:
     paths:
       - ".github/workflows/rust-quality.yml"
       - "rust-toolchain.toml"
-      - "src/c/**"
       - "src/rust/**"
       - "proto/**"
   pull_request:

--- a/.github/workflows/win32-quality.yml
+++ b/.github/workflows/win32-quality.yml
@@ -1,0 +1,28 @@
+name: Win32 Quality
+
+on:
+  workflow_dispatch:
+  workflow_call:
+  push:
+    paths:
+      - ".github/workflows/win32-quality.yml"
+      - "src/c/**"
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  win32-quality:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure CMake
+        run: cmake -B build -S src/c/qsoripper-win32 -G "Visual Studio 17 2022"
+
+      - name: Build (Release)
+        run: cmake --build build --config Release
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure -C Release

--- a/build.ps1
+++ b/build.ps1
@@ -77,6 +77,7 @@ function Invoke-Build([string]$Step, [string]$Command, [string[]]$Arguments) {
 
 $Win32SourceDir = Join-Path $PSScriptRoot 'src' 'c' 'qsoripper-win32'
 $Win32Source = Join-Path $Win32SourceDir 'src' 'main.c'
+$Win32FfiGateSource = Join-Path $Win32SourceDir 'src' 'backend_ffi_gate.c'
 $Win32PublishDir = Join-Path $PSScriptRoot 'artifacts' 'publish' | Join-Path -ChildPath 'qsoripper-win32' | Join-Path -ChildPath $Configuration
 
 function Build-Rust {
@@ -243,7 +244,8 @@ function Build-Win32 {
                  --suppress=missingIncludeSystem `
                  --suppress=missingInclude `
                  --inline-suppr `
-                 $Win32Source
+                 $Win32Source `
+                 $Win32FfiGateSource
         if ($LASTEXITCODE -ne 0) {
             Write-Host 'FAILED: cppcheck found errors' -ForegroundColor Red
             exit $LASTEXITCODE
@@ -264,7 +266,7 @@ function Build-Win32 {
     @"
 @echo off
 call "$vcvars" $arch >nul 2>&1
-cl /W4 /WX /analyze $optFlags /DUNICODE /D_UNICODE /I"$ffiInclude" "$Win32Source" /Fe:"$exe" /link user32.lib gdi32.lib shell32.lib comctl32.lib
+cl /W4 /WX /analyze $optFlags /DUNICODE /D_UNICODE /I"$ffiInclude" "$Win32Source" "$Win32FfiGateSource" /Fe:"$exe" /link user32.lib gdi32.lib shell32.lib comctl32.lib
 "@ | Set-Content -LiteralPath $buildScript -Encoding ASCII
 
     Push-Location $Win32PublishDir

--- a/src/c/qsoripper-win32/CMakeLists.txt
+++ b/src/c/qsoripper-win32/CMakeLists.txt
@@ -81,6 +81,7 @@ if(BUILD_TESTING)
     add_executable(qsoripper-win32-cli-exitcode-regression
         tests/cli_exit_code_regression.c
         src/main.c
+        src/backend_ffi_gate.c
     )
 
     target_include_directories(qsoripper-win32-cli-exitcode-regression PRIVATE ${FFI_INCLUDE})


### PR DESCRIPTION
## Summary

Adds a dedicated CI workflow for the Win32 C app so that build and test regressions (like the recent LNK2019 linker errors from missing `backend_ffi_gate.c`) are caught automatically.

## Changes

- **New workflow** `.github/workflows/win32-quality.yml`
  - Runs on `windows-latest` with MSVC via CMake
  - Triggers on `src/c/**` changes and PRs
  - Builds the Win32 app and runs CTest (backend lifetime + CLI exit code regression)
  - Supports `workflow_call` for reuse from full-stack-quality

- **CMakeLists.txt fix**: Added missing `backend_ffi_gate.c` to the `cli-exitcode-regression` test target (was causing LNK2019 errors)

- **build.ps1 fix**: Added missing `backend_ffi_gate.c` to the direct `cl` invocation and cppcheck analysis

- **full-stack-quality.yml**: Added Win32 quality as a third job in the daily scheduled run

- **rust-quality.yml**: Removed `src/c/**` trigger (now covered by `win32-quality.yml`)

## Verification

- CMake configure + build + CTest all pass locally (2/2 tests pass)
- All existing Rust and .NET builds unaffected
