### PR TITLE
feat(storage): soft-delete schema + filter foundation (B1 of #289)

### DIFF
--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -562,6 +562,12 @@ internal sealed class ManagedEngineState
                 Sort = request.Sort == QsoRipper.Services.QsoSortOrder.OldestFirst
                     ? Storage.QsoSortOrder.OldestFirst
                     : Storage.QsoSortOrder.NewestFirst,
+                DeletedFilter = request.DeletedFilter switch
+                {
+                    QsoRipper.Services.DeletedRecordsFilter.DeletedOnly => Storage.DeletedRecordsFilter.DeletedOnly,
+                    QsoRipper.Services.DeletedRecordsFilter.All => Storage.DeletedRecordsFilter.All,
+                    _ => Storage.DeletedRecordsFilter.ActiveOnly,
+                },
             };
 
             return Sync(_storage.Logbook.ListQsosAsync(storageQuery));

--- a/src/dotnet/QsoRipper.Engine.Storage.Abstractions/ILogbookStore.cs
+++ b/src/dotnet/QsoRipper.Engine.Storage.Abstractions/ILogbookStore.cs
@@ -18,6 +18,25 @@ public interface ILogbookStore
     /// <returns><c>true</c> if the record was found and deleted; <c>false</c> if not found.</returns>
     ValueTask<bool> DeleteQsoAsync(string localId);
 
+    /// <summary>
+    /// Soft-deletes a QSO by setting its tombstone (<c>DeletedAt</c>) and optionally
+    /// queueing it for remote QRZ delete on the next sync. The row remains in the
+    /// table so it can be restored.
+    /// </summary>
+    /// <param name="localId">Local identifier of the QSO to soft-delete.</param>
+    /// <param name="deletedAt">Wall-clock tombstone time recorded on the row.</param>
+    /// <param name="pendingRemoteDelete">When <c>true</c>, mark the row for QRZ removal on the next sync.</param>
+    /// <returns><c>true</c> if the record was found and updated; <c>false</c> if not found.</returns>
+    ValueTask<bool> SoftDeleteQsoAsync(string localId, DateTimeOffset deletedAt, bool pendingRemoteDelete);
+
+    /// <summary>
+    /// Restores a previously soft-deleted QSO, clearing both the tombstone and
+    /// the pending-remote-delete flag.
+    /// </summary>
+    /// <param name="localId">Local identifier of the QSO to restore.</param>
+    /// <returns><c>true</c> if the record was found and restored; <c>false</c> if not found.</returns>
+    ValueTask<bool> RestoreQsoAsync(string localId);
+
     /// <summary>Retrieves a single QSO record by its local identifier, or <c>null</c> if not found.</summary>
     ValueTask<QsoRecord?> GetQsoAsync(string localId);
 

--- a/src/dotnet/QsoRipper.Engine.Storage.Abstractions/QsoListQuery.cs
+++ b/src/dotnet/QsoRipper.Engine.Storage.Abstractions/QsoListQuery.cs
@@ -34,6 +34,9 @@ public sealed record QsoListQuery
 
     /// <summary>Sort order for the result set. Defaults to <see cref="QsoSortOrder.NewestFirst"/>.</summary>
     public QsoSortOrder Sort { get; init; } = QsoSortOrder.NewestFirst;
+
+    /// <summary>Filter for soft-deleted (tombstoned) QSOs. Defaults to <see cref="DeletedRecordsFilter.ActiveOnly"/>.</summary>
+    public DeletedRecordsFilter DeletedFilter { get; init; } = DeletedRecordsFilter.ActiveOnly;
 }
 
 /// <summary>Sort order for QSO list queries.</summary>
@@ -44,4 +47,17 @@ public enum QsoSortOrder
 
     /// <summary>Oldest QSOs first (ascending timestamp).</summary>
     OldestFirst,
+}
+
+/// <summary>Soft-delete inclusion mode for <see cref="QsoListQuery"/>.</summary>
+public enum DeletedRecordsFilter
+{
+    /// <summary>Only return rows where <c>DeletedAt</c> is null.</summary>
+    ActiveOnly,
+
+    /// <summary>Only return rows where <c>DeletedAt</c> is set.</summary>
+    DeletedOnly,
+
+    /// <summary>Return both active and soft-deleted rows.</summary>
+    All,
 }

--- a/src/dotnet/QsoRipper.Engine.Storage.Memory.Tests/MemoryStorageTests.cs
+++ b/src/dotnet/QsoRipper.Engine.Storage.Memory.Tests/MemoryStorageTests.cs
@@ -556,5 +556,79 @@ public sealed class MemoryStorageTests
             StoredAt = DateTimeOffset.UtcNow,
         };
     }
+
+    // ──────────────────────────────────────────────
+    //  Soft-delete & restore
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task SoftDelete_keeps_row_with_tombstone_set()
+    {
+        await _storage.Logbook.InsertQsoAsync(MakeQso("s1", "W1AW", Band._20M, Mode.Ft8, "2026-02-01T00:00:00Z"));
+        var ok = await _storage.Logbook.SoftDeleteQsoAsync("s1", DateTimeOffset.Parse("2026-02-02T00:00:00Z", System.Globalization.CultureInfo.InvariantCulture), pendingRemoteDelete: true);
+        Assert.True(ok);
+
+        var fetched = await _storage.Logbook.GetQsoAsync("s1");
+        Assert.NotNull(fetched);
+        Assert.NotNull(fetched!.DeletedAt);
+        Assert.True(fetched.PendingRemoteDelete);
+    }
+
+    [Fact]
+    public async Task ListQsos_active_only_excludes_soft_deleted_by_default()
+    {
+        await _storage.Logbook.InsertQsoAsync(MakeQso("a", "W1AW", Band._20M, Mode.Ft8, "2026-02-01T00:00:00Z"));
+        await _storage.Logbook.InsertQsoAsync(MakeQso("b", "W1NEW", Band._20M, Mode.Ft8, "2026-02-02T00:00:00Z"));
+        await _storage.Logbook.SoftDeleteQsoAsync("a", DateTimeOffset.UtcNow, pendingRemoteDelete: false);
+
+        var active = await _storage.Logbook.ListQsosAsync(new QsoListQuery());
+        Assert.Single(active);
+        Assert.Equal("b", active[0].LocalId);
+
+        var deleted = await _storage.Logbook.ListQsosAsync(new QsoListQuery { DeletedFilter = DeletedRecordsFilter.DeletedOnly });
+        Assert.Single(deleted);
+        Assert.Equal("a", deleted[0].LocalId);
+
+        var all = await _storage.Logbook.ListQsosAsync(new QsoListQuery { DeletedFilter = DeletedRecordsFilter.All });
+        Assert.Equal(2, all.Count);
+    }
+
+    [Fact]
+    public async Task GetCounts_excludes_soft_deleted_rows()
+    {
+        await _storage.Logbook.InsertQsoAsync(MakeQso("a", "W1AW", Band._20M, Mode.Ft8, "2026-02-01T00:00:00Z", SyncStatus.LocalOnly));
+        await _storage.Logbook.InsertQsoAsync(MakeQso("b", "W1NEW", Band._20M, Mode.Ft8, "2026-02-02T00:00:00Z", SyncStatus.LocalOnly));
+        await _storage.Logbook.SoftDeleteQsoAsync("b", DateTimeOffset.UtcNow, pendingRemoteDelete: false);
+
+        var counts = await _storage.Logbook.GetCountsAsync();
+        Assert.Equal(1, counts.LocalQsoCount);
+        Assert.Equal(1, counts.PendingUploadCount);
+    }
+
+    [Fact]
+    public async Task Restore_clears_tombstone_and_pending_flag()
+    {
+        await _storage.Logbook.InsertQsoAsync(MakeQso("r1", "W1AW", Band._20M, Mode.Ft8, "2026-03-01T00:00:00Z"));
+        await _storage.Logbook.SoftDeleteQsoAsync("r1", DateTimeOffset.UtcNow, pendingRemoteDelete: true);
+
+        Assert.True(await _storage.Logbook.RestoreQsoAsync("r1"));
+
+        var fetched = await _storage.Logbook.GetQsoAsync("r1");
+        Assert.NotNull(fetched);
+        Assert.Null(fetched!.DeletedAt);
+        Assert.False(fetched.PendingRemoteDelete);
+    }
+
+    [Fact]
+    public async Task SoftDelete_returns_false_for_missing_row()
+    {
+        Assert.False(await _storage.Logbook.SoftDeleteQsoAsync("missing", DateTimeOffset.UtcNow, pendingRemoteDelete: false));
+    }
+
+    [Fact]
+    public async Task Restore_returns_false_for_missing_row()
+    {
+        Assert.False(await _storage.Logbook.RestoreQsoAsync("missing"));
+    }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Engine.Storage.Memory/MemoryStorage.cs
+++ b/src/dotnet/QsoRipper.Engine.Storage.Memory/MemoryStorage.cs
@@ -73,6 +73,42 @@ public sealed class MemoryStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
     }
 
     /// <inheritdoc />
+    public ValueTask<bool> SoftDeleteQsoAsync(string localId, DateTimeOffset deletedAt, bool pendingRemoteDelete)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localId);
+
+        lock (_lock)
+        {
+            if (!_qsos.TryGetValue(localId.Trim(), out var stored))
+            {
+                return new ValueTask<bool>(false);
+            }
+
+            stored.DeletedAt = Timestamp.FromDateTimeOffset(deletedAt);
+            stored.PendingRemoteDelete = pendingRemoteDelete;
+            return new ValueTask<bool>(true);
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask<bool> RestoreQsoAsync(string localId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localId);
+
+        lock (_lock)
+        {
+            if (!_qsos.TryGetValue(localId.Trim(), out var stored))
+            {
+                return new ValueTask<bool>(false);
+            }
+
+            stored.DeletedAt = null;
+            stored.PendingRemoteDelete = false;
+            return new ValueTask<bool>(true);
+        }
+    }
+
+    /// <inheritdoc />
     public ValueTask<QsoRecord?> GetQsoAsync(string localId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(localId);
@@ -96,6 +132,14 @@ public sealed class MemoryStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
         lock (_lock)
         {
             IEnumerable<QsoRecord> items = _qsos.Values;
+
+            items = query.DeletedFilter switch
+            {
+                DeletedRecordsFilter.ActiveOnly => items.Where(q => q.DeletedAt is null),
+                DeletedRecordsFilter.DeletedOnly => items.Where(q => q.DeletedAt is not null),
+                DeletedRecordsFilter.All => items,
+                _ => items.Where(q => q.DeletedAt is null),
+            };
 
             if (query.After is { } after)
             {
@@ -154,9 +198,9 @@ public sealed class MemoryStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
     {
         lock (_lock)
         {
-            var total = _qsos.Count;
-            var pending = _qsos.Values.Count(q => q.SyncStatus != SyncStatus.Synced);
-            return new ValueTask<LogbookCounts>(new LogbookCounts(total, pending));
+            var active = _qsos.Values.Where(q => q.DeletedAt is null).ToArray();
+            var pending = active.Count(q => q.SyncStatus != SyncStatus.Synced);
+            return new ValueTask<LogbookCounts>(new LogbookCounts(active.Length, pending));
         }
     }
 

--- a/src/dotnet/QsoRipper.Engine.Storage.Sqlite.Tests/SqliteStorageTests.cs
+++ b/src/dotnet/QsoRipper.Engine.Storage.Sqlite.Tests/SqliteStorageTests.cs
@@ -707,5 +707,125 @@ public sealed class SqliteStorageTests : IDisposable
             StoredAt = DateTimeOffset.UtcNow,
         };
     }
+
+    // ──────────────────────────────────────────────
+    //  Soft-delete & restore
+    // ──────────────────────────────────────────────
+
+    [Fact]
+    public async Task SoftDelete_marks_row_and_keeps_it_persisted()
+    {
+        var qso = MakeQso("soft1", "W1AW", Band._20M, Mode.Ft8, "2026-02-01T00:00:00Z", SyncStatus.Synced);
+        qso.QrzLogid = "remote-1";
+        await _storage.Logbook.InsertQsoAsync(qso);
+
+        var deletedAt = DateTimeOffset.Parse("2026-02-02T00:00:00Z", System.Globalization.CultureInfo.InvariantCulture);
+        var ok = await _storage.Logbook.SoftDeleteQsoAsync("soft1", deletedAt, pendingRemoteDelete: true);
+        Assert.True(ok);
+
+        var fetched = await _storage.Logbook.GetQsoAsync("soft1");
+        Assert.NotNull(fetched);
+        Assert.NotNull(fetched!.DeletedAt);
+        Assert.Equal(deletedAt.ToUnixTimeSeconds(), fetched.DeletedAt.Seconds);
+        Assert.True(fetched.PendingRemoteDelete);
+    }
+
+    [Fact]
+    public async Task ListQsos_default_filter_excludes_soft_deleted()
+    {
+        await _storage.Logbook.InsertQsoAsync(MakeQso("a", "W1AW", Band._20M, Mode.Ft8, "2026-02-01T00:00:00Z"));
+        await _storage.Logbook.InsertQsoAsync(MakeQso("b", "W1NEW", Band._20M, Mode.Ft8, "2026-02-02T00:00:00Z"));
+        await _storage.Logbook.SoftDeleteQsoAsync("b", DateTimeOffset.UtcNow, pendingRemoteDelete: false);
+
+        var active = await _storage.Logbook.ListQsosAsync(new QsoListQuery());
+        Assert.Single(active);
+        Assert.Equal("a", active[0].LocalId);
+
+        var deletedOnly = await _storage.Logbook.ListQsosAsync(new QsoListQuery { DeletedFilter = DeletedRecordsFilter.DeletedOnly });
+        Assert.Single(deletedOnly);
+        Assert.Equal("b", deletedOnly[0].LocalId);
+
+        var all = await _storage.Logbook.ListQsosAsync(new QsoListQuery { DeletedFilter = DeletedRecordsFilter.All });
+        Assert.Equal(2, all.Count);
+    }
+
+    [Fact]
+    public async Task GetCounts_excludes_soft_deleted_rows()
+    {
+        await _storage.Logbook.InsertQsoAsync(MakeQso("c1", "W1AW", Band._20M, Mode.Ft8, "2026-02-01T00:00:00Z", SyncStatus.LocalOnly));
+        await _storage.Logbook.InsertQsoAsync(MakeQso("c2", "W1NEW", Band._20M, Mode.Ft8, "2026-02-02T00:00:00Z", SyncStatus.LocalOnly));
+        await _storage.Logbook.SoftDeleteQsoAsync("c2", DateTimeOffset.UtcNow, pendingRemoteDelete: false);
+
+        var counts = await _storage.Logbook.GetCountsAsync();
+        Assert.Equal(1, counts.LocalQsoCount);
+        Assert.Equal(1, counts.PendingUploadCount);
+    }
+
+    [Fact]
+    public async Task Restore_clears_tombstone_and_pending_flag()
+    {
+        var qso = MakeQso("r1", "W1AW", Band._20M, Mode.Ft8, "2026-03-01T00:00:00Z");
+        await _storage.Logbook.InsertQsoAsync(qso);
+        await _storage.Logbook.SoftDeleteQsoAsync("r1", DateTimeOffset.UtcNow, pendingRemoteDelete: true);
+
+        var ok = await _storage.Logbook.RestoreQsoAsync("r1");
+        Assert.True(ok);
+
+        var fetched = await _storage.Logbook.GetQsoAsync("r1");
+        Assert.NotNull(fetched);
+        Assert.Null(fetched!.DeletedAt);
+        Assert.False(fetched.PendingRemoteDelete);
+    }
+
+    [Fact]
+    public async Task SoftDelete_returns_false_for_missing_row()
+    {
+        var ok = await _storage.Logbook.SoftDeleteQsoAsync("missing", DateTimeOffset.UtcNow, pendingRemoteDelete: false);
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public async Task Restore_returns_false_for_missing_row()
+    {
+        var ok = await _storage.Logbook.RestoreQsoAsync("missing");
+        Assert.False(ok);
+    }
+
+    [Fact]
+    public async Task Migration_idempotent_when_storage_reopens_existing_file()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"qsoripper-soft-delete-{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var first = new SqliteStorageBuilder().Path(path).Build())
+            {
+                var qso = MakeQso("p1", "W1AW", Band._20M, Mode.Ft8, "2026-04-01T00:00:00Z");
+                await first.Logbook.InsertQsoAsync(qso);
+                await first.Logbook.SoftDeleteQsoAsync("p1", DateTimeOffset.UtcNow, pendingRemoteDelete: false);
+            }
+
+            using (var second = new SqliteStorageBuilder().Path(path).Build())
+            {
+                // Reopening must not throw and must preserve the soft-delete state.
+                var fetched = await second.Logbook.GetQsoAsync("p1");
+                Assert.NotNull(fetched);
+                Assert.NotNull(fetched!.DeletedAt);
+            }
+        }
+        finally
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (File.Exists(path))
+            {
+                try
+                {
+                    File.Delete(path);
+                }
+                catch (IOException)
+                {
+                }
+            }
+        }
+    }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Engine.Storage.Sqlite/SqliteStorage.cs
+++ b/src/dotnet/QsoRipper.Engine.Storage.Sqlite/SqliteStorage.cs
@@ -28,7 +28,9 @@ public sealed class SqliteStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
             created_at_ms INTEGER,
             updated_at_ms INTEGER,
             sync_status INTEGER NOT NULL,
-            record BLOB NOT NULL
+            record BLOB NOT NULL,
+            deleted_at_ms INTEGER,
+            pending_remote_delete INTEGER NOT NULL DEFAULT 0
         );
 
         CREATE INDEX IF NOT EXISTS idx_qsos_station_callsign ON qsos (station_callsign);
@@ -38,6 +40,7 @@ public sealed class SqliteStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
         CREATE INDEX IF NOT EXISTS idx_qsos_mode ON qsos (mode);
         CREATE INDEX IF NOT EXISTS idx_qsos_contest_id ON qsos (contest_id);
         CREATE INDEX IF NOT EXISTS idx_qsos_sync_status ON qsos (sync_status);
+        CREATE INDEX IF NOT EXISTS idx_qsos_deleted_at_ms ON qsos (deleted_at_ms);
 
         CREATE TABLE IF NOT EXISTS sync_metadata (
             id INTEGER PRIMARY KEY CHECK (id = 1),
@@ -92,9 +95,11 @@ public sealed class SqliteStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
                 cmd.CommandText =
                     """
                     INSERT INTO qsos (local_id, qrz_logid, qrz_bookid, station_callsign, worked_callsign,
-                        utc_timestamp_ms, band, mode, contest_id, created_at_ms, updated_at_ms, sync_status, record)
+                        utc_timestamp_ms, band, mode, contest_id, created_at_ms, updated_at_ms, sync_status, record,
+                        deleted_at_ms, pending_remote_delete)
                     VALUES ($local_id, $qrz_logid, $qrz_bookid, $station_callsign, $worked_callsign,
-                        $utc_timestamp_ms, $band, $mode, $contest_id, $created_at_ms, $updated_at_ms, $sync_status, $record)
+                        $utc_timestamp_ms, $band, $mode, $contest_id, $created_at_ms, $updated_at_ms, $sync_status, $record,
+                        $deleted_at_ms, $pending_remote_delete)
                     """;
                 BindQsoParameters(cmd, qso);
                 cmd.ExecuteNonQuery();
@@ -135,7 +140,9 @@ public sealed class SqliteStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
                     created_at_ms = $created_at_ms,
                     updated_at_ms = $updated_at_ms,
                     sync_status = $sync_status,
-                    record = $record
+                    record = $record,
+                    deleted_at_ms = $deleted_at_ms,
+                    pending_remote_delete = $pending_remote_delete
                 WHERE local_id = $local_id
                 """;
             BindQsoParameters(cmd, qso);
@@ -158,6 +165,38 @@ public sealed class SqliteStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
             var rows = cmd.ExecuteNonQuery();
             return new ValueTask<bool>(rows > 0);
         }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<bool> SoftDeleteQsoAsync(string localId, DateTimeOffset deletedAt, bool pendingRemoteDelete)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localId);
+
+        var existing = await GetQsoAsync(localId).ConfigureAwait(false);
+        if (existing is null)
+        {
+            return false;
+        }
+
+        existing.DeletedAt = Timestamp.FromDateTimeOffset(deletedAt);
+        existing.PendingRemoteDelete = pendingRemoteDelete;
+        return await UpdateQsoAsync(existing).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<bool> RestoreQsoAsync(string localId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localId);
+
+        var existing = await GetQsoAsync(localId).ConfigureAwait(false);
+        if (existing is null)
+        {
+            return false;
+        }
+
+        existing.DeletedAt = null;
+        existing.PendingRemoteDelete = false;
+        return await UpdateQsoAsync(existing).ConfigureAwait(false);
     }
 
     /// <inheritdoc />
@@ -192,6 +231,18 @@ public sealed class SqliteStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
             ThrowIfDisposed();
             using var cmd = _connection.CreateCommand();
             var whereClauses = new List<string>();
+
+            switch (query.DeletedFilter)
+            {
+                case DeletedRecordsFilter.ActiveOnly:
+                    whereClauses.Add("deleted_at_ms IS NULL");
+                    break;
+                case DeletedRecordsFilter.DeletedOnly:
+                    whereClauses.Add("deleted_at_ms IS NOT NULL");
+                    break;
+                case DeletedRecordsFilter.All:
+                    break;
+            }
 
             if (query.After is { } after)
             {
@@ -277,11 +328,11 @@ public sealed class SqliteStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
         {
             ThrowIfDisposed();
             using var totalCmd = _connection.CreateCommand();
-            totalCmd.CommandText = "SELECT COUNT(*) FROM qsos";
+            totalCmd.CommandText = "SELECT COUNT(*) FROM qsos WHERE deleted_at_ms IS NULL";
             var total = Convert.ToInt32(totalCmd.ExecuteScalar(), CultureInfo.InvariantCulture);
 
             using var pendingCmd = _connection.CreateCommand();
-            pendingCmd.CommandText = "SELECT COUNT(*) FROM qsos WHERE sync_status != $synced";
+            pendingCmd.CommandText = "SELECT COUNT(*) FROM qsos WHERE sync_status != $synced AND deleted_at_ms IS NULL";
             pendingCmd.Parameters.AddWithValue("$synced", (int)SyncStatus.Synced);
             var pending = Convert.ToInt32(pendingCmd.ExecuteScalar(), CultureInfo.InvariantCulture);
 
@@ -445,7 +496,40 @@ public sealed class SqliteStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = MigrationSql;
             cmd.ExecuteNonQuery();
+
+            ApplySoftDeleteMigration();
         }
+    }
+
+    private void ApplySoftDeleteMigration()
+    {
+        if (!HasColumn("qsos", "deleted_at_ms"))
+        {
+            using var alter = _connection.CreateCommand();
+            alter.CommandText = "ALTER TABLE qsos ADD COLUMN deleted_at_ms INTEGER";
+            alter.ExecuteNonQuery();
+        }
+
+        if (!HasColumn("qsos", "pending_remote_delete"))
+        {
+            using var alter = _connection.CreateCommand();
+            alter.CommandText = "ALTER TABLE qsos ADD COLUMN pending_remote_delete INTEGER NOT NULL DEFAULT 0";
+            alter.ExecuteNonQuery();
+        }
+
+        using var index = _connection.CreateCommand();
+        index.CommandText = "CREATE INDEX IF NOT EXISTS idx_qsos_deleted_at_ms ON qsos (deleted_at_ms)";
+        index.ExecuteNonQuery();
+    }
+
+    private bool HasColumn(string table, string column)
+    {
+        using var cmd = _connection.CreateCommand();
+        cmd.CommandText = "SELECT 1 FROM pragma_table_info($table) WHERE name = $column LIMIT 1";
+        cmd.Parameters.AddWithValue("$table", table);
+        cmd.Parameters.AddWithValue("$column", column);
+        using var reader = cmd.ExecuteReader();
+        return reader.Read();
     }
 
     internal void ConfigurePragmas(TimeSpan busyTimeout)
@@ -492,6 +576,8 @@ public sealed class SqliteStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
         cmd.Parameters.AddWithValue("$updated_at_ms", NullableMsToDbValue(TimestampToMs(qso.UpdatedAt)));
         cmd.Parameters.AddWithValue("$sync_status", (int)qso.SyncStatus);
         cmd.Parameters.AddWithValue("$record", qso.ToByteArray());
+        cmd.Parameters.AddWithValue("$deleted_at_ms", NullableMsToDbValue(TimestampToMs(qso.DeletedAt)));
+        cmd.Parameters.AddWithValue("$pending_remote_delete", qso.PendingRemoteDelete ? 1 : 0);
     }
 
     private static object NullableMsToDbValue(long? value)

--- a/src/rust/qsoripper-core/src/lookup/coordinator.rs
+++ b/src/rust/qsoripper-core/src/lookup/coordinator.rs
@@ -784,6 +784,17 @@ mod tests {
         async fn delete_qso(&self, _local_id: &str) -> Result<bool, StorageError> {
             unimplemented!()
         }
+        async fn soft_delete_qso(
+            &self,
+            _local_id: &str,
+            _deleted_at_ms: i64,
+            _pending_remote_delete: bool,
+        ) -> Result<bool, StorageError> {
+            unimplemented!()
+        }
+        async fn restore_qso(&self, _local_id: &str) -> Result<bool, StorageError> {
+            unimplemented!()
+        }
         async fn get_qso(
             &self,
             _local_id: &str,

--- a/src/rust/qsoripper-core/src/storage/mod.rs
+++ b/src/rust/qsoripper-core/src/storage/mod.rs
@@ -6,4 +6,6 @@ mod query;
 
 pub use error::StorageError;
 pub use ports::{EngineStorage, LogbookStore, LookupSnapshotStore};
-pub use query::{LogbookCounts, LookupSnapshot, QsoListQuery, QsoSortOrder, SyncMetadata};
+pub use query::{
+    DeletedRecordsFilter, LogbookCounts, LookupSnapshot, QsoListQuery, QsoSortOrder, SyncMetadata,
+};

--- a/src/rust/qsoripper-core/src/storage/ports.rs
+++ b/src/rust/qsoripper-core/src/storage/ports.rs
@@ -27,6 +27,25 @@ pub trait LogbookStore: Send + Sync {
     /// Delete a QSO by local ID. Returns `true` when a row was removed.
     async fn delete_qso(&self, local_id: &str) -> Result<bool, StorageError>;
 
+    /// Soft-delete a QSO by local ID, setting `deleted_at` and optionally
+    /// queuing it for remote QRZ delete on the next sync. Returns `true` when
+    /// a row was found and updated.
+    ///
+    /// `deleted_at_ms` is the wall-clock millisecond stamp recorded as the
+    /// tombstone time. `pending_remote_delete` should be `true` when the row
+    /// has a `qrz_logid` and the caller asked for remote deletion.
+    async fn soft_delete_qso(
+        &self,
+        local_id: &str,
+        deleted_at_ms: i64,
+        pending_remote_delete: bool,
+    ) -> Result<bool, StorageError>;
+
+    /// Restore a previously soft-deleted QSO. Clears `deleted_at` and
+    /// `pending_remote_delete`. Returns `true` when a row was found and
+    /// restored.
+    async fn restore_qso(&self, local_id: &str) -> Result<bool, StorageError>;
+
     /// Load a single QSO by local ID.
     async fn get_qso(&self, local_id: &str) -> Result<Option<QsoRecord>, StorageError>;
 

--- a/src/rust/qsoripper-core/src/storage/query.rs
+++ b/src/rust/qsoripper-core/src/storage/query.rs
@@ -3,6 +3,18 @@
 use crate::proto::qsoripper::domain::{Band, LookupResult, Mode};
 use prost_types::Timestamp;
 
+/// Soft-delete visibility filter for QSO list queries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DeletedRecordsFilter {
+    /// Only return rows that are not soft-deleted (default behavior).
+    #[default]
+    ActiveOnly,
+    /// Only return rows that have a `deleted_at` tombstone set (trash view).
+    DeletedOnly,
+    /// Return all rows regardless of soft-delete state.
+    All,
+}
+
 /// Filter and pagination options for listing QSOs from persistent storage.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QsoListQuery {
@@ -24,6 +36,8 @@ pub struct QsoListQuery {
     pub offset: u32,
     /// Requested sort order.
     pub sort: QsoSortOrder,
+    /// Visibility filter for soft-deleted rows. Defaults to `ActiveOnly`.
+    pub deleted_filter: DeletedRecordsFilter,
 }
 
 impl Default for QsoListQuery {
@@ -38,6 +52,7 @@ impl Default for QsoListQuery {
             limit: None,
             offset: 0,
             sort: QsoSortOrder::NewestFirst,
+            deleted_filter: DeletedRecordsFilter::ActiveOnly,
         }
     }
 }

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -12,7 +12,9 @@ use std::{fs, future::Future, io, net::SocketAddr, path::PathBuf, sync::Arc};
 use qsoripper_core::adif::{parse_adi_qsos, serialize_adi_qsos};
 use qsoripper_core::application::logbook::LogbookError;
 use qsoripper_core::lookup::QRZ_USER_AGENT_ENV_VAR;
-use qsoripper_core::storage::{EngineStorage, QsoListQuery, QsoSortOrder, StorageError};
+use qsoripper_core::storage::{
+    DeletedRecordsFilter, EngineStorage, QsoListQuery, QsoSortOrder, StorageError,
+};
 use qsoripper_storage_memory::MemoryStorage;
 use qsoripper_storage_sqlite::SqliteStorageBuilder;
 use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
@@ -30,7 +32,8 @@ use qsoripper_core::proto::qsoripper::services::{
     space_weather_service_server::{SpaceWeatherService, SpaceWeatherServiceServer},
     station_profile_service_server::StationProfileServiceServer,
     AdifChunk, ApplyRuntimeConfigRequest, ApplyRuntimeConfigResponse, BatchLookupRequest,
-    BatchLookupResponse, DeleteQsoRequest, DeleteQsoResponse, EngineInfo, ExportAdifRequest,
+    BatchLookupResponse, DeleteQsoRequest, DeleteQsoResponse,
+    DeletedRecordsFilter as ProtoDeletedRecordsFilter, EngineInfo, ExportAdifRequest,
     ExportAdifResponse, GetCachedCallsignRequest, GetCachedCallsignResponse,
     GetCurrentSpaceWeatherRequest, GetCurrentSpaceWeatherResponse, GetDxccEntityRequest,
     GetDxccEntityResponse, GetEngineInfoRequest, GetEngineInfoResponse, GetQsoRequest,
@@ -1092,6 +1095,19 @@ fn qso_list_query_from_request(request: &ListQsosRequest) -> Result<QsoListQuery
         Err(_) => return Err(Box::new(Status::invalid_argument("Invalid sort order."))),
     };
 
+    let deleted_filter = match ProtoDeletedRecordsFilter::try_from(request.deleted_filter) {
+        Ok(ProtoDeletedRecordsFilter::Unspecified | ProtoDeletedRecordsFilter::ActiveOnly) => {
+            DeletedRecordsFilter::ActiveOnly
+        }
+        Ok(ProtoDeletedRecordsFilter::DeletedOnly) => DeletedRecordsFilter::DeletedOnly,
+        Ok(ProtoDeletedRecordsFilter::All) => DeletedRecordsFilter::All,
+        Err(_) => {
+            return Err(Box::new(Status::invalid_argument(
+                "Invalid deleted_filter value.",
+            )))
+        }
+    };
+
     Ok(QsoListQuery {
         after: request.after,
         before: request.before,
@@ -1105,6 +1121,7 @@ fn qso_list_query_from_request(request: &ListQsosRequest) -> Result<QsoListQuery
         limit: (request.limit > 0).then_some(request.limit),
         offset: request.offset,
         sort,
+        deleted_filter,
     })
 }
 

--- a/src/rust/qsoripper-storage-memory/src/lib.rs
+++ b/src/rust/qsoripper-storage-memory/src/lib.rs
@@ -4,8 +4,8 @@ use qsoripper_core::application::logbook::is_pending_sync_status;
 use qsoripper_core::domain::lookup::normalize_callsign;
 use qsoripper_core::proto::qsoripper::domain::QsoRecord;
 use qsoripper_core::storage::{
-    EngineStorage, LogbookCounts, LogbookStore, LookupSnapshot, LookupSnapshotStore, QsoListQuery,
-    QsoSortOrder, StorageError, SyncMetadata,
+    DeletedRecordsFilter, EngineStorage, LogbookCounts, LogbookStore, LookupSnapshot,
+    LookupSnapshotStore, QsoListQuery, QsoSortOrder, StorageError, SyncMetadata,
 };
 use std::cmp::Reverse;
 use std::collections::BTreeMap;
@@ -73,6 +73,31 @@ impl LogbookStore for MemoryStorage {
         Ok(state.qsos.remove(local_id).is_some())
     }
 
+    async fn soft_delete_qso(
+        &self,
+        local_id: &str,
+        deleted_at_ms: i64,
+        pending_remote_delete: bool,
+    ) -> Result<bool, StorageError> {
+        let mut state = self.state.write().await;
+        let Some(record) = state.qsos.get_mut(local_id) else {
+            return Ok(false);
+        };
+        record.deleted_at = Some(millis_to_timestamp(deleted_at_ms));
+        record.pending_remote_delete = pending_remote_delete;
+        Ok(true)
+    }
+
+    async fn restore_qso(&self, local_id: &str) -> Result<bool, StorageError> {
+        let mut state = self.state.write().await;
+        let Some(record) = state.qsos.get_mut(local_id) else {
+            return Ok(false);
+        };
+        record.deleted_at = None;
+        record.pending_remote_delete = false;
+        Ok(true)
+    }
+
     async fn get_qso(&self, local_id: &str) -> Result<Option<QsoRecord>, StorageError> {
         let state = self.state.read().await;
         Ok(state.qsos.get(local_id).cloned())
@@ -128,14 +153,17 @@ impl LogbookStore for MemoryStorage {
 
     async fn qso_counts(&self) -> Result<LogbookCounts, StorageError> {
         let state = self.state.read().await;
-        let pending_upload_count = state
+        let active_iter = state
             .qsos
             .values()
+            .filter(|record| record.deleted_at.is_none());
+        let local_qso_count = active_iter.clone().count();
+        let pending_upload_count = active_iter
             .filter(|record| is_pending_sync_status(record.sync_status))
             .count();
 
         Ok(LogbookCounts {
-            local_qso_count: u32::try_from(state.qsos.len())
+            local_qso_count: u32::try_from(local_qso_count)
                 .map_err(|_| StorageError::backend("local_qso_count exceeds u32"))?,
             pending_upload_count: u32::try_from(pending_upload_count)
                 .map_err(|_| StorageError::backend("pending_upload_count exceeds u32"))?,
@@ -186,6 +214,20 @@ impl LookupSnapshotStore for MemoryStorage {
 }
 
 fn matches_query(record: &QsoRecord, query: &QsoListQuery) -> bool {
+    match query.deleted_filter {
+        DeletedRecordsFilter::ActiveOnly => {
+            if record.deleted_at.is_some() {
+                return false;
+            }
+        }
+        DeletedRecordsFilter::DeletedOnly => {
+            if record.deleted_at.is_none() {
+                return false;
+            }
+        }
+        DeletedRecordsFilter::All => {}
+    }
+
     if let Some(after) = query.after.as_ref() {
         if timestamp_to_millis(record.utc_timestamp.as_ref()) < timestamp_to_millis(Some(after)) {
             return false;
@@ -244,6 +286,14 @@ fn timestamp_to_millis(timestamp: Option<&prost_types::Timestamp>) -> i64 {
     })
 }
 
+fn millis_to_timestamp(millis: i64) -> prost_types::Timestamp {
+    let seconds = millis.div_euclid(1_000);
+    let nanos = i32::try_from(millis.rem_euclid(1_000))
+        .unwrap_or(0)
+        .saturating_mul(1_000_000);
+    prost_types::Timestamp { seconds, nanos }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::panic)]
 mod tests {
@@ -253,7 +303,8 @@ mod tests {
     use qsoripper_core::domain::qso::QsoRecordBuilder;
     use qsoripper_core::proto::qsoripper::domain::{Band, LookupResult, LookupState, Mode};
     use qsoripper_core::storage::{
-        EngineStorage, LookupSnapshot, LookupSnapshotStore, QsoListQuery, QsoSortOrder,
+        DeletedRecordsFilter, EngineStorage, LogbookStore, LookupSnapshot, LookupSnapshotStore,
+        QsoListQuery, QsoSortOrder,
     };
     use std::sync::Arc;
 
@@ -366,6 +417,156 @@ mod tests {
 
         assert_eq!(loaded.callsign, "W1AW");
         assert_eq!(loaded.result.state, LookupState::Found as i32);
+    }
+
+    #[tokio::test]
+    async fn memory_storage_soft_delete_keeps_row_with_tombstone() {
+        let storage = MemoryStorage::new();
+        let qso = QsoRecordBuilder::new("W1AW", "K7ABC")
+            .band(Band::Band20m)
+            .mode(Mode::Ft8)
+            .timestamp(Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            })
+            .build();
+        let local_id = qso.local_id.clone();
+        storage.insert_qso(&qso).await.unwrap();
+
+        assert!(storage
+            .soft_delete_qso(&local_id, 1_700_000_500_000, true)
+            .await
+            .unwrap());
+
+        let fetched = storage.get_qso(&local_id).await.unwrap().unwrap();
+        assert!(fetched.deleted_at.is_some());
+        assert!(fetched.pending_remote_delete);
+    }
+
+    #[tokio::test]
+    async fn memory_storage_list_qsos_active_only_excludes_soft_deleted() {
+        let storage = MemoryStorage::new();
+        for callsign in ["A1A", "B2B"] {
+            let qso = QsoRecordBuilder::new("W1AW", callsign)
+                .band(Band::Band20m)
+                .mode(Mode::Ft8)
+                .timestamp(Timestamp {
+                    seconds: 1_700_000_000,
+                    nanos: 0,
+                })
+                .build();
+            storage.insert_qso(&qso).await.unwrap();
+        }
+        let all = storage
+            .list_qsos(&QsoListQuery {
+                deleted_filter: DeletedRecordsFilter::All,
+                ..QsoListQuery::default()
+            })
+            .await
+            .unwrap();
+        let target = all
+            .iter()
+            .find(|r| r.worked_callsign == "B2B")
+            .map(|r| r.local_id.clone())
+            .unwrap();
+
+        storage
+            .soft_delete_qso(&target, 1_700_000_500_000, false)
+            .await
+            .unwrap();
+
+        let active = storage.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(active.len(), 1);
+        assert_eq!(active.first().unwrap().worked_callsign, "A1A");
+
+        let deleted_only = storage
+            .list_qsos(&QsoListQuery {
+                deleted_filter: DeletedRecordsFilter::DeletedOnly,
+                ..QsoListQuery::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(deleted_only.len(), 1);
+        assert_eq!(deleted_only.first().unwrap().worked_callsign, "B2B");
+
+        let all_after = storage
+            .list_qsos(&QsoListQuery {
+                deleted_filter: DeletedRecordsFilter::All,
+                ..QsoListQuery::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(all_after.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn memory_storage_qso_counts_excludes_soft_deleted() {
+        let storage = MemoryStorage::new();
+        for cs in ["A", "B"] {
+            let qso = QsoRecordBuilder::new("W1AW", cs)
+                .band(Band::Band20m)
+                .mode(Mode::Ft8)
+                .timestamp(Timestamp {
+                    seconds: 1_700_000_000,
+                    nanos: 0,
+                })
+                .build();
+            storage.insert_qso(&qso).await.unwrap();
+        }
+        let listed = storage
+            .list_qsos(&QsoListQuery {
+                deleted_filter: DeletedRecordsFilter::All,
+                ..QsoListQuery::default()
+            })
+            .await
+            .unwrap();
+        let target = listed
+            .iter()
+            .find(|r| r.worked_callsign == "B")
+            .map(|r| r.local_id.clone())
+            .unwrap();
+        storage
+            .soft_delete_qso(&target, 1_700_000_500_000, false)
+            .await
+            .unwrap();
+
+        let counts = storage.qso_counts().await.unwrap();
+        assert_eq!(counts.local_qso_count, 1);
+    }
+
+    #[tokio::test]
+    async fn memory_storage_restore_clears_tombstone() {
+        let storage = MemoryStorage::new();
+        let qso = QsoRecordBuilder::new("W1AW", "K7ABC")
+            .band(Band::Band20m)
+            .mode(Mode::Ft8)
+            .timestamp(Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            })
+            .build();
+        let local_id = qso.local_id.clone();
+        storage.insert_qso(&qso).await.unwrap();
+        storage
+            .soft_delete_qso(&local_id, 1_700_000_500_000, true)
+            .await
+            .unwrap();
+
+        assert!(storage.restore_qso(&local_id).await.unwrap());
+
+        let fetched = storage.get_qso(&local_id).await.unwrap().unwrap();
+        assert!(fetched.deleted_at.is_none());
+        assert!(!fetched.pending_remote_delete);
+    }
+
+    #[tokio::test]
+    async fn memory_storage_soft_delete_missing_returns_false() {
+        let storage = MemoryStorage::new();
+        assert!(!storage
+            .soft_delete_qso("missing", 1_700_000_500_000, false)
+            .await
+            .unwrap());
+        assert!(!storage.restore_qso("missing").await.unwrap());
     }
 
     #[test]

--- a/src/rust/qsoripper-storage-sqlite/src/builder.rs
+++ b/src/rust/qsoripper-storage-sqlite/src/builder.rs
@@ -1,9 +1,9 @@
 //! Builder for configuring the `SQLite` storage adapter.
 
-use crate::migrations::INITIAL_SCHEMA;
+use crate::migrations::{INITIAL_SCHEMA, SOFT_DELETE_MIGRATION};
 use crate::SqliteStorage;
 use qsoripper_core::storage::StorageError;
-use sqlite::Connection;
+use sqlite::{Connection, ConnectionThreadSafe, State, Value};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -83,11 +83,52 @@ impl SqliteStorageBuilder {
         connection
             .execute(INITIAL_SCHEMA)
             .map_err(map_sqlite_error)?;
+        apply_soft_delete_migration(&connection)?;
 
         Ok(SqliteStorage {
             connection: Mutex::new(connection),
         })
     }
+}
+
+/// Apply the soft-delete migration only when the columns are missing.
+/// `SQLite` has no `ALTER TABLE ADD COLUMN IF NOT EXISTS`, so we probe
+/// `pragma_table_info` first and skip the migration on databases that
+/// already carry the columns.
+fn apply_soft_delete_migration(connection: &ConnectionThreadSafe) -> Result<(), StorageError> {
+    if has_column(connection, "qsos", "deleted_at_ms")?
+        && has_column(connection, "qsos", "pending_remote_delete")?
+    {
+        // Index creation is `IF NOT EXISTS` already and cheap, but skipping
+        // the entire script avoids the `ALTER TABLE` failure path.
+        connection
+            .execute("CREATE INDEX IF NOT EXISTS idx_qsos_deleted_at_ms ON qsos (deleted_at_ms);")
+            .map_err(map_sqlite_error)?;
+        return Ok(());
+    }
+
+    connection
+        .execute(SOFT_DELETE_MIGRATION)
+        .map_err(map_sqlite_error)?;
+    Ok(())
+}
+
+fn has_column(
+    connection: &ConnectionThreadSafe,
+    table: &str,
+    column: &str,
+) -> Result<bool, StorageError> {
+    let mut statement = connection
+        .prepare("SELECT 1 FROM pragma_table_info(?) WHERE name = ? LIMIT 1")
+        .map_err(map_sqlite_error)?;
+    statement
+        .bind((1, Value::String(table.to_string())))
+        .map_err(map_sqlite_error)?;
+    statement
+        .bind((2, Value::String(column.to_string())))
+        .map_err(map_sqlite_error)?;
+    let state = statement.next().map_err(map_sqlite_error)?;
+    Ok(matches!(state, State::Row))
 }
 
 fn ensure_parent_directory(path: &Path) -> Result<(), StorageError> {

--- a/src/rust/qsoripper-storage-sqlite/src/lib.rs
+++ b/src/rust/qsoripper-storage-sqlite/src/lib.rs
@@ -7,8 +7,8 @@ use prost::Message;
 use qsoripper_core::domain::lookup::normalize_callsign;
 use qsoripper_core::proto::qsoripper::domain::{LookupResult, QsoRecord, SyncStatus};
 use qsoripper_core::storage::{
-    EngineStorage, LogbookCounts, LogbookStore, LookupSnapshot, LookupSnapshotStore, QsoListQuery,
-    QsoSortOrder, StorageError, SyncMetadata,
+    DeletedRecordsFilter, EngineStorage, LogbookCounts, LogbookStore, LookupSnapshot,
+    LookupSnapshotStore, QsoListQuery, QsoSortOrder, StorageError, SyncMetadata,
 };
 use sqlite::{ConnectionThreadSafe, ReadableWithIndex, State, Statement, Value};
 use std::sync::{Mutex, MutexGuard};
@@ -62,8 +62,10 @@ impl LogbookStore for SqliteStorage {
                 created_at_ms,
                 updated_at_ms,
                 sync_status,
-                record
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                record,
+                deleted_at_ms,
+                pending_remote_delete
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             &[
                 Value::from(qso.local_id.as_str()),
                 Value::from(qso.qrz_logid.as_deref()),
@@ -78,6 +80,8 @@ impl LogbookStore for SqliteStorage {
                 Value::from(timestamp_to_millis(qso.updated_at.as_ref())),
                 Value::Integer(i64::from(qso.sync_status)),
                 Value::Binary(encoded),
+                Value::from(timestamp_to_millis(qso.deleted_at.as_ref())),
+                Value::Integer(i64::from(qso.pending_remote_delete)),
             ],
         )
         .map_err(|err| map_insert_error(err, &qso.local_id))?;
@@ -102,7 +106,9 @@ impl LogbookStore for SqliteStorage {
                  created_at_ms = ?,
                  updated_at_ms = ?,
                  sync_status = ?,
-                 record = ?
+                 record = ?,
+                 deleted_at_ms = ?,
+                 pending_remote_delete = ?
              WHERE local_id = ?",
             &[
                 Value::from(qso.qrz_logid.as_deref()),
@@ -117,6 +123,8 @@ impl LogbookStore for SqliteStorage {
                 Value::from(timestamp_to_millis(qso.updated_at.as_ref())),
                 Value::Integer(i64::from(qso.sync_status)),
                 Value::Binary(encoded),
+                Value::from(timestamp_to_millis(qso.deleted_at.as_ref())),
+                Value::Integer(i64::from(qso.pending_remote_delete)),
                 Value::from(qso.local_id.as_str()),
             ],
         )
@@ -137,6 +145,29 @@ impl LogbookStore for SqliteStorage {
         Ok(rows > 0)
     }
 
+    async fn soft_delete_qso(
+        &self,
+        local_id: &str,
+        deleted_at_ms: i64,
+        pending_remote_delete: bool,
+    ) -> Result<bool, StorageError> {
+        let Some(mut record) = self.get_qso(local_id).await? else {
+            return Ok(false);
+        };
+        record.deleted_at = millis_to_timestamp(Some(deleted_at_ms));
+        record.pending_remote_delete = pending_remote_delete;
+        self.update_qso(&record).await
+    }
+
+    async fn restore_qso(&self, local_id: &str) -> Result<bool, StorageError> {
+        let Some(mut record) = self.get_qso(local_id).await? else {
+            return Ok(false);
+        };
+        record.deleted_at = None;
+        record.pending_remote_delete = false;
+        self.update_qso(&record).await
+    }
+
     async fn get_qso(&self, local_id: &str) -> Result<Option<QsoRecord>, StorageError> {
         let connection = self.connection()?;
         let payload = query_optional::<Vec<u8>>(
@@ -154,6 +185,16 @@ impl LogbookStore for SqliteStorage {
         let connection = self.connection()?;
         let mut sql = String::from("SELECT record FROM qsos WHERE 1 = 1");
         let mut values = Vec::<Value>::new();
+
+        match query.deleted_filter {
+            DeletedRecordsFilter::ActiveOnly => {
+                sql.push_str(" AND deleted_at_ms IS NULL");
+            }
+            DeletedRecordsFilter::DeletedOnly => {
+                sql.push_str(" AND deleted_at_ms IS NOT NULL");
+            }
+            DeletedRecordsFilter::All => {}
+        }
 
         if let Some(after) = query.after.as_ref() {
             sql.push_str(" AND utc_timestamp_ms >= ?");
@@ -224,13 +265,17 @@ impl LogbookStore for SqliteStorage {
 
     async fn qso_counts(&self) -> Result<LogbookCounts, StorageError> {
         let connection = self.connection()?;
-        let local_qso_count =
-            query_optional::<i64>(&connection, "SELECT COUNT(*) FROM qsos", &[], 0)
-                .map_err(map_sqlite_error)?
-                .unwrap_or(0);
+        let local_qso_count = query_optional::<i64>(
+            &connection,
+            "SELECT COUNT(*) FROM qsos WHERE deleted_at_ms IS NULL",
+            &[],
+            0,
+        )
+        .map_err(map_sqlite_error)?
+        .unwrap_or(0);
         let pending_upload_count = query_optional::<i64>(
             &connection,
-            "SELECT COUNT(*) FROM qsos WHERE sync_status != ?",
+            "SELECT COUNT(*) FROM qsos WHERE sync_status != ? AND deleted_at_ms IS NULL",
             &[Value::Integer(i64::from(SyncStatus::Synced as i32))],
             0,
         )

--- a/src/rust/qsoripper-storage-sqlite/src/migrations.rs
+++ b/src/rust/qsoripper-storage-sqlite/src/migrations.rs
@@ -2,3 +2,8 @@
 
 /// Initial schema for QSO, sync metadata, and lookup snapshot persistence.
 pub(crate) const INITIAL_SCHEMA: &str = include_str!("migrations/0001_initial.sql");
+
+/// Adds soft-delete columns (`deleted_at_ms`, `pending_remote_delete`) and
+/// supporting index. Applied only when the columns are missing — see
+/// `builder::apply_soft_delete_migration` for the conditional execution.
+pub(crate) const SOFT_DELETE_MIGRATION: &str = include_str!("migrations/0002_soft_delete.sql");

--- a/src/rust/qsoripper-storage-sqlite/src/migrations/0001_initial.sql
+++ b/src/rust/qsoripper-storage-sqlite/src/migrations/0001_initial.sql
@@ -11,7 +11,9 @@ CREATE TABLE IF NOT EXISTS qsos (
     created_at_ms INTEGER,
     updated_at_ms INTEGER,
     sync_status INTEGER NOT NULL,
-    record BLOB NOT NULL
+    record BLOB NOT NULL,
+    deleted_at_ms INTEGER,
+    pending_remote_delete INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE INDEX IF NOT EXISTS idx_qsos_station_callsign ON qsos (station_callsign);
@@ -21,6 +23,7 @@ CREATE INDEX IF NOT EXISTS idx_qsos_band ON qsos (band);
 CREATE INDEX IF NOT EXISTS idx_qsos_mode ON qsos (mode);
 CREATE INDEX IF NOT EXISTS idx_qsos_contest_id ON qsos (contest_id);
 CREATE INDEX IF NOT EXISTS idx_qsos_sync_status ON qsos (sync_status);
+CREATE INDEX IF NOT EXISTS idx_qsos_deleted_at_ms ON qsos (deleted_at_ms);
 
 CREATE TABLE IF NOT EXISTS sync_metadata (
     id INTEGER PRIMARY KEY CHECK (id = 1),

--- a/src/rust/qsoripper-storage-sqlite/src/migrations/0002_soft_delete.sql
+++ b/src/rust/qsoripper-storage-sqlite/src/migrations/0002_soft_delete.sql
@@ -1,0 +1,6 @@
+-- Soft-delete columns for the qsos table. Applied conditionally by
+-- the storage builder via pragma_table_info checks (SQLite has no
+-- ALTER TABLE ADD COLUMN IF NOT EXISTS).
+ALTER TABLE qsos ADD COLUMN deleted_at_ms INTEGER;
+ALTER TABLE qsos ADD COLUMN pending_remote_delete INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_qsos_deleted_at_ms ON qsos (deleted_at_ms);


### PR DESCRIPTION
Tracks #289. **No behavioral change** — this PR only lays the storage groundwork for soft-delete & restore. PRs B2 (engine semantics) and B3 (sync integration) follow.

## What changes

### Schema
- New columns on `qsos`: `deleted_at_ms INTEGER NULL` and `pending_remote_delete INTEGER NOT NULL DEFAULT 0`.
- New index `idx_qsos_deleted_at_ms`.
- Rust SQLite: new `0002_soft_delete.sql` applied idempotently via `pragma_table_info` probe in `builder.rs`. Migration 0001 also includes the new columns so fresh DBs get them up front and 0002 short-circuits.
- .NET SQLite: `ApplySoftDeleteMigration()` + `HasColumn()` in `SqliteStorage`; same idempotency contract.

### Storage trait surface (Rust + .NET parity)
- `QsoListQuery.deleted_filter` / `QsoListQuery.DeletedFilter` defaults to `ActiveOnly`.
- `LogbookStore.soft_delete_qso(local_id, deleted_at_ms, pending_remote_delete)` and `LogbookStore.restore_qso(local_id)` (Rust).
- `ILogbookStore.SoftDeleteQsoAsync` / `ILogbookStore.RestoreQsoAsync` (.NET).
- `qso_counts` excludes soft-deleted rows so totals stay consistent with default `ListQsos`.
- Proto `DeletedRecordsFilter` is plumbed from request → store on both engines.

### Tests
- Rust `qsoripper-storage-memory`: 5 new tests (round-trip, restore, filter values, count exclusion, missing-row).
- .NET `QsoRipper.Engine.Storage.Memory.Tests`: 6 new tests covering the same matrix.
- .NET `QsoRipper.Engine.Storage.Sqlite.Tests`: 7 new tests including a file-backed reopen test that proves migration idempotence.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (all green).
- `dotnet format --verify-no-changes`, `dotnet build`, `dotnet test` (all green; 670+ tests).

## Out of scope (B2 / B3)

- `DeleteQso` still hard-deletes — flipped in B2.
- `RestoreQso` RPC still `UNIMPLEMENTED` on both engines — wired in B2.
- Sync Phase 1 skip + Phase 2 queued remote-delete loop — B3.
- GUI / TUI trash view — separate tracking.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
