### PR TITLE
Fix Win32 issue bundle: #263 #262 #199

### DIFF
--- a/src/c/qsoripper-win32/CMakeLists.txt
+++ b/src/c/qsoripper-win32/CMakeLists.txt
@@ -105,4 +105,29 @@ if(BUILD_TESTING)
         NAME win32-cli-exitcode-regression
         COMMAND qsoripper-win32-cli-exitcode-regression
     )
+
+    add_executable(qsoripper-win32-issue-regressions
+        tests/win32_issue_regressions.c
+        src/main.c
+        src/backend_ffi_gate.c
+    )
+    target_include_directories(qsoripper-win32-issue-regressions PRIVATE ${FFI_INCLUDE})
+    target_link_libraries(qsoripper-win32-issue-regressions PRIVATE
+        user32 gdi32 shell32 comctl32
+    )
+    target_compile_definitions(qsoripper-win32-issue-regressions PRIVATE
+        UNICODE _UNICODE QSORIPPER_WIN32_TESTING
+    )
+    if(MSVC)
+        target_compile_options(qsoripper-win32-issue-regressions PRIVATE
+            /W4
+            /analyze
+        )
+    else()
+        target_compile_options(qsoripper-win32-issue-regressions PRIVATE -Wall -Wextra)
+    endif()
+    add_test(
+        NAME win32-issue-regressions
+        COMMAND qsoripper-win32-issue-regressions
+    )
 endif()

--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -43,6 +43,10 @@
 #define WM_APP_LOOKUP_DONE   (WM_APP + 1)
 #define WM_APP_RIG_DONE      (WM_APP + 2)
 #define WM_APP_QSO_LOADED    (WM_APP + 3)
+#define WM_APP_LOG_DONE      (WM_APP + 4)
+#define WM_APP_WEATHER_DONE  (WM_APP + 5)
+#define WM_APP_QSO_DETAIL_DONE (WM_APP + 6)
+#define WM_APP_QSO_DELETE_DONE (WM_APP + 7)
 
 /* ── Color palette (Win2K classic theme) ────────────────────────────────── */
 
@@ -164,6 +168,39 @@ typedef struct {
     char mode[16];
 } RigPollResult;
 
+typedef struct {
+    HWND hwnd;
+} SpaceWeatherArg;
+
+typedef struct {
+    int has_data;
+    double k_index;
+    double solar_flux;
+    int sunspot_number;
+} SpaceWeatherResult;
+
+typedef struct {
+    HWND hwnd;
+    char local_id[64];
+} QsoDetailLoadArg;
+
+typedef struct {
+    int loaded;
+    char local_id[64];
+    QsrQsoDetail detail;
+} QsoDetailLoadResult;
+
+typedef struct {
+    HWND hwnd;
+    char local_id[64];
+    char callsign[16];
+} QsoDeleteArg;
+
+typedef struct {
+    int ok;
+    char callsign[16];
+} QsoDeleteResult;
+
 /* ── Recent QSO record ─────────────────────────────────────────────────── */
 
 typedef struct {
@@ -257,6 +294,7 @@ typedef struct {
     int  lookup_in_progress;
     int  lookup_not_found;
     char lookup_error[128];
+    int  log_in_progress;
 
     /* Recent QSOs (heap-allocated; grows as needed) */
     RecentQso *recent_qsos;
@@ -273,6 +311,7 @@ typedef struct {
     double solar_flux;
     int sunspot_number;
     int has_weather;
+    int weather_loading;
 
     /* Rig control */
     int  rig_enabled;
@@ -286,6 +325,8 @@ typedef struct {
 
     /* Editing existing QSO */
     char editing_local_id[64];
+    int qso_detail_loading;
+    int qso_delete_in_progress;
 
     /* Lookup debounce */
     ULONGLONG last_callsign_change;
@@ -379,6 +420,9 @@ static int   FieldMaxLen(enum Field f);
 static void  DrawField(HDC, int, int, int, const char *, int, int, int, int);
 static void  DrawCycleField(HDC, int, int, int, const char *, int, int, int);
 static void  ApplyModeDefaults(void);
+static int   UiTextToWide(const char *text, int len, wchar_t *wbuf, int wbuf_len);
+static void  ApplyRigPollResult(const RigPollResult *res);
+static void  ApplyLoadedQsoDetail(const char *local_id, const QsrQsoDetail *detail);
 
 /* ── Utility: safe string helpers ──────────────────────────────────────── */
 
@@ -693,6 +737,130 @@ char *qsr_test_run_qr_command(const char *args)
 {
     return RunQrCommand(args);
 }
+
+int qsr_test_ui_text_to_wide(const char *text, wchar_t *wbuf, int wbuf_len)
+{
+    if (!text || !wbuf || wbuf_len <= 0) return 0;
+    return UiTextToWide(text, -1, wbuf, wbuf_len);
+}
+
+UINT qsr_test_ui_text_codepage(void)
+{
+    return CP_UTF8;
+}
+
+void qsr_test_reset_state(void)
+{
+    InitState();
+    ZeroMemory(&g_backend, sizeof(g_backend));
+}
+
+void qsr_test_set_backend_ffi(struct QsrClient *client,
+                              fn_qsr_log_qso log_qso_fn,
+                              fn_qsr_update_qso update_qso_fn)
+{
+    g_backend.mode = BACKEND_FFI;
+    g_backend.pf_log_qso = log_qso_fn;
+    g_backend.pf_update_qso = update_qso_fn;
+    backend_ffi_gate_init(&g_backend.ffi_gate, client);
+}
+
+void qsr_test_set_backend_ffi_get_delete_weather(struct QsrClient *client,
+                                                 fn_qsr_get_qso get_qso_fn,
+                                                 fn_qsr_delete_qso delete_qso_fn,
+                                                 fn_qsr_get_space_weather get_space_weather_fn)
+{
+    g_backend.mode = BACKEND_FFI;
+    g_backend.pf_get_qso = get_qso_fn;
+    g_backend.pf_delete_qso = delete_qso_fn;
+    g_backend.pf_get_space_weather = get_space_weather_fn;
+    backend_ffi_gate_init(&g_backend.ffi_gate, client);
+}
+
+void qsr_test_set_form_basics(const char *callsign, const char *date, const char *time_str)
+{
+    if (callsign) safe_strcpy(g_state.callsign, sizeof(g_state.callsign), callsign);
+    if (date) safe_strcpy(g_state.date, sizeof(g_state.date), date);
+    if (time_str) safe_strcpy(g_state.time_str, sizeof(g_state.time_str), time_str);
+}
+
+void qsr_test_set_band_mode_indices(int band_idx, int mode_idx)
+{
+    if (band_idx >= 0 && band_idx < NUM_BANDS) g_state.band_idx = band_idx;
+    if (mode_idx >= 0 && mode_idx < NUM_MODES) g_state.mode_idx = mode_idx;
+}
+
+void qsr_test_set_freq_field(const char *freq)
+{
+    if (freq) safe_strcpy(g_state.freq_mhz, sizeof(g_state.freq_mhz), freq);
+}
+
+void qsr_test_set_selected_recent_qso(const char *local_id, const char *callsign)
+{
+    free(g_state.recent_qsos);
+    g_state.recent_qsos = (RecentQso *)calloc(1, sizeof(RecentQso));
+    if (!g_state.recent_qsos) {
+        g_state.recent_count = 0;
+        g_state.recent_capacity = 0;
+        g_state.qso_selected = -1;
+        return;
+    }
+    if (local_id) safe_strcpy(g_state.recent_qsos[0].local_id, sizeof(g_state.recent_qsos[0].local_id), local_id);
+    if (callsign) safe_strcpy(g_state.recent_qsos[0].callsign, sizeof(g_state.recent_qsos[0].callsign), callsign);
+    g_state.recent_count = 1;
+    g_state.recent_capacity = 1;
+    g_state.qso_selected = 0;
+}
+
+void qsr_test_set_focused_field(enum Field field)
+{
+    if (field >= 0 && field < FIELD_COUNT) {
+        g_state.focused_field = field;
+    }
+}
+
+void qsr_test_set_rig_enabled(int enabled)
+{
+    g_state.rig_enabled = enabled;
+}
+
+void qsr_test_apply_rig_result(int connected, const char *freq_display,
+                               const char *freq_mhz, const char *band, const char *mode)
+{
+    RigPollResult res;
+    ZeroMemory(&res, sizeof(res));
+    res.connected = connected;
+    if (freq_display) safe_strcpy(res.freq_display, sizeof(res.freq_display), freq_display);
+    if (freq_mhz) safe_strcpy(res.freq_mhz, sizeof(res.freq_mhz), freq_mhz);
+    if (band) safe_strcpy(res.band, sizeof(res.band), band);
+    if (mode) safe_strcpy(res.mode, sizeof(res.mode), mode);
+    ApplyRigPollResult(&res);
+}
+
+const char *qsr_test_get_freq_field(void)
+{
+    return g_state.freq_mhz;
+}
+
+void qsr_test_invoke_log_qso(void)
+{
+    LogQso();
+}
+
+void qsr_test_invoke_load_selected_qso(void)
+{
+    LoadSelectedQso();
+}
+
+void qsr_test_invoke_delete_selected_qso(void)
+{
+    DeleteSelectedQso();
+}
+
+void qsr_test_invoke_fetch_space_weather(void)
+{
+    FetchSpaceWeather();
+}
 #endif
 
 /* Append a properly quoted Windows command-line argument to cmd.
@@ -785,6 +953,11 @@ static int FieldMaxLen(enum Field f)
 
 /* ── GDI drawing helpers ───────────────────────────────────────────────── */
 
+static int UiTextToWide(const char *text, int len, wchar_t *wbuf, int wbuf_len)
+{
+    return MultiByteToWideChar(CP_UTF8, 0, text, len, wbuf, wbuf_len);
+}
+
 static void DrawText_A(HDC hdc, int x, int y, COLORREF fg, const char *text)
 {
     SetTextColor(hdc, fg);
@@ -792,7 +965,7 @@ static void DrawText_A(HDC hdc, int x, int y, COLORREF fg, const char *text)
     int len = (int)strlen(text);
     /* Convert to wide */
     wchar_t wbuf[1024];
-    int wlen = MultiByteToWideChar(CP_ACP, 0, text, len, wbuf, 1024);
+    int wlen = UiTextToWide(text, len, wbuf, 1024);
     TextOutW(hdc, x, y, wbuf, wlen);
 }
 
@@ -803,7 +976,7 @@ static void DrawText_A_BG(HDC hdc, int x, int y, COLORREF fg, COLORREF bg, const
     SetBkMode(hdc, OPAQUE);
     int len = (int)strlen(text);
     wchar_t wbuf[1024];
-    int wlen = MultiByteToWideChar(CP_ACP, 0, text, len, wbuf, 1024);
+    int wlen = UiTextToWide(text, len, wbuf, 1024);
     TextOutW(hdc, x, y, wbuf, wlen);
     SetBkMode(hdc, TRANSPARENT);
 }
@@ -1145,6 +1318,57 @@ static void ReleaseFfiClient(void)
     backend_ffi_gate_release(&g_backend.ffi_gate);
 }
 
+typedef struct {
+    HWND hwnd;
+    int is_update;
+    QsrLogQsoRequest req;
+    QsrUpdateQsoRequest ureq;
+    char callsign[32];
+    int band_idx;
+    int mode_idx;
+} LogQsoThreadArg;
+
+typedef struct {
+    int is_update;
+    int success;
+    char callsign[32];
+    int band_idx;
+    int mode_idx;
+} LogQsoResultMsg;
+
+static unsigned __stdcall LogQsoThread(void *param)
+{
+    LogQsoThreadArg *arg = (LogQsoThreadArg *)param;
+    LogQsoResultMsg *res = (LogQsoResultMsg *)calloc(1, sizeof(LogQsoResultMsg));
+    if (!res) {
+        free(arg);
+        return 0;
+    }
+
+    res->is_update = arg->is_update;
+    res->band_idx = arg->band_idx;
+    res->mode_idx = arg->mode_idx;
+    safe_strcpy(res->callsign, sizeof(res->callsign), arg->callsign);
+
+    struct QsrClient *ffi_client = NULL;
+    if (AcquireFfiClient(&ffi_client)) {
+        if (arg->is_update) {
+            res->success = (g_backend.pf_update_qso(ffi_client, &arg->ureq) == 0);
+        } else {
+            QsrLogQsoResult log_res;
+            memset(&log_res, 0, sizeof(log_res));
+            res->success = (g_backend.pf_log_qso(ffi_client, &arg->req, &log_res) == 0);
+        }
+        ReleaseFfiClient();
+    }
+
+    if (!PostMessage(arg->hwnd, WM_APP_LOG_DONE, 0, (LPARAM)res))
+        free(res);
+
+    free(arg);
+    return 0;
+}
+
 static void LogQso(void)
 {
     if (g_state.callsign[0] == 0) {
@@ -1162,36 +1386,40 @@ static void LogQso(void)
     }
 
     if (g_backend.mode == BACKEND_FFI) {
-        struct QsrClient *ffi_client = NULL;
-        if (!AcquireFfiClient(&ffi_client)) {
-            SetStatus("Backend unavailable (shutting down)", 1);
+        if (g_state.log_in_progress) {
+            SetStatus("Log/update already in progress", 1);
             return;
         }
-        if (is_update) {
-            QsrUpdateQsoRequest ureq;
-            memset(&ureq, 0, sizeof(ureq));
-            safe_strcpy((char *)ureq.local_id, sizeof(ureq.local_id), g_state.editing_local_id);
-            fill_log_request(&ureq.qso);
-            if (g_backend.pf_update_qso(ffi_client, &ureq) == 0) {
-                SetStatus("QSO updated", 0);
-            } else {
-                SetStatus("Failed to update QSO", 1);
-            }
-        } else {
-            QsrLogQsoRequest req;
-            QsrLogQsoResult res;
-            fill_log_request(&req);
-            if (g_backend.pf_log_qso(ffi_client, &req, &res) == 0) {
-                char msg[128];
-                snprintf(msg, sizeof(msg), "Logged %s on %s %s",
-                          g_state.callsign, BANDS[g_state.band_idx],
-                          MODES[g_state.mode_idx]);
-                SetStatus(msg, 0);
-            } else {
-                SetStatus("Failed to log QSO", 1);
-            }
+        LogQsoThreadArg *arg = (LogQsoThreadArg *)calloc(1, sizeof(LogQsoThreadArg));
+        if (!arg) {
+            SetStatus("Failed to allocate logging task", 1);
+            return;
         }
-        ReleaseFfiClient();
+
+        arg->hwnd = g_state.hwnd;
+        arg->is_update = is_update;
+        arg->band_idx = g_state.band_idx;
+        arg->mode_idx = g_state.mode_idx;
+        safe_strcpy(arg->callsign, sizeof(arg->callsign), g_state.callsign);
+
+        if (is_update) {
+            safe_strcpy((char *)arg->ureq.local_id, sizeof(arg->ureq.local_id), g_state.editing_local_id);
+            fill_log_request(&arg->ureq.qso);
+        } else {
+            fill_log_request(&arg->req);
+        }
+
+        g_state.log_in_progress = 1;
+        HANDLE h = (HANDLE)_beginthreadex(NULL, 0, LogQsoThread, arg, 0, NULL);
+        if (h) {
+            CloseHandle(h);
+        } else {
+            g_state.log_in_progress = 0;
+            free(arg);
+            SetStatus("Failed to start background logging", 1);
+            return;
+        }
+        return;
     } else {
         /* CLI path */
         char cmd[4096];
@@ -1531,25 +1759,88 @@ static unsigned __stdcall RigPollThread(void *param)
     return 0;
 }
 
+static void ApplyRigPollResult(const RigPollResult *res)
+{
+    if (!res) return;
+    if (g_state.rig_enabled) {
+        g_state.rig_connected = res->connected;
+        if (res->connected) {
+            safe_strcpy(g_state.rig_freq_display, sizeof(g_state.rig_freq_display), res->freq_display);
+            safe_strcpy(g_state.rig_freq_mhz, sizeof(g_state.rig_freq_mhz), res->freq_mhz);
+            safe_strcpy(g_state.rig_band, sizeof(g_state.rig_band), res->band);
+            safe_strcpy(g_state.rig_mode, sizeof(g_state.rig_mode), res->mode);
+            /* Auto-fill band/mode defaults when callsign is empty */
+            if (g_state.callsign[0] == 0) {
+                for (int bi = 0; bi < NUM_BANDS; bi++) {
+                    if (_stricmp(BANDS[bi], res->band) == 0) {
+                        g_state.band_idx = bi;
+                        break;
+                    }
+                }
+                for (int mi = 0; mi < NUM_MODES; mi++) {
+                    if (_stricmp(MODES[mi], res->mode) == 0) {
+                        g_state.mode_idx = mi;
+                        ApplyModeDefaults();
+                        break;
+                    }
+                }
+            }
+            if (res->freq_display[0] && g_state.focused_field != FIELD_FREQ)
+                safe_strcpy(g_state.freq_mhz, sizeof(g_state.freq_mhz), res->freq_display);
+        }
+    }
+}
+
 /* ── FFI integration: Fetch space weather ──────────────────────────────── */
+
+static unsigned __stdcall SpaceWeatherThread(void *param)
+{
+    SpaceWeatherArg *arg = (SpaceWeatherArg *)param;
+    SpaceWeatherResult *res = (SpaceWeatherResult *)calloc(1, sizeof(SpaceWeatherResult));
+    if (!res) { free(arg); return 0; }
+
+    struct QsrClient *ffi_client = NULL;
+    QsrSpaceWeather sw;
+    memset(&sw, 0, sizeof(sw));
+    if (AcquireFfiClient(&ffi_client) &&
+        g_backend.pf_get_space_weather(ffi_client, &sw) == 0 &&
+        sw.has_data) {
+        res->has_data = 1;
+        res->k_index = sw.k_index;
+        res->solar_flux = sw.solar_flux;
+        res->sunspot_number = sw.sunspot_number;
+    }
+    if (ffi_client) {
+        ReleaseFfiClient();
+    }
+
+    if (!PostMessage(arg->hwnd, WM_APP_WEATHER_DONE, 0, (LPARAM)res))
+        free(res);
+
+    free(arg);
+    return 0;
+}
 
 static void FetchSpaceWeather(void)
 {
     if (g_backend.mode == BACKEND_FFI) {
-        struct QsrClient *ffi_client = NULL;
-        QsrSpaceWeather sw;
-        memset(&sw, 0, sizeof(sw));
-        if (AcquireFfiClient(&ffi_client) &&
-            g_backend.pf_get_space_weather(ffi_client, &sw) == 0 &&
-            sw.has_data) {
-            g_state.k_index = sw.k_index;
-            g_state.solar_flux = sw.solar_flux;
-            g_state.sunspot_number = sw.sunspot_number;
-            g_state.has_weather = 1;
+        if (g_state.weather_loading) {
+            return;
         }
-        if (ffi_client) {
-            ReleaseFfiClient();
+        SpaceWeatherArg *arg = (SpaceWeatherArg *)calloc(1, sizeof(SpaceWeatherArg));
+        if (!arg) {
+            return;
         }
+        arg->hwnd = g_state.hwnd;
+        g_state.weather_loading = 1;
+        HANDLE h = (HANDLE)_beginthreadex(NULL, 0, SpaceWeatherThread, arg, 0, NULL);
+        if (h) {
+            CloseHandle(h);
+        } else {
+            g_state.weather_loading = 0;
+            free(arg);
+        }
+        return;
     } else {
         /* CLI path */
         char *out = RunQrCommand("space-weather --json");
@@ -1565,6 +1856,107 @@ static void FetchSpaceWeather(void)
 }
 
 /* ── FFI integration: Load selected QSO into form ──────────────────────── */
+
+static unsigned __stdcall QsoDetailLoadThread(void *param)
+{
+    QsoDetailLoadArg *arg = (QsoDetailLoadArg *)param;
+    QsoDetailLoadResult *res = (QsoDetailLoadResult *)calloc(1, sizeof(QsoDetailLoadResult));
+    if (!res) { free(arg); return 0; }
+
+    safe_strcpy(res->local_id, sizeof(res->local_id), arg->local_id);
+    struct QsrClient *ffi_client = NULL;
+    if (AcquireFfiClient(&ffi_client) &&
+        g_backend.pf_get_qso(ffi_client, arg->local_id, &res->detail) == 0) {
+        res->loaded = 1;
+    }
+    if (ffi_client) {
+        ReleaseFfiClient();
+    }
+
+    if (!PostMessage(arg->hwnd, WM_APP_QSO_DETAIL_DONE, 0, (LPARAM)res))
+        free(res);
+
+    free(arg);
+    return 0;
+}
+
+static void ApplyLoadedQsoDetail(const char *local_id, const QsrQsoDetail *detail)
+{
+    if (!local_id || !detail) return;
+
+    ClearForm();
+
+    safe_strcpy(g_state.callsign, sizeof(g_state.callsign), (const char *)detail->callsign);
+
+    /* Match band to index */
+    {
+        const char *b = (const char *)detail->band;
+        for (int i = 0; i < NUM_BANDS; i++) {
+            if (_stricmp(BANDS[i], b) == 0) { g_state.band_idx = i; break; }
+        }
+    }
+
+    /* Match mode to index */
+    {
+        const char *m = (const char *)detail->mode;
+        for (int i = 0; i < NUM_MODES; i++) {
+            if (_stricmp(MODES[i], m) == 0) { g_state.mode_idx = i; break; }
+        }
+    }
+
+    safe_strcpy(g_state.date,     sizeof(g_state.date),     (const char *)detail->date);
+    safe_strcpy(g_state.time_str, sizeof(g_state.time_str), (const char *)detail->time);
+
+    if (detail->freq_mhz[0])
+        freq_to_radio_style((const char *)detail->freq_mhz, g_state.freq_mhz, sizeof(g_state.freq_mhz));
+    else
+        { char _tmp[32]; snprintf(_tmp, sizeof(_tmp), "%.5f", BAND_DEFAULT_FREQS[g_state.band_idx]); freq_to_radio_style(_tmp, g_state.freq_mhz, sizeof(g_state.freq_mhz)); }
+
+    if (detail->rst_sent[0])
+        safe_strcpy(g_state.rst_sent, sizeof(g_state.rst_sent), (const char *)detail->rst_sent);
+    else
+        safe_strcpy(g_state.rst_sent, sizeof(g_state.rst_sent), "59");
+
+    if (detail->rst_rcvd[0])
+        safe_strcpy(g_state.rst_rcvd, sizeof(g_state.rst_rcvd), (const char *)detail->rst_rcvd);
+    else
+        safe_strcpy(g_state.rst_rcvd, sizeof(g_state.rst_rcvd), "59");
+
+    if (detail->time_off[0])
+        safe_strcpy(g_state.time_off, sizeof(g_state.time_off), (const char *)detail->time_off);
+
+    safe_strcpy(g_state.comment,       sizeof(g_state.comment),       (const char *)detail->comment);
+    safe_strcpy(g_state.notes,          sizeof(g_state.notes),          (const char *)detail->notes);
+    safe_strcpy(g_state.worked_name,    sizeof(g_state.worked_name),    (const char *)detail->worked_name);
+    safe_strcpy(g_state.tx_power,       sizeof(g_state.tx_power),       (const char *)detail->tx_power);
+    safe_strcpy(g_state.submode,        sizeof(g_state.submode),        (const char *)detail->submode);
+    safe_strcpy(g_state.contest_id,     sizeof(g_state.contest_id),     (const char *)detail->contest_id);
+    safe_strcpy(g_state.serial_sent,    sizeof(g_state.serial_sent),    (const char *)detail->serial_sent);
+    safe_strcpy(g_state.serial_rcvd,    sizeof(g_state.serial_rcvd),    (const char *)detail->serial_rcvd);
+    safe_strcpy(g_state.exchange_sent,  sizeof(g_state.exchange_sent),  (const char *)detail->exchange_sent);
+    safe_strcpy(g_state.exchange_rcvd,  sizeof(g_state.exchange_rcvd),  (const char *)detail->exchange_rcvd);
+    safe_strcpy(g_state.prop_mode,      sizeof(g_state.prop_mode),      (const char *)detail->prop_mode);
+    safe_strcpy(g_state.sat_name,       sizeof(g_state.sat_name),       (const char *)detail->sat_name);
+    safe_strcpy(g_state.sat_mode,       sizeof(g_state.sat_mode),       (const char *)detail->sat_mode);
+    safe_strcpy(g_state.iota,           sizeof(g_state.iota),           (const char *)detail->iota);
+    safe_strcpy(g_state.arrl_section,   sizeof(g_state.arrl_section),   (const char *)detail->arrl_section);
+    safe_strcpy(g_state.worked_state,   sizeof(g_state.worked_state),   (const char *)detail->worked_state);
+    safe_strcpy(g_state.worked_county,  sizeof(g_state.worked_county),  (const char *)detail->worked_county);
+    safe_strcpy(g_state.skcc,           sizeof(g_state.skcc),           (const char *)detail->skcc);
+
+    safe_strcpy(g_state.editing_local_id, sizeof(g_state.editing_local_id), local_id);
+
+    g_state.cursor_pos[FIELD_CALLSIGN] = (int)strlen(g_state.callsign);
+    g_state.cursor_pos[FIELD_RST_SENT] = (int)strlen(g_state.rst_sent);
+    g_state.cursor_pos[FIELD_RST_RCVD] = (int)strlen(g_state.rst_rcvd);
+    g_state.cursor_pos[FIELD_FREQ]     = (int)strlen(g_state.freq_mhz);
+    g_state.cursor_pos[FIELD_DATE]     = (int)strlen(g_state.date);
+    g_state.cursor_pos[FIELD_TIME]     = (int)strlen(g_state.time_str);
+
+    g_state.qso_list_focused = 0;
+    SetFocusField(FIELD_CALLSIGN);
+    SetStatus("QSO loaded for editing", 0);
+}
 
 static void LoadSelectedQso(void)
 {
@@ -1583,14 +1975,27 @@ static void LoadSelectedQso(void)
     int loaded = 0;
 
     if (g_backend.mode == BACKEND_FFI) {
-        struct QsrClient *ffi_client = NULL;
-        if (AcquireFfiClient(&ffi_client) &&
-            g_backend.pf_get_qso(ffi_client, q->local_id, &detail) == 0) {
-            loaded = 1;
+        if (g_state.qso_detail_loading) {
+            SetStatus("QSO load already in progress", 1);
+            return;
         }
-        if (ffi_client) {
-            ReleaseFfiClient();
+        QsoDetailLoadArg *arg = (QsoDetailLoadArg *)calloc(1, sizeof(QsoDetailLoadArg));
+        if (!arg) {
+            SetStatus("Failed to allocate QSO load task", 1);
+            return;
         }
+        arg->hwnd = g_state.hwnd;
+        safe_strcpy(arg->local_id, sizeof(arg->local_id), q->local_id);
+        g_state.qso_detail_loading = 1;
+        HANDLE h = (HANDLE)_beginthreadex(NULL, 0, QsoDetailLoadThread, arg, 0, NULL);
+        if (h) {
+            CloseHandle(h);
+        } else {
+            g_state.qso_detail_loading = 0;
+            free(arg);
+            SetStatus("Failed to start background QSO load", 1);
+        }
+        return;
     } else {
         /* CLI path */
         char cmd[256];
@@ -1663,82 +2068,32 @@ static void LoadSelectedQso(void)
         return;
     }
 
-    ClearForm();
-
-    safe_strcpy(g_state.callsign, sizeof(g_state.callsign), (const char *)detail.callsign);
-
-    /* Match band to index */
-    {
-        const char *b = (const char *)detail.band;
-        for (int i = 0; i < NUM_BANDS; i++) {
-            if (_stricmp(BANDS[i], b) == 0) { g_state.band_idx = i; break; }
-        }
-    }
-
-    /* Match mode to index */
-    {
-        const char *m = (const char *)detail.mode;
-        for (int i = 0; i < NUM_MODES; i++) {
-            if (_stricmp(MODES[i], m) == 0) { g_state.mode_idx = i; break; }
-        }
-    }
-
-    safe_strcpy(g_state.date,     sizeof(g_state.date),     (const char *)detail.date);
-    safe_strcpy(g_state.time_str, sizeof(g_state.time_str), (const char *)detail.time);
-
-    if (detail.freq_mhz[0])
-        freq_to_radio_style((const char *)detail.freq_mhz, g_state.freq_mhz, sizeof(g_state.freq_mhz));
-    else
-        { char _tmp[32]; snprintf(_tmp, sizeof(_tmp), "%.5f", BAND_DEFAULT_FREQS[g_state.band_idx]); freq_to_radio_style(_tmp, g_state.freq_mhz, sizeof(g_state.freq_mhz)); }
-
-    if (detail.rst_sent[0])
-        safe_strcpy(g_state.rst_sent, sizeof(g_state.rst_sent), (const char *)detail.rst_sent);
-    else
-        safe_strcpy(g_state.rst_sent, sizeof(g_state.rst_sent), "59");
-
-    if (detail.rst_rcvd[0])
-        safe_strcpy(g_state.rst_rcvd, sizeof(g_state.rst_rcvd), (const char *)detail.rst_rcvd);
-    else
-        safe_strcpy(g_state.rst_rcvd, sizeof(g_state.rst_rcvd), "59");
-
-    if (detail.time_off[0])
-        safe_strcpy(g_state.time_off, sizeof(g_state.time_off), (const char *)detail.time_off);
-
-    safe_strcpy(g_state.comment,       sizeof(g_state.comment),       (const char *)detail.comment);
-    safe_strcpy(g_state.notes,          sizeof(g_state.notes),          (const char *)detail.notes);
-    safe_strcpy(g_state.worked_name,    sizeof(g_state.worked_name),    (const char *)detail.worked_name);
-    safe_strcpy(g_state.tx_power,       sizeof(g_state.tx_power),       (const char *)detail.tx_power);
-    safe_strcpy(g_state.submode,        sizeof(g_state.submode),        (const char *)detail.submode);
-    safe_strcpy(g_state.contest_id,     sizeof(g_state.contest_id),     (const char *)detail.contest_id);
-    safe_strcpy(g_state.serial_sent,    sizeof(g_state.serial_sent),    (const char *)detail.serial_sent);
-    safe_strcpy(g_state.serial_rcvd,    sizeof(g_state.serial_rcvd),    (const char *)detail.serial_rcvd);
-    safe_strcpy(g_state.exchange_sent,  sizeof(g_state.exchange_sent),  (const char *)detail.exchange_sent);
-    safe_strcpy(g_state.exchange_rcvd,  sizeof(g_state.exchange_rcvd),  (const char *)detail.exchange_rcvd);
-    safe_strcpy(g_state.prop_mode,      sizeof(g_state.prop_mode),      (const char *)detail.prop_mode);
-    safe_strcpy(g_state.sat_name,       sizeof(g_state.sat_name),       (const char *)detail.sat_name);
-    safe_strcpy(g_state.sat_mode,       sizeof(g_state.sat_mode),       (const char *)detail.sat_mode);
-    safe_strcpy(g_state.iota,           sizeof(g_state.iota),           (const char *)detail.iota);
-    safe_strcpy(g_state.arrl_section,   sizeof(g_state.arrl_section),   (const char *)detail.arrl_section);
-    safe_strcpy(g_state.worked_state,   sizeof(g_state.worked_state),   (const char *)detail.worked_state);
-    safe_strcpy(g_state.worked_county,  sizeof(g_state.worked_county),  (const char *)detail.worked_county);
-    safe_strcpy(g_state.skcc,           sizeof(g_state.skcc),           (const char *)detail.skcc);
-
-    safe_strcpy(g_state.editing_local_id, sizeof(g_state.editing_local_id), q->local_id);
-
-    g_state.cursor_pos[FIELD_CALLSIGN] = (int)strlen(g_state.callsign);
-    g_state.cursor_pos[FIELD_RST_SENT] = (int)strlen(g_state.rst_sent);
-    g_state.cursor_pos[FIELD_RST_RCVD] = (int)strlen(g_state.rst_rcvd);
-    g_state.cursor_pos[FIELD_FREQ]     = (int)strlen(g_state.freq_mhz);
-    g_state.cursor_pos[FIELD_DATE]     = (int)strlen(g_state.date);
-    g_state.cursor_pos[FIELD_TIME]     = (int)strlen(g_state.time_str);
-
-    g_state.qso_list_focused = 0;
-    SetFocusField(FIELD_CALLSIGN);
-
-    SetStatus("QSO loaded for editing", 0);
+    ApplyLoadedQsoDetail(q->local_id, &detail);
 }
 
 /* ── FFI integration: Delete selected QSO ──────────────────────────────── */
+
+static unsigned __stdcall QsoDeleteThread(void *param)
+{
+    QsoDeleteArg *arg = (QsoDeleteArg *)param;
+    QsoDeleteResult *res = (QsoDeleteResult *)calloc(1, sizeof(QsoDeleteResult));
+    if (!res) { free(arg); return 0; }
+
+    safe_strcpy(res->callsign, sizeof(res->callsign), arg->callsign);
+    struct QsrClient *ffi_client = NULL;
+    if (AcquireFfiClient(&ffi_client)) {
+        res->ok = (g_backend.pf_delete_qso(ffi_client, arg->local_id) == 0);
+    }
+    if (ffi_client) {
+        ReleaseFfiClient();
+    }
+
+    if (!PostMessage(arg->hwnd, WM_APP_QSO_DELETE_DONE, 0, (LPARAM)res))
+        free(res);
+
+    free(arg);
+    return 0;
+}
 
 static void DeleteSelectedQso(void)
 {
@@ -1753,11 +2108,29 @@ static void DeleteSelectedQso(void)
 
     int ok = 0;
     if (g_backend.mode == BACKEND_FFI) {
-        struct QsrClient *ffi_client = NULL;
-        if (AcquireFfiClient(&ffi_client)) {
-            ok = (g_backend.pf_delete_qso(ffi_client, q->local_id) == 0);
-            ReleaseFfiClient();
+        if (g_state.qso_delete_in_progress) {
+            SetStatus("Delete already in progress", 1);
+            return;
         }
+        QsoDeleteArg *arg = (QsoDeleteArg *)calloc(1, sizeof(QsoDeleteArg));
+        if (!arg) {
+            SetStatus("Failed to allocate delete task", 1);
+            return;
+        }
+        arg->hwnd = g_state.hwnd;
+        safe_strcpy(arg->local_id, sizeof(arg->local_id), q->local_id);
+        safe_strcpy(arg->callsign, sizeof(arg->callsign), q->callsign);
+        g_state.qso_delete_in_progress = 1;
+        HANDLE h = (HANDLE)_beginthreadex(NULL, 0, QsoDeleteThread, arg, 0, NULL);
+        if (h) {
+            CloseHandle(h);
+        } else {
+            g_state.qso_delete_in_progress = 0;
+            free(arg);
+            SetStatus("Failed to start background delete", 1);
+            return;
+        }
+        return;
     } else {
         char cmd[256];
         snprintf(cmd, sizeof(cmd), "delete \"%s\" --json", q->local_id);
@@ -3374,6 +3747,33 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
         SetTimer(hwnd, TIMER_ID, TIMER_MS, NULL);
         break;
 
+    case WM_APP_LOG_DONE:
+    {
+        LogQsoResultMsg *res = (LogQsoResultMsg *)lParam;
+        g_state.log_in_progress = 0;
+        if (res) {
+            if (res->success) {
+                if (res->is_update) {
+                    SetStatus("QSO updated", 0);
+                } else {
+                    char status_msg[128];
+                    snprintf(status_msg, sizeof(status_msg), "Logged %s on %s %s",
+                             res->callsign, BANDS[res->band_idx], MODES[res->mode_idx]);
+                    SetStatus(status_msg, 0);
+                }
+            } else {
+                SetStatus(res->is_update ? "Failed to update QSO" : "Failed to log QSO", 1);
+            }
+            free(res);
+        } else {
+            SetStatus("Failed to log QSO", 1);
+        }
+        ClearForm();
+        RefreshQsoList();
+        InvalidateRect(hwnd, NULL, FALSE);
+        break;
+    }
+
     case WM_APP_LOOKUP_DONE:
     {
         LookupResultMsg *res = (LookupResultMsg *)lParam;
@@ -3413,36 +3813,8 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
     {
         RigPollResult *res = (RigPollResult *)lParam;
         g_state.rig_poll_in_progress = 0;
-        if (res) {
-            if (g_state.rig_enabled) {
-                g_state.rig_connected = res->connected;
-                if (res->connected) {
-                    safe_strcpy(g_state.rig_freq_display, sizeof(g_state.rig_freq_display), res->freq_display);
-                    safe_strcpy(g_state.rig_freq_mhz, sizeof(g_state.rig_freq_mhz), res->freq_mhz);
-                    safe_strcpy(g_state.rig_band, sizeof(g_state.rig_band), res->band);
-                    safe_strcpy(g_state.rig_mode, sizeof(g_state.rig_mode), res->mode);
-                    /* Auto-fill band/mode/freq when callsign is empty */
-                    if (g_state.callsign[0] == 0) {
-                        for (int bi = 0; bi < NUM_BANDS; bi++) {
-                            if (_stricmp(BANDS[bi], res->band) == 0) {
-                                g_state.band_idx = bi;
-                                break;
-                            }
-                        }
-                        for (int mi = 0; mi < NUM_MODES; mi++) {
-                            if (_stricmp(MODES[mi], res->mode) == 0) {
-                                g_state.mode_idx = mi;
-                                ApplyModeDefaults();
-                                break;
-                            }
-                        }
-                        if (res->freq_display[0])
-                            safe_strcpy(g_state.freq_mhz, sizeof(g_state.freq_mhz), res->freq_display);
-                    }
-                }
-            }
-            free(res);
-        }
+        ApplyRigPollResult(res);
+        if (res) free(res);
         InvalidateRect(hwnd, NULL, FALSE);
         break;
     }
@@ -3458,6 +3830,64 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
             g_state.recent_capacity = res->capacity;
             free(res);
         }
+        InvalidateRect(hwnd, NULL, FALSE);
+        break;
+    }
+
+    case WM_APP_WEATHER_DONE:
+    {
+        SpaceWeatherResult *res = (SpaceWeatherResult *)lParam;
+        g_state.weather_loading = 0;
+        if (res) {
+            if (res->has_data) {
+                g_state.k_index = res->k_index;
+                g_state.solar_flux = res->solar_flux;
+                g_state.sunspot_number = res->sunspot_number;
+                g_state.has_weather = 1;
+            }
+            free(res);
+        }
+        InvalidateRect(hwnd, NULL, FALSE);
+        break;
+    }
+
+    case WM_APP_QSO_DETAIL_DONE:
+    {
+        QsoDetailLoadResult *res = (QsoDetailLoadResult *)lParam;
+        g_state.qso_detail_loading = 0;
+        if (res) {
+            if (res->loaded) {
+                ApplyLoadedQsoDetail(res->local_id, &res->detail);
+            } else {
+                SetStatus("Failed to load QSO data", 1);
+            }
+            free(res);
+        } else {
+            SetStatus("Failed to load QSO data", 1);
+        }
+        InvalidateRect(hwnd, NULL, FALSE);
+        break;
+    }
+
+    case WM_APP_QSO_DELETE_DONE:
+    {
+        QsoDeleteResult *res = (QsoDeleteResult *)lParam;
+        g_state.qso_delete_in_progress = 0;
+        if (res) {
+            if (res->ok) {
+                char msg[128];
+                snprintf(msg, sizeof(msg), "Deleted QSO with %s", res->callsign);
+                SetStatus(msg, 0);
+            } else {
+                SetStatus("Failed to delete QSO", 1);
+            }
+            free(res);
+        } else {
+            SetStatus("Failed to delete QSO", 1);
+        }
+        g_state.qso_selected = -1;
+        g_state.confirm_delete_visible = 0;
+        RefreshQsoList();
         InvalidateRect(hwnd, NULL, FALSE);
         break;
     }

--- a/src/c/qsoripper-win32/tests/win32_issue_regressions.c
+++ b/src/c/qsoripper-win32/tests/win32_issue_regressions.c
@@ -1,0 +1,326 @@
+#include <windows.h>
+#include <process.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <wchar.h>
+
+#include "qsoripper_ffi.h"
+
+typedef int32_t (*fn_qsr_log_qso)(struct QsrClient *, const struct QsrLogQsoRequest *, struct QsrLogQsoResult *);
+typedef int32_t (*fn_qsr_update_qso)(struct QsrClient *, const struct QsrUpdateQsoRequest *);
+typedef int32_t (*fn_qsr_get_qso)(struct QsrClient *, const char *, struct QsrQsoDetail *);
+typedef int32_t (*fn_qsr_delete_qso)(struct QsrClient *, const char *);
+typedef int32_t (*fn_qsr_get_space_weather)(struct QsrClient *, struct QsrSpaceWeather *);
+
+enum Field {
+    FIELD_CALLSIGN, FIELD_BAND, FIELD_MODE,
+    FIELD_RST_SENT, FIELD_RST_RCVD,
+    FIELD_COMMENT, FIELD_NOTES,
+    FIELD_FREQ, FIELD_DATE, FIELD_TIME,
+    FIELD_TIME_OFF, FIELD_QTH, FIELD_WORKED_NAME,
+    FIELD_TX_POWER, FIELD_SUBMODE, FIELD_CONTEST_ID,
+    FIELD_SERIAL_SENT, FIELD_SERIAL_RCVD,
+    FIELD_EXCHANGE_SENT, FIELD_EXCHANGE_RCVD,
+    FIELD_PROP_MODE, FIELD_SAT_NAME, FIELD_SAT_MODE,
+    FIELD_IOTA, FIELD_ARRL_SECTION, FIELD_WORKED_STATE, FIELD_WORKED_COUNTY,
+    FIELD_SKCC,
+    FIELD_COUNT
+};
+
+int qsr_test_ui_text_to_wide(const char *text, wchar_t *wbuf, int wbuf_len);
+UINT qsr_test_ui_text_codepage(void);
+void qsr_test_reset_state(void);
+void qsr_test_set_backend_ffi(struct QsrClient *client, fn_qsr_log_qso log_qso_fn, fn_qsr_update_qso update_qso_fn);
+void qsr_test_set_backend_ffi_get_delete_weather(struct QsrClient *client, fn_qsr_get_qso get_qso_fn, fn_qsr_delete_qso delete_qso_fn, fn_qsr_get_space_weather get_space_weather_fn);
+void qsr_test_set_form_basics(const char *callsign, const char *date, const char *time_str);
+void qsr_test_set_band_mode_indices(int band_idx, int mode_idx);
+void qsr_test_set_freq_field(const char *freq);
+void qsr_test_set_selected_recent_qso(const char *local_id, const char *callsign);
+void qsr_test_set_focused_field(enum Field field);
+void qsr_test_set_rig_enabled(int enabled);
+void qsr_test_apply_rig_result(int connected, const char *freq_display, const char *freq_mhz, const char *band, const char *mode);
+const char *qsr_test_get_freq_field(void);
+void qsr_test_invoke_log_qso(void);
+void qsr_test_invoke_load_selected_qso(void);
+void qsr_test_invoke_delete_selected_qso(void);
+void qsr_test_invoke_fetch_space_weather(void);
+
+static HANDLE g_log_entered = NULL;
+static HANDLE g_release_log = NULL;
+static HANDLE g_load_entered = NULL;
+static HANDLE g_release_load = NULL;
+static HANDLE g_delete_entered = NULL;
+static HANDLE g_release_delete = NULL;
+static HANDLE g_weather_entered = NULL;
+static HANDLE g_release_weather = NULL;
+
+static int32_t __cdecl stub_log_qso(struct QsrClient *client, const struct QsrLogQsoRequest *req, struct QsrLogQsoResult *res)
+{
+    (void)client;
+    (void)req;
+    (void)res;
+    SetEvent(g_log_entered);
+    WaitForSingleObject(g_release_log, 3000);
+    return 0;
+}
+
+static int32_t __cdecl stub_update_qso(struct QsrClient *client, const struct QsrUpdateQsoRequest *req)
+{
+    (void)client;
+    (void)req;
+    return 0;
+}
+
+static int32_t __cdecl stub_get_qso(struct QsrClient *client, const char *local_id, struct QsrQsoDetail *detail)
+{
+    (void)client;
+    (void)local_id;
+    (void)detail;
+    SetEvent(g_load_entered);
+    WaitForSingleObject(g_release_load, 3000);
+    return 0;
+}
+
+static int32_t __cdecl stub_delete_qso(struct QsrClient *client, const char *local_id)
+{
+    (void)client;
+    (void)local_id;
+    SetEvent(g_delete_entered);
+    WaitForSingleObject(g_release_delete, 3000);
+    return 0;
+}
+
+static int32_t __cdecl stub_get_space_weather(struct QsrClient *client, struct QsrSpaceWeather *sw)
+{
+    (void)client;
+    (void)sw;
+    SetEvent(g_weather_entered);
+    WaitForSingleObject(g_release_weather, 3000);
+    return 0;
+}
+
+static unsigned __stdcall invoke_log_thread(void *arg)
+{
+    (void)arg;
+    qsr_test_invoke_log_qso();
+    return 0;
+}
+
+static unsigned __stdcall invoke_load_thread(void *arg)
+{
+    (void)arg;
+    qsr_test_invoke_load_selected_qso();
+    return 0;
+}
+
+static unsigned __stdcall invoke_delete_thread(void *arg)
+{
+    (void)arg;
+    qsr_test_invoke_delete_selected_qso();
+    return 0;
+}
+
+static unsigned __stdcall invoke_weather_thread(void *arg)
+{
+    (void)arg;
+    qsr_test_invoke_fetch_space_weather();
+    return 0;
+}
+
+static int fail(const char *msg)
+{
+    fprintf(stderr, "FAIL: %s\n", msg);
+    return 1;
+}
+
+static int test_issue_262_utf8_conversion(void)
+{
+    if (qsr_test_ui_text_codepage() != CP_UTF8) {
+        return fail("UI text conversion is not using CP_UTF8");
+    }
+    wchar_t wbuf[64];
+    int wlen = qsr_test_ui_text_to_wide("caf\xC3\xA9", wbuf, 64);
+    if (wlen <= 4) {
+        return fail("UTF-8 conversion returned no content");
+    }
+    if (wbuf[0] != L'c' || wbuf[1] != L'a' || wbuf[2] != L'f' || wbuf[3] != 0x00E9) {
+        return fail("UTF-8 text was not converted correctly in UI path");
+    }
+    return 0;
+}
+
+static int test_issue_199_rig_tuning_updates_freq_field(void)
+{
+    qsr_test_reset_state();
+    qsr_test_set_rig_enabled(1);
+    qsr_test_set_form_basics("K1ABC", "2026-01-02", "03:04");
+    qsr_test_set_band_mode_indices(0, 0);
+    qsr_test_set_focused_field(FIELD_CALLSIGN);
+    qsr_test_set_freq_field("14.000.00");
+
+    qsr_test_apply_rig_result(1, "14.225.00", "14.22500", "20M", "SSB");
+
+    if (strcmp(qsr_test_get_freq_field(), "14.225.00") != 0) {
+        return fail("Rig tuning did not refresh frequency field while callsign was populated");
+    }
+    return 0;
+}
+
+static int test_issue_263_log_is_non_blocking(void)
+{
+    qsr_test_reset_state();
+    qsr_test_set_form_basics("K1ABC", "2026-01-02", "03:04");
+    qsr_test_set_band_mode_indices(0, 0);
+    qsr_test_set_backend_ffi((struct QsrClient *)0x1, stub_log_qso, stub_update_qso);
+
+    g_log_entered = CreateEventW(NULL, TRUE, FALSE, NULL);
+    g_release_log = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (!g_log_entered || !g_release_log) {
+        return fail("failed to create test events");
+    }
+
+    uintptr_t tid = _beginthreadex(NULL, 0, invoke_log_thread, NULL, 0, NULL);
+    if (!tid) {
+        return fail("failed to start log invocation thread");
+    }
+    HANDLE thread = (HANDLE)tid;
+
+    if (WaitForSingleObject(g_log_entered, 500) != WAIT_OBJECT_0) {
+        return fail("log backend call was not invoked");
+    }
+
+    DWORD wait = WaitForSingleObject(thread, 100);
+    SetEvent(g_release_log);
+    WaitForSingleObject(thread, 3000);
+    CloseHandle(thread);
+    CloseHandle(g_log_entered);
+    CloseHandle(g_release_log);
+
+    if (wait != WAIT_OBJECT_0) {
+        return fail("LogQso blocked caller while backend call was in flight");
+    }
+
+    return 0;
+}
+
+static int test_issue_263_load_selected_qso_is_non_blocking(void)
+{
+    qsr_test_reset_state();
+    qsr_test_set_selected_recent_qso("load-1", "K1ABC");
+    qsr_test_set_backend_ffi_get_delete_weather((struct QsrClient *)0x1, stub_get_qso, NULL, NULL);
+
+    g_load_entered = CreateEventW(NULL, TRUE, FALSE, NULL);
+    g_release_load = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (!g_load_entered || !g_release_load) {
+        return fail("failed to create load test events");
+    }
+
+    uintptr_t tid = _beginthreadex(NULL, 0, invoke_load_thread, NULL, 0, NULL);
+    if (!tid) {
+        return fail("failed to start load invocation thread");
+    }
+    HANDLE thread = (HANDLE)tid;
+
+    if (WaitForSingleObject(g_load_entered, 500) != WAIT_OBJECT_0) {
+        return fail("load backend call was not invoked");
+    }
+
+    DWORD wait = WaitForSingleObject(thread, 100);
+    SetEvent(g_release_load);
+    WaitForSingleObject(thread, 3000);
+    CloseHandle(thread);
+    CloseHandle(g_load_entered);
+    CloseHandle(g_release_load);
+
+    if (wait != WAIT_OBJECT_0) {
+        return fail("LoadSelectedQso blocked caller while backend call was in flight");
+    }
+    return 0;
+}
+
+static int test_issue_263_delete_selected_qso_is_non_blocking(void)
+{
+    qsr_test_reset_state();
+    qsr_test_set_selected_recent_qso("delete-1", "K1ABC");
+    qsr_test_set_backend_ffi_get_delete_weather((struct QsrClient *)0x1, NULL, stub_delete_qso, NULL);
+
+    g_delete_entered = CreateEventW(NULL, TRUE, FALSE, NULL);
+    g_release_delete = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (!g_delete_entered || !g_release_delete) {
+        return fail("failed to create delete test events");
+    }
+
+    uintptr_t tid = _beginthreadex(NULL, 0, invoke_delete_thread, NULL, 0, NULL);
+    if (!tid) {
+        return fail("failed to start delete invocation thread");
+    }
+    HANDLE thread = (HANDLE)tid;
+
+    if (WaitForSingleObject(g_delete_entered, 500) != WAIT_OBJECT_0) {
+        return fail("delete backend call was not invoked");
+    }
+
+    DWORD wait = WaitForSingleObject(thread, 100);
+    SetEvent(g_release_delete);
+    WaitForSingleObject(thread, 3000);
+    CloseHandle(thread);
+    CloseHandle(g_delete_entered);
+    CloseHandle(g_release_delete);
+
+    if (wait != WAIT_OBJECT_0) {
+        return fail("DeleteSelectedQso blocked caller while backend call was in flight");
+    }
+    return 0;
+}
+
+static int test_issue_263_fetch_space_weather_is_non_blocking(void)
+{
+    qsr_test_reset_state();
+    qsr_test_set_backend_ffi_get_delete_weather((struct QsrClient *)0x1, NULL, NULL, stub_get_space_weather);
+
+    g_weather_entered = CreateEventW(NULL, TRUE, FALSE, NULL);
+    g_release_weather = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (!g_weather_entered || !g_release_weather) {
+        return fail("failed to create weather test events");
+    }
+
+    uintptr_t tid = _beginthreadex(NULL, 0, invoke_weather_thread, NULL, 0, NULL);
+    if (!tid) {
+        return fail("failed to start weather invocation thread");
+    }
+    HANDLE thread = (HANDLE)tid;
+
+    if (WaitForSingleObject(g_weather_entered, 500) != WAIT_OBJECT_0) {
+        return fail("space weather backend call was not invoked");
+    }
+
+    DWORD wait = WaitForSingleObject(thread, 100);
+    SetEvent(g_release_weather);
+    WaitForSingleObject(thread, 3000);
+    CloseHandle(thread);
+    CloseHandle(g_weather_entered);
+    CloseHandle(g_release_weather);
+
+    if (wait != WAIT_OBJECT_0) {
+        return fail("FetchSpaceWeather blocked caller while backend call was in flight");
+    }
+    return 0;
+}
+
+int main(void)
+{
+    int failures = 0;
+    if (test_issue_262_utf8_conversion() != 0) failures++;
+    if (test_issue_199_rig_tuning_updates_freq_field() != 0) failures++;
+    if (test_issue_263_log_is_non_blocking() != 0) failures++;
+    if (test_issue_263_load_selected_qso_is_non_blocking() != 0) failures++;
+    if (test_issue_263_delete_selected_qso_is_non_blocking() != 0) failures++;
+    if (test_issue_263_fetch_space_weather_is_non_blocking() != 0) failures++;
+    if (failures != 0) {
+        fprintf(stderr, "FAIL: %d regression test(s) failed\n", failures);
+        return 1;
+    }
+    puts("PASS: win32 issue regressions");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Fix #263 by moving Win32 FFI log/load/delete/space-weather operations to background threads and handling completion via PostMessage on the UI thread
- Fix #262 by switching Win32 UTF-8 display conversion to CP_UTF8 for UI text rendering
- Fix #199 by ensuring rig poll updates refresh the frequency field while preserving active frequency edit focus
- Add regression coverage for all three issues in win32-issue-regressions

## Validation
- cmake -B build-win32 -S src/c/qsoripper-win32 -G "Visual Studio 17 2022"
- cmake --build build-win32 --config Release
- ctest --test-dir build-win32 --output-on-failure -C Release -R win32-issue-regressions
- ctest --test-dir build-win32 --output-on-failure -C Release

Closes #263
Closes #262
Closes #199