### PR TITLE
Fix CLI cancellation and ADIF/JSON regressions

### DIFF
--- a/src/dotnet/QsoRipper.Cli.Tests/CliCancellationCoverageTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliCancellationCoverageTests.cs
@@ -1,0 +1,29 @@
+using System.Reflection;
+using QsoRipper.Cli.Commands;
+
+namespace QsoRipper.Cli.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+public sealed class CliCancellationCoverageTests
+{
+    [Theory]
+    [InlineData(typeof(ImportAdifCommand))]
+    [InlineData(typeof(ExportAdifCommand))]
+    [InlineData(typeof(ListQsosCommand))]
+    [InlineData(typeof(SyncCommand))]
+    [InlineData(typeof(StreamLookupCommand))]
+    public void RunAsync_methods_accept_cancellation_token(Type commandType)
+    {
+        ArgumentNullException.ThrowIfNull(commandType);
+
+        var runAsync = commandType.GetMethod(
+            "RunAsync",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+
+        Assert.NotNull(runAsync);
+        Assert.Contains(
+            runAsync!.GetParameters(),
+            static parameter => parameter.ParameterType == typeof(CancellationToken));
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli.Tests/EngineRuntimeDiscoveryTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/EngineRuntimeDiscoveryTests.cs
@@ -116,6 +116,40 @@ public sealed class EngineRuntimeDiscoveryTests
         }
     }
 
+    [Fact]
+    public void DiscoverLocalEnginesTreatsConnectionRefusedAsNotRunning()
+    {
+        var runtimeDirectory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(runtimeDirectory);
+        try
+        {
+            WriteState(Path.Combine(runtimeDirectory, "qsoripper-engine-local-dotnet.json"), new
+            {
+                displayName = "QsoRipper .NET Engine",
+                engine = KnownEngineProfiles.LocalDotNet,
+                engineId = "dotnet-aspnet",
+                listenAddress = "127.0.0.1:1",
+                pid = Environment.ProcessId,
+                startedAtUtc = DateTimeOffset.UtcNow.ToString("O"),
+            });
+
+            var entries = EngineRuntimeDiscovery.DiscoverLocalEngines(new EngineRuntimeDiscoveryOptions
+            {
+                RuntimeDirectory = runtimeDirectory,
+                ValidateTcpReachability = true,
+                TcpProbeTimeout = TimeSpan.FromMilliseconds(100),
+            });
+
+            var entry = Assert.Single(entries);
+            Assert.True(entry.IsProcessAlive);
+            Assert.False(entry.IsRunning);
+        }
+        finally
+        {
+            Directory.Delete(runtimeDirectory, recursive: true);
+        }
+    }
+
     private static void WriteState(string path, object payload)
     {
         File.WriteAllText(path, JsonSerializer.Serialize(payload));

--- a/src/dotnet/QsoRipper.Cli.Tests/RigStatusCommandTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/RigStatusCommandTests.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using QsoRipper.Cli.Commands;
+using QsoRipper.Domain;
+
+namespace QsoRipper.Cli.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+public sealed class RigStatusCommandTests
+{
+    [Fact]
+    public void BuildConnectedJsonPayload_escapes_special_characters()
+    {
+        var snapshot = new RigSnapshot
+        {
+            Status = RigConnectionStatus.Connected,
+            FrequencyHz = 14_074_000,
+            Band = Band._20M,
+            Mode = Mode.Ft8,
+            RawMode = "FT8 \"DX\" \\ narrow",
+        };
+
+        var json = RigStatusCommand.BuildConnectedJsonPayload(snapshot, "14.074");
+        using var document = JsonDocument.Parse(json);
+
+        Assert.Equal("FT8 \"DX\" \\ narrow", document.RootElement.GetProperty("rawMode").GetString());
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli/Commands/ExportAdifCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ExportAdifCommand.cs
@@ -6,7 +6,10 @@ namespace QsoRipper.Cli.Commands;
 
 internal static class ExportAdifCommand
 {
-    public static async Task<int> RunAsync(GrpcChannel channel, string[] args)
+    public static async Task<int> RunAsync(
+        GrpcChannel channel,
+        string[] args,
+        CancellationToken cancellationToken = default)
     {
         string? outputFile = null;
         var includeHeader = false;
@@ -25,17 +28,19 @@ internal static class ExportAdifCommand
         }
 
         var client = new LogbookService.LogbookServiceClient(channel);
-        using var call = client.ExportAdif(new ExportAdifRequest { IncludeHeader = includeHeader });
+        using var call = client.ExportAdif(
+            new ExportAdifRequest { IncludeHeader = includeHeader },
+            cancellationToken: cancellationToken);
         using var output = outputFile is not null
             ? new FileStream(outputFile, FileMode.Create, FileAccess.Write)
             : Console.OpenStandardOutput();
 
-        while (await call.ResponseStream.MoveNext(CancellationToken.None))
+        while (await call.ResponseStream.MoveNext(cancellationToken))
         {
             var chunk = call.ResponseStream.Current.Chunk;
             if (chunk is not null)
             {
-                await output.WriteAsync(chunk.Data.Memory);
+                await output.WriteAsync(chunk.Data.Memory, cancellationToken);
             }
         }
 

--- a/src/dotnet/QsoRipper.Cli/Commands/ImportAdifCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ImportAdifCommand.cs
@@ -9,7 +9,11 @@ internal static class ImportAdifCommand
 {
     private const int ChunkSize = 65536;
 
-    public static async Task<int> RunAsync(GrpcChannel channel, string filePath, bool refresh)
+    public static async Task<int> RunAsync(
+        GrpcChannel channel,
+        string filePath,
+        bool refresh,
+        CancellationToken cancellationToken = default)
     {
         if (!File.Exists(filePath))
         {
@@ -18,16 +22,19 @@ internal static class ImportAdifCommand
         }
 
         var client = new LogbookService.LogbookServiceClient(channel);
-        using var call = client.ImportAdif();
+        using var call = client.ImportAdif(cancellationToken: cancellationToken);
         await using var input = File.OpenRead(filePath);
 
-        await foreach (var request in ReadRequestsAsync(input, refresh))
+        await foreach (var request in ReadRequestsAsync(input, refresh, cancellationToken))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+#pragma warning disable CA2016 // gRPC stream writer doesn't expose a CancellationToken overload
             await call.RequestStream.WriteAsync(request);
+#pragma warning restore CA2016
         }
 
-        await call.RequestStream.CompleteAsync();
-        var response = await call.ResponseAsync;
+        await call.RequestStream.CompleteAsync().WaitAsync(cancellationToken);
+        var response = await call.ResponseAsync.WaitAsync(cancellationToken);
 
         Console.WriteLine($"Imported:  {response.RecordsImported}");
         Console.WriteLine($"Updated:   {response.RecordsUpdated}");

--- a/src/dotnet/QsoRipper.Cli/Commands/ListQsosCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ListQsosCommand.cs
@@ -11,7 +11,11 @@ internal static class ListQsosCommand
 {
     private const int CommentColumnWidth = 40;
 
-    public static async Task<int> RunAsync(GrpcChannel channel, string[] args, bool jsonOutput = false)
+    public static async Task<int> RunAsync(
+        GrpcChannel channel,
+        string[] args,
+        bool jsonOutput = false,
+        CancellationToken cancellationToken = default)
     {
         if (!TryParseArgs(args, out var request, out var displayOptions, out var error))
         {
@@ -20,13 +24,13 @@ internal static class ListQsosCommand
         }
 
         var client = new LogbookService.LogbookServiceClient(channel);
-        using var call = client.ListQsos(request);
+        using var call = client.ListQsos(request, cancellationToken: cancellationToken);
 
         if (jsonOutput)
         {
             var records = new List<Google.Protobuf.IMessage>();
 
-            while (await call.ResponseStream.MoveNext(CancellationToken.None))
+            while (await call.ResponseStream.MoveNext(cancellationToken))
             {
                 var qso = call.ResponseStream.Current.Qso;
                 if (qso is not null)
@@ -43,7 +47,7 @@ internal static class ListQsosCommand
 
         var count = 0u;
 
-        while (await call.ResponseStream.MoveNext(CancellationToken.None))
+        while (await call.ResponseStream.MoveNext(cancellationToken))
         {
             var qso = call.ResponseStream.Current.Qso;
             if (qso is null)

--- a/src/dotnet/QsoRipper.Cli/Commands/RigStatusCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/RigStatusCommand.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.Json;
 using Grpc.Net.Client;
 using QsoRipper.Domain;
 using QsoRipper.Services;
@@ -81,36 +83,45 @@ internal static class RigStatusCommand
         var freqMhz = snapshot.FrequencyHz > 0
             ? FormattableString.Invariant($"{snapshot.FrequencyHz / 1_000_000.0:F3}")
             : "";
-        var freqDisplay = freqMhz.Length > 0 ? $"{freqMhz} MHz" : "";
-        var band = snapshot.Band != Band.Unspecified ? EnumHelpers.FormatBand(snapshot.Band) : "";
-        var mode = snapshot.Mode != Mode.Unspecified ? EnumHelpers.FormatMode(snapshot.Mode) : "";
-        var rawMode = snapshot.HasRawMode ? snapshot.RawMode : "";
+        Console.WriteLine(BuildConnectedJsonPayload(snapshot, freqMhz));
+        return 0;
+    }
 
-        var parts = new List<string> { "\"status\":\"connected\"" };
-        if (freqMhz.Length > 0)
+    internal static string BuildConnectedJsonPayload(RigSnapshot snapshot, string frequencyMhz)
+    {
+        using var stream = new MemoryStream();
+        using var writer = new Utf8JsonWriter(stream);
+        writer.WriteStartObject();
+        writer.WriteString("status", "connected");
+
+        if (frequencyMhz.Length > 0)
         {
-            parts.Add($"\"frequencyHz\":{snapshot.FrequencyHz}");
-            parts.Add($"\"frequencyDisplay\":\"{freqDisplay}\"");
-            parts.Add($"\"frequencyMhz\":\"{freqMhz}\"");
+            writer.WriteNumber("frequencyHz", snapshot.FrequencyHz);
+            writer.WriteString("frequencyDisplay", $"{frequencyMhz} MHz");
+            writer.WriteString("frequencyMhz", frequencyMhz);
         }
 
+        var band = snapshot.Band != Band.Unspecified ? EnumHelpers.FormatBand(snapshot.Band) : "";
         if (band.Length > 0)
         {
-            parts.Add($"\"band\":\"{band}\"");
+            writer.WriteString("band", band);
         }
 
+        var mode = snapshot.Mode != Mode.Unspecified ? EnumHelpers.FormatMode(snapshot.Mode) : "";
         if (mode.Length > 0)
         {
-            parts.Add($"\"mode\":\"{mode}\"");
+            writer.WriteString("mode", mode);
         }
 
+        var rawMode = snapshot.HasRawMode ? snapshot.RawMode : "";
         if (rawMode.Length > 0)
         {
-            parts.Add($"\"rawMode\":\"{rawMode}\"");
+            writer.WriteString("rawMode", rawMode);
         }
 
-        Console.WriteLine("{" + string.Join(",", parts) + "}");
-        return 0;
+        writer.WriteEndObject();
+        writer.Flush();
+        return Encoding.UTF8.GetString(stream.GetBuffer(), 0, checked((int)stream.Length));
     }
 
     private static string FormatStatus(RigConnectionStatus status)

--- a/src/dotnet/QsoRipper.Cli/Commands/StreamLookupCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/StreamLookupCommand.cs
@@ -7,14 +7,18 @@ namespace QsoRipper.Cli.Commands;
 
 internal static class StreamLookupCommand
 {
-    public static async Task<int> RunAsync(GrpcChannel channel, string callsign, bool skipCache)
+    public static async Task<int> RunAsync(
+        GrpcChannel channel,
+        string callsign,
+        bool skipCache,
+        CancellationToken cancellationToken = default)
     {
         var client = new LookupService.LookupServiceClient(channel);
         using var call = client.StreamLookup(new StreamLookupRequest
         {
             Callsign = callsign,
             SkipCache = skipCache,
-        });
+        }, cancellationToken: cancellationToken);
 
         Console.WriteLine($"Streaming lookup for {callsign}...");
         Console.WriteLine();
@@ -22,7 +26,7 @@ internal static class StreamLookupCommand
         var stopwatch = Stopwatch.StartNew();
         LookupResult? lastResult = null;
 
-        while (await call.ResponseStream.MoveNext(CancellationToken.None))
+        while (await call.ResponseStream.MoveNext(cancellationToken))
         {
             var update = call.ResponseStream.Current.Result ?? new LookupResult();
             var state = update.State;

--- a/src/dotnet/QsoRipper.Cli/Commands/SyncCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SyncCommand.cs
@@ -5,15 +5,18 @@ namespace QsoRipper.Cli.Commands;
 
 internal static class SyncCommand
 {
-    public static async Task<int> RunAsync(GrpcChannel channel, bool force)
+    public static async Task<int> RunAsync(
+        GrpcChannel channel,
+        bool force,
+        CancellationToken cancellationToken = default)
     {
         var client = new LogbookService.LogbookServiceClient(channel);
         var request = new SyncWithQrzRequest { FullSync = force };
-        using var call = client.SyncWithQrz(request);
+        using var call = client.SyncWithQrz(request, cancellationToken: cancellationToken);
 
         SyncWithQrzResponse? last = null;
 
-        while (await call.ResponseStream.MoveNext(CancellationToken.None))
+        while (await call.ResponseStream.MoveNext(cancellationToken))
         {
             var update = call.ResponseStream.Current;
 

--- a/src/dotnet/QsoRipper.Cli/Program.cs
+++ b/src/dotnet/QsoRipper.Cli/Program.cs
@@ -31,33 +31,47 @@ if (needsCallsign && string.IsNullOrEmpty(arguments.Callsign))
 try
 {
     using var channel = GrpcChannel.ForAddress(endpointUri!);
-
-    return arguments.Command switch
+    using var cancellationSource = new CancellationTokenSource();
+    ConsoleCancelEventHandler cancelHandler = (_, eventArgs) =>
     {
-        "status" => await StatusCommand.RunAsync(
-            channel,
-            arguments.Endpoint,
-            arguments.EngineProfile,
-            arguments.JsonOutput),
-        "space-weather" => await SpaceWeatherCommand.RunAsync(channel, arguments.Refresh, arguments.JsonOutput),
-        "lookup" => await LookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache, arguments.JsonOutput),
-        "stream-lookup" => await StreamLookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache),
-        "cache-check" => await CacheCheckCommand.RunAsync(channel, arguments.Callsign!, arguments.JsonOutput),
-        "log" => await LogQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.RemainingArgs),
-        "get" => await GetQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.JsonOutput),
-        "list" => await ListQsosCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput),
-        "update" => await UpdateQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.RemainingArgs),
-        "delete" => await DeleteQsoCommand.RunAsync(channel, arguments.Callsign!),
-        "import" => await ImportAdifCommand.RunAsync(channel, arguments.Callsign ?? arguments.RemainingArgs.FirstOrDefault() ?? "", arguments.Refresh),
-        "export" => await ExportAdifCommand.RunAsync(channel, arguments.RemainingArgs),
-        "config" => await ConfigCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput),
-        "setup" => await SetupCommand.RunAsync(channel, arguments),
-        "sync" => await SyncCommand.RunAsync(channel, arguments.Force),
-        "sync-status" => await SyncStatusCommand.RunAsync(channel, arguments.JsonOutput),
-        "rig-status" => await RigStatusCommand.RunAsync(channel, arguments.JsonOutput),
-        "test-logbook" => await TestLogbookCommand.RunAsync(channel, arguments.RemainingArgs),
-        _ => ShowHelp($"Unknown command: {arguments.Command}")
+        eventArgs.Cancel = true;
+        cancellationSource.Cancel();
     };
+    Console.CancelKeyPress += cancelHandler;
+
+    try
+    {
+        return arguments.Command switch
+        {
+            "status" => await StatusCommand.RunAsync(
+                channel,
+                arguments.Endpoint,
+                arguments.EngineProfile,
+                arguments.JsonOutput),
+            "space-weather" => await SpaceWeatherCommand.RunAsync(channel, arguments.Refresh, arguments.JsonOutput),
+            "lookup" => await LookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache, arguments.JsonOutput),
+            "stream-lookup" => await StreamLookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache, cancellationSource.Token),
+            "cache-check" => await CacheCheckCommand.RunAsync(channel, arguments.Callsign!, arguments.JsonOutput),
+            "log" => await LogQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.RemainingArgs),
+            "get" => await GetQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.JsonOutput),
+            "list" => await ListQsosCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput, cancellationSource.Token),
+            "update" => await UpdateQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.RemainingArgs),
+            "delete" => await DeleteQsoCommand.RunAsync(channel, arguments.Callsign!),
+            "import" => await ImportAdifCommand.RunAsync(channel, arguments.Callsign ?? arguments.RemainingArgs.FirstOrDefault() ?? "", arguments.Refresh, cancellationSource.Token),
+            "export" => await ExportAdifCommand.RunAsync(channel, arguments.RemainingArgs, cancellationSource.Token),
+            "config" => await ConfigCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput),
+            "setup" => await SetupCommand.RunAsync(channel, arguments),
+            "sync" => await SyncCommand.RunAsync(channel, arguments.Force, cancellationSource.Token),
+            "sync-status" => await SyncStatusCommand.RunAsync(channel, arguments.JsonOutput),
+            "rig-status" => await RigStatusCommand.RunAsync(channel, arguments.JsonOutput),
+            "test-logbook" => await TestLogbookCommand.RunAsync(channel, arguments.RemainingArgs),
+            _ => ShowHelp($"Unknown command: {arguments.Command}")
+        };
+    }
+    finally
+    {
+        Console.CancelKeyPress -= cancelHandler;
+    }
 }
 catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable)
 {
@@ -70,6 +84,11 @@ catch (RpcException ex)
 {
     Console.Error.WriteLine($"gRPC error: {ex.Status.Detail} ({ex.StatusCode})");
     return 1;
+}
+catch (OperationCanceledException)
+{
+    Console.Error.WriteLine("Operation canceled.");
+    return 130;
 }
 
 static int ShowHelp(string? error = null)

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -1,6 +1,7 @@
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
+using Grpc.Core;
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
 using QsoRipper.Engine.DotNet;
@@ -661,6 +662,22 @@ public sealed class ManagedEngineStateTests : IDisposable
         Assert.Equal(14074UL, stored.FrequencyKhz);
     }
 
+    [Fact]
+    public async Task Import_adif_grpc_converts_post_await_validation_errors_to_invalid_argument()
+    {
+        var state = CreateState();
+        var service = new ManagedLogbookGrpcService(state);
+        var stream = new TestAsyncStreamReader<ImportAdifRequest>([
+            new ImportAdifRequest()
+        ]);
+
+        var ex = await Assert.ThrowsAsync<RpcException>(
+            () => service.ImportAdif(stream, new TestServerCallContext()));
+
+        Assert.Equal(StatusCode.InvalidArgument, ex.StatusCode);
+        Assert.Equal("chunk is required.", ex.Status.Detail);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_tempDirectory))
@@ -745,6 +762,47 @@ public sealed class ManagedEngineStateTests : IDisposable
     private sealed class FakeRigControlProvider(Func<RigSnapshot> factory) : IRigControlProvider
     {
         public RigSnapshot GetSnapshot() => factory();
+    }
+
+    private sealed class TestAsyncStreamReader<T>(IReadOnlyList<T> items)
+        : IAsyncStreamReader<T>
+    {
+        private int _index = -1;
+
+        public T Current => items[_index];
+
+        public Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _index++;
+            return Task.FromResult(_index < items.Count);
+        }
+    }
+
+    private sealed class TestServerCallContext : ServerCallContext
+    {
+        private readonly Metadata _responseTrailers = [];
+        private readonly Dictionary<object, object> _userState = [];
+        private WriteOptions? _writeOptions;
+        private Status _status;
+
+        protected override string MethodCore => "test";
+        protected override string HostCore => "localhost";
+        protected override string PeerCore => "test-peer";
+        protected override DateTime DeadlineCore => DateTime.UtcNow.AddMinutes(1);
+        protected override Metadata RequestHeadersCore => [];
+        protected override CancellationToken CancellationTokenCore => CancellationToken.None;
+        protected override Metadata ResponseTrailersCore => _responseTrailers;
+        protected override Status StatusCore { get => _status; set => _status = value; }
+        protected override WriteOptions? WriteOptionsCore { get => _writeOptions; set => _writeOptions = value; }
+        protected override AuthContext AuthContextCore => new("none", []);
+
+        protected override ContextPropagationToken CreatePropagationTokenCore(ContextPropagationOptions? options) =>
+            throw new NotSupportedException();
+
+        protected override Task WriteResponseHeadersAsyncCore(Metadata responseHeaders) => Task.CompletedTask;
+
+        protected override IDictionary<object, object> UserStateCore => _userState;
     }
 
     /// <summary>

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -1,8 +1,8 @@
 using System.Net.Http;
 using System.Reflection;
 using System.Text;
-using Grpc.Core;
 using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
 using QsoRipper.Domain;
 using QsoRipper.Engine.DotNet;
 using QsoRipper.Engine.QrzLogbook;

--- a/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
@@ -321,13 +321,13 @@ internal sealed class ManagedLogbookGrpcService(ManagedEngineState state)
         return Task.FromResult(state.GetSyncStatus());
     }
 
-    public override Task<ImportAdifResponse> ImportAdif(
+    public override async Task<ImportAdifResponse> ImportAdif(
         IAsyncStreamReader<ImportAdifRequest> requestStream,
         ServerCallContext context)
     {
         try
         {
-            return ImportAdifCoreAsync(requestStream, context);
+            return await ImportAdifCoreAsync(requestStream, context);
         }
         catch (InvalidOperationException ex)
         {

--- a/src/dotnet/QsoRipper.EngineSelection/EngineRuntimeDiscovery.cs
+++ b/src/dotnet/QsoRipper.EngineSelection/EngineRuntimeDiscovery.cs
@@ -272,6 +272,12 @@ public static partial class EngineRuntimeDiscovery
 
             return client.Connected;
         }
+        catch (AggregateException ex) when (
+            ex.InnerException is SocketException ||
+            ex.InnerException is IOException)
+        {
+            return false;
+        }
         catch (SocketException)
         {
             return false;


### PR DESCRIPTION
## Summary
- fix async exception mapping in managed engine ImportAdif gRPC endpoint
- make rig-status --json serialization escape-safe
- wire Ctrl+C cancellation into long-running CLI commands (import, export, list, sync, stream-lookup)
- add regression tests for cancellation surface, rig-status JSON escaping, and import-adif exception mapping

## Issue handling
Fixes #252
Fixes #257
Fixes #272

Triaged without code fix (evidence posted on issues): #256, #270

## Validation
- dotnet test src/dotnet/QsoRipper.Cli.Tests/QsoRipper.Cli.Tests.csproj --nologo -v q
- dotnet test src/dotnet/QsoRipper.Engine.DotNet.Tests/QsoRipper.Engine.DotNet.Tests.csproj --nologo -v q