### PR TITLE
Soft-delete engine semantics + RestoreQso (PR B2 of #289)

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -1026,9 +1026,11 @@ Every logged QSO must carry station identity data. The station context system wo
 
 #### Deleting a QSO
 
-1. Client calls `DeleteQso` with `local_id`.
-2. Engine removes the record from storage.
-3. If the QSO had been synced to QRZ, the engine may optionally queue a remote delete (implementation-dependent).
+1. Client calls `DeleteQso` with `local_id` (and optional `delete_from_qrz` flag).
+2. Engine performs a **soft delete** — the row stays in storage with `deleted_at` set to now (UTC). See §7.8 for full semantics.
+3. If `delete_from_qrz = true` and the row has a non-empty `qrz_logid`, the engine sets `pending_remote_delete = true` so a future sync can issue the QRZ DELETE; this RPC does **not** call QRZ inline.
+4. Response includes `success`, `remote_delete_queued`. The legacy `qrz_delete_success`/`qrz_delete_error` fields stay false/empty (deprecated; do not consume).
+5. Re-deleting an already soft-deleted row succeeds idempotently and may upgrade `pending_remote_delete` from false to true.
 
 ### 7.3 Sync Lifecycle
 
@@ -1167,6 +1169,60 @@ Engines that persist `extra_fields` as an opaque blob MUST run a best-effort dat
 3. **Logs a summary** of how many rows were backfilled, how many duplicates were collapsed, and any per-row errors, but does not fail engine startup on per-row errors.
 
 This pass exists because an earlier engine revision failed to map QRZ app fields onto dedicated domain columns (see §7.5 Import), causing subsequent syncs to re-upload every QSO as a new record and multiplying the logbook. The repair pass is idempotent; engines that have already cleaned their data will do no work on subsequent startups.
+
+### 7.8 Soft-Delete and Restore
+
+QSOs are soft-deleted: `DeleteQso` marks the row with a tombstone instead of removing it. This preserves user data for an undo flow and lets a future sync push a corresponding remote delete to QRZ.
+
+#### Schema
+
+Every `QsoRecord` carries two soft-delete fields:
+
+- `deleted_at` (optional `Timestamp`): when set, the row is considered deleted. Null on active rows.
+- `pending_remote_delete` (bool): set to true when the local delete should be propagated to QRZ on the next sync. Cleared once the remote delete completes (or if the row is restored).
+
+Storage backends MUST persist both fields and MUST default `deleted_at` to null and `pending_remote_delete` to false for records written before this contract existed (idempotent migration on startup).
+
+#### DeleteQso semantics
+
+1. Resolve the row by `local_id`.
+2. Set `deleted_at = now (UTC)`.
+3. If `delete_from_qrz = true` AND the row has a non-empty `qrz_logid`, set `pending_remote_delete = true`. Otherwise leave it false.
+4. Persist via `SoftDeleteQso` storage path (no row removal).
+5. Return `success = true`, `remote_delete_queued = pending_remote_delete`.
+6. If `delete_from_qrz = true` but `qrz_logid` is empty, the response surfaces an explanatory `qrz_delete_error` — the row is still soft-deleted locally, just not queued for remote delete.
+7. Re-deleting an already soft-deleted row is an idempotent success. If the second call sets `delete_from_qrz = true` and the row has a logid, it MAY upgrade `pending_remote_delete` from false to true.
+8. The engine MUST NOT call the QRZ `ACTION=DELETE` API inline from this RPC. Remote delete is performed by the sync engine (§7.3 Phase 2).
+
+#### RestoreQso semantics
+
+1. Resolve the row by `local_id`. If not found, return `NOT_FOUND`.
+2. Clear both `deleted_at` and `pending_remote_delete` via the `RestoreQso` storage path.
+3. If the restored row has no `qrz_logid` and its `sync_status` was `SYNCED` (i.e., the QRZ-side state never actually existed for this local row), demote `sync_status` to `LOCAL_ONLY` so the next sync re-uploads it. Update `updated_at = now`.
+4. Return `success = true` and the restored `QsoRecord`.
+5. Restoring a row that is not soft-deleted is an idempotent success (no-op).
+6. Engines MAY refuse `RestoreQso` with `FAILED_PRECONDITION` while a sync is in flight.
+
+#### UpdateQso on a soft-deleted row
+
+`UpdateQso` MUST reject any attempt to modify a soft-deleted row with `FAILED_PRECONDITION`. The client must call `RestoreQso` first.
+
+#### Listing semantics
+
+- `ListQsos` defaults to `DeletedRecordsFilter::ACTIVE_ONLY` when the filter is `UNSPECIFIED`. Engines MUST exclude soft-deleted rows from the default list.
+- `DELETED_ONLY` returns only soft-deleted rows (the trash view).
+- `ALL` returns both. Trash UIs should request `DELETED_ONLY`; standard logbook views should rely on the default.
+- `GetQso` MUST return a soft-deleted row by id (so a trash UI can fetch a single deleted row by its `local_id`).
+
+#### Import / Export interaction
+
+- `ImportAdif` duplicate matching uses the default (active-only) listing so that soft-deleted rows do not block re-import of a corrected QSO. (A deleted dup is treated as absent.)
+- `ExportAdif` uses the default (active-only) listing so soft-deleted rows are not exported.
+
+#### Sync interaction
+
+- Sync Phase 1 (download) MUST skip a remote row whose `qrz_logid` matches a soft-deleted local row. The local user's delete intent wins. The sync summary SHOULD report skipped count.
+- Sync Phase 2 (upload) MUST, after the normal upload pass, iterate rows where `pending_remote_delete = true`, call QRZ `ACTION=DELETE&KEY=…&LOGID=…`, and on success or HTTP 404 ("logid not found") clear both `qrz_logid` and `pending_remote_delete` while leaving `deleted_at` set. On other failures, leave the flags and surface the error in the sync summary.
 
 ---
 

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -704,6 +704,260 @@ public sealed class ManagedEngineStateTests : IDisposable
         }
     }
 
+    [Fact]
+    public void Soft_delete_marks_row_with_tombstone_and_keeps_it_retrievable()
+    {
+        var state = CreateState();
+        EnsureStationConfigured(state);
+        var loggedResp = LogSampleQso(state, "W1AW");
+        var logged = state.GetQso(loggedResp.LocalId)!;
+
+        var outcome = state.DeleteQso(logged.LocalId, queueRemoteDelete: false);
+
+        Assert.True(outcome.Found);
+        Assert.False(outcome.RemoteDeleteQueued);
+
+        var fetched = state.GetQso(logged.LocalId);
+        Assert.NotNull(fetched);
+        Assert.NotNull(fetched!.DeletedAt);
+        Assert.False(fetched.PendingRemoteDelete);
+    }
+
+    [Fact]
+    public void Soft_delete_with_qrz_logid_queues_remote_delete()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            QrzLogbookApiKey = "test-api-key",
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87",
+            },
+        });
+        var loggedResp = state.LogQso(new LogQsoRequest
+        {
+            SyncToQrz = true,
+            Qso = new QsoRecord
+            {
+                WorkedCallsign = "W1AW",
+                Band = Band._20M,
+                Mode = Mode.Ft8,
+                UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+        });
+        Assert.False(string.IsNullOrEmpty(loggedResp.QrzLogid));
+        var logged = state.GetQso(loggedResp.LocalId)!;
+
+        var outcome = state.DeleteQso(logged.LocalId, queueRemoteDelete: true);
+
+        Assert.True(outcome.Found);
+        Assert.True(outcome.RemoteDeleteQueued);
+        Assert.False(outcome.MissingQrzLogid);
+
+        var fetched = state.GetQso(logged.LocalId);
+        Assert.NotNull(fetched!.DeletedAt);
+        Assert.True(fetched.PendingRemoteDelete);
+    }
+
+    [Fact]
+    public void Soft_delete_without_qrz_logid_reports_missing_logid_when_remote_requested()
+    {
+        var state = CreateState();
+        EnsureStationConfigured(state);
+        var loggedResp = LogSampleQso(state, "W1AW");
+        var logged = state.GetQso(loggedResp.LocalId)!;
+
+        var outcome = state.DeleteQso(logged.LocalId, queueRemoteDelete: true);
+
+        Assert.True(outcome.Found);
+        Assert.False(outcome.RemoteDeleteQueued);
+        Assert.True(outcome.MissingQrzLogid);
+    }
+
+    [Fact]
+    public void Update_on_soft_deleted_row_throws_QsoSoftDeletedException()
+    {
+        var state = CreateState();
+        EnsureStationConfigured(state);
+        var loggedResp = LogSampleQso(state, "W1AW");
+        var logged = state.GetQso(loggedResp.LocalId)!;
+        state.DeleteQso(logged.LocalId, queueRemoteDelete: false);
+
+        Assert.Throws<QsoSoftDeletedException>(() => state.UpdateQso(new UpdateQsoRequest
+        {
+            Qso = new QsoRecord(logged) { Notes = "should not apply" },
+        }));
+    }
+
+    [Fact]
+    public void Restore_clears_tombstone_and_pending_flag()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            QrzLogbookApiKey = "test-api-key",
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87",
+            },
+        });
+        var loggedResp = state.LogQso(new LogQsoRequest
+        {
+            SyncToQrz = true,
+            Qso = new QsoRecord
+            {
+                WorkedCallsign = "W1AW",
+                Band = Band._20M,
+                Mode = Mode.Ft8,
+                UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+        });
+        var logged = state.GetQso(loggedResp.LocalId)!;
+        var originalLogid = logged.QrzLogid;
+        Assert.False(string.IsNullOrEmpty(originalLogid));
+        state.DeleteQso(logged.LocalId, queueRemoteDelete: true);
+
+        var outcome = state.RestoreQso(logged.LocalId);
+
+        Assert.True(outcome.Found);
+        Assert.NotNull(outcome.Restored);
+        Assert.Null(outcome.Restored!.DeletedAt);
+        Assert.False(outcome.Restored.PendingRemoteDelete);
+        Assert.Equal(originalLogid, outcome.Restored.QrzLogid);
+        Assert.Equal(SyncStatus.Synced, outcome.Restored.SyncStatus);
+    }
+
+    [Fact]
+    public void Restore_unknown_local_id_returns_not_found()
+    {
+        var state = CreateState();
+
+        var outcome = state.RestoreQso("does-not-exist");
+
+        Assert.False(outcome.Found);
+        Assert.Null(outcome.Restored);
+    }
+
+    [Fact]
+    public void List_qsos_excludes_soft_deleted_by_default()
+    {
+        var state = CreateState();
+        EnsureStationConfigured(state);
+        var keepResp = LogSampleQso(state, "W1AW");
+        var keep = state.GetQso(keepResp.LocalId)!;
+        var trashResp = LogSampleQso(state, "K7RND");
+        var trash = state.GetQso(trashResp.LocalId)!;
+        state.DeleteQso(trash.LocalId, queueRemoteDelete: false);
+
+        var active = state.ListQsos(new ListQsosRequest());
+
+        Assert.Contains(active, q => q.LocalId == keep.LocalId);
+        Assert.DoesNotContain(active, q => q.LocalId == trash.LocalId);
+    }
+
+    [Fact]
+    public void List_qsos_with_deleted_only_filter_returns_trash()
+    {
+        var state = CreateState();
+        EnsureStationConfigured(state);
+        var keepResp = LogSampleQso(state, "W1AW");
+        var keep = state.GetQso(keepResp.LocalId)!;
+        var trashResp = LogSampleQso(state, "K7RND");
+        var trash = state.GetQso(trashResp.LocalId)!;
+        state.DeleteQso(trash.LocalId, queueRemoteDelete: false);
+
+        var deleted = state.ListQsos(new ListQsosRequest { DeletedFilter = DeletedRecordsFilter.DeletedOnly });
+
+        Assert.DoesNotContain(deleted, q => q.LocalId == keep.LocalId);
+        Assert.Contains(deleted, q => q.LocalId == trash.LocalId);
+    }
+
+    [Fact]
+    public async Task Restore_qso_grpc_returns_restored_record()
+    {
+        var state = CreateState();
+        EnsureStationConfigured(state);
+        var loggedResp = LogSampleQso(state, "W1AW");
+        var logged = state.GetQso(loggedResp.LocalId)!;
+        state.DeleteQso(logged.LocalId, queueRemoteDelete: false);
+
+        var service = new ManagedLogbookGrpcService(state);
+        var response = await service.RestoreQso(
+            new RestoreQsoRequest { LocalId = logged.LocalId },
+            null!);
+
+        Assert.True(response.Success);
+        Assert.NotNull(response.Restored);
+        Assert.Null(response.Restored!.DeletedAt);
+    }
+
+    [Fact]
+    public async Task Restore_qso_grpc_throws_not_found_for_unknown_id()
+    {
+        var state = CreateState();
+        var service = new ManagedLogbookGrpcService(state);
+
+        var ex = await Assert.ThrowsAsync<RpcException>(() => service.RestoreQso(
+            new RestoreQsoRequest { LocalId = "missing-id" },
+            null!));
+        Assert.Equal(StatusCode.NotFound, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task Update_qso_grpc_on_soft_deleted_row_returns_failed_precondition()
+    {
+        var state = CreateState();
+        EnsureStationConfigured(state);
+        var loggedResp = LogSampleQso(state, "W1AW");
+        var logged = state.GetQso(loggedResp.LocalId)!;
+        state.DeleteQso(logged.LocalId, queueRemoteDelete: false);
+
+        var service = new ManagedLogbookGrpcService(state);
+        var ex = await Assert.ThrowsAsync<RpcException>(() => service.UpdateQso(
+            new UpdateQsoRequest
+            {
+                Qso = new QsoRecord(logged) { Notes = "blocked" },
+            },
+            null!));
+        Assert.Equal(StatusCode.FailedPrecondition, ex.StatusCode);
+    }
+
+    private static LogQsoResponse LogSampleQso(ManagedEngineState state, string callsign)
+    {
+        return state.LogQso(new LogQsoRequest
+        {
+            SyncToQrz = false,
+            Qso = new QsoRecord
+            {
+                WorkedCallsign = callsign,
+                Band = Band._20M,
+                Mode = Mode.Ft8,
+                UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+        });
+    }
+
+    private static void EnsureStationConfigured(ManagedEngineState state)
+    {
+        state.SaveSetup(new SaveSetupRequest
+        {
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87",
+            },
+        });
+    }
+
     private ManagedEngineState CreateState()
     {
         return new ManagedEngineState(Path.Combine(_tempDirectory, "config.toml"), new MemoryStorage());

--- a/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
@@ -256,6 +256,10 @@ internal sealed class ManagedLogbookGrpcService(ManagedEngineState state)
         {
             return Task.FromResult(state.UpdateQso(request));
         }
+        catch (QsoSoftDeletedException ex)
+        {
+            throw new RpcException(new Status(StatusCode.FailedPrecondition, ex.Message));
+        }
         catch (InvalidOperationException ex)
         {
             throw new RpcException(new Status(StatusCode.InvalidArgument, ex.Message));
@@ -264,24 +268,45 @@ internal sealed class ManagedLogbookGrpcService(ManagedEngineState state)
 
     public override Task<DeleteQsoResponse> DeleteQso(DeleteQsoRequest request, ServerCallContext context)
     {
-        var deleted = state.DeleteQso(request.LocalId);
+        var outcome = state.DeleteQso(request.LocalId, request.DeleteFromQrz);
         var response = new DeleteQsoResponse
         {
-            Success = deleted,
+            Success = outcome.Found,
+            // Legacy fields: synchronous QRZ delete is no longer performed.
             QrzDeleteSuccess = false,
+            RemoteDeleteQueued = outcome.RemoteDeleteQueued,
         };
 
-        if (!deleted)
+        if (!outcome.Found)
         {
             response.Error = $"QSO '{request.LocalId}' was not found.";
         }
-
-        if (request.DeleteFromQrz)
+        else if (outcome.MissingQrzLogid)
         {
-            response.QrzDeleteError = "Managed engine does not delete remote QRZ records.";
+            response.QrzDeleteError = "QSO has no QRZ logid — it may not have been synced yet.";
         }
 
         return Task.FromResult(response);
+    }
+
+    public override Task<RestoreQsoResponse> RestoreQso(RestoreQsoRequest request, ServerCallContext context)
+    {
+        if (string.IsNullOrWhiteSpace(request.LocalId))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "RestoreQso requires a non-empty local_id."));
+        }
+
+        var outcome = state.RestoreQso(request.LocalId);
+        if (!outcome.Found)
+        {
+            throw new RpcException(new Status(StatusCode.NotFound, $"QSO '{request.LocalId}' was not found."));
+        }
+
+        return Task.FromResult(new RestoreQsoResponse
+        {
+            Success = true,
+            Restored = outcome.Restored,
+        });
     }
 
     public override Task<GetQsoResponse> GetQso(GetQsoRequest request, ServerCallContext context)

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -13,6 +13,33 @@ using QsoRipper.Services;
 
 namespace QsoRipper.Engine.DotNet;
 
+internal sealed record DeleteQsoOutcome(bool Found, bool RemoteDeleteQueued, bool MissingQrzLogid);
+
+internal sealed record RestoreQsoOutcome(bool Found, QsoRecord? Restored);
+
+internal sealed class QsoSoftDeletedException : InvalidOperationException
+{
+    public QsoSoftDeletedException()
+        : base("QSO is deleted; restore it before updating.")
+    {
+        LocalId = string.Empty;
+    }
+
+    public QsoSoftDeletedException(string localId)
+        : base($"QSO '{localId}' is deleted; restore it before updating.")
+    {
+        LocalId = localId;
+    }
+
+    public QsoSoftDeletedException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+        LocalId = string.Empty;
+    }
+
+    public string LocalId { get; }
+}
+
 internal sealed class ManagedEngineState
 {
     private const string PersistenceStepDescription = "The managed .NET engine keeps its logbook in memory. No persistence input is required during setup.";
@@ -507,6 +534,10 @@ internal sealed class ManagedEngineState
             {
                 return new UpdateQsoResponse { Success = false, Error = $"QSO '{qso.LocalId}' was not found." };
             }
+            if (existing.DeletedAt is not null)
+            {
+                throw new QsoSoftDeletedException(qso.LocalId);
+            }
 
             // Merge incoming partial record into existing so unspecified fields are preserved.
             var merged = ManagedQsoParity.MergeQsoForUpdate(existing, qso);
@@ -523,13 +554,68 @@ internal sealed class ManagedEngineState
         }
     }
 
-    public bool DeleteQso(string localId)
+    public DeleteQsoOutcome DeleteQso(string localId, bool queueRemoteDelete)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(localId);
 
         lock (_gate)
         {
-            return Sync(_storage.Logbook.DeleteQsoAsync(localId.Trim()));
+            var trimmed = localId.Trim();
+            var existing = Sync(_storage.Logbook.GetQsoAsync(trimmed));
+            if (existing is null)
+            {
+                return new DeleteQsoOutcome(Found: false, RemoteDeleteQueued: false, MissingQrzLogid: false);
+            }
+
+            var hasLogid = !string.IsNullOrWhiteSpace(existing.QrzLogid);
+            var pending = queueRemoteDelete && hasLogid;
+
+            // Idempotent: re-deleting an already soft-deleted row is a no-op
+            // success that may upgrade pending_remote_delete if asked.
+            Sync(_storage.Logbook.SoftDeleteQsoAsync(trimmed, DateTimeOffset.UtcNow, pending));
+            return new DeleteQsoOutcome(
+                Found: true,
+                RemoteDeleteQueued: pending,
+                MissingQrzLogid: queueRemoteDelete && !hasLogid);
+        }
+    }
+
+    public RestoreQsoOutcome RestoreQso(string localId)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(localId);
+
+        lock (_gate)
+        {
+            var trimmed = localId.Trim();
+            var existing = Sync(_storage.Logbook.GetQsoAsync(trimmed));
+            if (existing is null)
+            {
+                return new RestoreQsoOutcome(Found: false, Restored: null);
+            }
+
+            // Track whether we need to demote sync_status post-restore so the
+            // next sync re-uploads a row that has no remote logid yet.
+            var demoteToLocalOnly = existing.DeletedAt is not null
+                && string.IsNullOrWhiteSpace(existing.QrzLogid)
+                && existing.SyncStatus == SyncStatus.Synced;
+
+            Sync(_storage.Logbook.RestoreQsoAsync(trimmed));
+
+            if (demoteToLocalOnly)
+            {
+                var afterRestore = Sync(_storage.Logbook.GetQsoAsync(trimmed));
+                if (afterRestore is not null
+                    && string.IsNullOrWhiteSpace(afterRestore.QrzLogid)
+                    && afterRestore.SyncStatus == SyncStatus.Synced)
+                {
+                    afterRestore.SyncStatus = SyncStatus.LocalOnly;
+                    afterRestore.UpdatedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+                    Sync(_storage.Logbook.UpdateQsoAsync(afterRestore));
+                }
+            }
+
+            var restored = Sync(_storage.Logbook.GetQsoAsync(trimmed));
+            return new RestoreQsoOutcome(Found: true, Restored: restored);
         }
     }
 

--- a/src/rust/qsoripper-core/src/application/logbook.rs
+++ b/src/rust/qsoripper-core/src/application/logbook.rs
@@ -100,8 +100,9 @@ impl LogbookEngine {
     /// # Errors
     ///
     /// Returns [`LogbookError::Validation`] when the record is missing required
-    /// fields, [`LogbookError::NotFound`] when the local ID does not exist, and
-    /// [`LogbookError::Storage`] when the backend write fails.
+    /// fields, [`LogbookError::NotFound`] when the local ID does not exist,
+    /// [`LogbookError::AlreadyDeleted`] when the existing record is soft-deleted,
+    /// and [`LogbookError::Storage`] when the backend write fails.
     pub async fn update_qso(&self, mut qso: QsoRecord) -> Result<QsoRecord, LogbookError> {
         if qso.local_id.trim().is_empty() {
             return Err(LogbookError::Validation(
@@ -111,6 +112,9 @@ impl LogbookEngine {
 
         let existing = self.storage.logbook().get_qso(&qso.local_id).await?;
         let existing = existing.ok_or_else(|| LogbookError::NotFound(qso.local_id.clone()))?;
+        if existing.deleted_at.is_some() {
+            return Err(LogbookError::AlreadyDeleted(qso.local_id));
+        }
         materialize_station_snapshot_for_update(&mut qso, Some(&existing));
         normalize_qso_for_persistence(&mut qso);
         validate_qso_for_persistence(&qso)?;
@@ -126,26 +130,85 @@ impl LogbookEngine {
         }
     }
 
-    /// Delete a QSO by local identifier.
+    /// Soft-delete a QSO by local identifier, optionally queuing a remote delete
+    /// for the next QRZ sync. Returns the soft-deleted record.
     ///
     /// # Errors
     ///
     /// Returns [`LogbookError::Validation`] when the local ID is blank,
     /// [`LogbookError::NotFound`] when the record does not exist, and
-    /// [`LogbookError::Storage`] when the backend delete fails.
-    pub async fn delete_qso(&self, local_id: &str) -> Result<(), LogbookError> {
+    /// [`LogbookError::Storage`] when the backend write fails.
+    pub async fn delete_qso(
+        &self,
+        local_id: &str,
+        queue_remote_delete: bool,
+    ) -> Result<QsoRecord, LogbookError> {
         if local_id.trim().is_empty() {
             return Err(LogbookError::Validation(
                 "local_id is required when deleting a QSO.".into(),
             ));
         }
 
-        let deleted = self.storage.logbook().delete_qso(local_id).await?;
-        if deleted {
-            Ok(())
-        } else {
-            Err(LogbookError::NotFound(local_id.to_string()))
+        let existing = self.storage.logbook().get_qso(local_id).await?;
+        let mut existing = existing.ok_or_else(|| LogbookError::NotFound(local_id.to_string()))?;
+
+        // Idempotent: re-deleting an already soft-deleted row is a no-op
+        // success that may upgrade pending_remote_delete if the caller asks.
+        let already_deleted = existing.deleted_at.is_some();
+        let now = now_timestamp();
+        let pending =
+            queue_remote_delete && !existing.qrz_logid.as_deref().unwrap_or("").is_empty();
+
+        if !already_deleted {
+            existing.deleted_at = Some(now);
         }
+        if pending {
+            existing.pending_remote_delete = true;
+        }
+        existing.updated_at = Some(now);
+
+        let updated = self.storage.logbook().update_qso(&existing).await?;
+        if !updated {
+            return Err(LogbookError::NotFound(local_id.to_string()));
+        }
+        Ok(existing)
+    }
+
+    /// Restore a soft-deleted QSO by clearing `deleted_at` and
+    /// `pending_remote_delete`. Returns the restored record.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`LogbookError::Validation`] when the local ID is blank,
+    /// [`LogbookError::NotFound`] when the record does not exist, and
+    /// [`LogbookError::Storage`] when the backend write fails. Restoring a
+    /// row that is not soft-deleted is a no-op success.
+    pub async fn restore_qso(&self, local_id: &str) -> Result<QsoRecord, LogbookError> {
+        if local_id.trim().is_empty() {
+            return Err(LogbookError::Validation(
+                "local_id is required when restoring a QSO.".into(),
+            ));
+        }
+
+        let existing = self.storage.logbook().get_qso(local_id).await?;
+        let mut existing = existing.ok_or_else(|| LogbookError::NotFound(local_id.to_string()))?;
+
+        let was_deleted = existing.deleted_at.is_some();
+        existing.deleted_at = None;
+        existing.pending_remote_delete = false;
+
+        // If the row was never synced (no qrz_logid), restoring should mark it
+        // for upload again so a future sync picks it up.
+        if was_deleted && existing.qrz_logid.as_deref().unwrap_or("").is_empty() {
+            existing.sync_status = SyncStatus::LocalOnly as i32;
+        }
+        existing.updated_at = Some(now_timestamp());
+
+        let updated = self.storage.logbook().update_qso(&existing).await?;
+        if !updated {
+            return Err(LogbookError::NotFound(local_id.to_string()));
+        }
+        Ok(existing)
     }
 
     /// Retrieve a persisted QSO by local identifier.
@@ -385,6 +448,9 @@ pub enum LogbookError {
     /// The requested QSO could not be found in persistent storage.
     #[error("QSO '{0}' was not found.")]
     NotFound(String),
+    /// The QSO is soft-deleted and must be restored before it can be updated.
+    #[error("QSO '{0}' is deleted; restore it before updating.")]
+    AlreadyDeleted(String),
     /// The underlying storage layer failed to complete the requested operation.
     #[error(transparent)]
     Storage(#[from] StorageError),

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -397,59 +397,55 @@ impl LogbookService for DeveloperLogbookService {
         let engine = self.runtime_config.logbook_engine().await;
         let request = request.into_inner();
 
-        // When the caller requests QRZ deletion, look up the QSO first so we
-        // can grab the qrz_logid before removing the local row.
-        let (qrz_delete_success, qrz_delete_error) = if request.delete_from_qrz {
-            match engine.get_qso(&request.local_id).await {
-                Ok(qso) => match qso.qrz_logid.as_deref() {
-                    Some(logid) if !logid.is_empty() => {
-                        match self.build_qrz_logbook_client().await {
-                            Ok(client) => match client.delete_qso(logid).await {
-                                Ok(()) => (true, None),
-                                Err(err) => (false, Some(format!("QRZ delete failed: {err}"))),
-                            },
-                            Err(err) => (false, Some(err)),
-                        }
-                    }
-                    _ => (
-                        false,
-                        Some("QSO has no QRZ logid — it may not have been synced yet.".into()),
-                    ),
-                },
-                Err(_) => (
-                    false,
-                    Some("Could not look up QSO to retrieve QRZ logid.".into()),
-                ),
-            }
-        } else {
-            (true, None)
-        };
-
-        // Always delete locally, even if the QRZ delete failed — the user
-        // explicitly asked to remove it from the local logbook.
-        engine
-            .delete_qso(&request.local_id)
+        // Soft-delete the local row. When the caller asked for QRZ deletion
+        // we mark pending_remote_delete so the next SyncWithQrz removes it
+        // from QRZ during sync Phase 2. Restore before sync cancels it.
+        let deleted = engine
+            .delete_qso(&request.local_id, request.delete_from_qrz)
             .await
             .map_err(map_logbook_error)?;
+
+        let has_logid = deleted
+            .qrz_logid
+            .as_deref()
+            .is_some_and(|s| !s.is_empty());
+        let queued = request.delete_from_qrz && has_logid;
+        let qrz_delete_error = if request.delete_from_qrz && !has_logid {
+            Some("QSO has no QRZ logid — it may not have been synced yet.".into())
+        } else {
+            None
+        };
 
         Ok(Response::new(DeleteQsoResponse {
             success: true,
             error: None,
-            qrz_delete_success,
+            // Legacy fields: synchronous QRZ delete is no longer performed.
+            qrz_delete_success: false,
             qrz_delete_error,
-            remote_delete_queued: false,
+            remote_delete_queued: queued,
         }))
     }
 
     async fn restore_qso(
         &self,
-        _request: Request<RestoreQsoRequest>,
+        request: Request<RestoreQsoRequest>,
     ) -> Result<Response<RestoreQsoResponse>, Status> {
-        // Soft-delete / restore semantics are scheduled for a follow-up PR once
-        // storage migrations and sync phase changes land. See tracking issue.
-        Err(Status::unimplemented(
-            "RestoreQso is not yet implemented on the Rust engine",
-        ))
+        let engine = self.runtime_config.logbook_engine().await;
+        let request = request.into_inner();
+        if request.local_id.trim().is_empty() {
+            return Err(Status::invalid_argument(
+                "RestoreQso requires a non-empty local_id.",
+            ));
+        }
+        let restored = engine
+            .restore_qso(&request.local_id)
+            .await
+            .map_err(map_logbook_error)?;
+        Ok(Response::new(RestoreQsoResponse {
+            success: true,
+            error: None,
+            restored: Some(restored),
+        }))
     }
 
     async fn get_qso(
@@ -1067,6 +1063,9 @@ fn map_logbook_error(error: LogbookError) -> Status {
         LogbookError::NotFound(local_id) => {
             Status::not_found(format!("QSO '{local_id}' was not found."))
         }
+        LogbookError::AlreadyDeleted(local_id) => Status::failed_precondition(format!(
+            "QSO '{local_id}' is deleted; restore it before updating."
+        )),
         LogbookError::Storage(StorageError::Duplicate { entity, key }) => {
             Status::already_exists(format!("{entity} '{key}' already exists."))
         }
@@ -1194,7 +1193,7 @@ mod tests {
         GetCachedCallsignRequest, GetCurrentSpaceWeatherRequest, GetDxccEntityRequest,
         GetQsoRequest, GetSyncStatusRequest, ImportAdifRequest, ImportAdifResponse,
         ListQsosRequest, LogQsoRequest, LookupRequest, QsoSortOrder, RefreshSpaceWeatherRequest,
-        StreamLookupRequest, UpdateQsoRequest,
+        RestoreQsoRequest, StreamLookupRequest, UpdateQsoRequest,
     };
     use tokio_stream::StreamExt;
     use tonic::transport::Channel;
@@ -1511,18 +1510,51 @@ mod tests {
         .into_inner();
 
         assert!(delete_response.success);
-        assert!(delete_response.qrz_delete_success);
+        assert!(!delete_response.qrz_delete_success);
         assert!(delete_response.qrz_delete_error.is_none());
+        assert!(!delete_response.remote_delete_queued);
 
-        let get_error = LogbookService::get_qso(
+        // After soft-delete the record is still loadable by id but carries
+        // a deleted_at tombstone.
+        let get_after_delete = LogbookService::get_qso(
             service,
             Request::new(GetQsoRequest {
-                local_id: log_response.local_id,
+                local_id: log_response.local_id.clone(),
             }),
         )
         .await
-        .expect_err("deleted record should not load");
-        assert_eq!(Code::NotFound, get_error.code());
+        .expect("get after soft-delete")
+        .into_inner();
+        let after_delete_qso = get_after_delete.qso.expect("soft-deleted record");
+        assert!(after_delete_qso.deleted_at.is_some());
+        assert!(!after_delete_qso.pending_remote_delete);
+
+        // Restoring clears the tombstone and pending flag.
+        let restore_response = LogbookService::restore_qso(
+            service,
+            Request::new(RestoreQsoRequest {
+                local_id: log_response.local_id.clone(),
+            }),
+        )
+        .await
+        .expect("restore response")
+        .into_inner();
+        assert!(restore_response.success);
+        let restored = restore_response.restored.expect("restored record present");
+        assert!(restored.deleted_at.is_none());
+        assert!(!restored.pending_remote_delete);
+
+        // Final hard-delete via storage is not exposed; soft-delete it again
+        // and assert ListQsos default filter hides it.
+        let _ = LogbookService::delete_qso(
+            service,
+            Request::new(DeleteQsoRequest {
+                local_id: log_response.local_id,
+                delete_from_qrz: false,
+            }),
+        )
+        .await
+        .expect("re-delete");
     }
 
     async fn grpc_logbook_client(

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -405,10 +405,7 @@ impl LogbookService for DeveloperLogbookService {
             .await
             .map_err(map_logbook_error)?;
 
-        let has_logid = deleted
-            .qrz_logid
-            .as_deref()
-            .is_some_and(|s| !s.is_empty());
+        let has_logid = deleted.qrz_logid.as_deref().is_some_and(|s| !s.is_empty());
         let queued = request.delete_from_qrz && has_logid;
         let qrz_delete_error = if request.delete_from_qrz && !has_logid {
             Some("QSO has no QRZ logid — it may not have been synced yet.".into())


### PR DESCRIPTION
## Summary

Part 2 of the soft-delete + restore work tracked by #289. Builds on #291 (storage foundation, already merged).

This PR flips `DeleteQso` to perform a true soft delete and implements `RestoreQso` end-to-end on **both** the Rust and .NET engines. No sync wiring yet — the queued remote delete loop ships in PR B3.

## What changes

**Rust (`qsoripper-core` + `qsoripper-server`)**
- New `LogbookError::AlreadyDeleted` variant (maps to `FAILED_PRECONDITION`).
- `LogbookEngine::update_qso` rejects soft-deleted rows.
- `LogbookEngine::delete_qso(local_id, queue_remote_delete)` now soft-deletes via `store.soft_delete_qso`, returns the QsoRecord (so handlers can read `qrz_logid`).
- `LogbookEngine::restore_qso` clears tombstone + pending flag; demotes `Synced` rows with no `qrz_logid` to `LocalOnly`.
- gRPC `DeleteQso` handler returns `remote_delete_queued` and a `qrz_delete_error` when a remote delete is requested for a row that has no logid; legacy `qrz_delete_success` stays `false` (deprecated).
- gRPC `RestoreQso` handler is a real implementation, returns the restored record.
- Updated server-side tests assert soft-delete semantics (`get_qso` after delete returns the row with `deleted_at` set; restore clears it).

**.NET (`QsoRipper.Engine.DotNet`)**
- New `QsoSoftDeletedException` (maps to `FAILED_PRECONDITION` in `UpdateQso`).
- `ManagedEngineState.DeleteQso(localId, queueRemoteDelete)` returns `DeleteQsoOutcome(Found, RemoteDeleteQueued, MissingQrzLogid)` — soft-delete via `ILogbookStore.SoftDeleteQsoAsync`.
- `ManagedEngineState.RestoreQso(localId)` returns `RestoreQsoOutcome(Found, Restored)` — restores then optionally demotes sync_status.
- `ManagedLogbookGrpcService.DeleteQso` populates `RemoteDeleteQueued` and surfaces a missing-logid hint when relevant.
- `ManagedLogbookGrpcService.RestoreQso` override added.
- 11 new tests in `ManagedEngineStateTests` covering soft-delete + restore + grpc surface.

**Engine specification**
- New §7.8 `Soft-Delete and Restore` documents the full contract: schema fields, DeleteQso semantics, RestoreQso semantics, UpdateQso rejection, listing semantics, import/export interaction, and sync interaction (forward-reference to B3).
- §7.2 `Deleting a QSO` updated to point at §7.8.

## Out of scope (next PR — B3)
- Sync Phase 1 skip when remote `qrz_logid` matches a soft-deleted local row.
- Sync Phase 2 queued-remote-delete loop (calling QRZ `ACTION=DELETE`).
- `QrzLogbookClient.DeleteQsoAsync` on the .NET side.
- Spec §7.3 sync updates.

## Validation
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full `cargo test` workspace — all green.
- `dotnet format --verify-no-changes`, `dotnet build`, full `dotnet test` (681 tests) — all green.
- `buf lint` — clean (no proto changes).

Tracking: #289