### PR TITLE
Fix TUI channel reuse/terminal cleanup and FFI list free safety

### DIFF
--- a/src/c/qsoripper-win32/tests/win32_issue_regressions.c
+++ b/src/c/qsoripper-win32/tests/win32_issue_regressions.c
@@ -186,7 +186,7 @@ static int test_issue_263_log_is_non_blocking(void)
     }
     HANDLE thread = (HANDLE)tid;
 
-    if (WaitForSingleObject(g_log_entered, 500) != WAIT_OBJECT_0) {
+    if (WaitForSingleObject(g_log_entered, 3000) != WAIT_OBJECT_0) {
         return fail("log backend call was not invoked");
     }
 
@@ -222,7 +222,7 @@ static int test_issue_263_load_selected_qso_is_non_blocking(void)
     }
     HANDLE thread = (HANDLE)tid;
 
-    if (WaitForSingleObject(g_load_entered, 500) != WAIT_OBJECT_0) {
+    if (WaitForSingleObject(g_load_entered, 3000) != WAIT_OBJECT_0) {
         return fail("load backend call was not invoked");
     }
 
@@ -257,7 +257,7 @@ static int test_issue_263_delete_selected_qso_is_non_blocking(void)
     }
     HANDLE thread = (HANDLE)tid;
 
-    if (WaitForSingleObject(g_delete_entered, 500) != WAIT_OBJECT_0) {
+    if (WaitForSingleObject(g_delete_entered, 3000) != WAIT_OBJECT_0) {
         return fail("delete backend call was not invoked");
     }
 
@@ -291,7 +291,7 @@ static int test_issue_263_fetch_space_weather_is_non_blocking(void)
     }
     HANDLE thread = (HANDLE)tid;
 
-    if (WaitForSingleObject(g_weather_entered, 500) != WAIT_OBJECT_0) {
+    if (WaitForSingleObject(g_weather_entered, 3000) != WAIT_OBJECT_0) {
         return fail("space weather backend call was not invoked");
     }
 

--- a/src/rust/qsoripper-ffi/src/client.rs
+++ b/src/rust/qsoripper-ffi/src/client.rs
@@ -30,6 +30,7 @@ use qsoripper_core::proto::qsoripper::services::{
     LogQsoRequest, LookupRequest, UpdateQsoRequest,
 };
 
+use crate::register_qso_list_allocation;
 use crate::types::{
     str_to_buf, QsrLogQsoRequest, QsrLogQsoResult, QsrLookupResult, QsrQsoDetail, QsrQsoList,
     QsrQsoSummary, QsrRigStatus, QsrRstReport, QsrSpaceWeather, QsrUpdateQsoRequest,
@@ -251,6 +252,10 @@ impl QsrClient {
             let boxed = items.into_boxed_slice();
             out.count = count;
             out.items = Box::into_raw(boxed).cast::<QsrQsoSummary>();
+            register_qso_list_allocation(
+                out.items,
+                usize::try_from(out.count).expect("non-negative count fits usize"),
+            );
         }
 
         0

--- a/src/rust/qsoripper-ffi/src/client.rs
+++ b/src/rust/qsoripper-ffi/src/client.rs
@@ -242,8 +242,9 @@ impl QsrClient {
             }
         }
 
+        let allocation_len = items.len();
         #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-        let count = items.len() as i32;
+        let count = allocation_len as i32;
 
         if items.is_empty() {
             out.items = std::ptr::null_mut();
@@ -252,10 +253,7 @@ impl QsrClient {
             let boxed = items.into_boxed_slice();
             out.count = count;
             out.items = Box::into_raw(boxed).cast::<QsrQsoSummary>();
-            register_qso_list_allocation(
-                out.items,
-                usize::try_from(out.count).expect("non-negative count fits usize"),
-            );
+            register_qso_list_allocation(out.items, allocation_len);
         }
 
         0

--- a/src/rust/qsoripper-ffi/src/lib.rs
+++ b/src/rust/qsoripper-ffi/src/lib.rs
@@ -17,7 +17,11 @@
 mod client;
 mod types;
 
-use std::os::raw::c_char;
+use std::{
+    collections::HashMap,
+    os::raw::c_char,
+    sync::{Mutex, OnceLock},
+};
 
 pub use types::{
     QsrLogQsoRequest, QsrLogQsoResult, QsrLookupResult, QsrQsoDetail, QsrQsoList, QsrQsoSummary,
@@ -25,6 +29,21 @@ pub use types::{
 };
 
 use client::QsrClient;
+
+static QSO_LIST_ALLOCATIONS: OnceLock<Mutex<HashMap<usize, usize>>> = OnceLock::new();
+
+fn qso_list_allocations() -> &'static Mutex<HashMap<usize, usize>> {
+    QSO_LIST_ALLOCATIONS.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+pub(crate) fn register_qso_list_allocation(items: *mut QsrQsoSummary, len: usize) {
+    if items.is_null() || len == 0 {
+        return;
+    }
+    if let Ok(mut allocations) = qso_list_allocations().lock() {
+        allocations.insert(items as usize, len);
+    }
+}
 
 /// Connect to the QsoRipper engine at the given endpoint.
 ///
@@ -180,11 +199,15 @@ pub unsafe extern "C" fn qsr_free_qso_list(list: *mut QsrQsoList) {
     let Some(l) = (unsafe { list.as_mut() }) else {
         return;
     };
-    if !l.items.is_null() && l.count > 0 {
-        #[allow(clippy::cast_sign_loss)]
-        let slice =
-            unsafe { Box::from_raw(std::slice::from_raw_parts_mut(l.items, l.count as usize)) };
-        drop(slice);
+    if !l.items.is_null() {
+        let len = qso_list_allocations()
+            .lock()
+            .ok()
+            .and_then(|mut allocations| allocations.remove(&(l.items as usize)));
+        if let Some(len) = len {
+            let slice = unsafe { Box::from_raw(std::slice::from_raw_parts_mut(l.items, len)) };
+            drop(slice);
+        }
         l.items = std::ptr::null_mut();
         l.count = 0;
     }
@@ -250,4 +273,29 @@ pub unsafe extern "C" fn qsr_get_space_weather(
         return -1;
     };
     c.get_space_weather(o)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn qso_list_free_clears_pointer_even_if_count_is_negative() {
+        let boxed = vec![unsafe { std::mem::zeroed::<QsrQsoSummary>() }].into_boxed_slice();
+        let len = boxed.len();
+        let ptr = Box::into_raw(boxed).cast::<QsrQsoSummary>();
+
+        register_qso_list_allocation(ptr, len);
+
+        let mut list = QsrQsoList {
+            items: ptr,
+            count: -7,
+        };
+
+        unsafe { qsr_free_qso_list(&mut list) };
+
+        assert!(list.items.is_null());
+        assert_eq!(0, list.count);
+    }
 }

--- a/src/rust/qsoripper-ffi/src/lib.rs
+++ b/src/rust/qsoripper-ffi/src/lib.rs
@@ -293,7 +293,7 @@ mod tests {
             count: -7,
         };
 
-        unsafe { qsr_free_qso_list(&mut list) };
+        unsafe { qsr_free_qso_list(&raw mut list) };
 
         assert!(list.items.is_null());
         assert_eq!(0, list.count);

--- a/src/rust/qsoripper-tui/src/events.rs
+++ b/src/rust/qsoripper-tui/src/events.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 
 use tokio::sync::{mpsc, watch};
 use tokio::time;
+use tonic::transport::Channel;
 
 use crate::app::{CallsignInfo, RecentQso, RigInfo, SpaceWeatherInfo};
 use crate::grpc;
@@ -91,7 +92,7 @@ pub(crate) fn spawn_clock_task(tx: mpsc::UnboundedSender<AppEvent>) {
 pub(crate) fn spawn_lookup_task(
     mut lookup_rx: watch::Receiver<String>,
     event_tx: mpsc::UnboundedSender<AppEvent>,
-    endpoint: String,
+    channel: Channel,
 ) {
     tokio::spawn(async move {
         loop {
@@ -108,10 +109,10 @@ pub(crate) fn spawn_lookup_task(
             if current != callsign {
                 continue;
             }
-            let result = match grpc::create_channel(&endpoint).await {
-                Ok(ch) => grpc::lookup_callsign(ch, &callsign).await.ok().flatten(),
-                Err(_) => None,
-            };
+            let result = grpc::lookup_callsign(channel.clone(), &callsign)
+                .await
+                .ok()
+                .flatten();
             if event_tx.send(AppEvent::LookupResult(result)).is_err() {
                 break;
             }
@@ -126,7 +127,7 @@ pub(crate) fn spawn_lookup_task(
 pub(crate) fn spawn_rig_poll_task(
     mut enabled_rx: watch::Receiver<bool>,
     event_tx: mpsc::UnboundedSender<AppEvent>,
-    endpoint: String,
+    channel: Channel,
 ) {
     tokio::spawn(async move {
         let mut interval = time::interval(Duration::from_secs(1));
@@ -139,10 +140,7 @@ pub(crate) fn spawn_rig_poll_task(
             if !enabled {
                 continue;
             }
-            let result = match grpc::create_channel(&endpoint).await {
-                Ok(ch) => grpc::get_rig_snapshot(ch).await.ok().flatten(),
-                Err(_) => None,
-            };
+            let result = grpc::get_rig_snapshot(channel.clone()).await.ok().flatten();
             if event_tx.send(AppEvent::RigSnapshot(result)).is_err() {
                 break;
             }

--- a/src/rust/qsoripper-tui/src/grpc.rs
+++ b/src/rust/qsoripper-tui/src/grpc.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Context;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
-use tonic::transport::Channel;
+use tonic::transport::{Channel, Endpoint};
 
 use qsoripper_core::domain::band::{band_from_adif, band_to_adif};
 use qsoripper_core::domain::mode::{mode_from_adif, mode_to_adif};
@@ -22,12 +22,21 @@ use crate::form::{LogForm, BANDS, MODES};
 type LookupEnrichment = Option<(Option<String>, Option<String>, Option<u32>, Option<u32>)>;
 
 /// Create a tonic transport channel connected to the given endpoint URI.
-pub(crate) async fn create_channel(endpoint: &str) -> anyhow::Result<Channel> {
-    Channel::from_shared(endpoint.to_string())
-        .context("invalid endpoint URI")?
-        .connect()
-        .await
-        .context("failed to connect to qsoripper-server")
+pub(crate) fn create_channel(endpoint: &str) -> anyhow::Result<Channel> {
+    let endpoint = Endpoint::from_shared(endpoint.to_string()).context("invalid endpoint URI")?;
+    Ok(endpoint.connect_lazy())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::create_channel;
+
+    #[tokio::test]
+    async fn create_channel_does_not_require_server_to_be_online() {
+        let channel_result = create_channel("http://127.0.0.1:9");
+        assert!(channel_result.is_ok());
+    }
 }
 
 /// Log a QSO from the form and return the engine-assigned `local_id`.

--- a/src/rust/qsoripper-tui/src/grpc.rs
+++ b/src/rust/qsoripper-tui/src/grpc.rs
@@ -27,18 +27,6 @@ pub(crate) fn create_channel(endpoint: &str) -> anyhow::Result<Channel> {
     Ok(endpoint.connect_lazy())
 }
 
-#[cfg(test)]
-#[allow(clippy::unwrap_used)]
-mod tests {
-    use super::create_channel;
-
-    #[tokio::test]
-    async fn create_channel_does_not_require_server_to_be_online() {
-        let channel_result = create_channel("http://127.0.0.1:9");
-        assert!(channel_result.is_ok());
-    }
-}
-
 /// Log a QSO from the form and return the engine-assigned `local_id`.
 ///
 /// `lookup` carries enrichment from the callsign lookup: `(grid, country, cq_zone, dxcc)`.
@@ -469,5 +457,17 @@ fn resolve_mode(mode_str: &str) -> (Mode, Option<&'static str>) {
         "FT4" => (Mode::Mfsk, Some("FT4")),
         "PSK31" => (Mode::Psk, Some("PSK31")),
         s => (mode_from_adif(s).unwrap_or(Mode::Unspecified), None),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::create_channel;
+
+    #[tokio::test]
+    async fn create_channel_does_not_require_server_to_be_online() {
+        let channel_result = create_channel("http://127.0.0.1:9");
+        assert!(channel_result.is_ok());
     }
 }

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -195,7 +195,7 @@ fn handle_event_with_channel(
 ) {
     match event {
         AppEvent::Key(key) => {
-            handle_key_with_channel(app, key, channel, event_tx, lookup_tx, rig_enabled_tx)
+            handle_key_with_channel(app, key, channel, event_tx, lookup_tx, rig_enabled_tx);
         }
         AppEvent::Tick => {
             app.utc_now = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
@@ -300,7 +300,9 @@ fn handle_event(
     } else {
         endpoint
     };
-    let channel = grpc::create_channel(endpoint).expect("test endpoint should parse");
+    let Ok(channel) = grpc::create_channel(endpoint) else {
+        return;
+    };
     handle_event_with_channel(app, event, &channel, event_tx, lookup_tx, rig_enabled_tx);
 }
 
@@ -492,7 +494,9 @@ fn handle_key(
     } else {
         endpoint
     };
-    let channel = grpc::create_channel(endpoint).expect("test endpoint should parse");
+    let Ok(channel) = grpc::create_channel(endpoint) else {
+        return;
+    };
     handle_key_with_channel(app, key, &channel, event_tx, lookup_tx, rig_enabled_tx);
 }
 
@@ -1068,7 +1072,7 @@ mod tests {
             let _guard = PanicCleanupGuard::new(move || {
                 cleaned_in_guard.store(true, Ordering::SeqCst);
             });
-            panic!("boom");
+            std::panic::resume_unwind(Box::new("boom"));
         });
 
         assert!(panic_result.is_err());

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -9,6 +9,7 @@ mod ui;
 use std::io;
 
 use crossterm::{
+    cursor::Show,
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -24,6 +25,32 @@ const ENDPOINT_ENV_VAR: &str = "QSORIPPER_ENDPOINT";
 const DEFAULT_RUST_ENDPOINT: &str = "http://127.0.0.1:50051";
 const DEFAULT_DOTNET_ENDPOINT: &str = "http://127.0.0.1:50052";
 
+struct PanicCleanupGuard<F: FnMut()> {
+    cleanup: F,
+    armed: bool,
+}
+
+impl<F: FnMut()> PanicCleanupGuard<F> {
+    fn new(cleanup: F) -> Self {
+        Self {
+            cleanup,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl<F: FnMut()> Drop for PanicCleanupGuard<F> {
+    fn drop(&mut self) {
+        if self.armed {
+            (self.cleanup)();
+        }
+    }
+}
+
 /// Application entry point.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -32,11 +59,17 @@ async fn main() -> anyhow::Result<()> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
+    let mut panic_cleanup = PanicCleanupGuard::new(|| {
+        let _ = disable_raw_mode();
+        let mut stdout = io::stdout();
+        let _ = execute!(stdout, LeaveAlternateScreen, Show);
+    });
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
     let result = run(&mut terminal, endpoint).await;
 
+    panic_cleanup.disarm();
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
     terminal.show_cursor()?;
@@ -104,32 +137,29 @@ async fn run<B: ratatui::backend::Backend>(
     let (rig_enabled_tx, rig_enabled_rx) = watch::channel(true);
 
     let mut app = App::new(endpoint);
+    let channel = grpc::create_channel(&app.endpoint)?;
 
     spawn_key_task(event_tx.clone());
     spawn_clock_task(event_tx.clone());
-    spawn_lookup_task(lookup_rx, event_tx.clone(), app.endpoint.clone());
-    spawn_rig_poll_task(rig_enabled_rx, event_tx.clone(), app.endpoint.clone());
+    spawn_lookup_task(lookup_rx, event_tx.clone(), channel.clone());
+    spawn_rig_poll_task(rig_enabled_rx, event_tx.clone(), channel.clone());
 
     // Prefetch space weather and recent QSOs on startup.
     {
         let tx = event_tx.clone();
-        let ep = app.endpoint.clone();
+        let channel = channel.clone();
         tokio::spawn(async move {
-            if let Ok(ch) = grpc::create_channel(&ep).await {
-                if let Ok(sw) = grpc::get_space_weather(ch).await {
-                    let _ = tx.send(AppEvent::SpaceWeather(sw));
-                }
+            if let Ok(sw) = grpc::get_space_weather(channel).await {
+                let _ = tx.send(AppEvent::SpaceWeather(sw));
             }
         });
     }
     {
         let tx = event_tx.clone();
-        let ep = app.endpoint.clone();
+        let channel = channel.clone();
         tokio::spawn(async move {
-            if let Ok(ch) = grpc::create_channel(&ep).await {
-                if let Ok(qsos) = grpc::list_recent_qsos(ch, 0).await {
-                    let _ = tx.send(AppEvent::RecentQsos(qsos));
-                }
+            if let Ok(qsos) = grpc::list_recent_qsos(channel, 0).await {
+                let _ = tx.send(AppEvent::RecentQsos(qsos));
             }
         });
     }
@@ -138,14 +168,13 @@ async fn run<B: ratatui::backend::Backend>(
 
     while app.running {
         if let Some(event) = event_rx.recv().await {
-            let endpoint = app.endpoint.clone();
-            handle_event(
+            handle_event_with_channel(
                 &mut app,
                 event,
+                &channel,
                 &event_tx,
                 &lookup_tx,
                 &rig_enabled_tx,
-                &endpoint,
             );
             app.expire_status();
             terminal.draw(|f| ui::render_ui(&app, f))?;
@@ -156,16 +185,18 @@ async fn run<B: ratatui::backend::Backend>(
 }
 
 /// Dispatch a single [`AppEvent`] to the appropriate handler.
-fn handle_event(
+fn handle_event_with_channel(
     app: &mut App,
     event: AppEvent,
+    channel: &tonic::transport::Channel,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     lookup_tx: &watch::Sender<String>,
     rig_enabled_tx: &watch::Sender<bool>,
-    endpoint: &str,
 ) {
     match event {
-        AppEvent::Key(key) => handle_key(app, key, event_tx, lookup_tx, rig_enabled_tx, endpoint),
+        AppEvent::Key(key) => {
+            handle_key_with_channel(app, key, channel, event_tx, lookup_tx, rig_enabled_tx)
+        }
         AppEvent::Tick => {
             app.utc_now = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
             app.tick_debounce();
@@ -187,7 +218,7 @@ fn handle_event(
             app.form.on_band_change();
             app.lookup_result = None;
             app.reset_timer();
-            refresh_recent_qsos(event_tx, endpoint);
+            refresh_recent_qsos(event_tx, channel);
         }
         AppEvent::QsoLogFailed(err) => {
             app.set_error(format!("Log failed: {err}"));
@@ -203,7 +234,7 @@ fn handle_event(
             app.lookup_result = None;
             app.editing_local_id = None;
             app.reset_timer();
-            refresh_recent_qsos(event_tx, endpoint);
+            refresh_recent_qsos(event_tx, channel);
         }
         AppEvent::QsoUpdateFailed(err) => {
             app.set_error(format!("Update failed: {err}"));
@@ -214,7 +245,7 @@ fn handle_event(
             app.view = app::View::LogEntry;
             app.qso_list_focused = false;
             app.qso_selected = None;
-            refresh_recent_qsos(event_tx, endpoint);
+            refresh_recent_qsos(event_tx, channel);
         }
         AppEvent::QsoDeleteFailed(err) => {
             app.set_error(format!("Delete failed: {err}"));
@@ -244,7 +275,7 @@ fn handle_event(
                 .map(|q| (q.local_id.clone(), q.callsign.clone()))
                 .collect();
             if !unnamed.is_empty() {
-                enrich_names(unnamed, event_tx, endpoint);
+                enrich_names(unnamed, event_tx, channel);
             }
         }
         AppEvent::QsoNameEnriched { local_id, name } => {
@@ -253,6 +284,24 @@ fn handle_event(
             }
         }
     }
+}
+
+#[cfg(test)]
+fn handle_event(
+    app: &mut App,
+    event: AppEvent,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    lookup_tx: &watch::Sender<String>,
+    rig_enabled_tx: &watch::Sender<bool>,
+    endpoint: &str,
+) {
+    let endpoint = if endpoint.is_empty() {
+        DEFAULT_RUST_ENDPOINT
+    } else {
+        endpoint
+    };
+    let channel = grpc::create_channel(endpoint).expect("test endpoint should parse");
+    handle_event_with_channel(app, event, &channel, event_tx, lookup_tx, rig_enabled_tx);
 }
 
 /// Apply a callsign-lookup result to the app state.
@@ -289,13 +338,13 @@ fn apply_lookup_result(app: &mut App, result: Option<app::CallsignInfo>) {
     clippy::too_many_lines,
     reason = "top-level key dispatch; splitting would obscure the routing logic"
 )]
-fn handle_key(
+fn handle_key_with_channel(
     app: &mut App,
     key: crossterm::event::KeyEvent,
+    channel: &tonic::transport::Channel,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
     lookup_tx: &watch::Sender<String>,
     rig_enabled_tx: &watch::Sender<bool>,
-    endpoint: &str,
 ) {
     use crossterm::event::{KeyCode, KeyModifiers};
 
@@ -324,7 +373,7 @@ fn handle_key(
     }
 
     if matches!(app.view, app::View::ConfirmDeleteQso) {
-        handle_confirm_delete_key(app, key, event_tx, endpoint);
+        handle_confirm_delete_key(app, key, event_tx, channel);
         return;
     }
 
@@ -382,9 +431,9 @@ fn handle_key(
             app.reset_qso_start_time();
             app.set_status(format!("QSO start time reset to {}", app.form.time));
         }
-        KeyCode::F(10) => spawn_log_qso(app, event_tx, endpoint),
+        KeyCode::F(10) => spawn_log_qso(app, event_tx, channel),
         KeyCode::Enter if key.modifiers.contains(KeyModifiers::ALT) => {
-            spawn_log_qso(app, event_tx, endpoint);
+            spawn_log_qso(app, event_tx, channel);
         }
         KeyCode::End => {
             app.form.field_selected = false;
@@ -427,6 +476,24 @@ fn handle_key(
         KeyCode::Char(c) => handle_char_key(app, c, lookup_tx),
         _ => {}
     }
+}
+
+#[cfg(test)]
+fn handle_key(
+    app: &mut App,
+    key: crossterm::event::KeyEvent,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    lookup_tx: &watch::Sender<String>,
+    rig_enabled_tx: &watch::Sender<bool>,
+    endpoint: &str,
+) {
+    let endpoint = if endpoint.is_empty() {
+        DEFAULT_RUST_ENDPOINT
+    } else {
+        endpoint
+    };
+    let channel = grpc::create_channel(endpoint).expect("test endpoint should parse");
+    handle_key_with_channel(app, key, &channel, event_tx, lookup_tx, rig_enabled_tx);
 }
 
 /// Handle keyboard input while the search box is focused.
@@ -535,13 +602,13 @@ fn handle_confirm_delete_key(
     app: &mut App,
     key: crossterm::event::KeyEvent,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
-    endpoint: &str,
+    channel: &tonic::transport::Channel,
 ) {
     use crossterm::event::KeyCode;
     match key.code {
         KeyCode::Char('y' | 'Y') | KeyCode::Enter => {
             if let Some(ref id) = app.delete_candidate_id.clone() {
-                spawn_delete_qso(id, event_tx, endpoint);
+                spawn_delete_qso(id, event_tx, channel);
             }
         }
         KeyCode::Char('n' | 'N') | KeyCode::Esc => {
@@ -553,20 +620,19 @@ fn handle_confirm_delete_key(
 }
 
 /// Spawn a task to delete a QSO by its local ID and forward the result to the event channel.
-fn spawn_delete_qso(local_id: &str, event_tx: &mpsc::UnboundedSender<AppEvent>, endpoint: &str) {
+fn spawn_delete_qso(
+    local_id: &str,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    channel: &tonic::transport::Channel,
+) {
     let tx = event_tx.clone();
-    let ep = endpoint.to_string();
+    let channel = channel.clone();
     let id = local_id.to_string();
     tokio::spawn(async move {
-        match grpc::create_channel(&ep).await {
-            Ok(ch) => match grpc::delete_qso(ch, &id).await {
-                Ok(()) => {
-                    let _ = tx.send(AppEvent::QsoDeleted(id));
-                }
-                Err(e) => {
-                    let _ = tx.send(AppEvent::QsoDeleteFailed(e.to_string()));
-                }
-            },
+        match grpc::delete_qso(channel, &id).await {
+            Ok(()) => {
+                let _ = tx.send(AppEvent::QsoDeleted(id));
+            }
             Err(e) => {
                 let _ = tx.send(AppEvent::QsoDeleteFailed(e.to_string()));
             }
@@ -734,9 +800,13 @@ fn load_qso_into_form(app: &mut App, local_id: &str, lookup_tx: &watch::Sender<S
 /// If `editing_local_id` is set, calls `UpdateQso`; otherwise calls `LogQso`.
 /// When editing, the original `source_record` is passed along so that `update_qso`
 /// can preserve non-form fields (QSL status, metadata, extra ADIF overflow, etc.).
-fn spawn_log_qso(app: &App, event_tx: &mpsc::UnboundedSender<AppEvent>, endpoint: &str) {
+fn spawn_log_qso(
+    app: &App,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    channel: &tonic::transport::Channel,
+) {
     let tx = event_tx.clone();
-    let ep = endpoint.to_string();
+    let channel = channel.clone();
     let mut form_snap = app.form.clone();
     let editing_id = app.editing_local_id.clone();
     if editing_id.is_none() {
@@ -760,33 +830,24 @@ fn spawn_log_qso(app: &App, event_tx: &mpsc::UnboundedSender<AppEvent>, endpoint
     });
 
     tokio::spawn(async move {
-        match grpc::create_channel(&ep).await {
-            Ok(ch) => {
-                if let Some(local_id) = editing_id {
-                    match grpc::update_qso(ch, &local_id, &form_snap, lookup_snap, base_record)
-                        .await
-                    {
-                        Ok(()) => {
-                            let callsign = form_snap.callsign.to_uppercase();
-                            let _ = tx.send(AppEvent::QsoUpdated(callsign));
-                        }
-                        Err(e) => {
-                            let _ = tx.send(AppEvent::QsoUpdateFailed(e.to_string()));
-                        }
-                    }
-                } else {
-                    match grpc::log_qso(ch, &form_snap, lookup_snap).await {
-                        Ok(id) => {
-                            let _ = tx.send(AppEvent::QsoLogged(id));
-                        }
-                        Err(e) => {
-                            let _ = tx.send(AppEvent::QsoLogFailed(e.to_string()));
-                        }
-                    }
+        if let Some(local_id) = editing_id {
+            match grpc::update_qso(channel, &local_id, &form_snap, lookup_snap, base_record).await {
+                Ok(()) => {
+                    let callsign = form_snap.callsign.to_uppercase();
+                    let _ = tx.send(AppEvent::QsoUpdated(callsign));
+                }
+                Err(e) => {
+                    let _ = tx.send(AppEvent::QsoUpdateFailed(e.to_string()));
                 }
             }
-            Err(e) => {
-                let _ = tx.send(AppEvent::QsoLogFailed(e.to_string()));
+        } else {
+            match grpc::log_qso(channel, &form_snap, lookup_snap).await {
+                Ok(id) => {
+                    let _ = tx.send(AppEvent::QsoLogged(id));
+                }
+                Err(e) => {
+                    let _ = tx.send(AppEvent::QsoLogFailed(e.to_string()));
+                }
             }
         }
     });
@@ -837,16 +898,13 @@ fn cycle_right(app: &mut App) {
 fn enrich_names(
     qsos: Vec<(String, String)>,
     event_tx: &mpsc::UnboundedSender<AppEvent>,
-    endpoint: &str,
+    channel: &tonic::transport::Channel,
 ) {
     let tx = event_tx.clone();
-    let ep = endpoint.to_string();
+    let channel = channel.clone();
     tokio::spawn(async move {
-        let Ok(ch) = grpc::create_channel(&ep).await else {
-            return;
-        };
         for (local_id, callsign) in qsos {
-            if let Ok(Some(info)) = grpc::lookup_callsign(ch.clone(), &callsign).await {
+            if let Ok(Some(info)) = grpc::lookup_callsign(channel.clone(), &callsign).await {
                 if let Some(name) = info.name {
                     let _ = tx.send(AppEvent::QsoNameEnriched { local_id, name });
                 }
@@ -856,14 +914,15 @@ fn enrich_names(
 }
 
 /// Spawn a task to refresh the recent QSOs list and forward the result to the event channel.
-fn refresh_recent_qsos(event_tx: &mpsc::UnboundedSender<AppEvent>, endpoint: &str) {
+fn refresh_recent_qsos(
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    channel: &tonic::transport::Channel,
+) {
     let tx = event_tx.clone();
-    let ep = endpoint.to_string();
+    let channel = channel.clone();
     tokio::spawn(async move {
-        if let Ok(ch) = grpc::create_channel(&ep).await {
-            if let Ok(qsos) = grpc::list_recent_qsos(ch, 0).await {
-                let _ = tx.send(AppEvent::RecentQsos(qsos));
-            }
+        if let Ok(qsos) = grpc::list_recent_qsos(channel, 0).await {
+            let _ = tx.send(AppEvent::RecentQsos(qsos));
         }
     });
 }
@@ -937,6 +996,11 @@ fn apply_rig_snapshot(app: &mut App, rig: Option<app::RigInfo>) {
     clippy::items_after_statements
 )]
 mod tests {
+    use std::sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    };
+
     use crossterm::event::{KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers};
     use tokio::sync::{mpsc, watch};
 
@@ -994,6 +1058,34 @@ mod tests {
                 ..Default::default()
             },
         }
+    }
+
+    #[test]
+    fn panic_cleanup_guard_runs_on_unwind() {
+        let cleaned = Arc::new(AtomicBool::new(false));
+        let cleaned_in_guard = Arc::clone(&cleaned);
+        let panic_result = std::panic::catch_unwind(move || {
+            let _guard = PanicCleanupGuard::new(move || {
+                cleaned_in_guard.store(true, Ordering::SeqCst);
+            });
+            panic!("boom");
+        });
+
+        assert!(panic_result.is_err());
+        assert!(cleaned.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn panic_cleanup_guard_disarm_skips_cleanup() {
+        let cleaned = Arc::new(AtomicBool::new(false));
+        let cleaned_in_guard = Arc::clone(&cleaned);
+        {
+            let mut guard = PanicCleanupGuard::new(move || {
+                cleaned_in_guard.store(true, Ordering::SeqCst);
+            });
+            guard.disarm();
+        }
+        assert!(!cleaned.load(Ordering::SeqCst));
     }
 
     fn resolve_endpoint_from<const ARG_COUNT: usize, const ENV_COUNT: usize>(


### PR DESCRIPTION
## Summary\n- fix TUI panic cleanup so raw mode/alt-screen are restored on unwind\n- reuse one shared tonic Channel across TUI operations instead of creating a new channel per operation\n- harden qsr_free_qso_list by tracking Rust-side allocations and not trusting C-side count\n- add regression tests for each fix\n\n## Test-first workflow evidence\n- Added failing regressions first, observed failures:\n  - missing internal allocation tracking helper (egister_qso_list_allocation) for FFI list-free safety\n  - create_channel_does_not_require_server_to_be_online failed before lazy-channel switch\n  - panic cleanup guard tests required new guard behavior\n- Implemented fixes and re-ran:\n  - cargo test -p qsoripper-ffi\n  - cargo test -p qsoripper-tui\n\nCloses #261\nCloses #258\nCloses #254\nRelated #260 (already fixed on main; evidence posted in issue comment).