### PR TITLE
Fix SQLite constraint error mapping — distinguish UNIQUE from other violations

### DIFF
--- a/src/dotnet/QsoRipper.Engine.Storage.Sqlite.Tests/SqliteStorageTests.cs
+++ b/src/dotnet/QsoRipper.Engine.Storage.Sqlite.Tests/SqliteStorageTests.cs
@@ -1,4 +1,5 @@
 using Google.Protobuf.WellKnownTypes;
+using Microsoft.Data.Sqlite;
 using QsoRipper.Domain;
 using QsoRipper.Engine.Storage;
 using QsoRipper.Engine.Storage.Sqlite;
@@ -92,6 +93,44 @@ public sealed class SqliteStorageTests : IDisposable
 
         Assert.Equal(StorageErrorKind.Duplicate, ex.Kind);
         Assert.Contains("dup", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Insert_check_constraint_violation_throws_Backend_not_Duplicate()
+    {
+        // Use a file-based DB so we can add a CHECK constraint via a second connection.
+        var dbPath = Path.Combine(Path.GetTempPath(), $"qsoripper-check-test-{Guid.NewGuid():N}.db");
+        try
+        {
+            using var storage = new SqliteStorageBuilder().Path(dbPath).Build();
+
+            // Add a CHECK constraint that rejects worked_callsign = 'BLOCKED'.
+            using (var adminConn = new SqliteConnection($"Data Source={dbPath}"))
+            {
+                adminConn.Open();
+                using var cmd = adminConn.CreateCommand();
+                cmd.CommandText =
+                    "CREATE TRIGGER check_worked_callsign BEFORE INSERT ON qsos " +
+                    "BEGIN SELECT RAISE(ABORT, 'CHECK: worked_callsign blocked') " +
+                    "WHERE NEW.worked_callsign = 'BLOCKED'; END;";
+                cmd.ExecuteNonQuery();
+            }
+
+            var qso = MakeQso("chk1", "BLOCKED", Band._20M, Mode.Cw, "2026-01-15T12:00:00Z");
+            var ex = await Assert.ThrowsAsync<StorageException>(
+                () => storage.Logbook.InsertQsoAsync(qso).AsTask());
+
+            Assert.Equal(StorageErrorKind.Backend, ex.Kind);
+            Assert.Contains("Constraint violation", ex.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+            {
+                File.Delete(dbPath);
+            }
+        }
     }
 
     [Fact]

--- a/src/dotnet/QsoRipper.Engine.Storage.Sqlite/SqliteStorage.cs
+++ b/src/dotnet/QsoRipper.Engine.Storage.Sqlite/SqliteStorage.cs
@@ -99,9 +99,13 @@ public sealed class SqliteStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
                 BindQsoParameters(cmd, qso);
                 cmd.ExecuteNonQuery();
             }
-            catch (SqliteException ex) when (ex.SqliteErrorCode == 19) // SQLITE_CONSTRAINT
+            catch (SqliteException ex) when (ex.SqliteExtendedErrorCode is 1555 or 2067) // SQLITE_CONSTRAINT_PRIMARYKEY / UNIQUE
             {
                 throw StorageException.Duplicate("QsoRecord", qso.LocalId);
+            }
+            catch (SqliteException ex) when (ex.SqliteErrorCode == 19) // other SQLITE_CONSTRAINT (NOT NULL, CHECK, FK)
+            {
+                throw StorageException.Backend($"Constraint violation inserting QsoRecord {qso.LocalId}: {ex.Message}");
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes #267. `SqliteStorage.InsertQsoAsync` previously caught all `SQLITE_CONSTRAINT` errors (error code 19) and mapped them to `StorageException.Duplicate`. This is incorrect for NOT NULL, CHECK, and FOREIGN KEY violations.

## Changes

- **`SqliteStorage.cs`**: Now checks `SqliteExtendedErrorCode` for `PRIMARYKEY` (1555) and `UNIQUE` (2067) specifically. Other constraint violations fall through to `StorageException.Backend` with the original SQLite message.
- **`SqliteStorageTests.cs`**: Added test using a `BEFORE INSERT` trigger to verify non-UNIQUE constraint violations produce `Backend` errors, not `Duplicate`.

## Verification

All 44 SQLite storage tests pass. `dotnet format` clean.
