### PR TITLE
Wire per-operation QRZ sync for LogQso/UpdateQso (#176)

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -151,7 +151,8 @@ Creates a new QSO record in the local logbook.
 6. Set `created_at` and `updated_at` to the current UTC time.
 7. Set `sync_status` to `SYNC_STATUS_NOT_SYNCED`.
 8. Persist the record via the storage backend.
-9. Return the persisted `QsoRecord` in the response.
+9. If `sync_to_qrz=true`, immediately push the new record to QRZ Logbook (per-operation sync; see §7.3 below). On success, adopt the QRZ-assigned `qrz_logid`, set `sync_status=SYNC_STATUS_SYNCED`, and write the row back to storage. Populate `LogQsoResponse.sync_success=true`. On failure (no API key, network error, QRZ rejection), leave `sync_status=SYNC_STATUS_NOT_SYNCED`, set `sync_success=false`, and put a human-readable message in `sync_error`. The local persist MUST succeed regardless — per-op sync failure is reported, not raised.
+10. Return the persisted `QsoRecord` in the response.
 
 **Error semantics:**
 - `INVALID_ARGUMENT` — missing or invalid required fields.
@@ -168,7 +169,8 @@ Updates an existing QSO record by `local_id`.
 3. Set `updated_at` to the current UTC time.
 4. If the QSO was previously synced, set `sync_status` to `SYNC_STATUS_MODIFIED`.
 5. Persist the updated record.
-6. Return the updated `QsoRecord`.
+6. If `sync_to_qrz=true`, immediately push the updated record to QRZ Logbook (per-operation sync; see §7.3 below). If the row already has a `qrz_logid`, use REPLACE so the same remote row is updated in place; otherwise INSERT. On success, write back the QRZ-assigned `qrz_logid` and `sync_status=SYNC_STATUS_SYNCED`, and set `UpdateQsoResponse.sync_success=true`. On failure, leave the local row in its current state (`SYNC_STATUS_MODIFIED` or `SYNC_STATUS_NOT_SYNCED`), set `sync_success=false`, and put a human-readable message in `sync_error`. The local persist MUST succeed regardless.
+7. Return the updated `QsoRecord`.
 
 **Error semantics:**
 - `NOT_FOUND` — no QSO with the given `local_id`.
@@ -1079,7 +1081,23 @@ The QRZ logbook sync is a three-phase operation:
 1. Call QRZ logbook API `STATUS` to get the current logbook QSO count and owner callsign.
 2. Update `sync_metadata` with the count, timestamp, and owner. If `STATUS` fails, engines SHOULD fall back to locally-computed counts rather than leaving metadata stale.
 
-**Resilience:** A failure in any phase should not prevent other phases from executing. The engine should report partial success/failure in the stream.
+**Resilience:** A failure in any phase should not prevent other phases from executing. The engine should report partial success/failure in the stream. A fatal failure in Phase 1 (e.g., metadata load failure, fetch failure) MUST short-circuit the rest of `execute_sync` so that `last_sync` is NOT advanced — the next attempt re-fetches the same window.
+
+#### Per-Operation Sync (`sync_to_qrz=true` on LogQso/UpdateQso)
+
+When `LogQso.sync_to_qrz=true` or `UpdateQso.sync_to_qrz=true`, engines MUST attempt to push the affected row to QRZ immediately after the local persist. This is independent of the bulk sync flow (`SyncWithQrz`) and lets clients log a QSO and get an authoritative QRZ logid back in a single round-trip.
+
+**Selection rule (mirrors Phase 2):**
+- If the local row has a non-empty `qrz_logid`, REPLACE in place (`ACTION=INSERT&OPTION=REPLACE,LOGID:<logid>`).
+- Otherwise INSERT (`ACTION=INSERT`).
+
+**Success path:** adopt the QRZ-assigned `LOGID`, set `sync_status=SYNC_STATUS_SYNCED`, write the row back to local storage, and populate the response's `sync_success=true` (and `qrz_logid` for `LogQsoResponse`).
+
+**Failure path:** the local persist (step 1) MUST succeed regardless. The QRZ failure is reported, not raised: leave the row's `sync_status` untouched (`NOT_SYNCED` or `MODIFIED`), set `sync_success=false`, and put a human-readable message in `sync_error`. The next bulk `SyncWithQrz` will retry the row via Phase 2.
+
+**Configuration not present:** if no QRZ logbook API key is configured, return `sync_success=false` with `sync_error="QRZ Logbook API key is not configured."`. The local row still persists.
+
+**.NET divergence:** the .NET reference engine currently runs all `LogQso`/`UpdateQso` work under a synchronous lock and does not yet issue the per-op QRZ HTTP call from inside that critical section. It returns `sync_success=true` with a placeholder `qrz_logid` when configured, or a `sync_error` indicating the operation is not yet wired. Tracked as a follow-up; see Appendix C.
 
 ### 7.4 Lookup Lifecycle
 
@@ -1416,3 +1434,4 @@ The following gaps are documented tracking items. They do not affect the normati
 
 - **.NET engine — `SyncWithQrz` streaming granularity.** The .NET engine currently produces a single terminal `SyncWithQrzResponse` instead of per-phase progress messages. Matches the spec's RPC signature but loses UI progress fidelity vs. the Rust engine.
 - **.NET engine — QRZ ADIF field coverage.** The .NET `AdifCodec` does not yet parse/emit every QRZ-specific field the Rust mapper covers (e.g., `ARRL_SECT`, SKCC, QSL/LOTW/EQSL date and flag variants, `MY_LAT`/`MY_LON`, `MY_ARRL_SECT`, `MY_CQ_ZONE`/`MY_ITU_ZONE`). Missing fields round-trip via `extra_fields` today, but should graduate to dedicated domain columns.
+- **.NET engine — per-operation `sync_to_qrz=true` on `LogQso`/`UpdateQso`.** `ManagedEngineState.LogQso`/`UpdateQso` run inside a synchronous lock and do not yet issue the per-op QRZ HTTP call. Currently returns either a placeholder logid (when configured) or a `sync_error`. Reaching parity requires moving the HTTP call out of the lock (likely making the handlers async). The Rust engine implements this fully via `sync::sync_single_qso`. See §7.3 "Per-Operation Sync".

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -339,6 +339,33 @@ impl DeveloperLogbookService {
         qsoripper_core::qrz_logbook::QrzLogbookClient::new(config)
             .map_err(|err| format!("Failed to create QRZ logbook client: {err}"))
     }
+
+    /// Push a single QSO to QRZ for the per-RPC `sync_to_qrz=true` paths on
+    /// `LogQso` / `UpdateQso`. On success, mutates `stored` in-place to carry
+    /// the QRZ-assigned logid and `Synced` status, mirroring what the bulk
+    /// sync Phase 2 writes back to local storage.
+    ///
+    /// Returns `(sync_success, sync_error)` shaped for the gRPC response.
+    /// Failure leaves `stored` untouched; the local row keeps its current
+    /// status (`LocalOnly` or `Modified`) and the next bulk sync will retry.
+    async fn run_per_op_qrz_sync(
+        &self,
+        engine: &qsoripper_core::application::logbook::LogbookEngine,
+        stored: &mut qsoripper_core::proto::qsoripper::domain::QsoRecord,
+    ) -> (bool, Option<String>) {
+        let client = match self.build_qrz_logbook_client().await {
+            Ok(client) => client,
+            Err(err) => return (false, Some(err)),
+        };
+
+        match sync::sync_single_qso(&client, engine.logbook_store(), stored).await {
+            Ok(synced) => {
+                *stored = synced;
+                (true, None)
+            }
+            Err(err) => (false, Some(err)),
+        }
+    }
 }
 
 #[tonic::async_trait]
@@ -356,11 +383,15 @@ impl LogbookService for DeveloperLogbookService {
         let qso = request
             .qso
             .ok_or_else(|| Status::invalid_argument("LogQso requires a qso payload."))?;
-        let stored = engine
+        let mut stored = engine
             .log_qso_with_station_profile(qso, active_station_profile.as_ref())
             .await
             .map_err(map_logbook_error)?;
-        let (sync_success, sync_error) = sync_result(request.sync_to_qrz, "QRZ sync");
+        let (sync_success, sync_error) = if request.sync_to_qrz {
+            self.run_per_op_qrz_sync(&engine, &mut stored).await
+        } else {
+            (true, None)
+        };
 
         Ok(Response::new(LogQsoResponse {
             local_id: stored.local_id,
@@ -379,8 +410,12 @@ impl LogbookService for DeveloperLogbookService {
         let qso = request
             .qso
             .ok_or_else(|| Status::invalid_argument("UpdateQso requires a qso payload."))?;
-        let _ = engine.update_qso(qso).await.map_err(map_logbook_error)?;
-        let (sync_success, sync_error) = sync_result(request.sync_to_qrz, "QRZ sync");
+        let mut stored = engine.update_qso(qso).await.map_err(map_logbook_error)?;
+        let (sync_success, sync_error) = if request.sync_to_qrz {
+            self.run_per_op_qrz_sync(&engine, &mut stored).await
+        } else {
+            (true, None)
+        };
 
         Ok(Response::new(UpdateQsoResponse {
             success: true,
@@ -1139,14 +1174,6 @@ fn non_empty_string(value: &str) -> Option<String> {
         None
     } else {
         Some(trimmed.to_string())
-    }
-}
-
-fn sync_result(requested: bool, label: &str) -> (bool, Option<String>) {
-    if requested {
-        (false, Some(format!("{label} is not implemented yet.")))
-    } else {
-        (true, None)
     }
 }
 

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -452,40 +452,11 @@ async fn upload_phase(
     );
 
     for qso in &pending_qsos {
-        let is_modified = qso.sync_status == SyncStatus::Modified as i32;
-        let existing_logid = qso.qrz_logid.clone().filter(|s| !s.is_empty());
-
-        let result = match (is_modified, existing_logid.as_deref()) {
-            // Edited locally and we already know its QRZ logid -> REPLACE in
-            // place so QRZ keeps the same row instead of growing a duplicate.
-            (true, Some(logid)) => client.replace_qso(logid, qso).await,
-            // Either a brand-new QSO, or a "modified" QSO that somehow lost
-            // its logid (legacy data). Fall back to INSERT.
-            _ => client.upload_qso(qso).await,
-        };
-
-        match result {
-            Ok(result) => {
-                let mut synced = qso.clone();
-                synced.qrz_logid = Some(result.logid);
-                synced.sync_status = SyncStatus::Synced as i32;
-                match store.update_qso(&synced).await {
-                    Ok(_) => counters.uploaded += 1,
-                    Err(err) => {
-                        eprintln!(
-                            "[sync] Uploaded but failed to update local record {}: {err}",
-                            qso.local_id
-                        );
-                        counters.errors.push(format!(
-                            "Upload succeeded for {} but local update failed: {err}",
-                            qso.worked_callsign,
-                        ));
-                    }
-                }
-            }
+        match sync_single_qso(client, store, qso).await {
+            Ok(_) => counters.uploaded += 1,
             Err(err) => {
                 eprintln!(
-                    "[sync] Failed to upload QSO {} ({}): {err}",
+                    "[sync] Failed to push QSO {} ({}): {err}",
                     qso.local_id, qso.worked_callsign
                 );
                 counters
@@ -494,6 +465,50 @@ async fn upload_phase(
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Per-operation sync helper (used by Phase 2 and by per-RPC sync_to_qrz=true)
+// ---------------------------------------------------------------------------
+
+/// Push a single QSO to QRZ, then mirror the QRZ-assigned logid + Synced
+/// state back into local storage. Used by both bulk sync Phase 2 and the
+/// per-operation `sync_to_qrz=true` paths on `LogQso` / `UpdateQso`.
+///
+/// Selection rule:
+/// * If the local row already has a non-empty `qrz_logid`, REPLACE in place
+///   so QRZ keeps the same row (no duplicate). This applies regardless of
+///   whether `sync_status` is Modified or Synced.
+/// * Otherwise INSERT a new remote row and adopt the returned logid.
+///
+/// Returns the locally-persisted `QsoRecord` on success (with refreshed
+/// `qrz_logid` and `sync_status = Synced`). Returns a human-readable error
+/// string on either upload failure or local-store write failure; callers
+/// surface it as the gRPC `sync_error` field.
+pub(crate) async fn sync_single_qso(
+    client: &dyn QrzLogbookApi,
+    store: &dyn LogbookStore,
+    qso: &QsoRecord,
+) -> Result<QsoRecord, String> {
+    let existing_logid = qso.qrz_logid.clone().filter(|s| !s.is_empty());
+
+    let result = match existing_logid.as_deref() {
+        Some(logid) => client.replace_qso(logid, qso).await,
+        None => client.upload_qso(qso).await,
+    };
+
+    let upload = result.map_err(|err| format!("QRZ upload failed: {err}"))?;
+
+    let mut synced = qso.clone();
+    synced.qrz_logid = Some(upload.logid);
+    synced.sync_status = SyncStatus::Synced as i32;
+
+    store
+        .update_qso(&synced)
+        .await
+        .map_err(|err| format!("QRZ upload succeeded but local update failed: {err}"))?;
+
+    Ok(synced)
 }
 
 // ---------------------------------------------------------------------------
@@ -928,7 +943,7 @@ mod tests {
     use qsoripper_storage_memory::MemoryStorage;
     use tokio::sync::mpsc;
 
-    use super::{execute_sync, QrzLogbookApi};
+    use super::{execute_sync, sync_single_qso, QrzLogbookApi};
 
     // -- Mock API -----------------------------------------------------------
 
@@ -1220,6 +1235,85 @@ mod tests {
         let saved = store.get_qso(&q.local_id).await.unwrap().unwrap();
         assert_eq!(saved.sync_status, SyncStatus::Synced as i32);
         assert_eq!(saved.qrz_logid.as_deref(), Some("QRZ-EXISTING"));
+    }
+
+    // ---- sync_single_qso (per-operation sync_to_qrz=true path) -------------
+
+    #[tokio::test]
+    async fn sync_single_qso_inserts_when_no_logid_and_marks_synced() {
+        let store = MemoryStorage::new();
+        let mut q = make_qso("W1AW", "K7NEW", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        q.qrz_logid = None;
+        q.sync_status = SyncStatus::LocalOnly as i32;
+        store.insert_qso(&q).await.unwrap();
+
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![Ok(QrzUploadResult {
+                logid: "QRZ-NEW".into(),
+            })],
+        );
+
+        let synced = sync_single_qso(&api, &store, &q).await.expect("ok");
+        assert_eq!(synced.qrz_logid.as_deref(), Some("QRZ-NEW"));
+        assert_eq!(synced.sync_status, SyncStatus::Synced as i32);
+
+        let saved = store.get_qso(&q.local_id).await.unwrap().unwrap();
+        assert_eq!(saved.qrz_logid.as_deref(), Some("QRZ-NEW"));
+        assert_eq!(saved.sync_status, SyncStatus::Synced as i32);
+
+        // INSERT was used; REPLACE was not.
+        assert!(api.replace_calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn sync_single_qso_replaces_when_logid_present_preserving_id() {
+        let store = MemoryStorage::new();
+        let mut q = make_qso("W1AW", "K7EDIT", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        q.qrz_logid = Some("QRZ-EXISTING".into());
+        q.sync_status = SyncStatus::Modified as i32;
+        store.insert_qso(&q).await.unwrap();
+
+        // No upload_results queued — only REPLACE should be called and it
+        // defaults to echoing the logid back.
+        let api = MockQrzApi::new(Ok(vec![]), vec![]);
+
+        let synced = sync_single_qso(&api, &store, &q).await.expect("ok");
+        assert_eq!(synced.qrz_logid.as_deref(), Some("QRZ-EXISTING"));
+        assert_eq!(synced.sync_status, SyncStatus::Synced as i32);
+
+        let replace_calls = api.replace_calls.lock().unwrap().clone();
+        assert_eq!(replace_calls.len(), 1, "must REPLACE not INSERT");
+        assert_eq!(replace_calls[0].0, "QRZ-EXISTING");
+
+        let saved = store.get_qso(&q.local_id).await.unwrap().unwrap();
+        assert_eq!(saved.sync_status, SyncStatus::Synced as i32);
+        assert_eq!(saved.qrz_logid.as_deref(), Some("QRZ-EXISTING"));
+    }
+
+    #[tokio::test]
+    async fn sync_single_qso_returns_error_when_upload_fails_and_leaves_local_alone() {
+        let store = MemoryStorage::new();
+        let mut q = make_qso("W1AW", "K7FAIL", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        q.qrz_logid = None;
+        q.sync_status = SyncStatus::LocalOnly as i32;
+        store.insert_qso(&q).await.unwrap();
+
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![Err(QrzLogbookError::ApiError("boom".into()))],
+        );
+
+        let err = sync_single_qso(&api, &store, &q)
+            .await
+            .expect_err("should return error");
+        assert!(err.contains("QRZ upload failed"), "actual error: {err}");
+
+        // Local row must remain LocalOnly with no logid — caller (handler)
+        // surfaces the failure as sync_error and the next bulk sync will retry.
+        let saved = store.get_qso(&q.local_id).await.unwrap().unwrap();
+        assert_eq!(saved.sync_status, SyncStatus::LocalOnly as i32);
+        assert!(saved.qrz_logid.is_none());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Wires real per-operation QRZ sync into the Rust engine for `LogQso`/`UpdateQso` when `sync_to_qrz=true`. Closes part of #176.

## Before

`LogQso`/`UpdateQso` with `sync_to_qrz=true` returned `sync_success=false` and `sync_error="QRZ sync is not implemented yet."`. Operators had to wait for the next bulk `SyncWithQrz` to push fresh QSOs to QRZ.

## After (Rust engine)

The handler:
1. Persists locally (unchanged).
2. If `sync_to_qrz=true`, immediately pushes the row to QRZ via the new `sync::sync_single_qso` helper.
3. On success, adopts the QRZ-assigned `LOGID`, sets `sync_status=Synced`, writes the row back to local storage, and returns `sync_success=true` plus `qrz_logid`.
4. On failure (no API key, network, QRZ rejection, or local-store re-write failure), leaves the row's status untouched and returns `sync_success=false` + a descriptive `sync_error`. The local persist always succeeds.

Selection rule mirrors Phase 2 of bulk sync: REPLACE in place if the row already has a non-empty `qrz_logid`, otherwise INSERT. `upload_phase` is refactored to delegate to `sync_single_qso` so bulk and per-op share one code path.

## Engine spec

- §7.2 `LogQso` and `UpdateQso` behaviors updated to describe the per-op sync side-effect, response shape, and resilience contract (local persist must succeed regardless).
- §7.3 `Sync Lifecycle` gained a new `Per-Operation Sync` subsection covering the selection rule, success/failure paths, missing-API-key handling, and the .NET divergence note.
- Appendix C now tracks the .NET parity gap.

## .NET divergence (tracked, not blocking)

`ManagedEngineState.LogQso`/`UpdateQso` run inside a synchronous `lock(_gate)`. Issuing an HTTP call from inside that critical section is unacceptable, so the .NET handlers continue to use their existing placeholder behavior. Reaching parity requires moving the QRZ HTTP work out of the lock (likely making the handlers `async`). Documented in Appendix C and called out inline in §7.3; will be a separate PR.

## Tests (Rust)

New `sync.rs` unit tests for `sync_single_qso`:
- inserts when no logid, marks Synced, writes back to store
- replaces when a logid is present, preserves the id
- returns a descriptive error when upload fails and leaves the local row alone (so the next bulk sync retries it)

Full Rust suite: 268 + 128 + 208 + ... (workspace) — all green. `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `buf lint` clean.