### PR TITLE
Restore grid focus after closing inspector panel

### DIFF
--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -421,9 +421,10 @@ internal sealed partial class MainWindow : Window
             return;
         }
 
-        // Defer focus so the current key event finishes processing first —
-        // synchronous Focus() during a KeyBinding handler doesn't reliably
-        // move focus away from the active TextBox.
+        // Defer focus at Background priority so the current key event and any
+        // visual-tree changes (e.g. inspector panel collapse) finish first.
+        // Input priority was too early — Avalonia's focus cleanup after removing
+        // the inspector content could re-steal focus after our call.
         Dispatcher.UIThread.Post(
             () =>
             {
@@ -433,7 +434,7 @@ internal sealed partial class MainWindow : Window
                     _recentQsoGrid.SelectedIndex = 0;
                 }
             },
-            DispatcherPriority.Input);
+            DispatcherPriority.Background);
     }
 
     private async void OnSettingsRequested(object? sender, EventArgs e)


### PR DESCRIPTION
## Problem

When pressing Alt+Enter to open the inspector on a QSO row then closing it, the grid loses keyboard focus. The user has to click or tab back to the grid to resume keyboard navigation.

## Root Cause

\OnGridFocusRequested\ deferred the \Focus()\ call at \DispatcherPriority.Input\, which fires *before* Avalonia finishes removing the inspector panel's visual tree. Avalonia's focus cleanup (moving focus away from removed elements) could run after our focus call, re-stealing focus from the grid.

## Fix

Change the dispatcher priority from \Input\ to \Background\, so the focus restoration runs after all layout and visual tree updates complete. This is a one-line priority change in \MainWindow.axaml.cs\.