### PR TITLE
Add UTC clock to menu bar, fix rig mode casing, fix ESC focus restore

### DIFF
--- a/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
@@ -9,6 +9,36 @@ namespace QsoRipper.Gui.Tests;
 public sealed class MainWindowViewModelTests
 {
     [Fact]
+    public void FocusLoggerCommandDoesNotRequestGridFocus()
+    {
+        using var viewModel = new MainWindowViewModel(new FakeEngineClient());
+        var loggerFocusRequests = 0;
+        var gridFocusRequests = 0;
+        viewModel.LoggerFocusRequested += (_, _) => loggerFocusRequests++;
+        viewModel.GridFocusRequested += (_, _) => gridFocusRequests++;
+
+        viewModel.FocusLoggerCommand.Execute(null);
+
+        Assert.Equal(1, loggerFocusRequests);
+        Assert.Equal(0, gridFocusRequests);
+    }
+
+    [Fact]
+    public void FocusSearchCommandDoesNotRequestGridFocus()
+    {
+        using var viewModel = new MainWindowViewModel(new FakeEngineClient());
+        var searchFocusRequests = 0;
+        var gridFocusRequests = 0;
+        viewModel.SearchFocusRequested += (_, _) => searchFocusRequests++;
+        viewModel.GridFocusRequested += (_, _) => gridFocusRequests++;
+
+        viewModel.FocusSearchCommand.Execute(null);
+
+        Assert.Equal(1, searchFocusRequests);
+        Assert.Equal(0, gridFocusRequests);
+    }
+
+    [Fact]
     public async Task CheckFirstRunAsyncCompletesBeforeSlowSyncStatusFinishes()
     {
         var syncStatusSource = new TaskCompletionSource<GetSyncStatusResponse>(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -738,7 +738,8 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
                 if (snapshot.Status == QsoRipper.Domain.RigConnectionStatus.Connected)
                 {
                     var freqMhz = snapshot.FrequencyHz / 1_000_000.0;
-                    RigStatusText = $"Rig: {freqMhz.ToString("F3", CultureInfo.InvariantCulture)} {snapshot.Mode}";
+                    var modeDisplay = ProtoEnumDisplay.ForMode(snapshot.Mode);
+                    RigStatusText = $"Rig: {freqMhz.ToString("F3", CultureInfo.InvariantCulture)} {modeDisplay}";
                     Logger.ApplyRigSnapshot(snapshot);
                 }
                 else

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -490,7 +490,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     {
         if (!IsWizardOpen)
         {
-            CloseTransientPanels();
+            CloseTransientPanels(restoreGridFocus: false);
             SearchFocusRequested?.Invoke(this, EventArgs.Empty);
         }
     }
@@ -500,7 +500,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     {
         if (!IsWizardOpen)
         {
-            CloseTransientPanels();
+            CloseTransientPanels(restoreGridFocus: false);
             Logger.FocusLogger();
         }
     }
@@ -510,7 +510,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     {
         if (!IsWizardOpen)
         {
-            CloseTransientPanels();
+            CloseTransientPanels(restoreGridFocus: false);
             GridFocusRequested?.Invoke(this, EventArgs.Empty);
         }
     }
@@ -652,7 +652,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     }
 
     [RelayCommand]
-    private void CloseCallsignCard()
+    private void CloseCallsignCard(bool restoreFocus = true)
     {
         if (CallsignCard is { } card)
         {
@@ -663,6 +663,11 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         var wasLoggerFocused = IsLoggerFocused;
         IsCallsignCardOpen = false;
         CallsignCard = null;
+
+        if (!restoreFocus)
+        {
+            return;
+        }
 
         if (wasLoggerFocused)
         {
@@ -796,12 +801,15 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     }
 
     [RelayCommand]
-    private void CloseTransientPanels()
+    private void CloseTransientPanels(bool restoreGridFocus = true)
     {
         IsSortChooserOpen = false;
         IsColumnChooserOpen = false;
-        CloseCallsignCard();
-        GridFocusRequested?.Invoke(this, EventArgs.Empty);
+        CloseCallsignCard(restoreFocus: false);
+        if (restoreGridFocus)
+        {
+            GridFocusRequested?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     [RelayCommand]

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -105,7 +105,8 @@
   </Window.Styles>
 
   <DockPanel ClipToBounds="True">
-      <Menu DockPanel.Dock="Top">
+      <Panel DockPanel.Dock="Top">
+      <Menu>
         <MenuItem x:Name="FileMenuItem"
                   AutomationProperties.AutomationId="FileMenuItem"
                   Header="_File">
@@ -153,6 +154,17 @@
                   Command="{Binding RefreshEngineAvailabilityCommand}" />
       </MenuItem>
     </Menu>
+      <TextBlock HorizontalAlignment="Right"
+                 Text="{Binding CurrentUtcTime}"
+                 FontSize="16"
+                 FontWeight="SemiBold"
+                 FontFamily="Cascadia Mono, Consolas, monospace"
+                 Foreground="#00d4ff"
+                 Focusable="False"
+                 IsHitTestVisible="False"
+                 VerticalAlignment="Center"
+                 Margin="0,0,12,0" />
+      </Panel>
 
     <Panel>
       <Grid RowDefinitions="Auto,Auto,*,Auto"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -174,6 +174,14 @@ internal sealed partial class MainWindow : Window
                 e.Handled = true;
                 return;
             }
+
+            if (IsFocusWithinLogger())
+            {
+                _viewModel.Logger.ClearCommand.Execute(null);
+                _viewModel.Logger.FocusLogger();
+                e.Handled = true;
+                return;
+            }
         }
 
         base.OnKeyDown(e);
@@ -514,24 +522,31 @@ internal sealed partial class MainWindow : Window
                 return;
             }
 
-            var focused = FocusManager?.GetFocusedElement() as Control;
-            var loggerPanel = this.FindControl<Border>("LoggerPanel");
-            // Check if focus moved to another control within the logger panel
-            bool isStillInLogger = false;
-            var parent = focused;
-            while (parent is not null)
-            {
-                if (parent == loggerPanel)
-                {
-                    isStillInLogger = true;
-                    break;
-                }
+            _viewModel.IsLoggerFocused = IsFocusWithinLogger();
+        }, DispatcherPriority.Background);
+    }
 
-                parent = parent.Parent as Control;
+    private bool IsFocusWithinLogger()
+    {
+        var loggerPanel = this.FindControl<Border>("LoggerPanel");
+        return IsFocusWithin(loggerPanel);
+    }
+
+    private bool IsFocusWithin(Control? root)
+    {
+        var focused = FocusManager?.GetFocusedElement() as Control;
+        var parent = focused;
+        while (parent is not null)
+        {
+            if (parent == root)
+            {
+                return true;
             }
 
-            _viewModel.IsLoggerFocused = isStillInLogger;
-        }, DispatcherPriority.Background);
+            parent = parent.Parent as Control;
+        }
+
+        return false;
     }
 
     private void FocusRecentQsoSearchBox()

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -59,6 +59,10 @@ internal sealed partial class MainWindow : Window
         ClampToCurrentScreen();
         if (!IsInspectionMode)
         {
+            // Prime menu access keys immediately so it completes before
+            // the user can interact. Must run before the async first-run
+            // check which yields the UI thread.
+            Dispatcher.UIThread.Post(PrimeMenuAccessKeys, DispatcherPriority.Background);
             GuiPerformanceTrace.Write(nameof(OnOpened) + ".afterScheduleMenuAccessKeys");
             ApplyPersistedGridLayout();
             GuiPerformanceTrace.Write(nameof(OnOpened) + ".afterApplyPersistedGridLayout");
@@ -69,8 +73,6 @@ internal sealed partial class MainWindow : Window
                 await vm.CheckFirstRunAsync();
                 GuiPerformanceTrace.Write(nameof(OnOpened) + ".afterCheckFirstRun");
             }
-
-            Dispatcher.UIThread.Post(PrimeMenuAccessKeys, DispatcherPriority.Background);
         }
 
         EnsureColumnHeadersFit();
@@ -139,22 +141,10 @@ internal sealed partial class MainWindow : Window
             return;
         }
 
-        base.OnKeyDown(e);
-
-        if (e.Handled || _viewModel is null || _viewModel.IsWizardOpen)
-        {
-            return;
-        }
-
-        if (string.Equals(e.KeySymbol, "/", StringComparison.Ordinal)
-            && e.Source is not TextBox
-            && !(_recentQsoSearchBox?.IsFocused ?? false))
-        {
-            FocusRecentQsoSearchBox();
-            e.Handled = true;
-            return;
-        }
-
+        // Close open panels on Escape BEFORE base.OnKeyDown so the Menu
+        // control cannot consume the key first (Alt+Enter activates the
+        // menu bar; a subsequent Escape would deactivate it instead of
+        // closing the inspector/card if we let base handle it first).
         if (e.Key == Key.Escape)
         {
             if (_viewModel.IsFullQsoCardOpen)
@@ -182,7 +172,24 @@ internal sealed partial class MainWindow : Window
             {
                 _viewModel.ToggleInspectorCommand.Execute(null);
                 e.Handled = true;
+                return;
             }
+        }
+
+        base.OnKeyDown(e);
+
+        if (e.Handled || _viewModel is null || _viewModel.IsWizardOpen)
+        {
+            return;
+        }
+
+        if (string.Equals(e.KeySymbol, "/", StringComparison.Ordinal)
+            && e.Source is not TextBox
+            && !(_recentQsoSearchBox?.IsFocused ?? false))
+        {
+            FocusRecentQsoSearchBox();
+            e.Handled = true;
+            return;
         }
     }
 
@@ -366,12 +373,22 @@ internal sealed partial class MainWindow : Window
         _menuAccessKeysPrimed = true;
 
         // Avalonia access-key mode does not fully initialize until a menu has been shown once.
+        // Save focused element so we can restore it after the prime cycle.
         Dispatcher.UIThread.Post(
             () =>
             {
+                var previousFocus = FocusManager?.GetFocusedElement() as Control;
                 _fileMenuItem.IsSubMenuOpen = true;
                 Dispatcher.UIThread.Post(
-                    () => _fileMenuItem.IsSubMenuOpen = false,
+                    () =>
+                    {
+                        _fileMenuItem.IsSubMenuOpen = false;
+                        // Restore focus so the menu prime doesn't steal it
+                        // from whatever the user focused in the meantime.
+                        Dispatcher.UIThread.Post(
+                            () => previousFocus?.Focus(),
+                            DispatcherPriority.Background);
+                    },
                     DispatcherPriority.Background);
             },
             DispatcherPriority.Background);

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -17,6 +17,14 @@ namespace QsoRipper.Gui.Views;
 
 internal sealed partial class MainWindow : Window
 {
+    private enum FocusArea
+    {
+        None,
+        Grid,
+        Logger,
+        Search
+    }
+
     private readonly RecentQsoGridLayoutStore _gridLayoutStore = new();
     private readonly UiPreferencesStore _preferencesStore = new();
     private readonly MenuItem? _fileMenuItem;
@@ -30,6 +38,7 @@ internal sealed partial class MainWindow : Window
     private bool _gridLayoutApplied;
     private bool _menuAccessKeysPrimed;
     private bool _loggedFirstRecentQsoRow;
+    private FocusArea _lastFocusArea = FocusArea.Grid;
     private Dictionary<RecentQsoGridColumn, DataGridColumn> _columnMap = [];
     internal bool IsInspectionMode { get; set; }
 
@@ -46,6 +55,12 @@ internal sealed partial class MainWindow : Window
         if (_recentQsoGrid is not null)
         {
             _recentQsoGrid.LoadingRow += OnRecentQsoGridLoadingRow;
+            _recentQsoGrid.GotFocus += OnGridGotFocus;
+        }
+
+        if (_recentQsoSearchBox is not null)
+        {
+            _recentQsoSearchBox.GotFocus += OnSearchGotFocus;
         }
 
         DataContextChanged += OnDataContextChanged;
@@ -86,6 +101,7 @@ internal sealed partial class MainWindow : Window
         if (_viewModel is not null)
         {
             _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+            _viewModel.RecentQsos.PropertyChanged -= OnRecentQsosPropertyChanged;
             _viewModel.SearchFocusRequested -= OnSearchFocusRequested;
             _viewModel.GridFocusRequested -= OnGridFocusRequested;
             _viewModel.SettingsRequested -= OnSettingsRequested;
@@ -419,6 +435,7 @@ internal sealed partial class MainWindow : Window
         if (_viewModel is not null)
         {
             _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+            _viewModel.RecentQsos.PropertyChanged += OnRecentQsosPropertyChanged;
             _viewModel.SearchFocusRequested += OnSearchFocusRequested;
             _viewModel.GridFocusRequested += OnGridFocusRequested;
             _viewModel.SettingsRequested += OnSettingsRequested;
@@ -446,6 +463,8 @@ internal sealed partial class MainWindow : Window
             return;
         }
 
+        _lastFocusArea = FocusArea.Grid;
+
         // Defer focus at Background priority so the current key event and any
         // visual-tree changes (e.g. inspector panel collapse) finish first.
         // Input priority was too early — Avalonia's focus cleanup after removing
@@ -472,6 +491,7 @@ internal sealed partial class MainWindow : Window
         var loggerBox = this.FindControl<TextBox>("LoggerCallsignBox");
         if (loggerBox is not null)
         {
+            _lastFocusArea = FocusArea.Logger;
             Dispatcher.UIThread.Post(() =>
             {
                 loggerBox.Focus();
@@ -508,8 +528,19 @@ internal sealed partial class MainWindow : Window
     {
         if (_viewModel is not null)
         {
+            _lastFocusArea = FocusArea.Logger;
             _viewModel.IsLoggerFocused = true;
         }
+    }
+
+    private void OnGridGotFocus(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        _lastFocusArea = FocusArea.Grid;
+    }
+
+    private void OnSearchGotFocus(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        _lastFocusArea = FocusArea.Search;
     }
 
     private void OnLoggerLostFocus(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -555,6 +586,8 @@ internal sealed partial class MainWindow : Window
         {
             return;
         }
+
+        _lastFocusArea = FocusArea.Search;
 
         Dispatcher.UIThread.Post(
             () =>
@@ -1013,13 +1046,13 @@ internal sealed partial class MainWindow : Window
     private void CloseSortChooser()
     {
         _viewModel!.IsSortChooserOpen = false;
-        _recentQsoGrid?.Focus();
+        RestoreLastFocusArea();
     }
 
     private void CloseColumnChooser()
     {
         _viewModel!.IsColumnChooserOpen = false;
-        _recentQsoGrid?.Focus();
+        RestoreLastFocusArea();
     }
 
     private void NavigateFocusInPanel<T>(string panelName, bool forward) where T : Control
@@ -1064,6 +1097,30 @@ internal sealed partial class MainWindow : Window
         {
             FocusFirstInPanel<CheckBox>("ColumnChooserPanel");
         }
+        else if ((e.PropertyName == nameof(MainWindowViewModel.IsHelpOpen) && _viewModel?.IsHelpOpen == false)
+            || (e.PropertyName == nameof(MainWindowViewModel.IsFullQsoCardOpen) && _viewModel?.IsFullQsoCardOpen == false)
+            || (e.PropertyName == nameof(MainWindowViewModel.IsCallsignCardOpen) && _viewModel?.IsCallsignCardOpen == false)
+            || (e.PropertyName == nameof(MainWindowViewModel.IsInspectorOpen) && _viewModel?.IsInspectorOpen == false))
+        {
+            RestoreLastFocusArea();
+        }
+    }
+
+    private void OnRecentQsosPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (_viewModel is null || e.PropertyName != nameof(RecentQsoListViewModel.IsDeletePending))
+        {
+            return;
+        }
+
+        if (_viewModel.RecentQsos.IsDeletePending)
+        {
+            FocusFirstInPanel<Button>("DeleteConfirmOverlay");
+        }
+        else
+        {
+            RestoreLastFocusArea();
+        }
     }
 
     private void FocusFirstInPanel<T>(string panelName) where T : Control
@@ -1076,5 +1133,28 @@ internal sealed partial class MainWindow : Window
                 first?.Focus();
             },
             DispatcherPriority.Loaded);
+    }
+
+    private void RestoreLastFocusArea()
+    {
+        Dispatcher.UIThread.Post(
+            () => RestoreFocusArea(_lastFocusArea),
+            DispatcherPriority.Background);
+    }
+
+    private void RestoreFocusArea(FocusArea area)
+    {
+        switch (area)
+        {
+            case FocusArea.Logger:
+                _viewModel?.Logger.FocusLogger();
+                break;
+            case FocusArea.Search:
+                FocusRecentQsoSearchBox();
+                break;
+            case FocusArea.Grid:
+                OnGridFocusRequested(this, EventArgs.Empty);
+                break;
+        }
     }
 }


### PR DESCRIPTION
## Changes

### UTC Clock
- Added prominent UTC clock right-aligned in menu bar (monospace, 16pt, cyan)
- Bound to existing CurrentUtcTime property

### Rig Mode Casing
- Fixed rig mode showing 'Cw' instead of 'CW'
- Uses ProtoEnumDisplay.ForMode() per project conventions

### ESC Focus Restore
- Fixed ESC not closing inspector after Alt+Enter
- Moved panel-close ESC handling before base.OnKeyDown() so Menu cannot consume it first
