### PR TITLE
Standardize rig poll interval to 500ms across all surfaces

### DIFF
--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -30,6 +30,8 @@
 #define TIMER_MS        100
 #define STATUS_LIFETIME_MS  3000
 #define LOOKUP_DEBOUNCE_MS  500
+#define RIG_POLL_MS         500
+#define SPACE_WEATHER_REFRESH_MS (60 * 60 * 1000ULL)
 /* Tuning / behaviour constants */
 #define MAX_FIELD_LEN   256
 
@@ -3538,10 +3540,10 @@ static void OnTimer(HWND hwnd)
         }
     }
 
-    /* Rig poll: every 500ms when enabled and no poll in flight */
+    /* Rig poll: every RIG_POLL_MS when enabled and no poll in flight */
     if (g_state.rig_enabled && !g_state.rig_poll_in_progress) {
         ULONGLONG now = GetTickCount64();
-        if (now - g_state.last_rig_poll >= 500) {
+        if (now - g_state.last_rig_poll >= RIG_POLL_MS) {
             g_state.last_rig_poll = now;
             RigPollArg *rarg = (RigPollArg *)malloc(sizeof(RigPollArg));
             if (rarg) {
@@ -3557,7 +3559,7 @@ static void OnTimer(HWND hwnd)
     /* Space weather: refresh every hour */
     if (!g_state.weather_loading) {
         ULONGLONG now_sw = GetTickCount64();
-        if (now_sw - g_state.last_weather_refresh >= 3600000ULL) {
+        if (now_sw - g_state.last_weather_refresh >= SPACE_WEATHER_REFRESH_MS) {
             g_state.last_weather_refresh = now_sw;
             FetchSpaceWeather();
         }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -21,6 +21,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 {
     private static readonly TimeSpan PreferredEngineSwitchTimeout = TimeSpan.FromSeconds(1.5);
     private static readonly TimeSpan SpaceWeatherRefreshInterval = TimeSpan.FromHours(1);
+    private static readonly TimeSpan RigPollInterval = TimeSpan.FromMilliseconds(500);
 
     private readonly IEngineClient _engine;
     private readonly SwitchableEngineClient? _switchableEngine;
@@ -141,7 +142,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         ActiveEngineText = BuildEngineText(engineProfile, endpoint);
         UpdateUtcClock();
         _utcTimer = CreateUtcTimer();
-        _rigTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        _rigTimer = new DispatcherTimer { Interval = RigPollInterval };
         _rigTimer.Tick += OnRigTimerTick;
         _spaceWeatherTimer = new DispatcherTimer { Interval = SpaceWeatherRefreshInterval };
         _spaceWeatherTimer.Tick += OnSpaceWeatherTimerTick;
@@ -170,7 +171,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 
         UpdateUtcClock();
         _utcTimer = CreateUtcTimer();
-        _rigTimer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
+        _rigTimer = new DispatcherTimer { Interval = RigPollInterval };
         _rigTimer.Tick += OnRigTimerTick;
         _spaceWeatherTimer = new DispatcherTimer { Interval = SpaceWeatherRefreshInterval };
         _spaceWeatherTimer.Tick += OnSpaceWeatherTimerTick;

--- a/src/rust/qsoripper-tui/src/events.rs
+++ b/src/rust/qsoripper-tui/src/events.rs
@@ -10,6 +10,7 @@ use crate::app::{CallsignInfo, RecentQso, RigInfo, SpaceWeatherInfo};
 use crate::grpc;
 
 const SPACE_WEATHER_REFRESH_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const RIG_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Events produced by background tasks and forwarded to the main event loop.
 pub(crate) enum AppEvent {
@@ -146,7 +147,7 @@ pub(crate) fn spawn_space_weather_task(
     });
 }
 
-/// Spawn a rig control polling task that fetches rig snapshots every second.
+/// Spawn a rig control polling task that fetches rig snapshots every 500ms.
 ///
 /// The poll is gated by `enabled_rx`: when the value is `false`, the task pauses
 /// polling and sends `None` snapshots. This avoids leaking multiple poll loops on toggle.
@@ -156,7 +157,7 @@ pub(crate) fn spawn_rig_poll_task(
     channel: Channel,
 ) {
     tokio::spawn(async move {
-        let mut interval = time::interval(Duration::from_secs(1));
+        let mut interval = time::interval(RIG_POLL_INTERVAL);
         loop {
             interval.tick().await;
             if event_tx.is_closed() {


### PR DESCRIPTION
Fixes #285

- Rust TUI: replace Duration::from_secs(1) with RIG_POLL_INTERVAL const (500ms)
- Win32: add RIG_POLL_MS and SPACE_WEATHER_REFRESH_MS defines, replace bare literals
- Avalonia GUI: add RigPollInterval static field (500ms), replace two inline TimeSpan.FromSeconds(1) usages