### PR TITLE
Regression tests for sync conflict logid + last_sync guard (#160, #161)

### DIFF
--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
@@ -528,6 +528,35 @@ public sealed class QrzSyncEngineTests
     }
 
     [Fact]
+    public async Task Merge_last_write_wins_adopts_remote_qrz_logid_when_differs()
+    {
+        // Regression for #161: when remote wins under LastWriteWins, the
+        // overwritten local row must carry the REMOTE qrz_logid (not the
+        // stale local one), otherwise the next sync would point at a phantom.
+        var store = CreateStore();
+        var local = MakeLocalQso("W1AW", BaseTime, Band._20M, Mode.Ft8, SyncStatus.Modified);
+        local.QrzLogid = "LOG-LOCAL-OLD";
+        local.Notes = "local stale";
+        await store.Logbook.InsertQsoAsync(local);
+
+        var remote = MakeRemoteQso("W1AW", BaseTime, Band._20M, Mode.Ft8, "LOG-REMOTE-NEW");
+        remote.Notes = "remote authoritative";
+
+        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var engine = new QrzSyncEngine(api);
+
+        var result = await engine.ExecuteSyncAsync(
+            store.Logbook,
+            fullSync: true,
+            ConflictPolicy.LastWriteWins);
+
+        Assert.Equal(0u, result.ConflictCount);
+        var all = await store.Logbook.ListQsosAsync(new QsoListQuery());
+        Assert.Single(all);
+        Assert.Equal("LOG-REMOTE-NEW", all[0].QrzLogid);
+    }
+
+    [Fact]
     public async Task Merge_flag_for_review_preserves_local_and_marks_conflict()
     {
         var store = CreateStore();

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -1822,6 +1822,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn last_write_wins_remote_newer_overwrites_local_qrz_logid_when_differs() {
+        // Regression for #161: when remote wins under LastWriteWins, the
+        // overwritten local row must carry the REMOTE qrz_logid, not the
+        // stale local one. Otherwise the local row points at a phantom QRZ
+        // record on the next sync.
+        let store = MemoryStorage::new();
+
+        let mut local = make_qso(
+            "W1AW",
+            "K7LWW-DIFFER",
+            Band::Band20m,
+            Mode::Ft8,
+            1_700_000_000,
+        );
+        local.sync_status = SyncStatus::Modified as i32;
+        local.qrz_logid = Some("LOG-LOCAL-OLD".into());
+        local.updated_at = Some(Timestamp {
+            seconds: 1000,
+            nanos: 0,
+        });
+        local.notes = Some("local edit".into());
+        store.insert_qso(&local).await.unwrap();
+
+        // Remote is newer AND has a different logid (e.g., remote re-inserted
+        // outside QsoRipper, or a logid migration on QRZ).
+        let remote = {
+            let mut q = make_qso(
+                "W1AW",
+                "K7LWW-DIFFER",
+                Band::Band20m,
+                Mode::Ft8,
+                1_700_000_000,
+            );
+            q.qrz_logid = Some("LOG-REMOTE-NEW".into());
+            q.updated_at = Some(Timestamp {
+                seconds: 2000,
+                nanos: 0,
+            });
+            q.notes = Some("remote authoritative".into());
+            q
+        };
+
+        let api = MockQrzApi::new(Ok(vec![remote]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.downloaded_records, 1);
+        assert_eq!(final_msg.conflict_records, 0);
+
+        let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(
+            all[0].qrz_logid.as_deref(),
+            Some("LOG-REMOTE-NEW"),
+            "remote-wins overwrite must adopt the remote qrz_logid (not keep the stale local one)",
+        );
+    }
+
+    #[tokio::test]
     async fn last_write_wins_local_newer_keeps_modified() {
         let store = MemoryStorage::new();
 


### PR DESCRIPTION
## Summary

Regression tests for #160 and #161 — both bugs are **already fixed in both engines** (likely shipped during the soft-delete sync work in #293). This PR locks them in with explicit regression tests so they can't silently regress.

## #160 — `last_sync` not advanced on fatal Phase 1 failure

- Rust: `download_phase` calls `send_complete` + returns `None` on fatal failure; `execute_sync` short-circuits on `None` and never calls `update_metadata`. Already covered by existing test `metadata_last_sync_not_advanced_when_download_fails`.
- .NET: `QrzSyncEngine.ExecuteSyncAsync` returns a `SyncResult` with `ErrorSummary` on Phase 1 metadata-load or fetch failures (lines 100-104 + 134-138 of `QrzSyncEngine.cs`).

No code changes needed.

## #161 — preserve remote `qrz_logid` when conflict resolves to remote

- Rust `resolve_modified_conflict`: `updated.qrz_logid = extract_qrz_logid(remote).or_else(|| local.qrz_logid.clone());`
- .NET `QrzSyncEngine`: `merged.QrzLogid = remoteLogid ?? local.QrzLogid;`

Both already adopt the remote logid first. The existing Rust test only covered the case where local has NO logid; this PR adds the explicit "remote logid DIFFERS from local logid" regression test on both sides.

## Tests added

- `last_write_wins_remote_newer_overwrites_local_qrz_logid_when_differs` (Rust)
- `Merge_last_write_wins_adopts_remote_qrz_logid_when_differs` (.NET)

## Validation

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `dotnet format --verify-no-changes`, plus targeted test runs all pass locally.

Closes #160. Closes #161.