### PR TITLE
Add periodic space weather refresh to TUI and Win32 apps

### DIFF
--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -312,6 +312,7 @@ typedef struct {
     int sunspot_number;
     int has_weather;
     int weather_loading;
+    ULONGLONG last_weather_refresh;
 
     /* Rig control */
     int  rig_enabled;
@@ -3553,6 +3554,15 @@ static void OnTimer(HWND hwnd)
         }
     }
 
+    /* Space weather: refresh every hour */
+    if (!g_state.weather_loading) {
+        ULONGLONG now_sw = GetTickCount64();
+        if (now_sw - g_state.last_weather_refresh >= 3600000ULL) {
+            g_state.last_weather_refresh = now_sw;
+            FetchSpaceWeather();
+        }
+    }
+
     InvalidateRect(hwnd, NULL, FALSE);
 }
 
@@ -3646,6 +3656,7 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
 
         /* Kick off async data loads so the window appears immediately */
         RefreshQsoListAsync(hwnd);
+        g_state.last_weather_refresh = GetTickCount64();
         FetchSpaceWeather();
         if (g_backend.mode == BACKEND_FFI)
             SetStatus("Connected via gRPC (FFI)", 0);

--- a/src/dotnet/QsoRipper.Gui.Tests/AsyncVoidHandlerSafetyTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/AsyncVoidHandlerSafetyTests.cs
@@ -15,7 +15,26 @@ public sealed class AsyncVoidHandlerSafetyTests
         AssertMethodContains(source, "OnRigTimerTick", "catch (ObjectDisposedException)");
 
         AssertMethodContains(source, "OnSpaceWeatherTimerTick", "try");
-        AssertMethodContains(source, "OnSpaceWeatherTimerTick", "catch");
+        AssertMethodContains(source, "OnSpaceWeatherTimerTick", "catch (ObjectDisposedException)");
+        AssertMethodContains(source, "OnSpaceWeatherTimerTick", "catch (Grpc.Core.RpcException)");
+    }
+
+    [Fact]
+    public void MainWindowViewModel_space_weather_timer_uses_hourly_refresh_interval()
+    {
+        var source = File.ReadAllText(GetSourcePath("src", "dotnet", "QsoRipper.Gui", "ViewModels", "MainWindowViewModel.cs"));
+
+        Assert.Contains("SpaceWeatherRefreshInterval = TimeSpan.FromHours(1)", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MainWindowViewModel_space_weather_periodic_refresh_preserves_stale_data_on_failure()
+    {
+        var source = File.ReadAllText(GetSourcePath("src", "dotnet", "QsoRipper.Gui", "ViewModels", "MainWindowViewModel.cs"));
+
+        // Periodic timer must call FetchSpaceWeatherAsync with preserveOnFailure so that
+        // a transient network error does not overwrite good weather readings with an error string.
+        AssertMethodContains(source, "OnSpaceWeatherTimerTick", "preserveOnFailure: true");
     }
 
     [Fact]

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -20,6 +20,7 @@ namespace QsoRipper.Gui.ViewModels;
 internal sealed partial class MainWindowViewModel : ObservableObject, IDisposable
 {
     private static readonly TimeSpan PreferredEngineSwitchTimeout = TimeSpan.FromSeconds(1.5);
+    private static readonly TimeSpan SpaceWeatherRefreshInterval = TimeSpan.FromHours(1);
 
     private readonly IEngineClient _engine;
     private readonly SwitchableEngineClient? _switchableEngine;
@@ -142,7 +143,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         _utcTimer = CreateUtcTimer();
         _rigTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
         _rigTimer.Tick += OnRigTimerTick;
-        _spaceWeatherTimer = new DispatcherTimer { Interval = TimeSpan.FromMinutes(5) };
+        _spaceWeatherTimer = new DispatcherTimer { Interval = SpaceWeatherRefreshInterval };
         _spaceWeatherTimer.Tick += OnSpaceWeatherTimerTick;
     }
 
@@ -171,7 +172,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         _utcTimer = CreateUtcTimer();
         _rigTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
         _rigTimer.Tick += OnRigTimerTick;
-        _spaceWeatherTimer = new DispatcherTimer { Interval = TimeSpan.FromMinutes(5) };
+        _spaceWeatherTimer = new DispatcherTimer { Interval = SpaceWeatherRefreshInterval };
         _spaceWeatherTimer.Tick += OnSpaceWeatherTimerTick;
     }
 
@@ -782,19 +783,25 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     {
         try
         {
-            await FetchSpaceWeatherAsync();
+            // Periodic refresh: preserve stale data on failure so a transient
+            // network error never clears good weather readings.
+            await FetchSpaceWeatherAsync(preserveOnFailure: true);
         }
         catch (ObjectDisposedException)
         {
-            SpaceWeatherText = "Weather: unavailable";
+            // Timer fired after disposal; ignore.
+        }
+        catch (Grpc.Core.RpcException)
+        {
+            // Transient network failure — keep existing weather data.
         }
         catch (InvalidOperationException)
         {
-            SpaceWeatherText = "Weather: error";
+            // Engine not ready — keep existing weather data.
         }
     }
 
-    private async Task FetchSpaceWeatherAsync()
+    private async Task FetchSpaceWeatherAsync(bool preserveOnFailure = false)
     {
         try
         {
@@ -819,12 +826,12 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 
                 SpaceWeatherText = parts.Count > 0 ? string.Join(" ", parts) : "Weather: no data";
             }
-            else
+            else if (!preserveOnFailure)
             {
                 SpaceWeatherText = "Weather: unavailable";
             }
         }
-        catch (Grpc.Core.RpcException)
+        catch (Grpc.Core.RpcException) when (!preserveOnFailure)
         {
             SpaceWeatherText = "Weather: error";
         }

--- a/src/rust/qsoripper-tui/src/events.rs
+++ b/src/rust/qsoripper-tui/src/events.rs
@@ -9,6 +9,8 @@ use tonic::transport::Channel;
 use crate::app::{CallsignInfo, RecentQso, RigInfo, SpaceWeatherInfo};
 use crate::grpc;
 
+const SPACE_WEATHER_REFRESH_INTERVAL: Duration = Duration::from_secs(60 * 60);
+
 /// Events produced by background tasks and forwarded to the main event loop.
 pub(crate) enum AppEvent {
     /// A key press received from the terminal.
@@ -122,14 +124,14 @@ pub(crate) fn spawn_lookup_task(
 
 /// Spawn a background task that fetches space weather once per hour.
 ///
-/// Fires immediately on startup and then every 3600 seconds. Errors and empty responses
-/// are silently discarded so stale data is never cleared by a transient failure.
+/// Fires immediately on startup and then every [`SPACE_WEATHER_REFRESH_INTERVAL`]. Errors and
+/// empty responses are silently discarded so stale data is never cleared by a transient failure.
 pub(crate) fn spawn_space_weather_task(
     event_tx: mpsc::UnboundedSender<AppEvent>,
     channel: Channel,
 ) {
     tokio::spawn(async move {
-        let mut interval = time::interval(Duration::from_secs(3600));
+        let mut interval = time::interval(SPACE_WEATHER_REFRESH_INTERVAL);
         loop {
             interval.tick().await;
             if event_tx.is_closed() {

--- a/src/rust/qsoripper-tui/src/events.rs
+++ b/src/rust/qsoripper-tui/src/events.rs
@@ -120,6 +120,30 @@ pub(crate) fn spawn_lookup_task(
     });
 }
 
+/// Spawn a background task that fetches space weather once per hour.
+///
+/// Fires immediately on startup and then every 3600 seconds. Errors and empty responses
+/// are silently discarded so stale data is never cleared by a transient failure.
+pub(crate) fn spawn_space_weather_task(
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+    channel: Channel,
+) {
+    tokio::spawn(async move {
+        let mut interval = time::interval(Duration::from_secs(3600));
+        loop {
+            interval.tick().await;
+            if event_tx.is_closed() {
+                break;
+            }
+            if let Ok(Some(sw)) = grpc::get_space_weather(channel.clone()).await {
+                if event_tx.send(AppEvent::SpaceWeather(Some(sw))).is_err() {
+                    break;
+                }
+            }
+        }
+    });
+}
+
 /// Spawn a rig control polling task that fetches rig snapshots every second.
 ///
 /// The poll is gated by `enabled_rx`: when the value is `false`, the task pauses

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -17,7 +17,7 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 use tokio::sync::{mpsc, watch};
 
 use app::App;
-use events::{spawn_clock_task, spawn_key_task, spawn_lookup_task, spawn_rig_poll_task, AppEvent};
+use events::{spawn_clock_task, spawn_key_task, spawn_lookup_task, spawn_rig_poll_task, spawn_space_weather_task, AppEvent};
 use form::{AdvancedTab, Field, LogForm, BANDS, MODES};
 
 const ENGINE_ENV_VAR: &str = "QSORIPPER_ENGINE";
@@ -143,17 +143,9 @@ async fn run<B: ratatui::backend::Backend>(
     spawn_clock_task(event_tx.clone());
     spawn_lookup_task(lookup_rx, event_tx.clone(), channel.clone());
     spawn_rig_poll_task(rig_enabled_rx, event_tx.clone(), channel.clone());
+    spawn_space_weather_task(event_tx.clone(), channel.clone());
 
-    // Prefetch space weather and recent QSOs on startup.
-    {
-        let tx = event_tx.clone();
-        let channel = channel.clone();
-        tokio::spawn(async move {
-            if let Ok(sw) = grpc::get_space_weather(channel).await {
-                let _ = tx.send(AppEvent::SpaceWeather(sw));
-            }
-        });
-    }
+    // Prefetch recent QSOs on startup.
     {
         let tx = event_tx.clone();
         let channel = channel.clone();
@@ -203,7 +195,9 @@ fn handle_event_with_channel(
         }
         AppEvent::LookupResult(result) => apply_lookup_result(app, result),
         AppEvent::SpaceWeather(sw) => {
-            app.space_weather = sw;
+            if sw.is_some() {
+                app.space_weather = sw;
+            }
         }
         AppEvent::RigSnapshot(rig) => {
             apply_rig_snapshot(app, rig);

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -17,7 +17,10 @@ use ratatui::{backend::CrosstermBackend, Terminal};
 use tokio::sync::{mpsc, watch};
 
 use app::App;
-use events::{spawn_clock_task, spawn_key_task, spawn_lookup_task, spawn_rig_poll_task, spawn_space_weather_task, AppEvent};
+use events::{
+    spawn_clock_task, spawn_key_task, spawn_lookup_task, spawn_rig_poll_task,
+    spawn_space_weather_task, AppEvent,
+};
 use form::{AdvancedTab, Field, LogForm, BANDS, MODES};
 
 const ENGINE_ENV_VAR: &str = "QSORIPPER_ENGINE";


### PR DESCRIPTION
Fixes #282

TUI: replace one-shot startup fetch with spawn_space_weather_task that fires immediately via tokio interval and repeats every 3600 seconds. Errors and empty responses are discarded so stale data is never cleared by a transient network failure. The SpaceWeather event handler now also ignores None.

Win32: add last_weather_refresh timestamp to AppState, record it at startup before the initial FetchSpaceWeather() call, and check it in OnTimer every 3600000 ms. The existing weather_loading guard prevents overlapping fetches.