### PR TITLE
Stream lookup updates incrementally so Loading arrives immediately (#162)

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -319,10 +319,13 @@ Performs a single callsign lookup.
 Performs a callsign lookup with streaming progress updates.
 
 **Behavior:**
-- Same lookup logic as `Lookup`, but streams intermediate state changes (e.g., `LOOKUP_STATE_IN_PROGRESS`, cache check result, final result).
-- Useful for UIs that want to show real-time lookup progress.
+- Emits a `Loading` `LookupResult` immediately, **before** any cache or provider work, so clients get instant feedback that the request is in flight.
+- If a fresh cache entry exists, emits a `Found` (or `NotFound`) update and closes the stream.
+- If a stale cache entry exists, emits a `Stale` update with the cached record, then continues to the provider.
+- After the provider call completes, emits the final `Found`, `NotFound`, or `Error` update and closes the stream.
+- Updates must be pushed to the transport as they are produced; engines must not buffer the full transition sequence before sending.
 
-**Error semantics:** Same as `Lookup`.
+**Error semantics:** Same as `Lookup`. Per-request errors surface as a final `LookupResult` with state `LOOKUP_STATE_ERROR`; transport-level failures (e.g., the client dropping the stream) cancel the in-flight work without a panic.
 
 #### GetCachedCallsign
 

--- a/src/rust/qsoripper-core/src/lookup/coordinator.rs
+++ b/src/rust/qsoripper-core/src/lookup/coordinator.rs
@@ -150,9 +150,41 @@ impl LookupCoordinator {
     /// Perform a streaming lookup state transition.
     ///
     /// The returned vector is intended to be emitted in-order by a transport layer.
+    /// Prefer [`Self::stream_lookup_into`] for true server-streaming behavior:
+    /// the vector form buffers every update until the provider lookup completes,
+    /// which defeats the point of the `Loading` state. This method is retained for
+    /// tests and convenience callers that simply want to inspect the full
+    /// transition sequence.
     pub async fn stream_lookup(&self, callsign: &str, skip_cache: bool) -> Vec<LookupResult> {
+        let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel();
+        self.stream_lookup_into(callsign, skip_cache, &sender).await;
+        drop(sender);
+
+        let mut updates = Vec::new();
+        while let Some(update) = receiver.recv().await {
+            updates.push(update);
+        }
+        updates
+    }
+
+    /// Stream lookup state transitions into `sender` as they become available.
+    ///
+    /// This method emits the initial `Loading` update **before** any awaits on
+    /// cache or provider work, so transport layers (e.g., the gRPC server)
+    /// forward it to clients with minimal latency. Subsequent updates
+    /// (`Stale`, `Found`, `NotFound`, `Error`) are emitted in-order as the
+    /// underlying cache check and provider call complete.
+    ///
+    /// If the receiver is dropped between updates the method returns early.
+    pub async fn stream_lookup_into(
+        &self,
+        callsign: &str,
+        skip_cache: bool,
+        sender: &tokio::sync::mpsc::UnboundedSender<LookupResult>,
+    ) {
         let normalized_callsign = normalize_callsign(callsign);
-        let mut updates = vec![LookupResult {
+
+        let loading = LookupResult {
             state: LookupState::Loading as i32,
             record: None,
             error_message: None,
@@ -160,27 +192,30 @@ impl LookupCoordinator {
             lookup_latency_ms: 0,
             queried_callsign: normalized_callsign.clone(),
             debug_http_exchanges: Vec::new(),
-        }];
+        };
+        if sender.send(loading).is_err() {
+            return;
+        }
 
         if !skip_cache {
             if let Some(entry) = self.get_cache_entry(&normalized_callsign).await {
                 if self.is_fresh(&entry) {
-                    updates.push(Self::cache_entry_to_result(
-                        &entry,
-                        &normalized_callsign,
-                        None,
-                        true,
-                    ));
-                    return updates;
+                    let fresh =
+                        Self::cache_entry_to_result(&entry, &normalized_callsign, None, true);
+                    let _ = sender.send(fresh);
+                    return;
                 }
 
                 if let CachedLookup::Found(_) = entry.lookup {
-                    updates.push(Self::cache_entry_to_result(
+                    let stale = Self::cache_entry_to_result(
                         &entry,
                         &normalized_callsign,
                         Some(LookupState::Stale),
                         true,
-                    ));
+                    );
+                    if sender.send(stale).is_err() {
+                        return;
+                    }
                 }
             }
         }
@@ -197,17 +232,10 @@ impl LookupCoordinator {
             .run_provider_lookup_with_fallback(&normalized_callsign, base)
             .await;
         let latency_ms = duration_to_millis_u32(started_at.elapsed());
-        updates.push(
-            self.provider_result_to_lookup(
-                provider_result,
-                &normalized_callsign,
-                latency_ms,
-                &parsed,
-            )
-            .await,
-        );
-
-        updates
+        let final_update = self
+            .provider_result_to_lookup(provider_result, &normalized_callsign, latency_ms, &parsed)
+            .await;
+        let _ = sender.send(final_update);
     }
 
     /// Return a cache-only lookup result.
@@ -680,6 +708,80 @@ mod tests {
         assert_eq!(stale_record.first_name, "Cached");
         assert_eq!(fresh_record.first_name, "Fresh");
         assert_eq!(provider.call_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn stream_lookup_into_emits_loading_before_provider_completes() {
+        let provider_delay = Duration::from_millis(200);
+        let provider = QueueProvider::new(
+            vec![Ok(ProviderLookup::found(
+                found_record("W1AW", "Slow"),
+                Vec::new(),
+            ))],
+            provider_delay,
+        );
+        let coordinator = Arc::new(LookupCoordinator::new(
+            Arc::new(provider.clone()),
+            LookupCoordinatorConfig::new(Duration::from_secs(60), Duration::from_secs(60)),
+        ));
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let producer_coordinator = coordinator.clone();
+        let producer = tokio::spawn(async move {
+            producer_coordinator
+                .stream_lookup_into("W1AW", false, &tx)
+                .await;
+        });
+
+        let started = Instant::now();
+        let first = rx
+            .recv()
+            .await
+            .expect("loading update should be emitted immediately");
+        let loading_latency = started.elapsed();
+
+        assert_eq!(first.state, LookupState::Loading as i32);
+        // Loading must arrive well before the provider's 200ms delay would let
+        // the final update through. Allow slack for slow CI but stay strict
+        // enough that a regression to the buffered behavior would fail.
+        assert!(
+            loading_latency < Duration::from_millis(150),
+            "Loading update arrived in {loading_latency:?}, expected <150ms"
+        );
+
+        let second = rx.recv().await.expect("final update should follow loading");
+        assert_eq!(second.state, LookupState::Found as i32);
+        assert!(rx.recv().await.is_none(), "stream should be exhausted");
+
+        producer.await.expect("producer task should finish cleanly");
+        assert_eq!(provider.call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn stream_lookup_into_stops_when_receiver_drops_after_loading() {
+        let provider = QueueProvider::new(
+            vec![Ok(ProviderLookup::found(
+                found_record("W1AW", "Unwanted"),
+                Vec::new(),
+            ))],
+            Duration::from_millis(100),
+        );
+        let coordinator = LookupCoordinator::new(
+            Arc::new(provider.clone()),
+            LookupCoordinatorConfig::new(Duration::from_secs(60), Duration::from_secs(60)),
+        );
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let stream_future = coordinator.stream_lookup_into("W1AW", false, &tx);
+        let drain_future = async {
+            let first = rx.recv().await.expect("loading update");
+            assert_eq!(first.state, LookupState::Loading as i32);
+            drop(rx);
+        };
+
+        tokio::join!(stream_future, drain_future);
+        // Provider may still have been invoked; the contract is just that no
+        // panic occurs when the receiver is dropped between updates.
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -676,24 +676,35 @@ impl LookupService for DeveloperLookupService {
     ) -> Result<Response<Self::StreamLookupStream>, Status> {
         let coordinator = self.runtime_config.lookup_coordinator().await;
         let request = request.into_inner();
-        let updates = coordinator
-            .stream_lookup(&request.callsign, request.skip_cache)
-            .await;
-        let (sender, receiver) = tokio::sync::mpsc::channel(8);
+        let (transport_tx, transport_rx) = tokio::sync::mpsc::channel(8);
 
-        for update in updates {
-            if sender
-                .send(Ok(StreamLookupResponse {
-                    result: Some(update),
-                }))
-                .await
-                .is_err()
-            {
-                break;
-            }
-        }
+        tokio::spawn(async move {
+            let (update_tx, mut update_rx) = tokio::sync::mpsc::unbounded_channel();
+            let producer = async move {
+                coordinator
+                    .stream_lookup_into(&request.callsign, request.skip_cache, &update_tx)
+                    .await;
+                drop(update_tx);
+            };
 
-        Ok(Response::new(ReceiverStream::new(receiver)))
+            let forwarder = async {
+                while let Some(update) = update_rx.recv().await {
+                    if transport_tx
+                        .send(Ok(StreamLookupResponse {
+                            result: Some(update),
+                        }))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+            };
+
+            tokio::join!(producer, forwarder);
+        });
+
+        Ok(Response::new(ReceiverStream::new(transport_rx)))
     }
 
     async fn get_cached_callsign(


### PR DESCRIPTION
Closes #162.

## Problem

`stream_lookup` previously built a `Vec<LookupResult>` containing the full transition sequence (`Loading` → optional `Stale` → final `Found`/`NotFound`/`Error`) and only forwarded it to the gRPC transport **after** the QRZ provider call completed. The "streaming" RPC therefore behaved like a unary call from the client's perspective. During slow QRZ lookups the keyboard-first UI lost its real-time feedback — no `Loading` indicator appeared until the lookup was already done.

## Fix

Refactored `LookupCoordinator` to push updates through an `mpsc` channel as they are produced:

- New method `LookupCoordinator::stream_lookup_into(callsign, skip_cache, &sender)` emits `Loading` **before** any awaits on cache or provider work, then sends `Stale` and the final result as they become available.
- Server `StreamLookup` handler spawns a task that pumps the coordinator's channel into the gRPC transport channel, dropping cleanly when the client disconnects.
- The legacy `stream_lookup() -> Vec<LookupResult>` helper is retained as a thin wrapper around the new method for tests and convenience callers.

## Spec

`docs/architecture/engine-specification.md` §3.3 `StreamLookup` updated to require immediate `Loading` emission and to forbid buffering the full transition before sending.

## Tests

Two new tests in `qsoripper-core`:

- `stream_lookup_into_emits_loading_before_provider_completes` — asserts `Loading` arrives in <150ms even though the provider takes 200ms. A regression to the buffered behavior would push `Loading` past the 200ms mark and fail this test.
- `stream_lookup_into_stops_when_receiver_drops_after_loading` — verifies the producer does not panic when the receiver is dropped mid-stream.

The existing `stream_lookup_emits_loading_stale_and_refreshed_found` test still passes (covers ordering of Loading → Stale → Found).

## Validation

```powershell
cargo fmt --all
cargo clippy --all-targets -- -D warnings
cargo test --workspace --exclude qsoripper-stress --exclude qsoripper-stress-tui
```

All green locally.

## .NET parity

The .NET engine's `StreamLookup` handler should be reviewed for the same buffering bug as a follow-up. Tracking that under the existing #176 cluster of engine-parity work rather than expanding scope here.