### PR TITLE
fix: QRZ dedup bug + engine parity (REPLACE, STATUS, ConflictPolicy, logid round-trip)

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -1036,28 +1036,33 @@ The QRZ logbook sync is a three-phase operation:
 
 #### Phase 1: Download
 
-1. Call QRZ logbook API `FETCH` with `OPTION=ALL`.
-2. Parse the ADIF response into QSO records.
+1. Call QRZ logbook API `FETCH` with `OPTION=ALL` (full sync) or `OPTION=ALL,MODSINCE:YYYY-MM-DD` (incremental).
+2. Parse the ADIF response into QSO records. Engines MUST recognise QRZ-specific ADIF application fields and map them onto dedicated domain fields (see §7.5 Import).
 3. For each remote QSO:
-   a. Attempt to match against local records using fuzzy matching: callsign (case-insensitive) + UTC timestamp (within a tolerance window) + band + mode.
-   b. If matched, compare and update per the `ConflictPolicy`:
-      - `LOCAL_WINS` — keep local version, only update `qrz_logid`.
-      - `REMOTE_WINS` — overwrite local fields with remote data.
-      - `NEWEST_WINS` — keep the version with the later `updated_at`.
-   c. If unmatched, insert as a new local record with `sync_status = SYNCED`.
-4. Filter ghost records: QSOs that appear in the remote data but are clearly duplicates or artifacts.
+   a. Prefer a direct match on `qrz_logid` if one was returned for that record.
+   b. Otherwise, fuzzy-match against local records: callsign (case-insensitive) + UTC timestamp (within a tolerance window, typically ±60s) + band + mode.
+   c. If matched, apply the configured `ConflictPolicy`:
+      - `CONFLICT_POLICY_LAST_WRITE_WINS` — treat the remote record as authoritative and overwrite local fields; mark the merged row as `SYNCED`.
+      - `CONFLICT_POLICY_FLAG_FOR_REVIEW` — when the local row was locally edited (`sync_status = MODIFIED`), preserve the local fields, set `sync_status = CONFLICT`, and increment the sync result's conflict counter so operators can reconcile manually. When the local row is already `SYNCED`, remote wins (no conflict).
+      - `CONFLICT_POLICY_UNSPECIFIED` — engines MUST treat the zero value as `FLAG_FOR_REVIEW` (the safe, non-destructive default) per §6.3.
+   d. If unmatched, insert as a new local record with `sync_status = SYNCED` and populate `qrz_logid` from the remote record.
+4. Filter ghost records: remote QSOs missing required fields (callsign, timestamp) are skipped without incrementing any counter.
 
 #### Phase 2: Upload
 
 1. Query local QSOs with `sync_status` in (`NOT_SYNCED`, `MODIFIED`).
-2. For each, serialize to ADIF and call QRZ logbook API `INSERT`.
-3. On success, update `sync_status = SYNCED` and store the returned `qrz_logid`.
-4. On per-QSO failure, log the error and continue with remaining QSOs.
+2. For each QSO, serialize to ADIF and call the QRZ logbook API:
+   - If `sync_status = NOT_SYNCED` (new record, no `qrz_logid`), use `ACTION=INSERT`.
+   - If `sync_status = MODIFIED` and the record has a `qrz_logid`, use the documented replace form `ACTION=INSERT&OPTION=REPLACE,LOGID:<logid>`. Engines MUST NOT use the undocumented `ACTION=REPLACE` form, which can silently produce duplicate inserts on the remote logbook.
+   - If `sync_status = MODIFIED` but no `qrz_logid` is available (e.g., first sync after upgrading from an engine that didn't persist the logid), fall back to `ACTION=INSERT`. Engines SHOULD additionally run the repair pass described in §7.7 before the first sync so modified-without-logid rows are rare.
+3. Accept both `RESULT=OK` (insert) and `RESULT=REPLACE` (update) as success indicators when parsing the QRZ response.
+4. On success, set `sync_status = SYNCED` and store the returned `LOGID` (or the supplied one for a REPLACE that echoes nothing) in `qrz_logid`.
+5. On per-QSO failure, log the error and continue with remaining QSOs.
 
 #### Phase 3: Metadata
 
-1. Call QRZ logbook API `STATUS` to get the current QSO count and owner.
-2. Update `sync_metadata` with the count, timestamp, and owner callsign.
+1. Call QRZ logbook API `STATUS` to get the current logbook QSO count and owner callsign.
+2. Update `sync_metadata` with the count, timestamp, and owner. If `STATUS` fails, engines SHOULD fall back to locally-computed counts rather than leaving metadata stale.
 
 **Resilience:** A failure in any phase should not prevent other phases from executing. The engine should report partial success/failure in the stream.
 
@@ -1109,17 +1114,27 @@ When DXCC data is available, cascade zone information onto the lookup result if 
 
 1. Parse the ADI-format input (header + records delimited by `<eor>`).
 2. Map ADIF field names to `QsoRecord` proto fields.
-3. Preserve unrecognized ADIF fields in the `extra_fields` map for lossless round-trip.
-4. Generate a `local_id` for each imported record.
-5. Normalize callsigns and validate required fields.
-6. Insert into storage with `sync_status = NOT_SYNCED`.
+3. Map QRZ-specific application fields to dedicated domain fields — not generic `extra_fields` — so sync can round-trip them:
+   - `APP_QRZLOG_LOGID` (canonical) and the legacy alias `APP_QRZ_LOGID` → `qrz_logid`
+   - `APP_QRZLOG_QSO_ID` (canonical) and the legacy alias `APP_QRZ_BOOKID` → `qrz_bookid`
+   Engines MUST NOT leave these app keys in `extra_fields` once a dedicated domain field carries the value, otherwise downstream sync will treat the record as unlinked and re-upload it as a duplicate.
+4. Preserve any other unrecognized ADIF fields in the `extra_fields` map for lossless round-trip.
+5. Generate a `local_id` for each imported record.
+6. Normalize callsigns and validate required fields.
+7. Insert into storage with `sync_status = NOT_SYNCED`.
+
+See `docs/integrations/adif-specification.md` for the authoritative field-name table.
 
 #### Export
 
 1. Generate an ADIF header with program name and version.
 2. For each QSO, serialize proto fields back to ADIF field names.
-3. Include `extra_fields` to preserve data from previous imports.
-4. Output records delimited by `<eor>`.
+3. Emit QRZ app fields whenever the corresponding domain field is populated:
+   - `qrz_logid` → `APP_QRZLOG_LOGID`
+   - `qrz_bookid` → `APP_QRZLOG_QSO_ID`
+   When iterating `extra_fields`, skip keys already covered by these dedicated emissions (`APP_QRZLOG_LOGID`, `APP_QRZ_LOGID`, `APP_QRZLOG_QSO_ID`, `APP_QRZ_BOOKID`) to avoid duplicate ADIF fields.
+4. Include other `extra_fields` to preserve data from previous imports.
+5. Output records delimited by `<eor>`.
 
 ### 7.6 Error Handling
 
@@ -1142,6 +1157,16 @@ When DXCC data is available, cascade zone information onto the lookup result if 
 | `UNAVAILABLE` | External service unreachable |
 | `UNIMPLEMENTED` | RPC is defined but not yet implemented |
 | `INTERNAL` | Unexpected server error (storage failure, serialization bug) |
+
+### 7.7 Startup Data-Repair Pass
+
+Engines that persist `extra_fields` as an opaque blob MUST run a best-effort data-repair pass on startup against the active logbook store. The pass:
+
+1. **Backfills dedicated domain fields from legacy `extra_fields`.** Scans every QSO and, for each record where `qrz_logid`/`qrz_bookid` are empty but a legacy key exists in `extra_fields` (e.g. `APP_QRZ_LOGID`, `APP_QRZLOG_LOGID`, `APP_QRZ_BOOKID`, `APP_QRZLOG_QSO_ID`), moves the value into the dedicated field and removes the legacy key from `extra_fields`.
+2. **Collapses duplicate rows that share a `qrz_logid`.** After the backfill, any group of QSOs with the same non-empty `qrz_logid` represents a historical duplicate-import bug. The engine keeps the oldest row as the winner, merges non-empty string fields from the losing rows into the winner, and deletes the losers. The winner keeps `sync_status = SYNCED`.
+3. **Logs a summary** of how many rows were backfilled, how many duplicates were collapsed, and any per-row errors, but does not fail engine startup on per-row errors.
+
+This pass exists because an earlier engine revision failed to map QRZ app fields onto dedicated domain columns (see §7.5 Import), causing subsequent syncs to re-upload every QSO as a new record and multiplying the logbook. The repair pass is idempotent; engines that have already cleaned their data will do no work on subsequent startups.
 
 ---
 
@@ -1230,15 +1255,15 @@ A conformant engine must pass all of the following scenarios:
 
 #### Lookup (if credentials available)
 
-14. `Lookup` for a known callsign returns a populated `CallsignRecord`.
-15. `GetCachedCallsign` returns the cached result after a successful lookup.
-16. `Lookup` for an unknown callsign returns `LOOKUP_STATE_NOT_FOUND`.
+15. `Lookup` for a known callsign returns a populated `CallsignRecord`.
+16. `GetCachedCallsign` returns the cached result after a successful lookup.
+17. `Lookup` for an unknown callsign returns `LOOKUP_STATE_NOT_FOUND`.
 
 #### Degradation
 
-17. Engine starts successfully with no QRZ credentials configured.
-18. Engine starts successfully with no rigctld configured.
-19. `LogQso` works when external integrations are unavailable.
+18. Engine starts successfully with no QRZ credentials configured.
+19. Engine starts successfully with no rigctld configured.
+20. `LogQso` works when external integrations are unavailable.
 
 ---
 
@@ -1270,7 +1295,7 @@ A conformant engine must pass all of the following scenarios:
 | **Location** | `src/dotnet/QsoRipper.Engine.DotNet/` |
 | **Language** | C# |
 | **gRPC framework** | Grpc.Tools + ASP.NET Core |
-| **Storage backend** | In-memory (managed state) |
+| **Storage backend** | In-memory (managed state) or SQLite (`QsoRipper.Engine.Storage.Sqlite`) |
 | **Build** | `dotnet build src/dotnet/QsoRipper.Engine.DotNet/QsoRipper.Engine.DotNet.csproj` |
 | **Run** | `dotnet run --project src/dotnet/QsoRipper.Engine.DotNet/QsoRipper.Engine.DotNet.csproj` |
 | **Test** | `dotnet test src/dotnet/QsoRipper.Engine.DotNet.Tests/` |
@@ -1315,3 +1340,12 @@ A conformant engine must pass all of the following scenarios:
 - Run `buf lint` to validate proto files. Run `buf breaking` to guard against incompatible schema changes.
 
 See `docs/architecture/data-model.md` for the complete proto conventions and field-addition guide.
+
+## Appendix C: Known Follow-Up Work
+
+The following gaps are documented tracking items. They do not affect the normative behaviour above; they identify places where individual reference engines do not yet fully meet this spec and are being closed in follow-up PRs.
+
+- **.NET engine — `SyncWithQrz` streaming granularity.** The .NET engine currently produces a single terminal `SyncWithQrzResponse` instead of per-phase progress messages. Matches the spec's RPC signature but loses UI progress fidelity vs. the Rust engine.
+- **.NET engine — QRZ ADIF field coverage.** The .NET `AdifCodec` does not yet parse/emit every QRZ-specific field the Rust mapper covers (e.g., `ARRL_SECT`, SKCC, QSL/LOTW/EQSL date and flag variants, `MY_LAT`/`MY_LON`, `MY_ARRL_SECT`, `MY_CQ_ZONE`/`MY_ITU_ZONE`). Missing fields round-trip via `extra_fields` today, but should graduate to dedicated domain columns.
+- **.NET engine — Phase 3 `STATUS` call.** The .NET sync currently computes metadata from locally-merged results rather than calling QRZ `STATUS`. The Rust engine calls `STATUS` with local-fallback per §7.3 Phase 3; .NET should follow suit.
+- **.NET engine — `DeleteQsoAsync` parity.** The .NET `QrzLogbookClient` does not yet expose a delete helper matching the Rust client's semantics; currently local-only deletes are fully supported but remote `ACTION=DELETE` is not wired.

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -583,7 +583,8 @@ internal sealed class ManagedEngineState
 
             try
             {
-                var result = Sync(_syncEngine.ExecuteSyncAsync(_storage.Logbook, fullSync));
+                var conflictPolicy = _syncConfig?.ConflictPolicy ?? ConflictPolicy.Unspecified;
+                var result = Sync(_syncEngine.ExecuteSyncAsync(_storage.Logbook, fullSync, conflictPolicy));
 
                 var syncResponse = new SyncWithQrzResponse
                 {

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/AdifCodecTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/AdifCodecTests.cs
@@ -263,4 +263,48 @@ public sealed class AdifCodecTests
         Assert.Single(parsed);
         Assert.Equal("hello", parsed[0].ExtraFields["CUSTOM_APP_FIELD"]);
     }
+
+    [Fact]
+    public void Serialize_emits_qrz_logid_as_app_qrzlog_logid()
+    {
+        // Engines must round-trip qrz_logid via APP_QRZLOG_LOGID so that
+        // subsequent syncs can recognise previously-uploaded QSOs and avoid
+        // re-inserting them as duplicates (root cause of the April 2026 dup bug).
+        var original = new QsoRecord
+        {
+            WorkedCallsign = "W1AW",
+            Band = Band._20M,
+            Mode = Mode.Ft8,
+            UtcTimestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)),
+            QrzLogid = "123456",
+            QrzBookid = "bk-42",
+        };
+
+        var adif = AdifCodec.SerializeSingleQso(original);
+
+        Assert.Contains("<APP_QRZLOG_LOGID:6>123456", adif);
+        Assert.Contains("<APP_QRZLOG_QSO_ID:5>bk-42", adif);
+    }
+
+    [Fact]
+    public void Serialize_then_parse_preserves_qrz_logid()
+    {
+        var original = new QsoRecord
+        {
+            WorkedCallsign = "W1AW",
+            Band = Band._20M,
+            Mode = Mode.Ft8,
+            UtcTimestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)),
+            QrzLogid = "987654",
+        };
+
+        var adif = AdifCodec.SerializeSingleQso(original);
+        var parsed = AdifCodec.ParseAdif($"<EOH>\n{adif}");
+
+        Assert.Single(parsed);
+        Assert.Equal("987654", parsed[0].QrzLogid);
+        // The app key should not leak into ExtraFields — it is represented
+        // by the dedicated QrzLogid domain field only.
+        Assert.False(parsed[0].ExtraFields.ContainsKey("APP_QRZLOG_LOGID"));
+    }
 }

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzLogbookClientTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzLogbookClientTests.cs
@@ -127,6 +127,87 @@ public sealed class QrzLogbookClientTests
         }
     }
 
+    // -- UpdateQso (REPLACE) -------------------------------------------------
+
+    [Fact]
+    public async Task Update_sends_action_insert_with_option_replace_logid()
+    {
+        // QRZ logbook docs specify ACTION=INSERT&OPTION=REPLACE,LOGID:<id>
+        // for updating an existing QSO. Using the undocumented ACTION=REPLACE
+        // can cause duplicate inserts on some API endpoints.
+        var (client, handler) = CreateClient("RESULT=REPLACE&LOGID=42");
+
+        using (client)
+        {
+            var qso = new QsoRipper.Domain.QsoRecord
+            {
+                LocalId = "00000000-0000-0000-0000-000000000001",
+                WorkedCallsign = "W1AW",
+                Band = QsoRipper.Domain.Band._20M,
+                Mode = QsoRipper.Domain.Mode.Ft8,
+                UtcTimestamp = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(
+                    new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)),
+                QrzLogid = "42",
+            };
+
+            var returned = await client.UpdateQsoAsync(qso);
+
+            Assert.Equal("42", returned);
+        }
+
+        Assert.NotNull(handler.CapturedBody);
+        Assert.Contains("ACTION=INSERT", handler.CapturedBody!);
+        Assert.Contains("OPTION=REPLACE%2CLOGID%3A42", handler.CapturedBody!);
+    }
+
+    [Fact]
+    public async Task Update_accepts_response_with_result_replace()
+    {
+        // The REPLACE action returns RESULT=REPLACE (not RESULT=OK). Parser
+        // must treat that as success.
+        var (client, _) = CreateClient("RESULT=REPLACE&LOGID=99");
+
+        using (client)
+        {
+            var qso = new QsoRipper.Domain.QsoRecord
+            {
+                LocalId = "00000000-0000-0000-0000-000000000002",
+                WorkedCallsign = "K5ABC",
+                Band = QsoRipper.Domain.Band._40M,
+                Mode = QsoRipper.Domain.Mode.Cw,
+                UtcTimestamp = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(
+                    new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)),
+                QrzLogid = "99",
+            };
+
+            var returned = await client.UpdateQsoAsync(qso);
+            Assert.Equal("99", returned);
+        }
+    }
+
+    [Fact]
+    public async Task Update_falls_back_to_supplied_logid_when_response_omits_it()
+    {
+        var (client, _) = CreateClient("RESULT=REPLACE");
+
+        using (client)
+        {
+            var qso = new QsoRipper.Domain.QsoRecord
+            {
+                LocalId = "00000000-0000-0000-0000-000000000003",
+                WorkedCallsign = "N0ABC",
+                Band = QsoRipper.Domain.Band._20M,
+                Mode = QsoRipper.Domain.Mode.Ft8,
+                UtcTimestamp = Google.Protobuf.WellKnownTypes.Timestamp.FromDateTimeOffset(
+                    new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)),
+                QrzLogid = "777",
+            };
+
+            var returned = await client.UpdateQsoAsync(qso);
+            Assert.Equal("777", returned);
+        }
+    }
+
     // -- Helpers --------------------------------------------------------------
 
     private static (QrzLogbookClient Client, CapturingHandler Handler) CreateClient(string responseBody)

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
@@ -422,6 +422,119 @@ public sealed class QrzSyncEngineTests
         Assert.Null(QrzSyncEngine.ExtractQrzLogid(qso));
     }
 
+    // -- ConflictPolicy -----------------------------------------------------
+
+    [Fact]
+    public async Task Merge_last_write_wins_overwrites_local_modifications()
+    {
+        var store = CreateStore();
+        var local = MakeLocalQso("W1AW", BaseTime, Band._20M, Mode.Ft8, SyncStatus.Modified);
+        local.QrzLogid = "700";
+        local.Notes = "Local edit that should be overwritten";
+        await store.Logbook.InsertQsoAsync(local);
+
+        var remote = MakeRemoteQso("W1AW", BaseTime, Band._20M, Mode.Ft8, "700");
+        remote.Notes = "Remote copy";
+
+        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var engine = new QrzSyncEngine(api);
+
+        var result = await engine.ExecuteSyncAsync(
+            store.Logbook,
+            fullSync: true,
+            ConflictPolicy.LastWriteWins);
+
+        Assert.Equal(0u, result.ConflictCount);
+        var all = await store.Logbook.ListQsosAsync(new QsoListQuery());
+        Assert.Single(all);
+        Assert.Equal("Remote copy", all[0].Notes);
+        Assert.Equal(SyncStatus.Synced, all[0].SyncStatus);
+    }
+
+    [Fact]
+    public async Task Merge_flag_for_review_preserves_local_and_marks_conflict()
+    {
+        var store = CreateStore();
+        var local = MakeLocalQso("W1AW", BaseTime, Band._20M, Mode.Ft8, SyncStatus.Modified);
+        local.QrzLogid = "800";
+        local.Notes = "Local operator edit";
+        await store.Logbook.InsertQsoAsync(local);
+
+        var remote = MakeRemoteQso("W1AW", BaseTime, Band._20M, Mode.Ft8, "800");
+        remote.Notes = "Remote that should NOT win";
+
+        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var engine = new QrzSyncEngine(api);
+
+        var result = await engine.ExecuteSyncAsync(
+            store.Logbook,
+            fullSync: true,
+            ConflictPolicy.FlagForReview);
+
+        Assert.Equal(1u, result.ConflictCount);
+        var all = await store.Logbook.ListQsosAsync(new QsoListQuery());
+        Assert.Single(all);
+        Assert.Equal("Local operator edit", all[0].Notes);
+        Assert.Equal(SyncStatus.Conflict, all[0].SyncStatus);
+        Assert.Equal("800", all[0].QrzLogid);
+    }
+
+    [Fact]
+    public async Task Merge_unspecified_policy_defaults_to_flag_for_review()
+    {
+        var store = CreateStore();
+        var local = MakeLocalQso("W1AW", BaseTime, Band._20M, Mode.Ft8, SyncStatus.Modified);
+        local.QrzLogid = "900";
+        local.Notes = "Local edit";
+        await store.Logbook.InsertQsoAsync(local);
+
+        var remote = MakeRemoteQso("W1AW", BaseTime, Band._20M, Mode.Ft8, "900");
+        remote.Notes = "Remote copy";
+
+        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var engine = new QrzSyncEngine(api);
+
+        // Unspecified must act like FlagForReview per engine spec §6.3.
+        var result = await engine.ExecuteSyncAsync(
+            store.Logbook,
+            fullSync: true,
+            ConflictPolicy.Unspecified);
+
+        Assert.Equal(1u, result.ConflictCount);
+        var all = await store.Logbook.ListQsosAsync(new QsoListQuery());
+        Assert.Equal("Local edit", all[0].Notes);
+        Assert.Equal(SyncStatus.Conflict, all[0].SyncStatus);
+    }
+
+    [Fact]
+    public async Task Merge_synced_local_always_accepts_remote_regardless_of_policy()
+    {
+        // When local is already Synced (no user edits since last sync), the
+        // remote is authoritative no matter what the conflict policy is, and
+        // the row is not counted as a conflict.
+        var store = CreateStore();
+        var local = MakeLocalQso("W1AW", BaseTime, Band._20M, Mode.Ft8, SyncStatus.Synced);
+        local.QrzLogid = "1000";
+        local.Notes = "Old synced value";
+        await store.Logbook.InsertQsoAsync(local);
+
+        var remote = MakeRemoteQso("W1AW", BaseTime, Band._20M, Mode.Ft8, "1000");
+        remote.Notes = "Fresh from QRZ";
+
+        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var engine = new QrzSyncEngine(api);
+
+        var result = await engine.ExecuteSyncAsync(
+            store.Logbook,
+            fullSync: true,
+            ConflictPolicy.FlagForReview);
+
+        Assert.Equal(0u, result.ConflictCount);
+        var all = await store.Logbook.ListQsosAsync(new QsoListQuery());
+        Assert.Equal("Fresh from QRZ", all[0].Notes);
+        Assert.Equal(SyncStatus.Synced, all[0].SyncStatus);
+    }
+
     // -- Helpers ------------------------------------------------------------
 
     private static MemoryStorage CreateStore() => new();

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/AdifCodec.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/AdifCodec.cs
@@ -540,12 +540,31 @@ internal static class AdifCodec
             AppendOptional(sb, "MY_COUNTRY", snap.Country);
         }
 
+        // QRZ-specific round-trip fields. Without these the returned-logid
+        // dedup key is lost on ADIF round-trip, causing subsequent syncs to
+        // duplicate every QSO.
+        AppendOptional(sb, "APP_QRZLOG_LOGID", qso.QrzLogid);
+        AppendOptional(sb, "APP_QRZLOG_QSO_ID", qso.QrzBookid);
+
         // Round-trip: emit any extra fields the parser didn't map.
         foreach (var extra in qso.ExtraFields)
         {
+            // Skip keys we emitted via the dedicated proto fields so we
+            // never emit the same ADIF key twice.
+            if (IsQrzAppExtraKey(extra.Key))
+            {
+                continue;
+            }
+
             AppendField(sb, extra.Key, extra.Value);
         }
     }
+
+    private static bool IsQrzAppExtraKey(string key) =>
+        string.Equals(key, "APP_QRZLOG_LOGID", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(key, "APP_QRZ_LOGID", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(key, "APP_QRZLOG_QSO_ID", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(key, "APP_QRZ_BOOKID", StringComparison.OrdinalIgnoreCase);
 
     // -- Helpers -------------------------------------------------------------
 

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
@@ -133,11 +133,14 @@ public sealed class QrzLogbookClient : IQrzLogbookApi, IDisposable
 
         var adifRecord = AdifCodec.SerializeSingleQso(qso);
 
+        // Per docs/integrations/qrz-logbook-api.md the documented way to
+        // update an existing QSO is ACTION=INSERT with
+        // OPTION=REPLACE,LOGID:<id>. The API returns RESULT=REPLACE.
         var formFields = new List<KeyValuePair<string, string>>(4)
         {
-            new("ACTION", "REPLACE"),
+            new("ACTION", "INSERT"),
+            new("OPTION", $"REPLACE,LOGID:{qso.QrzLogid}"),
             new("KEY", _apiKey),
-            new("LOGID", qso.QrzLogid),
             new("ADIF", adifRecord),
         };
 
@@ -145,12 +148,13 @@ public sealed class QrzLogbookClient : IQrzLogbookApi, IDisposable
         var map = QrzResponseParser.ParseKeyValueResponse(body);
         QrzResponseParser.CheckResult(map);
 
-        if (!map.TryGetValue("LOGID", out var logid) || string.IsNullOrWhiteSpace(logid))
+        // QRZ echoes the same LOGID on REPLACE; if absent, fall back.
+        if (map.TryGetValue("LOGID", out var logid) && !string.IsNullOrWhiteSpace(logid))
         {
-            throw new QrzLogbookException("REPLACE response missing LOGID.");
+            return logid;
         }
 
-        return logid;
+        return qso.QrzLogid;
     }
 
     /// <inheritdoc cref="IDisposable.Dispose"/>

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzResponseParser.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzResponseParser.cs
@@ -42,7 +42,8 @@ internal static class QrzResponseParser
             throw new QrzLogbookException("QRZ response missing RESULT field.");
         }
 
-        if (result.Equals("OK", StringComparison.OrdinalIgnoreCase))
+        if (result.Equals("OK", StringComparison.OrdinalIgnoreCase)
+            || result.Equals("REPLACE", StringComparison.OrdinalIgnoreCase))
         {
             return map;
         }

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
@@ -42,10 +42,23 @@ public sealed class QrzSyncEngine
     /// </summary>
     /// <param name="store">The logbook store to sync.</param>
     /// <param name="fullSync">When <c>true</c>, re-fetches all QRZ records instead of incremental.</param>
+    /// <param name="conflictPolicy">
+    /// How to resolve QSOs modified locally and remotely since the last sync.
+    /// <c>CONFLICT_POLICY_UNSPECIFIED</c> is treated as <c>FLAG_FOR_REVIEW</c>
+    /// per the engine spec (safe/non-destructive default).
+    /// </param>
     /// <returns>A <see cref="SyncResult"/> with counts and any error summary.</returns>
-    public async Task<SyncResult> ExecuteSyncAsync(ILogbookStore store, bool fullSync)
+    public async Task<SyncResult> ExecuteSyncAsync(
+        ILogbookStore store,
+        bool fullSync,
+        ConflictPolicy conflictPolicy = ConflictPolicy.Unspecified)
     {
         ArgumentNullException.ThrowIfNull(store);
+
+        // Treat the proto zero-value as the safe default per engine spec §6.3.
+        var effectivePolicy = conflictPolicy == ConflictPolicy.Unspecified
+            ? ConflictPolicy.FlagForReview
+            : conflictPolicy;
 
         var errors = new List<string>();
         uint downloaded = 0;
@@ -156,10 +169,16 @@ public sealed class QrzSyncEngine
             }
             else
             {
-                // Matched existing QSO — merge.
+                // Matched existing QSO — merge using the requested conflict policy.
                 try
                 {
-                    var merged = MergeRemoteIntoLocal(localMatch, remote, remoteLogid);
+                    var (merged, isConflict) =
+                        MergeRemoteIntoLocal(localMatch, remote, remoteLogid, effectivePolicy);
+                    if (isConflict)
+                    {
+                        conflicts++;
+                    }
+
                     if (await store.UpdateQsoAsync(merged).ConfigureAwait(false))
                     {
                         downloaded++;
@@ -315,20 +334,60 @@ public sealed class QrzSyncEngine
     }
 
     /// <summary>
-    /// Merge remote QSO data into an existing local QSO. Preserves the local ID and updates sync metadata.
+    /// Merge remote QSO data into an existing local QSO, honoring the requested conflict policy.
+    /// Returns the merged record along with a flag indicating whether this merge required
+    /// operator attention (conflict) — which is only true when the policy is FlagForReview
+    /// and the local row had unsynced edits.
     /// </summary>
-    private static QsoRecord MergeRemoteIntoLocal(QsoRecord local, QsoRecord remote, string? remoteLogid)
+    private static (QsoRecord Merged, bool IsConflict) MergeRemoteIntoLocal(
+        QsoRecord local,
+        QsoRecord remote,
+        string? remoteLogid,
+        ConflictPolicy policy)
     {
-        // For already-synced records, remote wins (overwrite with fresh remote data).
-        // For local-only records, link to remote and mark synced to avoid duplicate upload.
-        var merged = local.SyncStatus == SyncStatus.Synced ? remote.Clone() : local.Clone();
-        merged.LocalId = local.LocalId;
-        merged.SyncStatus = SyncStatus.Synced;
+        var localHasUnsyncedEdits = local.SyncStatus == SyncStatus.Modified;
 
-        // Preserve or assign logid.
+        // Happy path: local was already Synced (never edited since last sync) or the
+        // QSO is LocalOnly with no prior remote link. Remote wins for previously-synced
+        // rows (they reflect authoritative QRZ state), local is kept otherwise.
+        if (!localHasUnsyncedEdits)
+        {
+            var nonConflict = local.SyncStatus == SyncStatus.Synced ? remote.Clone() : local.Clone();
+            nonConflict.LocalId = local.LocalId;
+            nonConflict.SyncStatus = SyncStatus.Synced;
+            nonConflict.QrzLogid = remoteLogid ?? local.QrzLogid;
+            return (nonConflict, false);
+        }
+
+        // Conflict: local edits exist and remote also has a current version.
+        // The resolver choice determines who wins and whether we mark the row
+        // for operator review per engine spec §6.3.
+        QsoRecord merged;
+        bool requiresReview;
+        switch (policy)
+        {
+            case ConflictPolicy.LastWriteWins:
+                // Remote wins silently — no operator intervention needed, so
+                // this is NOT counted as a conflict in the sync result.
+                merged = remote.Clone();
+                merged.LocalId = local.LocalId;
+                merged.SyncStatus = SyncStatus.Synced;
+                requiresReview = false;
+                break;
+
+            case ConflictPolicy.FlagForReview:
+            default:
+                // Preserve the local edit but mark the row so operators can
+                // reconcile manually. Do NOT silently discard user data.
+                merged = local.Clone();
+                merged.LocalId = local.LocalId;
+                merged.SyncStatus = SyncStatus.Conflict;
+                requiresReview = true;
+                break;
+        }
+
         merged.QrzLogid = remoteLogid ?? local.QrzLogid;
-
-        return merged;
+        return (merged, requiresReview);
     }
 
     private static string? FormatSinceDate(SyncMetadata metadata)

--- a/src/rust/qsoripper-core/src/adif/mapper.rs
+++ b/src/rust/qsoripper-core/src/adif/mapper.rs
@@ -267,6 +267,24 @@ impl AdifMapper {
                 "COMMENT" => qso.comment = Some(value_str.to_owned()),
                 "NOTES" => qso.notes = Some(value_str.to_owned()),
 
+                // --- QRZ-specific application fields ---
+                //
+                // QRZ Logbook returns each record with `<APP_QRZLOG_LOGID:N>`
+                // as the per-record identifier (and `<APP_QRZLOG_QSO_ID:N>`
+                // for the QRZ "book" id). These must land in the dedicated
+                // proto fields so QRZ-pull dedup matches by logid instead of
+                // falling back to fuzzy callsign+band+mode+timestamp matching
+                // (which is what created the duplicate-import regression).
+                // See docs/integrations/qrz-logbook-api.md for the canonical
+                // field names. `APP_QRZ_LOGID` is accepted as a legacy alias
+                // because earlier internal builds used that key.
+                "APP_QRZLOG_LOGID" | "APP_QRZ_LOGID" => {
+                    qso.qrz_logid = Some(value_str.to_owned());
+                }
+                "APP_QRZLOG_QSO_ID" | "APP_QRZ_BOOKID" => {
+                    qso.qrz_bookid = Some(value_str.to_owned());
+                }
+
                 // --- Everything else → extra_fields for round-trip ---
                 _ => {
                     qso.extra_fields.insert(key_upper, value_str.to_owned());
@@ -563,6 +581,18 @@ impl AdifMapper {
         }
         if let Some(v) = qso.notes.as_deref() {
             push_field(&mut fields, "NOTES", v);
+        }
+
+        // QRZ application fields (canonical names from the QRZ Logbook API).
+        if let Some(v) = qso.qrz_logid.as_deref() {
+            if !v.is_empty() {
+                push_field(&mut fields, "APP_QRZLOG_LOGID", v);
+            }
+        }
+        if let Some(v) = qso.qrz_bookid.as_deref() {
+            if !v.is_empty() {
+                push_field(&mut fields, "APP_QRZLOG_QSO_ID", v);
+            }
         }
 
         // Extra fields (round-trip overflow)
@@ -870,6 +900,14 @@ fn field_is_overridden(
             .is_some()
     } else if key.eq_ignore_ascii_case("QSO_DATE_OFF") || key.eq_ignore_ascii_case("TIME_OFF") {
         qso.utc_end_timestamp.is_some()
+    } else if key.eq_ignore_ascii_case("APP_QRZLOG_LOGID")
+        || key.eq_ignore_ascii_case("APP_QRZ_LOGID")
+    {
+        qso.qrz_logid.is_some()
+    } else if key.eq_ignore_ascii_case("APP_QRZLOG_QSO_ID")
+        || key.eq_ignore_ascii_case("APP_QRZ_BOOKID")
+    {
+        qso.qrz_bookid.is_some()
     } else {
         false
     }
@@ -1685,5 +1723,103 @@ mod tests {
             .map(|(_, v)| v.as_str())
             .collect();
         assert_eq!(skcc_out, vec!["999S"]);
+    }
+
+    // ---- QRZ-specific application fields ---------------------------------
+    //
+    // Regression coverage for the QRZ sync duplicate-import bug: the QRZ
+    // logbook returns each QSO with `<APP_QRZLOG_LOGID:N>` as the per-record
+    // identifier (and `<APP_QRZLOG_QSO_ID:N>` for the book id). Without these
+    // mappings, every pull from QRZ leaves `qrz_logid` empty, which forces
+    // the sync layer to fall back to fuzzy callsign+band+mode+timestamp
+    // matching and produces duplicate rows whenever any of those drift.
+
+    #[test]
+    fn record_to_qso_maps_app_qrzlog_logid_to_qrz_logid() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "W1AW").unwrap();
+        rec.insert("APP_QRZLOG_LOGID", "987654321").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+        assert_eq!(
+            qso.qrz_logid.as_deref(),
+            Some("987654321"),
+            "APP_QRZLOG_LOGID must populate the dedicated qrz_logid field, not extra_fields"
+        );
+        assert!(
+            !qso.extra_fields.contains_key("APP_QRZLOG_LOGID"),
+            "QRZ logid should not be duplicated into extra_fields"
+        );
+    }
+
+    #[test]
+    fn record_to_qso_maps_legacy_app_qrz_logid_alias() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "W1AW").unwrap();
+        rec.insert("APP_QRZ_LOGID", "12345").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+        assert_eq!(
+            qso.qrz_logid.as_deref(),
+            Some("12345"),
+            "Legacy APP_QRZ_LOGID alias should also populate qrz_logid"
+        );
+    }
+
+    #[test]
+    fn record_to_qso_maps_app_qrzlog_qso_id_to_qrz_bookid() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "W1AW").unwrap();
+        rec.insert("APP_QRZLOG_QSO_ID", "BOOK-42").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+        assert_eq!(qso.qrz_bookid.as_deref(), Some("BOOK-42"));
+        assert!(!qso.extra_fields.contains_key("APP_QRZLOG_QSO_ID"));
+    }
+
+    #[test]
+    fn qso_to_adif_fields_emits_qrz_logid_and_bookid() {
+        let qso = crate::proto::qsoripper::domain::QsoRecord {
+            worked_callsign: "W1AW".into(),
+            qrz_logid: Some("987654321".into()),
+            qrz_bookid: Some("BOOK-1".into()),
+            ..Default::default()
+        };
+
+        let fields = AdifMapper::qso_to_adif_fields(&qso);
+        let logid = fields
+            .iter()
+            .find(|(k, _)| k == "APP_QRZLOG_LOGID")
+            .map(|(_, v)| v.as_str());
+        let bookid = fields
+            .iter()
+            .find(|(k, _)| k == "APP_QRZLOG_QSO_ID")
+            .map(|(_, v)| v.as_str());
+        assert_eq!(logid, Some("987654321"));
+        assert_eq!(bookid, Some("BOOK-1"));
+    }
+
+    #[test]
+    fn qrz_logid_round_trips_through_adif() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "K7ABC").unwrap();
+        rec.insert("APP_QRZLOG_LOGID", "55555").unwrap();
+        rec.insert("APP_QRZLOG_QSO_ID", "BOOK-99").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+        let fields = AdifMapper::qso_to_adif_fields(&qso);
+
+        // Each field must appear exactly once on the way back out — never
+        // both as the dedicated mapping AND as a leftover extra_field.
+        let logid_count = fields
+            .iter()
+            .filter(|(k, _)| k == "APP_QRZLOG_LOGID")
+            .count();
+        let bookid_count = fields
+            .iter()
+            .filter(|(k, _)| k == "APP_QRZLOG_QSO_ID")
+            .count();
+        assert_eq!(logid_count, 1, "logid should round-trip exactly once");
+        assert_eq!(bookid_count, 1, "bookid should round-trip exactly once");
     }
 }

--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -1359,9 +1359,15 @@ mod tests {
         assert!(body.contains("ACTION=INSERT"));
         // OPTION=REPLACE,LOGID:555444333 — the comma and colon are URL-encoded
         // so we just verify the discriminating substrings are present.
-        assert!(body.contains("OPTION=REPLACE"), "missing OPTION=REPLACE: {body}");
+        assert!(
+            body.contains("OPTION=REPLACE"),
+            "missing OPTION=REPLACE: {body}"
+        );
         assert!(body.contains("LOGID"), "missing logid in OPTION: {body}");
-        assert!(body.contains("555444333"), "missing logid value in OPTION: {body}");
+        assert!(
+            body.contains("555444333"),
+            "missing logid value in OPTION: {body}"
+        );
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -200,7 +200,10 @@ fn parse_kv_response(body: &str) -> HashMap<String, String> {
 /// [`QrzLogbookError`] variant when it is not.
 fn check_result(map: HashMap<String, String>) -> Result<HashMap<String, String>, QrzLogbookError> {
     match map.get("RESULT").map(String::as_str) {
-        Some("OK") => Ok(map),
+        // QRZ returns RESULT=OK for INSERT/FETCH/STATUS/DELETE successes and
+        // RESULT=REPLACE for `INSERT&OPTION=REPLACE,LOGID:...` successes.
+        // Treat both as success per docs/integrations/qrz-logbook-api.md.
+        Some("OK" | "REPLACE") => Ok(map),
         Some("FAIL") => {
             let reason = map
                 .get("REASON")
@@ -467,7 +470,7 @@ impl QrzLogbookClient {
             .map_err(QrzLogbookError::ParseError)
     }
 
-    /// Upload a single QSO to the QRZ Logbook.
+    /// Upload a single QSO to the QRZ Logbook as a new record.
     ///
     /// The QSO is serialized to an ADIF record string and sent via the
     /// `INSERT` action.
@@ -493,6 +496,55 @@ impl QrzLogbookClient {
         }
 
         Ok(QrzUploadResult { logid })
+    }
+
+    /// Replace an existing QSO on the QRZ Logbook in place.
+    ///
+    /// Per the QRZ Logbook API contract this is `ACTION=INSERT` with
+    /// `OPTION=REPLACE,LOGID:<id>`. The server keeps the same `LOGID`
+    /// rather than minting a new one. Modified QSOs that already have a
+    /// `qrz_logid` MUST go through this path instead of `upload_qso` to
+    /// avoid creating duplicate rows on QRZ.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on network failure, authentication failure, or if
+    /// the QRZ API rejects the record (including when `logid` does not
+    /// match an existing record on QRZ).
+    pub async fn replace_qso(
+        &self,
+        logid: &str,
+        qso: &QsoRecord,
+    ) -> Result<QrzUploadResult, QrzLogbookError> {
+        if logid.is_empty() {
+            return Err(QrzLogbookError::ParseError(
+                "replace_qso called with empty logid".to_string(),
+            ));
+        }
+        let adif_record = AdifMapper::qso_to_adi(qso);
+        let option = format!("REPLACE,LOGID:{logid}");
+
+        let body = self
+            .post_form(&[
+                ("ACTION", "INSERT"),
+                ("OPTION", option.as_str()),
+                ("ADIF", &adif_record),
+            ])
+            .await?;
+        let map = parse_kv_response(&body);
+        let map = check_result(map)?;
+
+        // QRZ returns the same LOGID on REPLACE; if absent, fall back to the
+        // one we sent.
+        let returned_logid = map
+            .get("LOGID")
+            .cloned()
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| logid.to_string());
+
+        Ok(QrzUploadResult {
+            logid: returned_logid,
+        })
     }
 
     /// Delete a QSO from the QRZ Logbook by its logbook record ID.
@@ -1282,6 +1334,56 @@ mod tests {
     }
 
     // -- delete_qso integration ---------------------------------------------
+
+    #[tokio::test]
+    async fn replace_qso_sends_replace_option_with_logid() {
+        let (base_url, requests) =
+            spawn_logbook_server(&[("text/plain", "RESULT=REPLACE&LOGID=555444333")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            ..Default::default()
+        };
+        let result = client
+            .replace_qso("555444333", &qso)
+            .await
+            .expect("replace");
+
+        assert_eq!(
+            result.logid, "555444333",
+            "REPLACE should preserve the original logid"
+        );
+
+        let body = &requests.lock().expect("requests")[0];
+        assert!(body.contains("ACTION=INSERT"));
+        // OPTION=REPLACE,LOGID:555444333 — the comma and colon are URL-encoded
+        // so we just verify the discriminating substrings are present.
+        assert!(body.contains("OPTION=REPLACE"), "missing OPTION=REPLACE: {body}");
+        assert!(body.contains("LOGID"), "missing logid in OPTION: {body}");
+        assert!(body.contains("555444333"), "missing logid value in OPTION: {body}");
+    }
+
+    #[tokio::test]
+    async fn replace_qso_falls_back_to_supplied_logid_when_response_missing_it() {
+        let (base_url, _) = spawn_logbook_server(&[("text/plain", "RESULT=REPLACE")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        let qso = QsoRecord::default();
+        let result = client.replace_qso("777", &qso).await.expect("replace");
+        assert_eq!(result.logid, "777");
+    }
+
+    #[tokio::test]
+    async fn replace_qso_rejects_empty_logid() {
+        let client =
+            QrzLogbookClient::new(test_config("http://127.0.0.1:1".to_string())).expect("client");
+        let err = client
+            .replace_qso("", &QsoRecord::default())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, QrzLogbookError::ParseError(_)));
+    }
 
     #[tokio::test]
     async fn delete_qso_success() {

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -1,5 +1,6 @@
 //! Runnable tonic gRPC host for the `QsoRipper` Rust engine.
 
+mod repair;
 mod runtime_config;
 mod setup;
 mod station_profile_support;
@@ -77,6 +78,27 @@ where
     );
     let sync_scheduler = Arc::new(sync_scheduler::SyncScheduler::new());
     sync_scheduler.start(runtime_config.clone());
+
+    // One-shot QRZ logid backfill + duplicate collapse. Older builds never
+    // mapped APP_QRZLOG_LOGID into qrz_logid, so QRZ pulls produced rows
+    // that subsequent syncs duplicated whenever fuzzy matching missed.
+    // Repair is idempotent — clean stores are a no-op.
+    {
+        let logbook_engine = runtime_config.logbook_engine().await;
+        match repair::backfill_qrz_logids(logbook_engine.logbook_store()).await {
+            Ok(report) => {
+                if !report.is_no_op() {
+                    eprintln!(
+                        "[repair] QRZ logid backfill: backfilled={}, duplicates_removed={}, merged_groups={}",
+                        report.backfilled, report.duplicates_removed, report.merged_groups,
+                    );
+                }
+            }
+            Err(err) => {
+                eprintln!("[repair] QRZ logid backfill failed (continuing startup): {err}");
+            }
+        }
+    }
     let logbook_service =
         DeveloperLogbookService::new(runtime_config.clone(), sync_scheduler.clone());
     let lookup_service = DeveloperLookupService::new(runtime_config.clone());

--- a/src/rust/qsoripper-server/src/repair.rs
+++ b/src/rust/qsoripper-server/src/repair.rs
@@ -1,0 +1,401 @@
+//! One-shot data-repair helpers run during engine startup.
+//!
+//! Older builds of the Rust engine never extracted `APP_QRZLOG_LOGID` from
+//! ADIF responses into the dedicated [`QsoRecord::qrz_logid`] field. As a
+//! result, every QRZ pull persisted records with `qrz_logid = None`, which
+//! caused the QRZ sync layer to fall back to fuzzy
+//! callsign+band+mode+timestamp matching and produced duplicate rows
+//! whenever any of those keys drifted between the local entry and the
+//! QRZ-returned ADIF.
+//!
+//! This module performs a startup sweep over the persisted logbook that:
+//!
+//! 1. Backfills `qrz_logid` from the historical
+//!    `extra_fields["APP_QRZLOG_LOGID"]` / `extra_fields["APP_QRZ_LOGID"]`
+//!    aliases that the old mapper left behind.
+//! 2. Collapses any remaining duplicate rows that share the same
+//!    `qrz_logid`, keeping the row with the earliest `created_at` (or, as a
+//!    tie-break, the lexicographically smallest `local_id`) and deleting
+//!    the rest. The kept row inherits any non-empty fields from the rows
+//!    being removed so user-edited data is preserved when possible.
+//!
+//! Both steps are idempotent — running them on a clean store is a no-op.
+
+use std::collections::HashMap;
+
+use qsoripper_core::proto::qsoripper::domain::QsoRecord;
+use qsoripper_core::storage::{LogbookStore, QsoListQuery, StorageError};
+
+/// Extra-field keys to consult when backfilling `qrz_logid` from records
+/// persisted before the ADIF mapper recognised them.
+const QRZ_LOGID_EXTRA_FIELD_KEYS: &[&str] = &["APP_QRZLOG_LOGID", "APP_QRZ_LOGID"];
+
+/// Aggregate counters describing what the repair pass touched.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct RepairReport {
+    /// Number of rows whose `qrz_logid` was populated from `extra_fields`.
+    pub(crate) backfilled: usize,
+    /// Number of duplicate rows removed (rows kept are not counted here).
+    pub(crate) duplicates_removed: usize,
+    /// Number of distinct logids that had >1 row before merging.
+    pub(crate) merged_groups: usize,
+}
+
+impl RepairReport {
+    /// Did the repair pass make any changes?
+    #[must_use]
+    pub(crate) fn is_no_op(&self) -> bool {
+        self.backfilled == 0 && self.duplicates_removed == 0
+    }
+}
+
+/// Backfill `qrz_logid` from legacy extra-field aliases and merge any rows
+/// that end up sharing the same logid.
+///
+/// The repair pass is best-effort: errors on individual rows are logged via
+/// `eprintln!` but do not abort the sweep, so a single malformed row cannot
+/// keep the engine from starting.
+pub(crate) async fn backfill_qrz_logids(
+    store: &dyn LogbookStore,
+) -> Result<RepairReport, StorageError> {
+    let qsos = store.list_qsos(&QsoListQuery::default()).await?;
+    let mut report = RepairReport::default();
+
+    // ---- Step 1: backfill the dedicated field from extra_fields ----------
+    let mut after_backfill: Vec<QsoRecord> = Vec::with_capacity(qsos.len());
+    for mut qso in qsos {
+        let needs_backfill = qso.qrz_logid.as_deref().is_none_or(str::is_empty)
+            && extract_legacy_logid(&qso).is_some();
+
+        if needs_backfill {
+            if let Some(logid) = extract_legacy_logid(&qso) {
+                qso.qrz_logid = Some(logid);
+                for key in QRZ_LOGID_EXTRA_FIELD_KEYS {
+                    qso.extra_fields.remove(*key);
+                }
+                match store.update_qso(&qso).await {
+                    Ok(true) => report.backfilled += 1,
+                    Ok(false) => {
+                        eprintln!(
+                            "[repair] update_qso reported no row for {} during backfill",
+                            qso.local_id
+                        );
+                    }
+                    Err(err) => {
+                        eprintln!(
+                            "[repair] failed to backfill qrz_logid for {}: {err}",
+                            qso.local_id
+                        );
+                    }
+                }
+            }
+        }
+        after_backfill.push(qso);
+    }
+
+    // ---- Step 2: collapse duplicates that share a qrz_logid --------------
+    let mut groups: HashMap<String, Vec<QsoRecord>> = HashMap::new();
+    for qso in after_backfill {
+        if let Some(logid) = qso.qrz_logid.as_deref() {
+            if !logid.is_empty() {
+                groups.entry(logid.to_string()).or_default().push(qso);
+            }
+        }
+    }
+
+    for (logid, mut rows) in groups {
+        if rows.len() < 2 {
+            continue;
+        }
+        report.merged_groups += 1;
+
+        // Keep the oldest row (smallest created_at_ms; fall back to
+        // lexicographic local_id so the choice is deterministic).
+        rows.sort_by(|a, b| {
+            let a_key = (
+                a.created_at.as_ref().map_or(i64::MAX, |t| t.seconds),
+                a.local_id.as_str(),
+            );
+            let b_key = (
+                b.created_at.as_ref().map_or(i64::MAX, |t| t.seconds),
+                b.local_id.as_str(),
+            );
+            a_key.cmp(&b_key)
+        });
+
+        let mut keeper = rows.remove(0);
+        let mut keeper_changed = false;
+        for victim in rows {
+            keeper_changed |= merge_in_place(&mut keeper, &victim);
+            match store.delete_qso(&victim.local_id).await {
+                Ok(true) => report.duplicates_removed += 1,
+                Ok(false) => {
+                    eprintln!(
+                        "[repair] delete_qso reported no row for duplicate {} (logid {logid})",
+                        victim.local_id
+                    );
+                }
+                Err(err) => {
+                    eprintln!(
+                        "[repair] failed to delete duplicate {} (logid {logid}): {err}",
+                        victim.local_id
+                    );
+                }
+            }
+        }
+        if keeper_changed {
+            if let Err(err) = store.update_qso(&keeper).await {
+                eprintln!(
+                    "[repair] failed to write merged keeper {} (logid {logid}): {err}",
+                    keeper.local_id
+                );
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+/// Look up a non-empty logid in the historical extra-field aliases.
+fn extract_legacy_logid(qso: &QsoRecord) -> Option<String> {
+    for key in QRZ_LOGID_EXTRA_FIELD_KEYS {
+        if let Some(value) = qso.extra_fields.get(*key) {
+            if !value.is_empty() {
+                return Some(value.clone());
+            }
+        }
+    }
+    None
+}
+
+/// Merge any non-empty fields from `victim` into `keeper` without overwriting
+/// values the keeper already has. Returns `true` when at least one field on
+/// the keeper was filled in from the victim.
+fn merge_in_place(keeper: &mut QsoRecord, victim: &QsoRecord) -> bool {
+    let mut changed = false;
+
+    macro_rules! fill_optional_string {
+        ($field:ident) => {
+            if keeper.$field.as_deref().is_none_or(str::is_empty) {
+                if let Some(v) = victim.$field.as_deref().filter(|s| !s.is_empty()) {
+                    keeper.$field = Some(v.to_owned());
+                    changed = true;
+                }
+            }
+        };
+    }
+
+    fill_optional_string!(qrz_bookid);
+    fill_optional_string!(notes);
+    fill_optional_string!(comment);
+    fill_optional_string!(submode);
+    fill_optional_string!(worked_grid);
+    fill_optional_string!(worked_operator_name);
+
+    if keeper.rst_sent.is_none() {
+        if let Some(v) = victim.rst_sent.clone() {
+            keeper.rst_sent = Some(v);
+            changed = true;
+        }
+    }
+    if keeper.rst_received.is_none() {
+        if let Some(v) = victim.rst_received.clone() {
+            keeper.rst_received = Some(v);
+            changed = true;
+        }
+    }
+
+    for (k, v) in &victim.extra_fields {
+        if v.is_empty() {
+            continue;
+        }
+        if !keeper.extra_fields.contains_key(k) {
+            keeper.extra_fields.insert(k.clone(), v.clone());
+            changed = true;
+        }
+    }
+
+    changed
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use prost_types::Timestamp;
+    use qsoripper_core::domain::qso::QsoRecordBuilder;
+    use qsoripper_core::proto::qsoripper::domain::{Band, Mode};
+    use qsoripper_core::storage::{LogbookStore, QsoListQuery};
+    use qsoripper_storage_memory::MemoryStorage;
+
+    use super::backfill_qrz_logids;
+
+    fn qso(
+        local_id: &str,
+        worked: &str,
+        band: Band,
+        mode: Mode,
+        ts: i64,
+    ) -> qsoripper_core::proto::qsoripper::domain::QsoRecord {
+        let mut q = QsoRecordBuilder::new("W1AW", worked)
+            .band(band)
+            .mode(mode)
+            .timestamp(Timestamp {
+                seconds: ts,
+                nanos: 0,
+            })
+            .build();
+        q.local_id = local_id.to_string();
+        q.created_at = Some(Timestamp {
+            seconds: ts,
+            nanos: 0,
+        });
+        q
+    }
+
+    #[tokio::test]
+    async fn backfill_populates_qrz_logid_from_canonical_extra_field() {
+        let store = MemoryStorage::new();
+        let mut q = qso("L1", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        q.extra_fields
+            .insert("APP_QRZLOG_LOGID".into(), "987".into());
+        store.insert_qso(&q).await.unwrap();
+
+        let report = backfill_qrz_logids(&store).await.unwrap();
+        assert_eq!(report.backfilled, 1);
+        assert_eq!(report.duplicates_removed, 0);
+
+        let saved = store.get_qso("L1").await.unwrap().unwrap();
+        assert_eq!(saved.qrz_logid.as_deref(), Some("987"));
+        assert!(
+            !saved.extra_fields.contains_key("APP_QRZLOG_LOGID"),
+            "backfill must remove the legacy extra-field alias once promoted"
+        );
+    }
+
+    #[tokio::test]
+    async fn backfill_populates_qrz_logid_from_legacy_alias() {
+        let store = MemoryStorage::new();
+        let mut q = qso("L1", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        q.extra_fields
+            .insert("APP_QRZ_LOGID".into(), "LEGACY".into());
+        store.insert_qso(&q).await.unwrap();
+
+        let report = backfill_qrz_logids(&store).await.unwrap();
+        assert_eq!(report.backfilled, 1);
+
+        let saved = store.get_qso("L1").await.unwrap().unwrap();
+        assert_eq!(saved.qrz_logid.as_deref(), Some("LEGACY"));
+    }
+
+    #[tokio::test]
+    async fn backfill_skips_rows_with_existing_logid() {
+        let store = MemoryStorage::new();
+        let mut q = qso("L1", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        q.qrz_logid = Some("ALREADY".into());
+        q.extra_fields
+            .insert("APP_QRZLOG_LOGID".into(), "STALE".into());
+        store.insert_qso(&q).await.unwrap();
+
+        let report = backfill_qrz_logids(&store).await.unwrap();
+        assert_eq!(report.backfilled, 0);
+
+        let saved = store.get_qso("L1").await.unwrap().unwrap();
+        assert_eq!(
+            saved.qrz_logid.as_deref(),
+            Some("ALREADY"),
+            "existing dedicated logid takes precedence"
+        );
+        assert_eq!(
+            saved
+                .extra_fields
+                .get("APP_QRZLOG_LOGID")
+                .map(String::as_str),
+            Some("STALE"),
+            "stale extra_field should be left alone when the dedicated field is already set"
+        );
+    }
+
+    #[tokio::test]
+    async fn dedup_removes_duplicate_rows_sharing_a_logid() {
+        let store = MemoryStorage::new();
+        // Two rows that share the same qrz_logid but differ in band/mode —
+        // the kind of pair fuzzy-match would have failed to dedup. The
+        // older row (lower created_at) must be preserved.
+        let mut a = qso("OLD", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        a.qrz_logid = Some("DUP".into());
+        a.notes = Some("operator notes".into());
+        let mut b = qso("NEW", "K7ABC", Band::Band40m, Mode::Cw, 1_700_010_000);
+        b.qrz_logid = Some("DUP".into());
+        b.created_at = Some(Timestamp {
+            seconds: 1_700_010_000,
+            nanos: 0,
+        });
+
+        store.insert_qso(&a).await.unwrap();
+        store.insert_qso(&b).await.unwrap();
+
+        let report = backfill_qrz_logids(&store).await.unwrap();
+        assert_eq!(report.duplicates_removed, 1);
+        assert_eq!(report.merged_groups, 1);
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1);
+        let row = all.first().unwrap();
+        assert_eq!(row.local_id, "OLD", "the older row is the canonical one");
+        assert_eq!(row.qrz_logid.as_deref(), Some("DUP"));
+        assert_eq!(row.notes.as_deref(), Some("operator notes"));
+    }
+
+    #[tokio::test]
+    async fn dedup_after_backfill_collapses_orphaned_pairs() {
+        // Models the user's actual situation: a previously-unkeyed row
+        // (qrz_logid = None, but the legacy extra_field alias carries the
+        // logid) lives next to a keyed row from a later sync. Backfill +
+        // dedup should leave exactly one row with the dedicated logid set.
+        let store = MemoryStorage::new();
+        let mut old = qso("OLD", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        old.qrz_logid = None;
+        old.extra_fields
+            .insert("APP_QRZLOG_LOGID".into(), "DUP".into());
+        let mut newer = qso("NEW", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_010_000);
+        newer.qrz_logid = Some("DUP".into());
+        newer.created_at = Some(Timestamp {
+            seconds: 1_700_010_000,
+            nanos: 0,
+        });
+
+        store.insert_qso(&old).await.unwrap();
+        store.insert_qso(&newer).await.unwrap();
+
+        let report = backfill_qrz_logids(&store).await.unwrap();
+        assert_eq!(report.backfilled, 1);
+        assert_eq!(report.duplicates_removed, 1);
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all.first().unwrap().qrz_logid.as_deref(), Some("DUP"));
+    }
+
+    #[tokio::test]
+    async fn repair_is_idempotent_no_op_on_clean_store() {
+        let store = MemoryStorage::new();
+        let mut q = qso("L1", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        q.qrz_logid = Some("L1".into());
+        store.insert_qso(&q).await.unwrap();
+
+        let r1 = backfill_qrz_logids(&store).await.unwrap();
+        let r2 = backfill_qrz_logids(&store).await.unwrap();
+        assert!(r1.is_no_op());
+        assert!(r2.is_no_op());
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn repair_handles_empty_store() {
+        let store = MemoryStorage::new();
+        let report = backfill_qrz_logids(&store).await.unwrap();
+        assert!(report.is_no_op());
+    }
+}

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -9,7 +9,9 @@ use std::collections::HashMap;
 use qsoripper_core::domain::qso::new_local_id;
 use qsoripper_core::proto::qsoripper::domain::{ConflictPolicy, QsoRecord, SyncStatus};
 use qsoripper_core::proto::qsoripper::services::SyncWithQrzResponse;
-use qsoripper_core::qrz_logbook::{QrzLogbookClient, QrzLogbookError, QrzUploadResult};
+use qsoripper_core::qrz_logbook::{
+    QrzLogbookClient, QrzLogbookError, QrzLogbookStatus, QrzUploadResult,
+};
 use qsoripper_core::storage::{LogbookStore, QsoListQuery, SyncMetadata};
 use tokio::sync::mpsc;
 use tonic::Status;
@@ -56,6 +58,16 @@ pub(crate) trait QrzLogbookApi: Send + Sync {
 
     /// Upload a single QSO and return its QRZ-assigned log ID.
     async fn upload_qso(&self, qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError>;
+
+    /// Replace an existing QSO on the remote logbook (preserves logid).
+    async fn replace_qso(
+        &self,
+        logid: &str,
+        qso: &QsoRecord,
+    ) -> Result<QrzUploadResult, QrzLogbookError>;
+
+    /// Query the remote logbook for the current owner callsign and QSO count.
+    async fn fetch_status(&self) -> Result<QrzLogbookStatus, QrzLogbookError>;
 }
 
 #[tonic::async_trait]
@@ -66,6 +78,18 @@ impl QrzLogbookApi for QrzLogbookClient {
 
     async fn upload_qso(&self, qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError> {
         QrzLogbookClient::upload_qso(self, qso).await
+    }
+
+    async fn replace_qso(
+        &self,
+        logid: &str,
+        qso: &QsoRecord,
+    ) -> Result<QrzUploadResult, QrzLogbookError> {
+        QrzLogbookClient::replace_qso(self, logid, qso).await
+    }
+
+    async fn fetch_status(&self) -> Result<QrzLogbookStatus, QrzLogbookError> {
+        QrzLogbookClient::test_connection(self).await
     }
 }
 
@@ -123,7 +147,7 @@ pub(crate) async fn execute_sync(
 
     upload_phase(client, store, progress_tx, &mut counters).await;
 
-    update_metadata(store, &metadata, &mut counters).await;
+    update_metadata(client, store, &metadata, &mut counters).await;
 
     let error_summary = if counters.errors.is_empty() {
         None
@@ -363,7 +387,19 @@ async fn upload_phase(
     );
 
     for qso in &pending_qsos {
-        match client.upload_qso(qso).await {
+        let is_modified = qso.sync_status == SyncStatus::Modified as i32;
+        let existing_logid = qso.qrz_logid.clone().filter(|s| !s.is_empty());
+
+        let result = match (is_modified, existing_logid.as_deref()) {
+            // Edited locally and we already know its QRZ logid -> REPLACE in
+            // place so QRZ keeps the same row instead of growing a duplicate.
+            (true, Some(logid)) => client.replace_qso(logid, qso).await,
+            // Either a brand-new QSO, or a "modified" QSO that somehow lost
+            // its logid (legacy data). Fall back to INSERT.
+            _ => client.upload_qso(qso).await,
+        };
+
+        match result {
             Ok(result) => {
                 let mut synced = qso.clone();
                 synced.qrz_logid = Some(result.logid);
@@ -400,22 +436,40 @@ async fn upload_phase(
 // ---------------------------------------------------------------------------
 
 async fn update_metadata(
+    client: &dyn QrzLogbookApi,
     store: &dyn LogbookStore,
     prev_metadata: &SyncMetadata,
     counters: &mut SyncCounters,
 ) {
     let now = chrono::Utc::now();
 
-    // Refresh the QRZ QSO count from what the local store now knows.
-    // After a successful bidirectional sync the number of locally-synced
-    // QSOs is the best available estimate of the remote logbook count.
-    let qrz_qso_count = match store.qso_counts().await {
-        Ok(counts) => counts
-            .local_qso_count
-            .saturating_sub(counts.pending_upload_count),
+    // Prefer the authoritative remote STATUS result. If QRZ's STATUS call
+    // fails (auth blip, transient network error) we fall back to estimating
+    // from local counts so metadata at least stays approximately correct.
+    let (qrz_qso_count, qrz_logbook_owner) = match client.fetch_status().await {
+        Ok(status) => {
+            let owner = if status.owner.is_empty() {
+                prev_metadata.qrz_logbook_owner.clone()
+            } else {
+                Some(status.owner)
+            };
+            (status.qso_count, owner)
+        }
         Err(err) => {
-            eprintln!("[sync] Failed to refresh local QSO counts: {err}");
-            prev_metadata.qrz_qso_count
+            eprintln!("[sync] STATUS call failed during metadata refresh: {err}");
+            counters
+                .errors
+                .push(format!("STATUS refresh failed: {err}"));
+            let fallback_count = match store.qso_counts().await {
+                Ok(counts) => counts
+                    .local_qso_count
+                    .saturating_sub(counts.pending_upload_count),
+                Err(err) => {
+                    eprintln!("[sync] Failed to refresh local QSO counts: {err}");
+                    prev_metadata.qrz_qso_count
+                }
+            };
+            (fallback_count, prev_metadata.qrz_logbook_owner.clone())
         }
     };
 
@@ -425,7 +479,7 @@ async fn update_metadata(
             seconds: now.timestamp(),
             nanos: 0,
         }),
-        qrz_logbook_owner: prev_metadata.qrz_logbook_owner.clone(),
+        qrz_logbook_owner,
     };
 
     if let Err(err) = store.upsert_sync_metadata(&updated).await {
@@ -699,7 +753,7 @@ mod tests {
     use qsoripper_core::proto::qsoripper::domain::{
         Band, ConflictPolicy, Mode, QsoRecord, SyncStatus,
     };
-    use qsoripper_core::qrz_logbook::{QrzLogbookError, QrzUploadResult};
+    use qsoripper_core::qrz_logbook::{QrzLogbookError, QrzLogbookStatus, QrzUploadResult};
     use qsoripper_core::storage::{LogbookStore, QsoListQuery, SyncMetadata};
     use qsoripper_storage_memory::MemoryStorage;
     use tokio::sync::mpsc;
@@ -711,6 +765,9 @@ mod tests {
     struct MockQrzApi {
         fetch_result: Mutex<Option<Result<Vec<QsoRecord>, QrzLogbookError>>>,
         upload_results: Mutex<Vec<Result<QrzUploadResult, QrzLogbookError>>>,
+        replace_calls: Mutex<Vec<(String, String)>>, // (logid, local_id)
+        replace_results: Mutex<Vec<Result<QrzUploadResult, QrzLogbookError>>>,
+        status_result: Mutex<Option<Result<QrzLogbookStatus, QrzLogbookError>>>,
     }
 
     impl MockQrzApi {
@@ -721,7 +778,18 @@ mod tests {
             Self {
                 fetch_result: Mutex::new(Some(fetch)),
                 upload_results: Mutex::new(uploads),
+                replace_calls: Mutex::new(Vec::new()),
+                replace_results: Mutex::new(Vec::new()),
+                status_result: Mutex::new(Some(Ok(QrzLogbookStatus {
+                    owner: String::new(),
+                    qso_count: 0,
+                }))),
             }
+        }
+
+        fn with_status(self, status: Result<QrzLogbookStatus, QrzLogbookError>) -> Self {
+            *self.status_result.lock().unwrap() = Some(status);
+            self
         }
     }
 
@@ -748,6 +816,39 @@ mod tests {
                 results.remove(0)
             }
         }
+
+        async fn replace_qso(
+            &self,
+            logid: &str,
+            qso: &QsoRecord,
+        ) -> Result<QrzUploadResult, QrzLogbookError> {
+            self.replace_calls
+                .lock()
+                .unwrap()
+                .push((logid.to_string(), qso.local_id.clone()));
+            let mut results = self.replace_results.lock().unwrap();
+            if results.is_empty() {
+                // Default: succeed and echo the logid back.
+                Ok(QrzUploadResult {
+                    logid: logid.to_string(),
+                })
+            } else {
+                results.remove(0)
+            }
+        }
+
+        async fn fetch_status(&self) -> Result<QrzLogbookStatus, QrzLogbookError> {
+            self.status_result
+                .lock()
+                .unwrap()
+                .take()
+                .unwrap_or_else(|| {
+                    Ok(QrzLogbookStatus {
+                        owner: String::new(),
+                        qso_count: 0,
+                    })
+                })
+        }
     }
 
     /// Capturing mock that records what `since` value was passed to `fetch_qsos`.
@@ -765,6 +866,23 @@ mod tests {
         async fn upload_qso(&self, _qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError> {
             Ok(QrzUploadResult {
                 logid: "ignored".into(),
+            })
+        }
+
+        async fn replace_qso(
+            &self,
+            logid: &str,
+            _qso: &QsoRecord,
+        ) -> Result<QrzUploadResult, QrzLogbookError> {
+            Ok(QrzUploadResult {
+                logid: logid.to_string(),
+            })
+        }
+
+        async fn fetch_status(&self) -> Result<QrzLogbookStatus, QrzLogbookError> {
+            Ok(QrzLogbookStatus {
+                owner: String::new(),
+                qso_count: 0,
             })
         }
     }
@@ -868,6 +986,146 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn modified_qso_with_logid_uses_replace_not_insert() {
+        // Regression for the bug where Modified QSOs were uploaded via INSERT,
+        // producing a brand-new row on QRZ every sync instead of updating the
+        // existing one. The fix routes Modified + existing logid through the
+        // REPLACE (ACTION=INSERT&OPTION=REPLACE,LOGID:...) path.
+        let store = MemoryStorage::new();
+        let mut q = make_qso("W1AW", "K7EDIT", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        q.qrz_logid = Some("QRZ-EXISTING".into());
+        q.sync_status = SyncStatus::Modified as i32;
+        store.insert_qso(&q).await.unwrap();
+
+        let api = MockQrzApi::new(Ok(vec![]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.uploaded_records, 1, "should have uploaded the modified QSO");
+        assert!(final_msg.error.is_none(), "error: {:?}", final_msg.error);
+
+        let replace_calls = api.replace_calls.lock().unwrap().clone();
+        assert_eq!(
+            replace_calls.len(),
+            1,
+            "modified QSO must use REPLACE, got replace_calls={:?}",
+            replace_calls
+        );
+        assert_eq!(
+            replace_calls[0].0, "QRZ-EXISTING",
+            "REPLACE must be called with the existing QRZ logid"
+        );
+
+        let upload_results_remaining = api.upload_results.lock().unwrap().len();
+        assert_eq!(
+            upload_results_remaining, 0,
+            "INSERT path should never have been exercised for a modified QSO with a logid"
+        );
+
+        // Local row should remain Synced with the same logid intact.
+        let saved = store.get_qso(&q.local_id).await.unwrap().unwrap();
+        assert_eq!(saved.sync_status, SyncStatus::Synced as i32);
+        assert_eq!(saved.qrz_logid.as_deref(), Some("QRZ-EXISTING"));
+    }
+
+    #[tokio::test]
+    async fn modified_qso_without_logid_falls_back_to_insert() {
+        // Edge case: a QSO is flagged Modified but somehow has no logid
+        // (legacy data, migrations). We must still upload it, just via INSERT.
+        let store = MemoryStorage::new();
+        let mut q = make_qso("W1AW", "K7LEGACY", Band::Band40m, Mode::Cw, 1_700_010_000);
+        q.qrz_logid = None;
+        q.sync_status = SyncStatus::Modified as i32;
+        store.insert_qso(&q).await.unwrap();
+
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![Ok(QrzUploadResult {
+                logid: "QRZ-NEW".into(),
+            })],
+        );
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.uploaded_records, 1);
+        let replace_calls = api.replace_calls.lock().unwrap().clone();
+        assert!(
+            replace_calls.is_empty(),
+            "should NOT have called REPLACE without a logid: {:?}",
+            replace_calls
+        );
+        let saved = store.get_qso(&q.local_id).await.unwrap().unwrap();
+        assert_eq!(saved.qrz_logid.as_deref(), Some("QRZ-NEW"));
+    }
+
+    #[tokio::test]
+    async fn update_metadata_uses_status_call_result() {
+        // Regression: Phase 3 used to derive qrz_qso_count from local counts
+        // and just copy the previous owner. Now it must call STATUS and use
+        // the remote-authoritative values.
+        let store = MemoryStorage::new();
+        let api = MockQrzApi::new(Ok(vec![]), vec![]).with_status(Ok(QrzLogbookStatus {
+            owner: "NEW_OWNER".to_string(),
+            qso_count: 4242,
+        }));
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+        let _ = collect_final(rx).await;
+
+        let meta = store.get_sync_metadata().await.unwrap();
+        assert_eq!(meta.qrz_qso_count, 4242);
+        assert_eq!(meta.qrz_logbook_owner.as_deref(), Some("NEW_OWNER"));
+    }
+
+    #[tokio::test]
+    async fn update_metadata_falls_back_when_status_call_fails() {
+        // If STATUS fails transiently we still want to finish sync with
+        // a best-effort count from the local store, rather than overwriting
+        // metadata with zero/garbage.
+        let store = MemoryStorage::new();
+
+        // Pre-seed some metadata so we can prove owner is preserved.
+        store
+            .upsert_sync_metadata(&SyncMetadata {
+                qrz_qso_count: 0,
+                last_sync: None,
+                qrz_logbook_owner: Some("ORIG_OWNER".into()),
+            })
+            .await
+            .unwrap();
+
+        // And pre-seed two already-synced local QSOs so count has something
+        // to derive from.
+        for cs in ["KA", "KB"] {
+            let mut q = make_qso("W1AW", cs, Band::Band20m, Mode::Ft8, 1_700_000_000);
+            q.sync_status = SyncStatus::Synced as i32;
+            store.insert_qso(&q).await.unwrap();
+        }
+
+        let api = MockQrzApi::new(Ok(vec![]), vec![])
+            .with_status(Err(QrzLogbookError::ApiError("boom".into())));
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+        let _ = collect_final(rx).await;
+
+        let meta = store.get_sync_metadata().await.unwrap();
+        assert_eq!(meta.qrz_logbook_owner.as_deref(), Some("ORIG_OWNER"));
+        assert_eq!(meta.qrz_qso_count, 2);
+    }
+
+    #[tokio::test]
     async fn mixed_sync_downloads_and_uploads() {
         let store = MemoryStorage::new();
 
@@ -967,7 +1225,12 @@ mod tests {
             q.qrz_logid = Some("QRZ002".into());
             q
         };
-        let api = MockQrzApi::new(Ok(vec![remote1, remote2]), vec![]);
+        let api = MockQrzApi::new(Ok(vec![remote1, remote2]), vec![]).with_status(Ok(
+            QrzLogbookStatus {
+                owner: String::new(),
+                qso_count: 2,
+            },
+        ));
 
         let (tx, rx) = mpsc::channel(16);
         execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
@@ -978,7 +1241,7 @@ mod tests {
         assert!(metadata.last_sync.is_some(), "last_sync should be set");
         assert_eq!(
             metadata.qrz_qso_count, 2,
-            "qrz_qso_count should reflect the two synced remote QSOs"
+            "qrz_qso_count should come from STATUS"
         );
     }
 

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -1015,8 +1015,7 @@ mod tests {
         assert_eq!(
             replace_calls.len(),
             1,
-            "modified QSO must use REPLACE, got replace_calls={:?}",
-            replace_calls
+            "modified QSO must use REPLACE, got replace_calls={replace_calls:?}"
         );
         assert_eq!(
             replace_calls[0].0, "QRZ-EXISTING",
@@ -1062,8 +1061,7 @@ mod tests {
         let replace_calls = api.replace_calls.lock().unwrap().clone();
         assert!(
             replace_calls.is_empty(),
-            "should NOT have called REPLACE without a logid: {:?}",
-            replace_calls
+            "should NOT have called REPLACE without a logid: {replace_calls:?}"
         );
         let saved = store.get_qso(&q.local_id).await.unwrap().unwrap();
         assert_eq!(saved.qrz_logid.as_deref(), Some("QRZ-NEW"));

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -1005,7 +1005,10 @@ mod tests {
 
         let final_msg = collect_final(rx).await;
         assert!(final_msg.complete);
-        assert_eq!(final_msg.uploaded_records, 1, "should have uploaded the modified QSO");
+        assert_eq!(
+            final_msg.uploaded_records, 1,
+            "should have uploaded the modified QSO"
+        );
         assert!(final_msg.error.is_none(), "error: {:?}", final_msg.error);
 
         let replace_calls = api.replace_calls.lock().unwrap().clone();
@@ -1225,12 +1228,11 @@ mod tests {
             q.qrz_logid = Some("QRZ002".into());
             q
         };
-        let api = MockQrzApi::new(Ok(vec![remote1, remote2]), vec![]).with_status(Ok(
-            QrzLogbookStatus {
+        let api =
+            MockQrzApi::new(Ok(vec![remote1, remote2]), vec![]).with_status(Ok(QrzLogbookStatus {
                 owner: String::new(),
                 qso_count: 2,
-            },
-        ));
+            }));
 
         let (tx, rx) = mpsc::channel(16);
         execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -28,8 +28,15 @@ type FuzzyIndex = HashMap<(String, i32, i32), Vec<QsoRecord>>;
 // Constants
 // ---------------------------------------------------------------------------
 
-/// Extra-field key that QRZ ADIF responses use for the logbook record ID.
-const QRZ_LOGID_EXTRA_FIELD: &str = "APP_QRZ_LOGID";
+/// Extra-field keys that historical QRZ ADIF responses may carry for the
+/// logbook record id. The canonical key per the QRZ Logbook API is
+/// `APP_QRZLOG_LOGID`; `APP_QRZ_LOGID` is kept as a legacy alias because
+/// older internal builds wrote that variant. The ADIF mapper now extracts
+/// either alias into [`QsoRecord::qrz_logid`] directly, so this fallback is
+/// only exercised against records that bypass the mapper (e.g. ones that
+/// were already persisted before the mapper started recognising the field
+/// and have not yet been backfilled by [`crate::repair::backfill_qrz_logids`]).
+const QRZ_LOGID_EXTRA_FIELDS: &[&str] = &["APP_QRZLOG_LOGID", "APP_QRZ_LOGID"];
 
 /// Maximum time difference (seconds) for fuzzy timestamp matching.
 const TIMESTAMP_TOLERANCE_SECONDS: i64 = 60;
@@ -584,18 +591,23 @@ fn build_local_indexes(local_qsos: &[QsoRecord]) -> (LogidIndex, FuzzyIndex) {
 
 /// Extract the QRZ logbook record ID from a QSO.
 ///
-/// Checks the dedicated `qrz_logid` field first, then falls back to
-/// `extra_fields["APP_QRZ_LOGID"]`.
+/// Checks the dedicated `qrz_logid` field first (populated by the ADIF
+/// mapper), then falls back to the historical `extra_fields` aliases for
+/// records that were persisted before the mapper recognised the field.
 fn extract_qrz_logid(qso: &QsoRecord) -> Option<String> {
     if let Some(logid) = qso.qrz_logid.as_deref() {
         if !logid.is_empty() {
             return Some(logid.to_string());
         }
     }
-    qso.extra_fields
-        .get(QRZ_LOGID_EXTRA_FIELD)
-        .filter(|v| !v.is_empty())
-        .cloned()
+    for key in QRZ_LOGID_EXTRA_FIELDS {
+        if let Some(value) = qso.extra_fields.get(*key) {
+            if !value.is_empty() {
+                return Some(value.clone());
+            }
+        }
+    }
+    None
 }
 
 /// Find a local QSO matching by worked callsign, band, mode, and timestamp
@@ -1213,9 +1225,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn extract_logid_from_extra_fields() {
+    async fn extract_logid_from_extra_fields_canonical_key() {
         let qso = QsoRecord {
-            extra_fields: [(super::QRZ_LOGID_EXTRA_FIELD.into(), "EX123".into())]
+            extra_fields: [("APP_QRZLOG_LOGID".into(), "EX123".into())]
                 .into_iter()
                 .collect(),
             ..QsoRecord::default()
@@ -1226,10 +1238,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn extract_logid_from_extra_fields_legacy_alias() {
+        let qso = QsoRecord {
+            extra_fields: [("APP_QRZ_LOGID".into(), "LEGACY".into())]
+                .into_iter()
+                .collect(),
+            ..QsoRecord::default()
+        };
+
+        let logid = super::extract_qrz_logid(&qso);
+        assert_eq!(logid.as_deref(), Some("LEGACY"));
+    }
+
+    #[tokio::test]
     async fn extract_logid_prefers_dedicated_field() {
         let qso = QsoRecord {
             qrz_logid: Some("DIRECT".into()),
-            extra_fields: [(super::QRZ_LOGID_EXTRA_FIELD.into(), "EXTRA".into())]
+            extra_fields: [("APP_QRZLOG_LOGID".into(), "EXTRA".into())]
                 .into_iter()
                 .collect(),
             ..QsoRecord::default()


### PR DESCRIPTION
## Summary

Fixes the QRZ-sync duplicate-import bug and closes several engine parity gaps discovered during the investigation. Root cause: the Rust engine did not map QRZ ADIF's `APP_QRZLOG_LOGID` onto the dedicated `qrz_logid` domain field, so every subsequent sync re-uploaded every previously-synced QSO as a new record and multiplied the logbook.

## Root Cause

On import from QRZ ADIF, the Rust `AdifMapper` stashed `APP_QRZLOG_LOGID` into `extra_fields` instead of `qrz_logid`. `sync.rs::extract_qrz_logid` checked only a single legacy key (`APP_QRZ_LOGID`), so the link between a remote QSO and its local row was lost on re-sync. Every pending QSO then went through `INSERT` even when it had already been uploaded.

## Changes

### Rust engine

- **Mapper (`adif/mapper.rs`)**: map `APP_QRZLOG_LOGID` / `APP_QRZ_LOGID` into `qrz_logid` and `APP_QRZLOG_QSO_ID` / `APP_QRZ_BOOKID` into `qrz_bookid` on import; emit both on export; include them in `field_is_overridden` so the generic `extra_fields` writer does not double-emit.
- **Sync (`sync.rs`)**: fix `extract_qrz_logid` to check both canonical and legacy keys. Route `MODIFIED` QSOs with a `qrz_logid` through the new `replace_qso` path using the documented `ACTION=INSERT&OPTION=REPLACE,LOGID:<id>` form. Call QRZ `STATUS` in Phase 3 with local-count fallback.
- **QRZ client (`qrz_logbook/mod.rs`)**: add `replace_qso`; accept `RESULT=REPLACE` as success.
- **New `repair.rs`**: startup data-repair pass that backfills `qrz_logid`/`qrz_bookid` from legacy `extra_fields` and collapses existing duplicates (keeper = oldest, merges non-empty fields from victims). Idempotent.

### .NET engine

- **`AdifCodec`**: emit `APP_QRZLOG_LOGID` / `APP_QRZLOG_QSO_ID` on export; skip the same keys when iterating `extra_fields` to avoid duplicates.
- **`QrzLogbookClient.UpdateQsoAsync`**: switch from the undocumented `ACTION=REPLACE` to the documented `ACTION=INSERT&OPTION=REPLACE,LOGID:<id>` form; fall back to the supplied logid if the response omits it.
- **`QrzResponseParser.CheckResult`**: accept `RESULT=REPLACE`.
- **`QrzSyncEngine.ExecuteSyncAsync`**: accept `ConflictPolicy`. `LastWriteWins` overwrites silently (not counted as conflict). `FlagForReview` preserves local edits on MODIFIED rows and marks them `Conflict` with the counter incremented. `Unspecified` defaults to `FlagForReview` per spec §6.3.
- **`ManagedEngineState.SyncWithQrz`**: thread the stored `SyncConfig.ConflictPolicy` into the sync engine.

### Engine specification

- §7.3 Phase 1–3: document correct `ConflictPolicy` values, the `REPLACE` form for MODIFIED QSOs, and the Phase 3 `STATUS` call with fallback.
- §7.5 Import/Export: document QRZ-specific ADIF app fields and the requirement to route them onto dedicated domain fields (not `extra_fields`).
- §7.7: new section documenting the startup data-repair pass as a required capability.
- §9.2: fix duplicate test-scenario numbering.
- §10.2: .NET storage backend row now lists SQLite alongside in-memory.
- Appendix C: track known follow-up gaps (.NET streaming progress, .NET ADIF field coverage, .NET `STATUS` call, .NET `DeleteQsoAsync`).

## Tests

- **Rust**: 5 new mapper tests; 3 new QRZ client tests; 4 new sync tests; 7 repair tests. `cargo test` = 120 server tests pass. `cargo llvm-cov` = 87.8% (threshold 80%).
- **.NET**: 3 new AdifCodec tests; 3 new QrzLogbookClient tests; 4 new QrzSyncEngine tests. 77 QrzLogbook tests pass. Full `.\build.ps1 check-dotnet` = all 39 test suites pass, 51% line coverage (threshold 50%), 0 vulnerable packages.

## Deferred (tracked in Appendix C)

- .NET `SyncWithQrz` streaming progress messages (requires `ManagedEngineState` refactor).
- .NET `AdifCodec` full field coverage parity (ARRL_SECT, SKCC, QSL/LOTW/EQSL variants, etc.).
- .NET Phase 3 `STATUS` call wiring.
- .NET `QrzLogbookClient.DeleteQsoAsync`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
