### PR TITLE
Soft-delete sync integration (PR B3 of #289)

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -1049,10 +1049,11 @@ The QRZ logbook sync is a three-phase operation:
       - `CONFLICT_POLICY_UNSPECIFIED` — engines MUST treat the zero value as `FLAG_FOR_REVIEW` (the safe, non-destructive default) per §6.3.
    d. If unmatched, insert as a new local record with `sync_status = SYNCED` and populate `qrz_logid` from the remote record.
 4. Filter ghost records: remote QSOs missing required fields (callsign, timestamp) are skipped without incrementing any counter.
+5. **Soft-delete suppression:** before matching, engines MUST load the full local record set including soft-deleted rows (see §7.8) and build the set of `qrz_logid` values associated with locally soft-deleted QSOs. Any remote QSO whose `qrz_logid` is in that set MUST be skipped (no insert, no merge), and the engine MUST increment the `deletes_skipped_remote` counter on the sync result. This prevents resurrection of QSOs the operator has trashed locally before the queued remote-delete (Phase 2.5) has propagated.
 
 #### Phase 2: Upload
 
-1. Query local QSOs with `sync_status` in (`NOT_SYNCED`, `MODIFIED`).
+1. Query local QSOs with `sync_status` in (`NOT_SYNCED`, `MODIFIED`). Soft-deleted rows MUST NOT be uploaded as inserts/updates regardless of `sync_status`; they are handled by Phase 2.5.
 2. For each QSO, serialize to ADIF and call the QRZ logbook API:
    - If `sync_status = NOT_SYNCED` (new record, no `qrz_logid`), use `ACTION=INSERT`.
    - If `sync_status = MODIFIED` and the record has a `qrz_logid`, use the documented replace form `ACTION=INSERT&OPTION=REPLACE,LOGID:<logid>`. Engines MUST NOT use the undocumented `ACTION=REPLACE` form, which can silently produce duplicate inserts on the remote logbook.
@@ -1060,6 +1061,18 @@ The QRZ logbook sync is a three-phase operation:
 3. Accept both `RESULT=OK` (insert) and `RESULT=REPLACE` (update) as success indicators when parsing the QRZ response.
 4. On success, set `sync_status = SYNCED` and store the returned `LOGID` (or the supplied one for a REPLACE that echoes nothing) in `qrz_logid`.
 5. On per-QSO failure, log the error and continue with remaining QSOs.
+
+#### Phase 2.5: Push pending remote deletes
+
+1. Query local QSOs where `deleted_at IS NOT NULL AND pending_remote_delete = true AND qrz_logid` is non-empty.
+2. For each such row, call the QRZ logbook API `ACTION=DELETE&KEY=<api_key>&LOGID=<qrz_logid>`.
+3. Treat the following responses as success (the remote row is gone or never existed — the operator's intent is satisfied):
+   - `RESULT=OK`
+   - `RESULT=FAIL&REASON=<text>` where `<text>` matches a not-found indicator (case-insensitive substring match on `not found`, `no such`, `does not exist`, or `no record`)
+   - HTTP 404 from the QRZ endpoint
+4. On success, the engine MUST clear `pending_remote_delete` and clear `qrz_logid` (so a future re-sync cannot re-target a now-detached logid) while leaving `deleted_at` set so the row remains in the trash view. Increment the `remote_deletes_pushed` counter.
+5. On other failures (network, authentication, unrecognized REASON), the engine MUST leave `pending_remote_delete = true` and `qrz_logid` intact so the next sync retries. Append a description of the failure to the sync error summary.
+6. Authentication errors MUST propagate from the QRZ adapter as auth-failure exceptions (not collapsed into "not found"); engines surface them in the same way as other Phase 2 auth errors.
 
 #### Phase 3: Metadata
 
@@ -1403,4 +1416,3 @@ The following gaps are documented tracking items. They do not affect the normati
 
 - **.NET engine — `SyncWithQrz` streaming granularity.** The .NET engine currently produces a single terminal `SyncWithQrzResponse` instead of per-phase progress messages. Matches the spec's RPC signature but loses UI progress fidelity vs. the Rust engine.
 - **.NET engine — QRZ ADIF field coverage.** The .NET `AdifCodec` does not yet parse/emit every QRZ-specific field the Rust mapper covers (e.g., `ARRL_SECT`, SKCC, QSL/LOTW/EQSL date and flag variants, `MY_LAT`/`MY_LON`, `MY_ARRL_SECT`, `MY_CQ_ZONE`/`MY_ITU_ZONE`). Missing fields round-trip via `extra_fields` today, but should graduate to dedicated domain columns.
-- **Both engines — soft-delete with restore.** The proto contracts expose `QsoRecord.deleted_at` (field 73), `QsoRecord.pending_remote_delete` (field 74), the tri-state `DeletedRecordsFilter` on `ListQsosRequest`, `DeleteQsoResponse.remote_delete_queued` (field 5), and the `RestoreQso` RPC. Both engines currently return `UNIMPLEMENTED` for `RestoreQso` and still perform hard local deletes. The full soft-delete semantics — setting `deleted_at` instead of row removal, honouring `deleted_filter` in `ListQsos`, rejecting updates to soft-deleted rows, ignoring soft-deleted rows in `ImportAdif` duplicate matching, skipping soft-deleted rows in sync Phase 1 download, and queuing QRZ `ACTION=DELETE` via `pending_remote_delete` in sync Phase 2 — are scheduled for a follow-up PR on both engines in lockstep. Storage backends also need `ALTER TABLE ADD COLUMN` migration paths for the two new columns. Treat the new `DeleteQsoResponse.qrz_delete_success` / `qrz_delete_error` fields as deprecated once the queued-delete path lands; `remote_delete_queued` will be the canonical signal. Tracked in #289.

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -1101,6 +1101,8 @@ public sealed class ManagedEngineStateTests : IDisposable
 
         public Task<QrzLogbookStatus> GetStatusAsync() =>
             Task.FromResult(new QrzLogbookStatus("K7RND", (uint)_logIdCounter));
+
+        public Task DeleteQsoAsync(string logid) => Task.CompletedTask;
     }
 
     private sealed class FakeMalformedQrzLogbookApi : IQrzLogbookApi
@@ -1114,6 +1116,8 @@ public sealed class ManagedEngineStateTests : IDisposable
 
         public Task<QrzLogbookStatus> GetStatusAsync() =>
             Task.FromResult(new QrzLogbookStatus("K7RND", 0));
+
+        public Task DeleteQsoAsync(string logid) => Task.CompletedTask;
     }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzLogbookClientTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzLogbookClientTests.cs
@@ -282,6 +282,57 @@ public sealed class QrzLogbookClientTests
         }
     }
 
+    // -- DELETE --------------------------------------------------------------
+
+    [Fact]
+    public async Task Delete_sends_action_delete_with_logid()
+    {
+        var (client, handler) = CreateClient("RESULT=OK");
+
+        using (client)
+        {
+            await client.DeleteQsoAsync("123456");
+        }
+
+        Assert.Contains("ACTION=DELETE", handler.CapturedBody);
+        Assert.Contains("LOGID=123456", handler.CapturedBody);
+    }
+
+    [Fact]
+    public async Task Delete_treats_not_found_reason_as_success()
+    {
+        var (client, _) = CreateClient("RESULT=FAIL&REASON=record not found");
+
+        using (client)
+        {
+            // Should NOT throw — queued-remote-delete loop relies on this.
+            await client.DeleteQsoAsync("000000");
+        }
+    }
+
+    [Fact]
+    public async Task Delete_propagates_other_failure_reasons()
+    {
+        var (client, _) = CreateClient("RESULT=FAIL&REASON=bad record format");
+
+        using (client)
+        {
+            var ex = await Assert.ThrowsAsync<QrzLogbookException>(() => client.DeleteQsoAsync("000000"));
+            Assert.Contains("bad record format", ex.Message, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    [Fact]
+    public async Task Delete_propagates_auth_failure()
+    {
+        var (client, _) = CreateClient("RESULT=FAIL&REASON=invalid api key");
+
+        using (client)
+        {
+            await Assert.ThrowsAsync<QrzLogbookAuthException>(() => client.DeleteQsoAsync("000000"));
+        }
+    }
+
     // -- Client helper --------------------------------------------------------
 
     private static (QrzLogbookClient Client, CapturingHandler Handler) CreateClient(string responseBody)

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
@@ -611,6 +611,112 @@ public sealed class QrzSyncEngineTests
         Assert.Equal(SyncStatus.Synced, all[0].SyncStatus);
     }
 
+    // -- Soft-delete sync integration ---------------------------------------
+
+    [Fact]
+    public async Task Download_skips_remote_matching_soft_deleted_local()
+    {
+        // A previously-synced local row was soft-deleted. The next sync
+        // must NOT resurrect it from QRZ.
+        var store = CreateStore();
+        var local = MakeLocalQso("K7ABC", BaseTime, Band._20M, Mode.Ft8, SyncStatus.Synced);
+        local.QrzLogid = "LOG-DELETED";
+        await store.Logbook.InsertQsoAsync(local);
+        await store.Logbook.SoftDeleteQsoAsync(local.LocalId, DateTimeOffset.UtcNow, pendingRemoteDelete: false);
+
+        var remote = MakeRemoteQso("K7ABC", BaseTime, Band._20M, Mode.Ft8, "LOG-DELETED");
+        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var engine = new QrzSyncEngine(api);
+
+        var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
+
+        Assert.Equal(0u, result.DownloadedCount);
+        Assert.Equal(1u, result.DeletesSkippedRemote);
+
+        var all = await store.Logbook.ListQsosAsync(new QsoListQuery
+        {
+            DeletedFilter = DeletedRecordsFilter.All,
+        });
+        Assert.Single(all);
+        Assert.NotNull(all[0].DeletedAt);
+    }
+
+    [Fact]
+    public async Task PushPendingRemoteDeletes_calls_qrz_and_clears_local_flags()
+    {
+        var store = CreateStore();
+        var local = MakeLocalQso("JA1ZZZ", BaseTime, Band._40M, Mode.Cw, SyncStatus.Synced);
+        local.QrzLogid = "LOG-PENDING";
+        await store.Logbook.InsertQsoAsync(local);
+        await store.Logbook.SoftDeleteQsoAsync(local.LocalId, DateTimeOffset.UtcNow, pendingRemoteDelete: true);
+
+        var api = new FakeQrzLogbookApi();
+        var engine = new QrzSyncEngine(api);
+
+        var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
+
+        Assert.Equal(1u, result.RemoteDeletesPushed);
+        Assert.Null(result.ErrorSummary);
+        Assert.Single(api.DeletedLogids);
+        Assert.Equal("LOG-PENDING", api.DeletedLogids[0]);
+
+        var all = await store.Logbook.ListQsosAsync(new QsoListQuery
+        {
+            DeletedFilter = DeletedRecordsFilter.All,
+        });
+        Assert.Single(all);
+        Assert.NotNull(all[0].DeletedAt);
+        Assert.False(all[0].PendingRemoteDelete);
+        Assert.True(string.IsNullOrEmpty(all[0].QrzLogid));
+    }
+
+    [Fact]
+    public async Task PushPendingRemoteDeletes_does_not_call_when_pending_flag_unset()
+    {
+        var store = CreateStore();
+        var local = MakeLocalQso("K7ABC", BaseTime, Band._20M, Mode.Ft8, SyncStatus.Synced);
+        local.QrzLogid = "LOG-LOCAL-ONLY-TRASH";
+        await store.Logbook.InsertQsoAsync(local);
+        await store.Logbook.SoftDeleteQsoAsync(local.LocalId, DateTimeOffset.UtcNow, pendingRemoteDelete: false);
+
+        var api = new FakeQrzLogbookApi();
+        var engine = new QrzSyncEngine(api);
+
+        await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
+
+        Assert.Empty(api.DeletedLogids);
+    }
+
+    [Fact]
+    public async Task PushPendingRemoteDeletes_preserves_state_on_failure()
+    {
+        var store = CreateStore();
+        var local = MakeLocalQso("DL1ABC", BaseTime, Band._20M, Mode.Ssb, SyncStatus.Synced);
+        local.QrzLogid = "LOG-FAIL";
+        await store.Logbook.InsertQsoAsync(local);
+        await store.Logbook.SoftDeleteQsoAsync(local.LocalId, DateTimeOffset.UtcNow, pendingRemoteDelete: true);
+
+        var api = new FakeQrzLogbookApi
+        {
+            DeleteException = new QrzLogbookException("server angry"),
+        };
+        var engine = new QrzSyncEngine(api);
+
+        var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
+
+        Assert.Equal(0u, result.RemoteDeletesPushed);
+        Assert.NotNull(result.ErrorSummary);
+
+        var all = await store.Logbook.ListQsosAsync(new QsoListQuery
+        {
+            DeletedFilter = DeletedRecordsFilter.All,
+        });
+        Assert.Single(all);
+        Assert.NotNull(all[0].DeletedAt);
+        Assert.True(all[0].PendingRemoteDelete);
+        Assert.Equal("LOG-FAIL", all[0].QrzLogid);
+    }
+
     // -- Helpers ------------------------------------------------------------
 
     private static MemoryStorage CreateStore() => new();
@@ -703,6 +809,21 @@ public sealed class QrzSyncEngineTests
             }
 
             return Task.FromResult(new QrzLogbookStatus(StatusOwner, StatusQsoCount));
+        }
+
+        public List<string> DeletedLogids { get; } = [];
+
+        public Exception? DeleteException { get; set; }
+
+        public Task DeleteQsoAsync(string logid)
+        {
+            DeletedLogids.Add(logid);
+            if (DeleteException is not null)
+            {
+                return Task.FromException(DeleteException);
+            }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/IQrzLogbookApi.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/IQrzLogbookApi.cs
@@ -33,6 +33,13 @@ public interface IQrzLogbookApi
     /// keep <c>SyncMetadata</c> aligned with what QRZ actually has.
     /// </summary>
     Task<QrzLogbookStatus> GetStatusAsync();
+
+    /// <summary>
+    /// Delete a remote QSO by its QRZ logid via the <c>DELETE</c> action.
+    /// Implementations must treat QRZ "not found"-style failures as success
+    /// so the queued-remote-delete sync loop is idempotent.
+    /// </summary>
+    Task DeleteQsoAsync(string logid);
 }
 
 /// <summary>

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
@@ -188,6 +188,47 @@ public sealed class QrzLogbookClient : IQrzLogbookApi, IDisposable
         return new QrzLogbookStatus(owner, qsoCount);
     }
 
+    /// <inheritdoc />
+    public async Task DeleteQsoAsync(string logid)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(logid);
+
+        var formFields = new List<KeyValuePair<string, string>>(3)
+        {
+            new("ACTION", "DELETE"),
+            new("KEY", _apiKey),
+            new("LOGID", logid),
+        };
+
+        string body;
+        try
+        {
+            body = await PostFormAsync(formFields).ConfigureAwait(false);
+        }
+        catch (QrzLogbookException ex) when (ex.Message.StartsWith("HTTP 404", StringComparison.Ordinal))
+        {
+            // Already gone server-side — treat as success.
+            return;
+        }
+
+        var map = QrzResponseParser.ParseKeyValueResponse(body);
+        try
+        {
+            QrzResponseParser.CheckResult(map);
+        }
+        catch (QrzLogbookAuthException)
+        {
+            throw;
+        }
+        catch (QrzLogbookException ex) when (QrzResponseParser.IsNotFoundError(ex.Message))
+        {
+            // QRZ says the record is already gone — treat as success so the
+            // queued-remote-delete loop can clear local pending flags and
+            // doesn't loop forever.
+            return;
+        }
+    }
+
     /// <inheritdoc cref="IDisposable.Dispose"/>
     public void Dispose()
     {

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzResponseParser.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzResponseParser.cs
@@ -145,6 +145,19 @@ internal static class QrzResponseParser
             || reason.Contains("api key required", StringComparison.OrdinalIgnoreCase)
             || reason.Contains("access denied", StringComparison.OrdinalIgnoreCase);
     }
+
+    /// <summary>
+    /// Detect QRZ "logid does not exist"-style failure reasons. The DELETE
+    /// path treats these as success so the queued-remote-delete loop is
+    /// idempotent against rows that were already removed remotely.
+    /// </summary>
+    internal static bool IsNotFoundError(string reason)
+    {
+        return reason.Contains("not found", StringComparison.OrdinalIgnoreCase)
+            || reason.Contains("no such", StringComparison.OrdinalIgnoreCase)
+            || reason.Contains("does not exist", StringComparison.OrdinalIgnoreCase)
+            || reason.Contains("no record", StringComparison.OrdinalIgnoreCase);
+    }
 }
 
 /// <summary>

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
@@ -64,6 +64,8 @@ public sealed class QrzSyncEngine
         uint downloaded = 0;
         uint uploaded = 0;
         uint conflicts = 0;
+        uint remoteDeletesPushed = 0;
+        uint deletesSkippedRemote = 0;
 
         // ---------------------------------------------------------------
         // Phase 1 — Download from QRZ
@@ -80,10 +82,18 @@ public sealed class QrzSyncEngine
             errors.Add($"Failed to read sync metadata: {ex.Message}");
         }
 
-        IReadOnlyList<QsoRecord> localQsos;
+        IReadOnlyList<QsoRecord> localQsosAll;
         try
         {
-            localQsos = await store.ListQsosAsync(new QsoListQuery { Sort = QsoSortOrder.OldestFirst }).ConfigureAwait(false);
+            // Load active + soft-deleted rows so we can both match against
+            // active rows AND skip remote downloads whose qrz_logid belongs
+            // to a soft-deleted local row (otherwise trashed QSOs would be
+            // resurrected on the next sync).
+            localQsosAll = await store.ListQsosAsync(new QsoListQuery
+            {
+                Sort = QsoSortOrder.OldestFirst,
+                DeletedFilter = DeletedRecordsFilter.All,
+            }).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -91,6 +101,24 @@ public sealed class QrzSyncEngine
             {
                 ErrorSummary = $"Failed to load local QSOs: {ex.Message}",
             };
+        }
+
+        var deletedLogids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var localQsos = new List<QsoRecord>(localQsosAll.Count);
+        foreach (var qso in localQsosAll)
+        {
+            if (qso.DeletedAt is not null)
+            {
+                var logid = ExtractQrzLogid(qso);
+                if (!string.IsNullOrWhiteSpace(logid))
+                {
+                    deletedLogids.Add(logid);
+                }
+            }
+            else
+            {
+                localQsos.Add(qso);
+            }
         }
 
         // Force full fetch when local logbook is empty (first sync or data loss recovery).
@@ -121,6 +149,13 @@ public sealed class QrzSyncEngine
             }
 
             var remoteLogid = ExtractQrzLogid(remote);
+
+            // Phase 1 skip: don't resurrect soft-deleted local rows.
+            if (remoteLogid is not null && deletedLogids.Contains(remoteLogid))
+            {
+                deletesSkippedRemote++;
+                continue;
+            }
 
             // Try match by QRZ logid first, then fuzzy match.
             var localMatch = remoteLogid is not null && byLogid.TryGetValue(remoteLogid, out var logidMatch)
@@ -237,6 +272,56 @@ public sealed class QrzSyncEngine
         }
 
         // ---------------------------------------------------------------
+        // Phase 2.5 — Push queued remote deletes to QRZ
+        // ---------------------------------------------------------------
+
+        IReadOnlyList<QsoRecord> pendingRemoteDeletes;
+        try
+        {
+            var deletedRows = await store.ListQsosAsync(new QsoListQuery
+            {
+                Sort = QsoSortOrder.OldestFirst,
+                DeletedFilter = DeletedRecordsFilter.DeletedOnly,
+            }).ConfigureAwait(false);
+            pendingRemoteDeletes = deletedRows
+                .Where(q => q.PendingRemoteDelete && !string.IsNullOrWhiteSpace(q.QrzLogid))
+                .ToList();
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"Failed to list deleted QSOs for remote-delete pass: {ex.Message}");
+            pendingRemoteDeletes = [];
+        }
+
+        foreach (var qso in pendingRemoteDeletes)
+        {
+            try
+            {
+                await _client.DeleteQsoAsync(qso.QrzLogid).ConfigureAwait(false);
+
+                // Success (including QRZ "not found"): clear local pending
+                // flags but keep the deleted_at tombstone so the row stays
+                // in the trash view.
+                var cleared = qso.Clone();
+                cleared.QrzLogid = string.Empty;
+                cleared.PendingRemoteDelete = false;
+                try
+                {
+                    await store.UpdateQsoAsync(cleared).ConfigureAwait(false);
+                    remoteDeletesPushed++;
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Remote delete cleared for {qso.WorkedCallsign} failed locally: {ex.Message}");
+                }
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"Remote delete failed for {qso.WorkedCallsign}: {ex.Message}");
+            }
+        }
+
+        // ---------------------------------------------------------------
         // Phase 3 — Refresh metadata from authoritative QRZ STATUS
         // ---------------------------------------------------------------
         // Mirrors src/rust/qsoripper-server/src/sync.rs::refresh_metadata:
@@ -300,6 +385,8 @@ public sealed class QrzSyncEngine
             RemoteQsoCount = remoteCount,
             RemoteOwner = string.IsNullOrWhiteSpace(remoteOwner) ? null : remoteOwner,
             ErrorSummary = errors.Count > 0 ? string.Join("; ", errors) : null,
+            RemoteDeletesPushed = remoteDeletesPushed,
+            DeletesSkippedRemote = deletesSkippedRemote,
         };
     }
 

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/SyncResult.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/SyncResult.cs
@@ -28,4 +28,16 @@ public sealed record SyncResult
 
     /// <summary>Semicolon-delimited error messages from partial failures, or <c>null</c> when clean.</summary>
     public string? ErrorSummary { get; init; }
+
+    /// <summary>
+    /// Number of remote-delete operations successfully pushed to QRZ in
+    /// the Phase 2.5 queued-remote-delete loop.
+    /// </summary>
+    public uint RemoteDeletesPushed { get; init; }
+
+    /// <summary>
+    /// Number of remote QSO downloads skipped because their <c>QrzLogid</c>
+    /// matches a soft-deleted local row. Counted in Phase 1.
+    /// </summary>
+    public uint DeletesSkippedRemote { get; init; }
 }

--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -232,6 +232,16 @@ fn is_auth_error(reason: &str) -> bool {
         || lower.contains("access denied")
 }
 
+/// Detect QRZ "logid does not exist" responses, which we treat as success
+/// for delete operations to keep the queued-remote-delete loop idempotent.
+fn is_not_found_error(reason: &str) -> bool {
+    let lower = reason.to_ascii_lowercase();
+    lower.contains("not found")
+        || lower.contains("no such")
+        || lower.contains("does not exist")
+        || lower.contains("no record")
+}
+
 fn find_adif_marker_index(body: &str) -> Option<usize> {
     body.to_ascii_uppercase().find("ADIF=")
 }
@@ -553,13 +563,23 @@ impl QrzLogbookClient {
     ///
     /// Returns an error on network failure, authentication failure, or if
     /// the QRZ API rejects the deletion.
+    /// Delete a QSO from the QRZ logbook by its server-side logid.
+    ///
+    /// Treats QRZ "not found" / "no record" responses as **success** so that
+    /// the caller's queued-remote-delete loop is idempotent: if a row was
+    /// already removed remotely (manually, or by an earlier sync attempt that
+    /// got far enough to delete but not far enough to clear local flags), the
+    /// next sync just clears the local pending flag instead of looping forever.
     pub async fn delete_qso(&self, logid: &str) -> Result<(), QrzLogbookError> {
         let body = self
             .post_form(&[("ACTION", "DELETE"), ("LOGID", logid)])
             .await?;
         let map = parse_kv_response(&body);
-        check_result(map)?;
-        Ok(())
+        match check_result(map) {
+            Ok(_) => Ok(()),
+            Err(QrzLogbookError::ApiError(reason)) if is_not_found_error(&reason) => Ok(()),
+            Err(other) => Err(other),
+        }
     }
 
     /// Send a form-encoded POST to the QRZ Logbook API.
@@ -1404,15 +1424,30 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_qso_api_failure() {
+    async fn delete_qso_treats_not_found_as_success() {
+        // QRZ returns RESULT=FAIL with a "not found"-ish reason when the row
+        // was already gone. The queued-remote-delete loop relies on this
+        // being treated as success so the local pending flag clears.
         let (base_url, _) =
             spawn_logbook_server(&[("text/plain", "RESULT=FAIL&REASON=record not found")]).await;
+        let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
+
+        client
+            .delete_qso("000000")
+            .await
+            .expect("not-found is success");
+    }
+
+    #[tokio::test]
+    async fn delete_qso_api_failure_other_reasons_propagate() {
+        let (base_url, _) =
+            spawn_logbook_server(&[("text/plain", "RESULT=FAIL&REASON=bad record format")]).await;
         let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
 
         let err = client.delete_qso("000000").await.unwrap_err();
 
         match err {
-            QrzLogbookError::ApiError(reason) => assert_eq!(reason, "record not found"),
+            QrzLogbookError::ApiError(reason) => assert_eq!(reason, "bad record format"),
             other => panic!("expected ApiError, got: {other:?}"),
         }
     }

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -4,7 +4,7 @@
 //! **Phase 2** — Upload local-only and modified QSOs to QRZ.
 //! **Phase 3** — Update sync metadata with the current timestamp.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use qsoripper_core::domain::qso::new_local_id;
 use qsoripper_core::proto::qsoripper::domain::{ConflictPolicy, QsoRecord, SyncStatus};
@@ -12,7 +12,7 @@ use qsoripper_core::proto::qsoripper::services::SyncWithQrzResponse;
 use qsoripper_core::qrz_logbook::{
     QrzLogbookClient, QrzLogbookError, QrzLogbookStatus, QrzUploadResult,
 };
-use qsoripper_core::storage::{LogbookStore, QsoListQuery, SyncMetadata};
+use qsoripper_core::storage::{DeletedRecordsFilter, LogbookStore, QsoListQuery, SyncMetadata};
 use tokio::sync::mpsc;
 use tonic::Status;
 
@@ -68,6 +68,10 @@ pub(crate) trait QrzLogbookApi: Send + Sync {
 
     /// Query the remote logbook for the current owner callsign and QSO count.
     async fn fetch_status(&self) -> Result<QrzLogbookStatus, QrzLogbookError>;
+
+    /// Delete a remote QSO by its QRZ logid. Implementations should treat
+    /// "not found" as success so the queued-remote-delete loop is idempotent.
+    async fn delete_qso(&self, logid: &str) -> Result<(), QrzLogbookError>;
 }
 
 #[tonic::async_trait]
@@ -91,6 +95,10 @@ impl QrzLogbookApi for QrzLogbookClient {
     async fn fetch_status(&self) -> Result<QrzLogbookStatus, QrzLogbookError> {
         QrzLogbookClient::test_connection(self).await
     }
+
+    async fn delete_qso(&self, logid: &str) -> Result<(), QrzLogbookError> {
+        QrzLogbookClient::delete_qso(self, logid).await
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +109,10 @@ struct SyncCounters {
     downloaded: u32,
     uploaded: u32,
     conflicts: u32,
+    /// Number of remote rows skipped because they match a soft-deleted local row.
+    deletes_skipped_remote: u32,
+    /// Number of queued remote deletes that were pushed to QRZ in Phase 2.
+    remote_deletes_pushed: u32,
     errors: Vec<String>,
 }
 
@@ -110,6 +122,8 @@ impl SyncCounters {
             downloaded: 0,
             uploaded: 0,
             conflicts: 0,
+            deletes_skipped_remote: 0,
+            remote_deletes_pushed: 0,
             errors: Vec::new(),
         }
     }
@@ -147,6 +161,8 @@ pub(crate) async fn execute_sync(
 
     upload_phase(client, store, progress_tx, &mut counters).await;
 
+    push_pending_remote_deletes(client, store, progress_tx, &mut counters).await;
+
     update_metadata(client, store, &metadata, &mut counters).await;
 
     let error_summary = if counters.errors.is_empty() {
@@ -156,10 +172,12 @@ pub(crate) async fn execute_sync(
     };
 
     eprintln!(
-        "[sync] Sync completed: downloaded={} uploaded={} conflicts={} errors={}",
+        "[sync] Sync completed: downloaded={} uploaded={} conflicts={} remote_deletes_pushed={} deletes_skipped_remote={} errors={}",
         counters.downloaded,
         counters.uploaded,
         counters.conflicts,
+        counters.remote_deletes_pushed,
+        counters.deletes_skipped_remote,
         counters.errors.len(),
     );
 
@@ -195,8 +213,17 @@ async fn download_phase(
         }
     };
 
-    // Load all local QSOs for matching and sync-policy decisions.
-    let local_qsos = match store.list_qsos(&QsoListQuery::default()).await {
+    // Load all local QSOs (including soft-deleted) so we can both match
+    // against active rows AND honor user intent: any remote row whose
+    // qrz_logid matches a soft-deleted local row must be skipped, otherwise
+    // the next sync would resurrect the trashed QSO.
+    let local_qsos = match store
+        .list_qsos(&QsoListQuery {
+            deleted_filter: DeletedRecordsFilter::All,
+            ..QsoListQuery::default()
+        })
+        .await
+    {
         Ok(qsos) => qsos,
         Err(err) => {
             send_complete(
@@ -210,6 +237,12 @@ async fn download_phase(
             return None;
         }
     };
+
+    // Partition into active (used for matching) and deleted (used as a skip
+    // set keyed by qrz_logid). We don't fuzzy-skip on deleted rows; QRZ
+    // logid is the only signal stable enough to safely suppress a download.
+    let (active_local, deleted_logids) = partition_local_for_sync(&local_qsos);
+    let local_qsos = active_local;
 
     // If the local logbook is empty, force a full remote fetch even for
     // incremental sync requests. This recovers from stale metadata and gives
@@ -254,10 +287,35 @@ async fn download_phase(
     .await;
 
     // Build lookup indexes.
-    let (mut by_qrz_logid, mut by_key) = build_local_indexes(&local_qsos);
+    let (by_qrz_logid, by_key) = build_local_indexes(&local_qsos);
 
-    // Process each remote QSO.
-    for remote in &remote_qsos {
+    process_remote_qsos(
+        &remote_qsos,
+        &deleted_logids,
+        by_qrz_logid,
+        by_key,
+        store,
+        conflict_policy,
+        counters,
+    )
+    .await;
+
+    Some(metadata)
+}
+
+/// Iterate downloaded remote QSOs, applying the soft-delete skip set, then
+/// either inserting a new row or merging with the matched local one.
+#[allow(clippy::too_many_arguments)]
+async fn process_remote_qsos(
+    remote_qsos: &[QsoRecord],
+    deleted_logids: &HashSet<String>,
+    mut by_qrz_logid: LogidIndex,
+    mut by_key: FuzzyIndex,
+    store: &dyn LogbookStore,
+    conflict_policy: ConflictPolicy,
+    counters: &mut SyncCounters,
+) {
+    for remote in remote_qsos {
         // Defense-in-depth: skip records that lack the minimum fields needed
         // for matching and storage. These are artefacts of ADIF
         // header/trailer fragments that slip through the parser.
@@ -266,6 +324,15 @@ async fn download_phase(
         }
 
         let remote_logid = extract_qrz_logid(remote);
+
+        // Skip remote rows that match a soft-deleted local row. The user
+        // intentionally trashed it; download must not resurrect it.
+        if let Some(logid) = remote_logid.as_deref() {
+            if deleted_logids.contains(logid) {
+                counters.deletes_skipped_remote += 1;
+                continue;
+            }
+        }
 
         let local_match = remote_logid
             .as_deref()
@@ -297,8 +364,6 @@ async fn download_phase(
             }
         }
     }
-
-    Some(metadata)
 }
 
 /// Insert a QSO downloaded from QRZ that has no local match.
@@ -426,6 +491,90 @@ async fn upload_phase(
                 counters
                     .errors
                     .push(format!("Upload failed for {}: {err}", qso.worked_callsign));
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Phase 2.5 — Push queued remote deletes
+// ---------------------------------------------------------------------------
+
+/// Push every locally soft-deleted QSO whose `pending_remote_delete` flag is
+/// set to QRZ. On success (including QRZ "not found"), clears `qrz_logid`
+/// and `pending_remote_delete` while keeping `deleted_at` set.
+async fn push_pending_remote_deletes(
+    client: &dyn QrzLogbookApi,
+    store: &dyn LogbookStore,
+    progress_tx: &mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
+    counters: &mut SyncCounters,
+) {
+    let candidates = match store
+        .list_qsos(&QsoListQuery {
+            deleted_filter: DeletedRecordsFilter::DeletedOnly,
+            ..QsoListQuery::default()
+        })
+        .await
+    {
+        Ok(qsos) => qsos,
+        Err(err) => {
+            eprintln!("[sync] Failed to load deleted QSOs for remote-delete pass: {err}");
+            counters
+                .errors
+                .push(format!("List deleted QSOs failed: {err}"));
+            return;
+        }
+    };
+
+    let pending: Vec<&QsoRecord> = candidates
+        .iter()
+        .filter(|q| {
+            q.pending_remote_delete && !q.qrz_logid.as_deref().unwrap_or("").trim().is_empty()
+        })
+        .collect();
+
+    if pending.is_empty() {
+        return;
+    }
+
+    send_progress(
+        progress_tx,
+        &format!("Pushing {} queued remote delete(s)…", pending.len()),
+        counters.downloaded,
+        counters.uploaded,
+        counters.conflicts,
+    )
+    .await;
+
+    for qso in pending {
+        let logid = qso.qrz_logid.as_deref().unwrap_or("").to_string();
+        match client.delete_qso(&logid).await {
+            Ok(()) => {
+                let mut cleared = qso.clone();
+                cleared.qrz_logid = None;
+                cleared.pending_remote_delete = false;
+                if let Err(err) = store.update_qso(&cleared).await {
+                    eprintln!(
+                        "[sync] Remote delete succeeded for {} but local clear failed: {err}",
+                        qso.worked_callsign
+                    );
+                    counters.errors.push(format!(
+                        "Remote delete cleared for {} failed locally: {err}",
+                        qso.worked_callsign
+                    ));
+                } else {
+                    counters.remote_deletes_pushed += 1;
+                }
+            }
+            Err(err) => {
+                eprintln!(
+                    "[sync] Remote delete failed for logid {logid} ({}): {err}",
+                    qso.worked_callsign
+                );
+                counters.errors.push(format!(
+                    "Remote delete failed for {}: {err}",
+                    qso.worked_callsign
+                ));
             }
         }
     }
@@ -643,6 +792,27 @@ fn build_local_indexes(local_qsos: &[QsoRecord]) -> (LogidIndex, FuzzyIndex) {
     (by_qrz_logid, by_key)
 }
 
+/// Split rows fetched with `DeletedRecordsFilter::All` into:
+/// 1. Active rows usable for matching (returned as a Vec).
+/// 2. A `HashSet<String>` of QRZ logids belonging to soft-deleted rows.
+///    Phase 1 download uses this set to skip resurrecting trashed QSOs.
+fn partition_local_for_sync(local_qsos: &[QsoRecord]) -> (Vec<QsoRecord>, HashSet<String>) {
+    let mut active: Vec<QsoRecord> = Vec::with_capacity(local_qsos.len());
+    let mut deleted_logids: HashSet<String> = HashSet::new();
+    for qso in local_qsos {
+        if qso.deleted_at.is_some() {
+            if let Some(logid) = qso.qrz_logid.as_deref() {
+                if !logid.is_empty() {
+                    deleted_logids.insert(logid.to_string());
+                }
+            }
+        } else {
+            active.push(qso.clone());
+        }
+    }
+    (active, deleted_logids)
+}
+
 /// Extract the QRZ logbook record ID from a QSO.
 ///
 /// Checks the dedicated `qrz_logid` field first (populated by the ADIF
@@ -754,7 +924,7 @@ mod tests {
         Band, ConflictPolicy, Mode, QsoRecord, SyncStatus,
     };
     use qsoripper_core::qrz_logbook::{QrzLogbookError, QrzLogbookStatus, QrzUploadResult};
-    use qsoripper_core::storage::{LogbookStore, QsoListQuery, SyncMetadata};
+    use qsoripper_core::storage::{DeletedRecordsFilter, LogbookStore, QsoListQuery, SyncMetadata};
     use qsoripper_storage_memory::MemoryStorage;
     use tokio::sync::mpsc;
 
@@ -768,6 +938,8 @@ mod tests {
         replace_calls: Mutex<Vec<(String, String)>>, // (logid, local_id)
         replace_results: Mutex<Vec<Result<QrzUploadResult, QrzLogbookError>>>,
         status_result: Mutex<Option<Result<QrzLogbookStatus, QrzLogbookError>>>,
+        delete_calls: Mutex<Vec<String>>,
+        delete_results: Mutex<Vec<Result<(), QrzLogbookError>>>,
     }
 
     impl MockQrzApi {
@@ -784,6 +956,8 @@ mod tests {
                     owner: String::new(),
                     qso_count: 0,
                 }))),
+                delete_calls: Mutex::new(Vec::new()),
+                delete_results: Mutex::new(Vec::new()),
             }
         }
 
@@ -849,6 +1023,16 @@ mod tests {
                     })
                 })
         }
+
+        async fn delete_qso(&self, logid: &str) -> Result<(), QrzLogbookError> {
+            let mut results = self.delete_results.lock().unwrap();
+            self.delete_calls.lock().unwrap().push(logid.to_string());
+            if results.is_empty() {
+                Ok(())
+            } else {
+                results.remove(0)
+            }
+        }
     }
 
     /// Capturing mock that records what `since` value was passed to `fetch_qsos`.
@@ -884,6 +1068,10 @@ mod tests {
                 owner: String::new(),
                 qso_count: 0,
             })
+        }
+
+        async fn delete_qso(&self, _logid: &str) -> Result<(), QrzLogbookError> {
+            Ok(())
         }
     }
 
@@ -1831,5 +2019,170 @@ mod tests {
 
         let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
         assert!(all.is_empty());
+    }
+
+    // -- Soft-delete sync integration ---------------------------------------
+
+    /// Phase 1 must skip remote downloads whose qrz_logid matches a
+    /// soft-deleted local row, otherwise trashed QSOs would be resurrected.
+    #[tokio::test]
+    async fn download_skips_remote_matching_soft_deleted_local() {
+        let store = MemoryStorage::new();
+
+        // Locally have one QSO that's already synced (qrz_logid set), then
+        // soft-delete it. It should NOT be re-downloaded by Phase 1.
+        let mut local = make_qso("W1AW", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        local.qrz_logid = Some("LOG-DELETED".into());
+        local.sync_status = SyncStatus::Synced as i32;
+        store.insert_qso(&local).await.unwrap();
+        let soft_deleted = store
+            .soft_delete_qso(&local.local_id, 1_700_000_500_000, false)
+            .await
+            .unwrap();
+        assert!(soft_deleted);
+
+        let mut remote = make_qso("W1AW", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        remote.qrz_logid = Some("LOG-DELETED".into());
+        let api = MockQrzApi::new(Ok(vec![remote]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.downloaded_records, 0);
+
+        // The local row stays soft-deleted (deleted_at preserved).
+        let after = store
+            .list_qsos(&QsoListQuery {
+                deleted_filter: DeletedRecordsFilter::All,
+                ..QsoListQuery::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(after.len(), 1);
+        assert!(after[0].deleted_at.is_some());
+    }
+
+    /// Phase 2.5 must call QRZ delete for every soft-deleted row whose
+    /// `pending_remote_delete` flag is set, then clear the flag + qrz_logid
+    /// while keeping `deleted_at` set.
+    #[tokio::test]
+    async fn push_pending_remote_deletes_succeeds_and_clears_flags() {
+        let store = MemoryStorage::new();
+
+        let mut local = make_qso("W1AW", "JA1ZZZ", Band::Band40m, Mode::Cw, 1_700_000_100);
+        local.qrz_logid = Some("LOG-PENDING".into());
+        local.sync_status = SyncStatus::Synced as i32;
+        store.insert_qso(&local).await.unwrap();
+        store
+            .soft_delete_qso(&local.local_id, 1_700_000_600_000, true)
+            .await
+            .unwrap();
+
+        let api = MockQrzApi::new(Ok(vec![]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete, "sync should complete cleanly");
+        assert!(final_msg.error.is_none(), "no errors expected");
+
+        // QRZ delete was invoked exactly once for the queued logid.
+        let calls: Vec<String> = api.delete_calls.lock().unwrap().clone();
+        assert_eq!(calls.as_slice(), &["LOG-PENDING".to_string()]);
+
+        // Local row keeps tombstone, but qrz_logid + pending_remote_delete are cleared.
+        let after = store
+            .list_qsos(&QsoListQuery {
+                deleted_filter: DeletedRecordsFilter::All,
+                ..QsoListQuery::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(after.len(), 1);
+        assert!(after[0].deleted_at.is_some());
+        assert!(!after[0].pending_remote_delete);
+        assert!(after[0].qrz_logid.is_none() || after[0].qrz_logid.as_deref() == Some(""));
+    }
+
+    /// Soft-deleted rows with `pending_remote_delete = false` (e.g. local-only
+    /// trash) must NOT trigger a QRZ delete call.
+    #[tokio::test]
+    async fn push_pending_remote_deletes_skips_when_flag_unset() {
+        let store = MemoryStorage::new();
+
+        let mut local = make_qso("W1AW", "K7ABC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        local.qrz_logid = Some("LOG-LOCAL-ONLY-TRASH".into());
+        local.sync_status = SyncStatus::Synced as i32;
+        store.insert_qso(&local).await.unwrap();
+        store
+            .soft_delete_qso(&local.local_id, 1_700_000_700_000, false)
+            .await
+            .unwrap();
+
+        let api = MockQrzApi::new(Ok(vec![]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+        let _ = collect_final(rx).await;
+
+        let calls = api.delete_calls.lock().unwrap();
+        assert!(
+            calls.is_empty(),
+            "no remote delete should be attempted when pending flag is false"
+        );
+    }
+
+    /// When QRZ returns an error for a queued delete, the local pending flag
+    /// must remain set so the next sync retries.
+    #[tokio::test]
+    async fn push_pending_remote_deletes_preserves_state_on_failure() {
+        let store = MemoryStorage::new();
+
+        let mut local = make_qso("W1AW", "DL1ABC", Band::Band20m, Mode::Ssb, 1_700_000_200);
+        local.qrz_logid = Some("LOG-FAIL".into());
+        local.sync_status = SyncStatus::Synced as i32;
+        store.insert_qso(&local).await.unwrap();
+        store
+            .soft_delete_qso(&local.local_id, 1_700_000_800_000, true)
+            .await
+            .unwrap();
+
+        let api = MockQrzApi::new(Ok(vec![]), vec![]);
+        api.delete_results
+            .lock()
+            .unwrap()
+            .push(Err(QrzLogbookError::ApiError("server angry".into())));
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert!(
+            final_msg.error.is_some(),
+            "failed remote delete should surface in summary"
+        );
+
+        let after = store
+            .list_qsos(&QsoListQuery {
+                deleted_filter: DeletedRecordsFilter::All,
+                ..QsoListQuery::default()
+            })
+            .await
+            .unwrap();
+        assert_eq!(after.len(), 1);
+        assert!(after[0].deleted_at.is_some());
+        assert!(
+            after[0].pending_remote_delete,
+            "pending flag must remain set so the next sync retries"
+        );
+        assert_eq!(after[0].qrz_logid.as_deref(), Some("LOG-FAIL"));
     }
 }


### PR DESCRIPTION
## Summary

Final PR in the soft-delete trio for #289. Builds on #291 (storage) and #292 (engine semantics + RestoreQso) to make the queued remote-delete actually call QRZ on the next sync, and to stop resurrecting locally-trashed QSOs from QRZ downloads.

## Changes

**Phase 1 (download) — soft-delete suppression**
- Engines now load the full local set including soft-deleted rows, build the set of `qrz_logid` values for soft-deleted locals, and skip any remote QSO whose logid matches.
- New counter: `deletes_skipped_remote` / `DeletesSkippedRemote`.

**Phase 2.5 (new) — push pending remote deletes**
- For each local row with `deleted_at` set, `pending_remote_delete = true`, and a non-empty `qrz_logid`, call QRZ `ACTION=DELETE`.
- HTTP 404 and not-found-style `REASON` values (`not found`, `no such`, `does not exist`, `no record`) are treated as success — delete is idempotent.
- On success: clear `pending_remote_delete` + `qrz_logid`; keep `deleted_at` so the row stays in trash.
- On other failures (incl. auth): preserve the pending flag for retry; surface the error in the sync summary.
- New counter: `remote_deletes_pushed` / `RemoteDeletesPushed`.

**Rust**
- `qsoripper-core/qrz_logbook`: `delete_qso` now idempotent for not-found REASONs.
- `qsoripper-server/sync.rs`: new `push_pending_remote_deletes`, refactored `download_phase`, new fields on `SyncCounters`, four new tests.

**.NET**
- `IQrzLogbookApi.DeleteQsoAsync` + `QrzLogbookClient.DeleteQsoAsync` with HTTP 404 / not-found REASON handling and explicit auth-error rethrow.
- `QrzSyncEngine`: Phase 1 skip + Phase 2.5 loop mirroring Rust.
- `SyncResult` gains `RemoteDeletesPushed` + `DeletesSkippedRemote`.
- New tests in `QrzLogbookClientTests` and `QrzSyncEngineTests`.

**Engine spec**
- §7.3 documents Phase 1 soft-delete suppression and the new Phase 2.5 (idempotent 404/not-found semantics).
- Appendix C: removed the deferred-work entry for soft-delete sync (now done).

## Validation

```powershell
cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check
cargo clippy --manifest-path src\rust\Cargo.toml --all-targets -- -D warnings
cargo test --manifest-path src\rust\Cargo.toml --workspace --exclude qsoripper-stress --exclude qsoripper-stress-tui
dotnet format src\dotnet\QsoRipper.slnx --verify-no-changes
dotnet test src\dotnet\QsoRipper.slnx
buf lint
```

All green locally. Rust workspace 208+ tests, full .NET solution all projects passing.

Closes the sync portion of #289 — the full soft-delete + restore feature is now end-to-end across both engines.