### PR TITLE
Fix issue set b1 (271, 266, 265, 264) with regression tests

### DIFF
--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -142,6 +142,39 @@ public sealed class ManagedEngineStateTests : IDisposable
     }
 
     [Fact]
+    public void Sync_with_qrz_unexpected_exception_does_not_include_stack_trace()
+    {
+        var storage = new MemoryStorage();
+        var syncEngine = new QrzSyncEngine(new FakeMalformedQrzLogbookApi());
+        var state = new ManagedEngineState(
+            Path.Combine(_tempDirectory, "config.toml"),
+            storage,
+            lookupCoordinator: null,
+            rigControlMonitor: null,
+            spaceWeatherMonitor: null,
+            syncEngine: syncEngine);
+
+        state.SaveSetup(new SaveSetupRequest
+        {
+            QrzLogbookApiKey = "api-key",
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87"
+            }
+        });
+
+        var response = state.SyncWithQrz();
+
+        Assert.True(response.Complete);
+        Assert.False(string.IsNullOrWhiteSpace(response.Error));
+        Assert.DoesNotContain("\n", response.Error, StringComparison.Ordinal);
+        Assert.DoesNotContain(" at ", response.Error, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Apply_runtime_config_rejects_non_memory_storage()
     {
         var state = CreateState();
@@ -735,6 +768,16 @@ public sealed class ManagedEngineStateTests : IDisposable
             var logId = $"FAKE-{Interlocked.Increment(ref _logIdCounter)}";
             return Task.FromResult(logId);
         }
+    }
+
+    private sealed class FakeMalformedQrzLogbookApi : IQrzLogbookApi
+    {
+        public Task<List<QsoRecord>> FetchQsosAsync(string? sinceDateYmd)
+            => Task.FromResult(new List<QsoRecord> { null! });
+
+        public Task<string> UploadQsoAsync(QsoRecord qso) => Task.FromResult("FAKE-1");
+
+        public Task<string> UpdateQsoAsync(QsoRecord qso) => Task.FromResult("FAKE-1");
     }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -609,7 +609,7 @@ internal sealed class ManagedEngineState
                 return new SyncWithQrzResponse
                 {
                     Complete = true,
-                    Error = $"{ex.Message}\n{ex.StackTrace}",
+                    Error = ex.Message,
                 };
             }
         }

--- a/src/dotnet/QsoRipper.Engine.Lookup.Qrz/QrzXmlProvider.cs
+++ b/src/dotnet/QsoRipper.Engine.Lookup.Qrz/QrzXmlProvider.cs
@@ -19,6 +19,7 @@ public sealed class QrzXmlProvider : ICallsignProvider
     private readonly string _baseUrl;
     private readonly string _userAgent;
     private readonly Lock _sessionLock = new();
+    private Task<string?>? _pendingLoginTask;
     private string? _sessionKey;
 
     public string ProviderName => "QRZ XML";
@@ -198,18 +199,34 @@ public sealed class QrzXmlProvider : ICallsignProvider
 
     private async Task<string?> EnsureSessionKeyAsync(CancellationToken ct)
     {
-        string? existing;
+        Task<string?> loginTask;
         lock (_sessionLock)
         {
-            existing = _sessionKey;
+            if (_sessionKey is { } existing)
+            {
+                return existing;
+            }
+
+            loginTask = _pendingLoginTask ??= LoginAsync(ct);
         }
 
-        if (existing is not null)
+        try
         {
-            return existing;
+            return await loginTask.ConfigureAwait(false);
         }
-
-        return await LoginAsync(ct).ConfigureAwait(false);
+        finally
+        {
+            if (loginTask.IsCompleted)
+            {
+                lock (_sessionLock)
+                {
+                    if (ReferenceEquals(_pendingLoginTask, loginTask))
+                    {
+                        _pendingLoginTask = null;
+                    }
+                }
+            }
+        }
     }
 
     /// <summary>

--- a/src/dotnet/QsoRipper.Engine.Lookup.Tests/QrzXmlProviderTests.cs
+++ b/src/dotnet/QsoRipper.Engine.Lookup.Tests/QrzXmlProviderTests.cs
@@ -47,6 +47,24 @@ public sealed class QrzXmlProviderTests
         Assert.Equal("Managed Agent/1.0", loginQuery["agent"]);
     }
 
+    [Fact]
+    public async Task Concurrent_first_lookups_share_single_login()
+    {
+        using var handler = new ConcurrentLoginCountingHandler();
+        using var httpClient = new HttpClient(handler);
+        var provider = new QrzXmlProvider(httpClient, "demo-user", "demo-password", userAgent: "Managed Agent/1.0");
+
+        var results = await Task.WhenAll(
+            provider.LookupAsync("W1AW"),
+            provider.LookupAsync("K7RND"));
+
+        var first = results[0];
+        var second = results[1];
+        Assert.Equal(ProviderLookupState.Found, first.State);
+        Assert.Equal(ProviderLookupState.Found, second.State);
+        Assert.Equal(1, handler.LoginRequestCount);
+    }
+
     private static HttpResponseMessage CreateXmlResponse(string body)
     {
         return new HttpResponseMessage(HttpStatusCode.OK)
@@ -79,6 +97,52 @@ public sealed class QrzXmlProviderTests
             RequestUris.Add(request.RequestUri!);
             Assert.NotEmpty(_responses);
             return Task.FromResult(_responses.Dequeue());
+        }
+    }
+
+    private sealed class ConcurrentLoginCountingHandler : HttpMessageHandler
+    {
+        private int _loginRequestCount;
+
+        public int LoginRequestCount => _loginRequestCount;
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Assert.NotNull(request.RequestUri);
+            var query = ParseQuery(request.RequestUri!);
+            if (query.ContainsKey("username"))
+            {
+                Interlocked.Increment(ref _loginRequestCount);
+                await Task.Delay(TimeSpan.FromMilliseconds(40), cancellationToken);
+                return CreateXmlResponse(
+                    """
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <QRZDatabase version="1.34" xmlns="http://xmldata.qrz.com">
+                        <Session>
+                            <Key>abc123</Key>
+                        </Session>
+                    </QRZDatabase>
+                    """);
+            }
+
+            if (query.ContainsKey("s") && query.ContainsKey("callsign"))
+            {
+                Assert.True(query.TryGetValue("callsign", out var callsign));
+                return CreateXmlResponse(
+                    $"""
+                    <?xml version="1.0" encoding="utf-8" ?>
+                    <QRZDatabase version="1.34" xmlns="http://xmldata.qrz.com">
+                        <Callsign>
+                            <call>{callsign}</call>
+                        </Callsign>
+                        <Session>
+                            <Key>abc123</Key>
+                        </Session>
+                    </QRZDatabase>
+                    """);
+            }
+
+            throw new InvalidOperationException($"Unexpected request URI: {request.RequestUri}");
         }
     }
 }

--- a/src/rust/qsoripper-core/src/lookup/coordinator.rs
+++ b/src/rust/qsoripper-core/src/lookup/coordinator.rs
@@ -345,10 +345,11 @@ impl LookupCoordinator {
     }
 
     async fn store_cache_entry(&self, normalized_callsign: &str, entry: CacheEntry) {
-        self.cache
-            .write()
-            .await
-            .insert(normalized_callsign.to_string(), entry.clone());
+        {
+            let mut cache = self.cache.write().await;
+            cache.insert(normalized_callsign.to_string(), entry.clone());
+            cache.retain(|_, cached_entry| self.is_fresh(cached_entry));
+        }
 
         // Persist to the snapshot store if available.
         if let Some(ref storage) = self.snapshot_storage {
@@ -449,10 +450,11 @@ impl LookupCoordinator {
         let entry = CacheEntry { lookup, cached_at };
 
         // Promote into in-memory cache so subsequent reads are fast.
-        self.cache
-            .write()
-            .await
-            .insert(normalized_callsign.to_string(), entry.clone());
+        {
+            let mut cache = self.cache.write().await;
+            cache.insert(normalized_callsign.to_string(), entry.clone());
+            cache.retain(|_, cached_entry| self.is_fresh(cached_entry));
+        }
 
         Some(entry)
     }
@@ -704,6 +706,29 @@ mod tests {
         assert_eq!(first.state, LookupState::Found as i32);
         assert_eq!(second.state, LookupState::Found as i32);
         assert_eq!(provider.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn inserting_new_entry_evicts_expired_cache_entries() {
+        let provider = QueueProvider::new(Vec::new(), Duration::ZERO);
+        let coordinator = LookupCoordinator::new(
+            Arc::new(provider),
+            LookupCoordinatorConfig::new(Duration::from_millis(1), Duration::from_millis(1)),
+        );
+
+        for index in 0..5 {
+            let callsign = format!("W1AW{index}");
+            let _ = coordinator.lookup(&callsign, false).await;
+        }
+        sleep(Duration::from_millis(5)).await;
+
+        let _ = coordinator.lookup("K7RND", false).await;
+
+        let cache_len = coordinator.cache.read().await.len();
+        assert_eq!(
+            cache_len, 1,
+            "expected expired cache entries to be evicted when inserting a new entry"
+        );
     }
 
     // -- Snapshot persistence tests -----------------------------------------

--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -42,6 +42,9 @@ pub const QRZ_LOGBOOK_USER_AGENT_ENV_VAR: &str = "QSORIPPER_QRZ_LOGBOOK_USER_AGE
 
 /// Default HTTP timeout in seconds for logbook requests.
 const DEFAULT_HTTP_TIMEOUT_SECONDS: u64 = 30;
+/// Retry count for transient HTTP failures (5xx / transport).
+const DEFAULT_HTTP_MAX_RETRIES: u32 = 2;
+const RETRY_BASE_DELAY_MILLIS: u64 = 200;
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -515,25 +518,56 @@ impl QrzLogbookClient {
         let mut form: Vec<(&str, &str)> = vec![("KEY", &self.config.api_key)];
         form.extend_from_slice(params);
 
-        let response = self
-            .client
-            .post(&self.config.base_url)
-            .form(&form)
-            .send()
-            .await?;
+        for attempt in 0..=DEFAULT_HTTP_MAX_RETRIES {
+            let response = self
+                .client
+                .post(&self.config.base_url)
+                .form(&form)
+                .send()
+                .await;
 
-        let status = response.status();
+            match response {
+                Ok(response) => {
+                    let status = response.status();
 
-        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            return Err(QrzLogbookError::RateLimited);
+                    if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                        return Err(QrzLogbookError::RateLimited);
+                    }
+
+                    if status.is_server_error() && attempt < DEFAULT_HTTP_MAX_RETRIES {
+                        tokio::time::sleep(retry_delay(attempt)).await;
+                        continue;
+                    }
+
+                    if !status.is_success() {
+                        return Err(QrzLogbookError::ApiError(format!("HTTP {status}")));
+                    }
+
+                    return response.text().await.map_err(QrzLogbookError::NetworkError);
+                }
+                Err(error) => {
+                    if is_retryable_transport_error(&error) && attempt < DEFAULT_HTTP_MAX_RETRIES {
+                        tokio::time::sleep(retry_delay(attempt)).await;
+                        continue;
+                    }
+                    return Err(QrzLogbookError::NetworkError(error));
+                }
+            }
         }
 
-        if !status.is_success() {
-            return Err(QrzLogbookError::ApiError(format!("HTTP {status}")));
-        }
-
-        response.text().await.map_err(QrzLogbookError::NetworkError)
+        Err(QrzLogbookError::ApiError(
+            "request retries exhausted".to_string(),
+        ))
     }
+}
+
+fn retry_delay(attempt: u32) -> Duration {
+    let shift = attempt.min(6);
+    Duration::from_millis(RETRY_BASE_DELAY_MILLIS.saturating_mul(1_u64 << shift))
+}
+
+fn is_retryable_transport_error(error: &reqwest::Error) -> bool {
+    error.is_timeout() || error.is_connect() || error.is_request() || error.is_body()
 }
 
 // ---------------------------------------------------------------------------
@@ -1276,6 +1310,41 @@ mod tests {
     }
 
     // -- Rate limiting ------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_connection_retries_transient_http_failure_then_succeeds() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("local addr");
+
+        tokio::spawn(async move {
+            let (mut first_socket, _) = listener.accept().await.expect("accept first");
+            let _ = read_http_request(&mut first_socket).await;
+            write_http_response_with_status(
+                &mut first_socket,
+                503,
+                "Service Unavailable",
+                "temporary outage",
+            )
+            .await;
+
+            let (mut second_socket, _) = listener.accept().await.expect("accept second");
+            let _ = read_http_request(&mut second_socket).await;
+            write_http_response(
+                &mut second_socket,
+                "text/plain",
+                "RESULT=OK&CALLSIGN=KC7AVA&COUNT=500",
+            )
+            .await;
+        });
+
+        let config = test_config(format!("http://{address}/api"));
+        let client = QrzLogbookClient::new(config).expect("client");
+
+        let status = client.test_connection().await.expect("status");
+
+        assert_eq!("KC7AVA", status.owner);
+        assert_eq!(500, status.qso_count);
+    }
 
     #[tokio::test]
     async fn rate_limited_response_returns_error() {


### PR DESCRIPTION
## Summary
Bundled test-first fixes for the real bugs in issue set b1.

### Fixed
- #271 sanitize SyncWithQrz exception response (no stack trace leakage)
- #266 serialize QRZ XML session login to prevent duplicate concurrent logins
- #265 add transient retry/backoff for QRZ logbook HTTP failures (5xx/transport)
- #264 evict expired lookup cache entries on cache insert

### Triage notes (no code change)
- #268 evidence posted in issue comments
- #267 evidence posted in issue comments

## Validation
- dotnet test src/dotnet/QsoRipper.Engine.DotNet.Tests/QsoRipper.Engine.DotNet.Tests.csproj
- dotnet test src/dotnet/QsoRipper.Engine.Lookup.Tests/QsoRipper.Engine.Lookup.Tests.csproj
- cargo test -p qsoripper-core qrz_logbook::tests:: -- --nocapture
- cargo test -p qsoripper-core lookup::coordinator::tests:: -- --nocapture

Closes #271
Closes #266
Closes #265
Closes #264