### PR TITLE
Fix issue batch: #269 #259 #255 #253

### DIFF
--- a/.github/workflows/dotnet-quality.yml
+++ b/.github/workflows/dotnet-quality.yml
@@ -74,4 +74,11 @@ jobs:
           path: coverage/report/
 
       - name: Check for vulnerable packages
-        run: dotnet list src/dotnet/QsoRipper.slnx package --vulnerable --include-transitive
+        run: |
+          output="$(dotnet list src/dotnet/QsoRipper.slnx package --vulnerable --include-transitive 2>&1)"
+          echo "$output"
+          if echo "$output" | grep -q "has the following vulnerable packages"; then
+            echo "FAIL: Vulnerable NuGet packages detected. Review output above and update affected packages."
+            exit 1
+          fi
+          echo "PASS: No vulnerable packages found."

--- a/build.ps1
+++ b/build.ps1
@@ -320,6 +320,7 @@ function Check-Rust {
         Invoke-Build 'Rust tests (with coverage)' cargo @(
             'llvm-cov', '--manifest-path', $RustManifest,
             '--workspace',
+            '--exclude', 'qsoripper-ffi',
             '--exclude', 'qsoripper-stress',
             '--exclude', 'qsoripper-stress-tui'
         )
@@ -329,7 +330,7 @@ function Check-Rust {
         try {
             cargo llvm-cov report `
                 --manifest-path $RustManifest `
-                --ignore-filename-regex 'qsoripper-stress' `
+                --ignore-filename-regex 'qsoripper-(stress|ffi)' `
                 --json --summary-only `
                 --output-path $summaryPath
             if ($LASTEXITCODE -ne 0) {

--- a/src/dotnet/QsoRipper.DebugHost.Tests/DebugCommandServiceTimeoutSafetyTests.cs
+++ b/src/dotnet/QsoRipper.DebugHost.Tests/DebugCommandServiceTimeoutSafetyTests.cs
@@ -1,0 +1,32 @@
+namespace QsoRipper.DebugHost.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+public class DebugCommandServiceTimeoutSafetyTests
+{
+    [Fact]
+    public void RunAsync_catches_timeout_cancellation_and_kills_process_tree()
+    {
+        var source = File.ReadAllText(GetDebugCommandServicePath());
+
+        Assert.Contains("catch (OperationCanceledException)", source, StringComparison.Ordinal);
+        Assert.Contains("process.Kill(entireProcessTree: true)", source, StringComparison.Ordinal);
+    }
+
+    private static string GetDebugCommandServicePath()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine(directory.FullName, "src", "dotnet", "QsoRipper.DebugHost", "Services", "DebugCommandService.cs");
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate DebugCommandService.cs from test output directory.");
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.DebugHost/Services/DebugCommandService.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Services/DebugCommandService.cs
@@ -145,13 +145,49 @@ internal sealed class DebugCommandService
 
         using var timeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeoutSource.CancelAfter(TimeSpan.FromSeconds(_options.CommandTimeoutSeconds));
-        await process.WaitForExitAsync(timeoutSource.Token);
+        try
+        {
+            await process.WaitForExitAsync(timeoutSource.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+
+            await process.WaitForExitAsync(cancellationToken);
+            return CreateTimeoutResult(command, _options.CommandTimeoutSeconds, await standardOutput, await standardError, startedAt, effectiveEnvironment);
+        }
 
         return new CommandExecutionResult(
             command,
             process.ExitCode,
             await standardOutput,
             await standardError,
+            startedAt,
+            DateTimeOffset.UtcNow,
+            effectiveEnvironment);
+    }
+
+    private static CommandExecutionResult CreateTimeoutResult(
+        DebugCommandDefinition command,
+        int timeoutSeconds,
+        string standardOutput,
+        string standardError,
+        DateTimeOffset startedAt,
+        IReadOnlyDictionary<string, string> effectiveEnvironment)
+    {
+        var timeoutMessage = $"Command timed out after {timeoutSeconds} second(s).";
+        var combinedError = string.IsNullOrWhiteSpace(standardError)
+            ? timeoutMessage
+            : $"{standardError}{Environment.NewLine}{timeoutMessage}";
+
+        return new CommandExecutionResult(
+            command,
+            -1,
+            standardOutput,
+            combinedError,
             startedAt,
             DateTimeOffset.UtcNow,
             effectiveEnvironment);

--- a/src/dotnet/QsoRipper.Gui.Tests/AsyncVoidHandlerSafetyTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/AsyncVoidHandlerSafetyTests.cs
@@ -1,0 +1,57 @@
+namespace QsoRipper.Gui.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+public sealed class AsyncVoidHandlerSafetyTests
+{
+    [Fact]
+    public void MainWindowViewModel_async_void_handlers_have_top_level_exception_guards()
+    {
+        var source = File.ReadAllText(GetSourcePath("src", "dotnet", "QsoRipper.Gui", "ViewModels", "MainWindowViewModel.cs"));
+
+        AssertMethodContains(source, "OnQsoLogged", "try");
+        AssertMethodContains(source, "OnQsoLogged", "catch");
+
+        AssertMethodContains(source, "OnRigTimerTick", "catch (Grpc.Core.RpcException)");
+        AssertMethodContains(source, "OnRigTimerTick", "catch (ObjectDisposedException)");
+
+        AssertMethodContains(source, "OnSpaceWeatherTimerTick", "try");
+        AssertMethodContains(source, "OnSpaceWeatherTimerTick", "catch");
+    }
+
+    [Fact]
+    public void MainWindow_async_void_handlers_have_top_level_exception_guards()
+    {
+        var source = File.ReadAllText(GetSourcePath("src", "dotnet", "QsoRipper.Gui", "Views", "MainWindow.axaml.cs"));
+
+        AssertMethodContains(source, "OnOpened", "try");
+        AssertMethodContains(source, "OnOpened", "catch");
+        AssertMethodContains(source, "OnSettingsRequested", "try");
+        AssertMethodContains(source, "OnSettingsRequested", "catch");
+    }
+
+    private static void AssertMethodContains(string source, string methodName, string expected)
+    {
+        var methodIndex = source.IndexOf($"{methodName}(", StringComparison.Ordinal);
+        Assert.True(methodIndex >= 0, $"Method '{methodName}' was not found.");
+        var snippet = source.Substring(methodIndex, Math.Min(3000, source.Length - methodIndex));
+        Assert.Contains(expected, snippet, StringComparison.Ordinal);
+    }
+
+    private static string GetSourcePath(params string[] segments)
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            var candidate = Path.Combine([directory.FullName, .. segments]);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate source file from test output directory.");
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -720,7 +720,22 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 
     private async void OnQsoLogged(object? sender, EventArgs e)
     {
-        await RecentQsos.RefreshAsync();
+        try
+        {
+            await RecentQsos.RefreshAsync();
+        }
+        catch (Grpc.Core.RpcException)
+        {
+            StatusMessage = "Ready (refresh failed)";
+        }
+        catch (ObjectDisposedException)
+        {
+            StatusMessage = "Ready (engine restarting...)";
+        }
+        catch (InvalidOperationException)
+        {
+            StatusMessage = "Ready (refresh failed)";
+        }
     }
 
     private void OnLoggerFocusRequested(object? sender, EventArgs e)
@@ -751,11 +766,26 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         {
             RigStatusText = "Rig: error";
         }
+        catch (ObjectDisposedException)
+        {
+            RigStatusText = "Rig: unavailable";
+        }
     }
 
     private async void OnSpaceWeatherTimerTick(object? sender, EventArgs e)
     {
-        await FetchSpaceWeatherAsync();
+        try
+        {
+            await FetchSpaceWeatherAsync();
+        }
+        catch (ObjectDisposedException)
+        {
+            SpaceWeatherText = "Weather: unavailable";
+        }
+        catch (InvalidOperationException)
+        {
+            SpaceWeatherText = "Weather: error";
+        }
     }
 
     private async Task FetchSpaceWeatherAsync()

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -56,24 +56,43 @@ internal sealed partial class MainWindow : Window
     {
         base.OnOpened(e);
         GuiPerformanceTrace.Write(nameof(OnOpened) + ".start");
-        ClampToCurrentScreen();
-        if (!IsInspectionMode)
+        try
         {
-            GuiPerformanceTrace.Write(nameof(OnOpened) + ".afterScheduleMenuAccessKeys");
-            ApplyPersistedGridLayout();
-            GuiPerformanceTrace.Write(nameof(OnOpened) + ".afterApplyPersistedGridLayout");
-            if (DataContext is MainWindowViewModel vm)
+            ClampToCurrentScreen();
+            if (!IsInspectionMode)
             {
-                vm.ApplyPreferences(_preferencesStore.Load());
-                GuiPerformanceTrace.Write(nameof(OnOpened) + ".afterApplyPreferences");
-                await vm.CheckFirstRunAsync();
-                GuiPerformanceTrace.Write(nameof(OnOpened) + ".afterCheckFirstRun");
+                GuiPerformanceTrace.Write(nameof(OnOpened) + ".afterScheduleMenuAccessKeys");
+                ApplyPersistedGridLayout();
+                GuiPerformanceTrace.Write(nameof(OnOpened) + ".afterApplyPersistedGridLayout");
+                if (DataContext is MainWindowViewModel vm)
+                {
+                    vm.ApplyPreferences(_preferencesStore.Load());
+                    GuiPerformanceTrace.Write(nameof(OnOpened) + ".afterApplyPreferences");
+                    await vm.CheckFirstRunAsync();
+                    GuiPerformanceTrace.Write(nameof(OnOpened) + ".afterCheckFirstRun");
+                }
+
+                Dispatcher.UIThread.Post(PrimeMenuAccessKeys, DispatcherPriority.Background);
             }
 
-            Dispatcher.UIThread.Post(PrimeMenuAccessKeys, DispatcherPriority.Background);
+            EnsureColumnHeadersFit();
         }
-
-        EnsureColumnHeadersFit();
+        catch (ObjectDisposedException ex)
+        {
+            GuiPerformanceTrace.Write(nameof(OnOpened) + ".error", ex.ToString());
+            if (DataContext is MainWindowViewModel vm)
+            {
+                vm.StatusMessage = "Error: startup did not fully complete.";
+            }
+        }
+        catch (InvalidOperationException ex)
+        {
+            GuiPerformanceTrace.Write(nameof(OnOpened) + ".error", ex.ToString());
+            if (DataContext is MainWindowViewModel vm)
+            {
+                vm.StatusMessage = "Error: startup did not fully complete.";
+            }
+        }
     }
 
     protected override void OnClosed(EventArgs e)
@@ -438,7 +457,26 @@ internal sealed partial class MainWindow : Window
 
     private async void OnSettingsRequested(object? sender, EventArgs e)
     {
-        await ShowSettingsDialogAsync();
+        try
+        {
+            await ShowSettingsDialogAsync();
+        }
+        catch (ObjectDisposedException ex)
+        {
+            GuiPerformanceTrace.Write(nameof(OnSettingsRequested) + ".error", ex.ToString());
+            if (_viewModel is not null)
+            {
+                _viewModel.StatusMessage = "Error: unable to open settings.";
+            }
+        }
+        catch (InvalidOperationException ex)
+        {
+            GuiPerformanceTrace.Write(nameof(OnSettingsRequested) + ".error", ex.ToString());
+            if (_viewModel is not null)
+            {
+                _viewModel.StatusMessage = "Error: unable to open settings.";
+            }
+        }
     }
 
     private void OnLoggerFocusRequested(object? sender, EventArgs e)

--- a/tests/Build.Tests.ps1
+++ b/tests/Build.Tests.ps1
@@ -10,6 +10,10 @@
 $repoRoot = Split-Path -Parent $PSScriptRoot
 $scriptPath = Join-Path $repoRoot 'build.ps1'
 $scriptContent = Get-Content $scriptPath -Raw
+$rustWorkflowPath = Join-Path $repoRoot '.github' 'workflows' 'rust-quality.yml'
+$rustWorkflowContent = Get-Content $rustWorkflowPath -Raw
+$dotnetWorkflowPath = Join-Path $repoRoot '.github' 'workflows' 'dotnet-quality.yml'
+$dotnetWorkflowContent = Get-Content $dotnetWorkflowPath -Raw
 $win32MainPath = Join-Path $repoRoot 'src' 'c' 'qsoripper-win32' 'src' 'main.c'
 $win32MainContent = Get-Content $win32MainPath -Raw
 
@@ -52,6 +56,21 @@ Describe 'build.ps1 Check-Rust CI parity (Bug #202)' {
     }
 }
 
+Describe 'build.ps1 Rust coverage exclusion parity (Bug #269)' {
+
+    It 'excludes qsoripper-ffi during local cargo llvm-cov runs' {
+        $checkRustBody | Should Match "'--exclude', 'qsoripper-ffi'"
+    }
+
+    It 'matches CI ignore-filename-regex for stress and ffi' {
+        $checkRustBody | Should Match "ignore-filename-regex 'qsoripper-\(stress\|ffi\)'"
+    }
+
+    It 'CI workflow still excludes qsoripper-ffi' {
+        $rustWorkflowContent | Should Match '--exclude qsoripper-ffi'
+    }
+}
+
 Describe 'build.ps1 Check-Dotnet CI parity (Bug #202)' {
 
     It 'runs tests with coverage collection' {
@@ -71,6 +90,14 @@ Describe 'build.ps1 Check-Dotnet CI parity (Bug #202)' {
     It 'runs vulnerable package check' {
         # Must reference --vulnerable for package vulnerability scanning
         $checkDotnetBody | Should Match '--vulnerable'
+    }
+}
+
+Describe '.github/workflows/dotnet-quality.yml vulnerable package gate (Bug #259)' {
+
+    It 'fails the workflow when vulnerable packages are reported' {
+        $dotnetWorkflowContent | Should Match 'has the following vulnerable packages'
+        $dotnetWorkflowContent | Should Match 'exit 1'
     }
 }
 


### PR DESCRIPTION
## Summary\n- add tests/checks first for issue set #269 #259 #255 #253\n- align Rust coverage exclusions between local build and CI\n- make .NET CI vulnerable-package step fail when vulnerabilities are detected\n- harden DebugHost timeout handling to kill timed-out child process trees\n- add top-level exception guards to GUI async void handlers to avoid fatal crashes\n\n## Verification\n- Invoke-Pester -Path tests/Build.Tests.ps1\n- dotnet test src/dotnet/QsoRipper.DebugHost.Tests/QsoRipper.DebugHost.Tests.csproj\n- dotnet test src/dotnet/QsoRipper.Gui.Tests/QsoRipper.Gui.Tests.csproj\n- dotnet test src/dotnet/QsoRipper.slnx --no-build\n\nCloses #269\nCloses #259\nCloses #255\nCloses #253