### PR TITLE
Implement GetDxccEntity and BatchLookup in Rust engine (#176)

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -343,11 +343,21 @@ Returns DXCC entity information for a given DXCC code.
 **Behavior:**
 - Look up the `DxccEntity` by numeric DXCC code from the engine's DXCC reference data.
 - Return country name, continent, zones, and geographic data.
+- Engines that derive entity data from the embedded ADIF DXCC table populate
+  `dxcc_code`, `country_name`, `continent`, `cq_zone`, and `itu_zone`. Optional
+  geographic fields (`utc_offset`, `latitude`, `longitude`, `notes`) remain unset
+  unless the engine has access to a richer reference source (for example, QRZ DXCC
+  XML).
+- Prefix-based lookup (`GetDxccEntityRequest.prefix`) is reserved for a future engine
+  release that integrates QRZ's prefix reduction algorithm. Engines that have not yet
+  shipped prefix support must return `UNIMPLEMENTED` for that branch and `INVALID_ARGUMENT`
+  when neither `dxcc_code` nor `prefix` is set.
 
 **Error semantics:**
 - `NOT_FOUND` — unknown DXCC code.
-
-> **Note:** This RPC may be marked as unimplemented in early engine versions. Engines should return `UNIMPLEMENTED` if not yet supported.
+- `UNIMPLEMENTED` — request used the `prefix` branch and the engine has not yet
+  implemented prefix-based DXCC resolution.
+- `INVALID_ARGUMENT` — neither `dxcc_code` nor `prefix` was specified.
 
 #### BatchLookup
 
@@ -358,11 +368,15 @@ Performs lookups for multiple callsigns in a single request.
 - Perform lookups for each (cache-first, then external).
 - Return a list of `LookupResult` entries, one per input callsign.
 - Order of results matches order of input callsigns.
+- Engines should bound concurrency (the reference implementations cap parallel
+  lookups at 5) and reuse the same `LookupCoordinator` path that powers the unary
+  `Lookup` RPC so cache, debounce, and provider fallback semantics stay consistent.
+- Empty input is valid and returns an empty `results` list.
 
 **Error semantics:**
 - Per-callsign errors are reported in individual `LookupResult` entries, not as top-level gRPC errors.
-
-> **Note:** This RPC may be marked as unimplemented in early engine versions.
+- `INTERNAL` — orchestration failure (e.g., a worker task panicked) before a per-callsign
+  result could be produced.
 
 ### 3.4 RigControlService
 

--- a/proto/services/lookup_service.proto
+++ b/proto/services/lookup_service.proto
@@ -24,8 +24,8 @@ import "services/stream_lookup_response.proto";
 //   Lookup             — implemented (both engines)
 //   StreamLookup       — implemented (both engines)
 //   GetCachedCallsign  — implemented (both engines)
-//   GetDxccEntity      — implemented (.NET, by DXCC code; prefix lookup not yet supported); unimplemented (Rust)
-//   BatchLookup        — implemented (.NET); unimplemented (Rust)
+//   GetDxccEntity      — implemented (both engines, by DXCC code; prefix lookup not yet supported)
+//   BatchLookup        — implemented (both engines)
 //
 // Transport: native gRPC (HTTP/2 + binary protobuf).
 // Browser clients must go through a gRPC-Web proxy — see docs/api/client-integration.md.

--- a/src/rust/qsoripper-core/src/adif/mod.rs
+++ b/src/rust/qsoripper-core/src/adif/mod.rs
@@ -6,6 +6,7 @@ mod normalize;
 mod zone_lookup;
 
 pub(crate) use normalize::enrich_callsign_record_from_dxcc;
+pub use normalize::lookup_dxcc_entity_by_code;
 pub(crate) use zone_lookup::enrich_zones_from_location;
 
 use crate::proto::qsoripper::domain::QsoRecord;

--- a/src/rust/qsoripper-core/src/adif/normalize.rs
+++ b/src/rust/qsoripper-core/src/adif/normalize.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use crate::proto::qsoripper::domain::{CallsignRecord, QsoRecord, RstReport};
+use crate::proto::qsoripper::domain::{CallsignRecord, DxccEntity, QsoRecord, RstReport};
 
 #[derive(Clone, Copy)]
 struct DxccEntityInfo {
@@ -102,6 +102,30 @@ pub(crate) fn enrich_callsign_record_from_dxcc(record: &mut CallsignRecord) {
     if string_is_blank(record.dxcc_country_name.as_deref()) && !entity.country.is_empty() {
         record.dxcc_country_name = Some(entity.country.to_owned());
     }
+}
+
+/// Look up a DXCC entity by its numeric code from the embedded ADIF DXCC table.
+///
+/// Returns a [`DxccEntity`] populated with the fields available locally
+/// (`dxcc_code`, `country_name`, `continent`, `cq_zone`, `itu_zone`). Optional
+/// fields that QRZ would normally provide (`utc_offset`, `latitude`, `longitude`,
+/// `notes`) are left unset because the embedded table does not carry them.
+///
+/// Returns `None` when no entity matches the requested code.
+#[must_use]
+pub fn lookup_dxcc_entity_by_code(dxcc_code: u32) -> Option<DxccEntity> {
+    let entity = DXCC_ENTITIES.get(&dxcc_code).copied()?;
+    Some(DxccEntity {
+        dxcc_code,
+        country_name: entity.country.to_owned(),
+        continent: entity.continent.to_owned(),
+        itu_zone: entity.itu_zone,
+        cq_zone: entity.cq_zone,
+        utc_offset: None,
+        latitude: None,
+        longitude: None,
+        notes: None,
+    })
 }
 
 fn string_is_blank(value: Option<&str>) -> bool {

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -710,20 +710,73 @@ impl LookupService for DeveloperLookupService {
 
     async fn get_dxcc_entity(
         &self,
-        _request: Request<GetDxccEntityRequest>,
+        request: Request<GetDxccEntityRequest>,
     ) -> Result<Response<GetDxccEntityResponse>, Status> {
-        Err(Status::unimplemented(
-            "GetDxccEntity is out of scope for the first lookup slice.",
-        ))
+        use qsoripper_core::proto::qsoripper::services::get_dxcc_entity_request::Query;
+
+        let request = request.into_inner();
+        match request.query {
+            Some(Query::DxccCode(code)) => {
+                match qsoripper_core::adif::lookup_dxcc_entity_by_code(code) {
+                    Some(entity) => Ok(Response::new(GetDxccEntityResponse {
+                        entity: Some(entity),
+                    })),
+                    None => Err(Status::not_found(format!("DXCC entity {code} not found."))),
+                }
+            }
+            Some(Query::Prefix(_)) => Err(Status::unimplemented(
+                "Prefix-based DXCC lookup is not yet supported.",
+            )),
+            None => Err(Status::invalid_argument(
+                "Either dxcc_code or prefix must be specified.",
+            )),
+        }
     }
 
     async fn batch_lookup(
         &self,
-        _request: Request<BatchLookupRequest>,
+        request: Request<BatchLookupRequest>,
     ) -> Result<Response<BatchLookupResponse>, Status> {
-        Err(Status::unimplemented(
-            "BatchLookup is out of scope for the first lookup slice.",
-        ))
+        use std::sync::Arc;
+        use tokio::sync::Semaphore;
+
+        const MAX_CONCURRENCY: usize = 5;
+
+        let coordinator = self.runtime_config.lookup_coordinator().await;
+        let request = request.into_inner();
+        let callsigns = request.callsigns;
+
+        if callsigns.is_empty() {
+            return Ok(Response::new(BatchLookupResponse {
+                results: Vec::new(),
+            }));
+        }
+
+        let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENCY));
+        let mut handles = Vec::with_capacity(callsigns.len());
+
+        for callsign in callsigns {
+            let coordinator = coordinator.clone();
+            let semaphore = semaphore.clone();
+            handles.push(tokio::spawn(async move {
+                let permit = semaphore.acquire().await.map_err(|_| {
+                    Status::internal("batch lookup semaphore was closed unexpectedly")
+                })?;
+                let result = coordinator.lookup(&callsign, false).await;
+                drop(permit);
+                Ok::<_, Status>(result)
+            }));
+        }
+
+        let mut results = Vec::with_capacity(handles.len());
+        for handle in handles {
+            let result = handle
+                .await
+                .map_err(|err| Status::internal(format!("batch lookup task failed: {err}")))??;
+            results.push(result);
+        }
+
+        Ok(Response::new(BatchLookupResponse { results }))
     }
 }
 
@@ -1986,26 +2039,105 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dxcc_and_batch_lookup_remain_unimplemented_for_first_slice() {
+    async fn get_dxcc_entity_returns_known_us_entity_by_code() {
         let service = test_lookup_service();
 
-        let dxcc_error = LookupService::get_dxcc_entity(
+        let response = LookupService::get_dxcc_entity(
+            &service,
+            Request::new(GetDxccEntityRequest {
+                query: Some(get_dxcc_entity_request::Query::DxccCode(291)),
+            }),
+        )
+        .await
+        .expect("dxcc lookup should succeed");
+
+        let entity = response
+            .into_inner()
+            .entity
+            .expect("dxcc entity payload present");
+        assert_eq!(291, entity.dxcc_code);
+        assert_eq!("UNITED STATES OF AMERICA", entity.country_name.as_str());
+        assert_eq!("NA", entity.continent.as_str());
+    }
+
+    #[tokio::test]
+    async fn get_dxcc_entity_returns_not_found_for_unknown_code() {
+        let service = test_lookup_service();
+
+        let error = LookupService::get_dxcc_entity(
+            &service,
+            Request::new(GetDxccEntityRequest {
+                query: Some(get_dxcc_entity_request::Query::DxccCode(9_999)),
+            }),
+        )
+        .await
+        .expect_err("unknown dxcc should not be found");
+
+        assert_eq!(Code::NotFound, error.code());
+    }
+
+    #[tokio::test]
+    async fn get_dxcc_entity_prefix_query_remains_unimplemented() {
+        let service = test_lookup_service();
+
+        let error = LookupService::get_dxcc_entity(
             &service,
             Request::new(GetDxccEntityRequest {
                 query: Some(get_dxcc_entity_request::Query::Prefix("W1AW".to_string())),
             }),
         )
         .await
-        .expect_err("dxcc should be unimplemented");
-        let batch_error = LookupService::batch_lookup(
+        .expect_err("prefix lookup should be unimplemented");
+
+        assert_eq!(Code::Unimplemented, error.code());
+    }
+
+    #[tokio::test]
+    async fn get_dxcc_entity_rejects_missing_query() {
+        let service = test_lookup_service();
+
+        let error =
+            LookupService::get_dxcc_entity(&service, Request::new(GetDxccEntityRequest::default()))
+                .await
+                .expect_err("missing query should be rejected");
+
+        assert_eq!(Code::InvalidArgument, error.code());
+    }
+
+    #[tokio::test]
+    async fn batch_lookup_returns_empty_results_for_empty_input() {
+        let service = test_lookup_service();
+
+        let response = LookupService::batch_lookup(
             &service,
             Request::new(BatchLookupRequest { callsigns: vec![] }),
         )
         .await
-        .expect_err("batch should be unimplemented");
+        .expect("empty batch lookup should succeed");
 
-        assert_eq!(Code::Unimplemented, dxcc_error.code());
-        assert_eq!(Code::Unimplemented, batch_error.code());
+        assert!(response.into_inner().results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn batch_lookup_returns_one_result_per_callsign_in_order() {
+        let service = test_lookup_service();
+
+        let response = LookupService::batch_lookup(
+            &service,
+            Request::new(BatchLookupRequest {
+                callsigns: vec!["W1AW".to_string(), "K7DBG".to_string(), "AE7XI".to_string()],
+            }),
+        )
+        .await
+        .expect("batch lookup should succeed");
+
+        let results = response.into_inner().results;
+        assert_eq!(3, results.len());
+        let actual: Vec<&str> = results
+            .iter()
+            .map(|result| result.queried_callsign.as_str())
+            .collect();
+        assert_eq!(vec!["W1AW", "K7DBG", "AE7XI"], actual);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Wires up the two remaining `LookupService` RPCs that previously returned `UNIMPLEMENTED` from the Rust engine, bringing it to feature parity with the .NET engine for #176.

## What changed

**`GetDxccEntity` (Rust)**
- New public API `qsoripper_core::adif::lookup_dxcc_entity_by_code(u32) -> Option<DxccEntity>` that wraps the embedded ADIF DXCC table.
- Handler returns:
  - Populated `DxccEntity` for a known code (fills `dxcc_code`, `country_name`, `continent`, `cq_zone`, `itu_zone`; QRZ-only fields like `utc_offset`/`latitude`/`longitude`/`notes` stay unset).
  - `NOT_FOUND` for unknown codes.
  - `UNIMPLEMENTED` for the `prefix` branch (matches .NET; reserved for QRZ DXCC integration).
  - `INVALID_ARGUMENT` when the oneof is unset.

**`BatchLookup` (Rust)**
- Fans out to `LookupCoordinator` via `tokio::spawn` + `Semaphore`-bounded concurrency (cap 5, matching .NET `BatchLookupOrchestrator.DefaultMaxConcurrency`).
- Preserves request order in the response.
- Empty input → empty result list (no orchestration overhead).
- Per-callsign errors stay inside individual `LookupResult` envelopes; only orchestration failures (e.g., a worker task panic) surface as `INTERNAL`.

**Spec + proto comments**
- `proto/services/lookup_service.proto`: implementation-status comment updated — both RPCs are now implemented in both engines.
- `docs/architecture/engine-specification.md` §3.3: `GetDxccEntity` and `BatchLookup` sections expanded with embedded-DXCC source notes, prefix-branch behavior, concurrency bound, and full error semantics.

## Tests

Replaces the prior single "unimplemented" regression test with six focused tests in `qsoripper-server`:
- `get_dxcc_entity_returns_known_us_entity_by_code` (291 → United States, NA)
- `get_dxcc_entity_returns_not_found_for_unknown_code` (9999 → NOT_FOUND)
- `get_dxcc_entity_prefix_query_remains_unimplemented`
- `get_dxcc_entity_rejects_missing_query`
- `batch_lookup_returns_empty_results_for_empty_input`
- `batch_lookup_returns_one_result_per_callsign_in_order`

## Validation

```powershell
cargo fmt --all
cargo clippy --all-targets -- -D warnings
cargo test --workspace --exclude qsoripper-stress --exclude qsoripper-stress-tui
buf lint
```
All green locally.

## Follow-ups still open under #176
- `K7DBG` / `placeholder_lookup_error` housekeeping (move to test-only module).
- .NET per-op QRZ sync parity (tracked in spec Appendix C; needs `ManagedEngineState` async refactor).

Closes part of #176.