### PR TITLE
Add calculated QSO duration to CLI list/get and Avalonia GUI grid (#201)

### DIFF
--- a/src/dotnet/QsoRipper.Cli.Tests/QsoDurationFormatterTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/QsoDurationFormatterTests.cs
@@ -1,0 +1,77 @@
+using QsoRipper.EngineSelection;
+
+namespace QsoRipper.Cli.Tests;
+
+public sealed class QsoDurationFormatterTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-3600)]
+    public void FormatSecondsReturnsNullForNonPositiveValues(long seconds)
+    {
+        Assert.Null(QsoDurationFormatter.FormatSeconds(seconds));
+    }
+
+    [Theory]
+    [InlineData(1, "1s")]
+    [InlineData(45, "45s")]
+    [InlineData(59, "59s")]
+    public void FormatSecondsFormatsSecondsOnlyUnderOneMinute(long seconds, string expected)
+    {
+        Assert.Equal(expected, QsoDurationFormatter.FormatSeconds(seconds));
+    }
+
+    [Theory]
+    [InlineData(60, "1m 00s")]
+    [InlineData(155, "2m 35s")]
+    [InlineData(3599, "59m 59s")]
+    public void FormatSecondsFormatsMinutesAndSecondsUnderOneHour(long seconds, string expected)
+    {
+        Assert.Equal(expected, QsoDurationFormatter.FormatSeconds(seconds));
+    }
+
+    [Theory]
+    [InlineData(3600, "1h 00m")]
+    [InlineData(4320, "1h 12m")]
+    [InlineData(7265, "2h 01m")]
+    [InlineData(86400, "24h 00m")]
+    public void FormatSecondsFormatsHoursAndMinutesAtOrAboveOneHour(long seconds, string expected)
+    {
+        Assert.Equal(expected, QsoDurationFormatter.FormatSeconds(seconds));
+    }
+
+    [Fact]
+    public void FormatReturnsNullWhenEitherTimestampIsMissing()
+    {
+        var t = DateTimeOffset.UtcNow;
+        Assert.Null(QsoDurationFormatter.Format(null, null));
+        Assert.Null(QsoDurationFormatter.Format(t, null));
+        Assert.Null(QsoDurationFormatter.Format(null, t));
+    }
+
+    [Fact]
+    public void FormatReturnsNullWhenEndIsNotAfterStart()
+    {
+        var start = DateTimeOffset.UtcNow;
+        Assert.Null(QsoDurationFormatter.Format(start, start));
+        Assert.Null(QsoDurationFormatter.Format(start, start.AddSeconds(-30)));
+    }
+
+    [Fact]
+    public void FormatUsesElapsedSeconds()
+    {
+        var start = new DateTimeOffset(2026, 4, 21, 0, 0, 0, TimeSpan.Zero);
+        Assert.Equal("45s", QsoDurationFormatter.Format(start, start.AddSeconds(45)));
+        Assert.Equal("2m 35s", QsoDurationFormatter.Format(start, start.AddSeconds(155)));
+        Assert.Equal("1h 12m", QsoDurationFormatter.Format(start, start.AddSeconds(4320)));
+    }
+
+    [Fact]
+    public void FormatTruncatesFractionalSeconds()
+    {
+        var start = new DateTimeOffset(2026, 4, 21, 0, 0, 0, TimeSpan.Zero);
+        var end = start.AddMilliseconds(45_999);
+        Assert.Equal("45s", QsoDurationFormatter.Format(start, end));
+    }
+}

--- a/src/dotnet/QsoRipper.Cli/Commands/GetQsoCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/GetQsoCommand.cs
@@ -35,6 +35,16 @@ internal static class GetQsoCommand
             Console.WriteLine($"UTC:              {qso.UtcTimestamp.ToDateTime():u}");
         }
 
+        if (qso.UtcEndTimestamp is not null)
+        {
+            Console.WriteLine($"UTC End:          {qso.UtcEndTimestamp.ToDateTime():u}");
+        }
+
+        if (ListQsosCommand.FormatDuration(qso) is { } duration)
+        {
+            Console.WriteLine($"Duration:         {duration}");
+        }
+
         if (qso.HasFrequencyKhz)
         {
             Console.WriteLine($"Frequency:        {qso.FrequencyKhz} kHz");

--- a/src/dotnet/QsoRipper.Cli/Commands/ListQsosCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ListQsosCommand.cs
@@ -2,6 +2,7 @@ using Grpc.Core;
 using Grpc.Net.Client;
 using QsoRipper.Cli;
 using QsoRipper.Domain;
+using QsoRipper.EngineSelection;
 using QsoRipper.Services;
 using static QsoRipper.Cli.EnumHelpers;
 
@@ -81,6 +82,11 @@ internal static class ListQsosCommand
 
         header += $" {"Freq",-10} {"Grid",-8}";
 
+        if (options.ShowDuration)
+        {
+            header += $" {"Duration",-10}";
+        }
+
         if (options.ShowComment)
         {
             header += $" {"Comment",-40}";
@@ -111,6 +117,12 @@ internal static class ListQsosCommand
         var grid = qso.HasWorkedGrid ? qso.WorkedGrid : "";
         row += $" {freq,-10} {grid,-8}";
 
+        if (options.ShowDuration)
+        {
+            var duration = FormatDuration(qso) ?? "";
+            row += $" {duration,-10}";
+        }
+
         if (options.ShowComment)
         {
             row += $" {FormatCommentPreview(qso),-40}";
@@ -137,6 +149,9 @@ internal static class ListQsosCommand
                     break;
                 case "--show-comment":
                     displayOptions.ShowComment = true;
+                    break;
+                case "--show-duration":
+                    displayOptions.ShowDuration = true;
                     break;
                 case "--callsign" when i < args.Length - 1:
                     request.CallsignFilter = args[++i].ToUpperInvariant();
@@ -240,6 +255,13 @@ internal static class ListQsosCommand
         return TrimComment(comment);
     }
 
+    internal static string? FormatDuration(QsoRecord qso)
+    {
+        var start = qso.UtcTimestamp?.ToDateTimeOffset();
+        var end = qso.UtcEndTimestamp?.ToDateTimeOffset();
+        return QsoDurationFormatter.Format(start, end);
+    }
+
     internal static string TrimComment(string value)
     {
         var sanitized = value.ReplaceLineEndings(" ").Trim();
@@ -255,6 +277,8 @@ internal static class ListQsosCommand
 internal sealed class ListDisplayOptions
 {
     public bool ShowComment { get; set; } = true;
+
+    public bool ShowDuration { get; set; }
 
     public bool ShowId { get; set; }
 

--- a/src/dotnet/QsoRipper.EngineSelection/QsoDurationFormatter.cs
+++ b/src/dotnet/QsoRipper.EngineSelection/QsoDurationFormatter.cs
@@ -1,0 +1,69 @@
+using System;
+
+namespace QsoRipper.EngineSelection;
+
+/// <summary>
+/// Formats QSO durations consistently across all .NET surfaces (CLI, GUI, DebugHost).
+///
+/// Mirrors <c>qsoripper-core::domain::duration::format_duration_seconds</c> in the Rust
+/// engine so output is identical regardless of which engine or client renders the value.
+///
+/// Format conventions (compact, suitable for log columns):
+/// <list type="bullet">
+///   <item><c>&lt; 1m</c> -> <c>"Ns"</c>   e.g. <c>"45s"</c></item>
+///   <item><c>&lt; 1h</c> -> <c>"Mm SSs"</c> e.g. <c>"2m 35s"</c></item>
+///   <item><c>&gt;= 1h</c> -> <c>"Hh MMm"</c> e.g. <c>"1h 12m"</c></item>
+/// </list>
+///
+/// Returns <c>null</c> when the duration is not strictly positive so callers can render
+/// <c>"—"</c> or omit the column entirely.
+///
+/// See <see href="https://github.com/rtreit/qsoripper/issues/201"/>.
+/// </summary>
+public static class QsoDurationFormatter
+{
+    /// <summary>
+    /// Format a positive duration in whole seconds. Returns <c>null</c> when
+    /// <paramref name="seconds"/> is zero or negative.
+    /// </summary>
+    public static string? FormatSeconds(long seconds)
+    {
+        if (seconds <= 0)
+        {
+            return null;
+        }
+
+        var hours = seconds / 3600;
+        var minutes = (seconds % 3600) / 60;
+        var secs = seconds % 60;
+
+        if (hours > 0)
+        {
+            return $"{hours}h {minutes:D2}m";
+        }
+
+        if (minutes > 0)
+        {
+            return $"{minutes}m {secs:D2}s";
+        }
+
+        return $"{secs}s";
+    }
+
+    /// <summary>
+    /// Compute and format the QSO duration when both timestamps are present and
+    /// <paramref name="end"/> is strictly after <paramref name="start"/>. Returns
+    /// <c>null</c> otherwise.
+    /// </summary>
+    public static string? Format(DateTimeOffset? start, DateTimeOffset? end)
+    {
+        if (start is null || end is null)
+        {
+            return null;
+        }
+
+        var delta = end.Value - start.Value;
+        var seconds = (long)delta.TotalSeconds;
+        return FormatSeconds(seconds);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
@@ -5,6 +5,7 @@ using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
+using QsoRipper.EngineSelection;
 using QsoRipper.Gui.Utilities;
 
 namespace QsoRipper.Gui.ViewModels;
@@ -200,9 +201,20 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
             {
                 _utcEndSortKey = ParseUtcSortKey(value);
                 OnPropertyChanged(nameof(UtcEndSortKey));
+                OnPropertyChanged(nameof(DurationDisplay));
             }
         }
     }
+
+    /// <summary>
+    /// Calculated QSO duration when both start and end timestamps are present.
+    /// Returns an em dash when the duration cannot be calculated so the column reads cleanly.
+    /// See https://github.com/rtreit/qsoripper/issues/201.
+    /// </summary>
+    public string DurationDisplay =>
+        QsoDurationFormatter.Format(
+            _sourceQso.UtcTimestamp?.ToDateTimeOffset(),
+            _sourceQso.UtcEndTimestamp?.ToDateTimeOffset()) ?? "—";
 
     public string CqZone
     {
@@ -385,6 +397,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         State = NoteOrNull(_sourceQso.WorkedState) ?? string.Empty;
         County = ParseCountyName(_sourceQso.WorkedCounty);
         Comment = NoteOrNull(_sourceQso.Comment) ?? "-";
+        OnPropertyChanged(nameof(DurationDisplay));
         RecomputeDirty();
     }
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -640,6 +640,11 @@
                                       Binding="{ReflectionBinding UtcEndDisplay, Mode=TwoWay}"
                                       SortMemberPath="UtcEndSortKey"
                                       IsVisible="False" />
+                  <DataGridTextColumn Header="Dur"
+                                      Width="72"
+                                      MinWidth="64"
+                                      Binding="{ReflectionBinding DurationDisplay}"
+                                      IsReadOnly="True" />
                   <DataGridTextColumn Header="CQ"
                                       Width="64"
                                       MinWidth="64"

--- a/src/rust/qsoripper-core/src/domain/duration.rs
+++ b/src/rust/qsoripper-core/src/domain/duration.rs
@@ -1,0 +1,146 @@
+//! Helpers for formatting QSO durations consistently across UI surfaces.
+//!
+//! See <https://github.com/rtreit/qsoripper/issues/201>.
+
+use prost_types::Timestamp;
+
+use crate::proto::qsoripper::domain::QsoRecord;
+
+/// Format a positive duration in whole seconds into an operator-friendly string.
+///
+/// Format conventions (kept compact for log columns):
+/// - `<1m`     -> `"Ns"`            e.g. `"45s"`
+/// - `<1h`     -> `"Mm SSs"`        e.g. `"2m 35s"`
+/// - `>=1h`    -> `"Hh MMm"`        e.g. `"1h 12m"`
+///
+/// Returns `None` if `seconds <= 0` so callers can render `"—"` or omit the column entirely.
+#[must_use]
+pub fn format_duration_seconds(seconds: i64) -> Option<String> {
+    if seconds <= 0 {
+        return None;
+    }
+    let total = u64::try_from(seconds).ok()?;
+    let hours = total / 3600;
+    let minutes = (total % 3600) / 60;
+    let secs = total % 60;
+    let formatted = if hours > 0 {
+        format!("{hours}h {minutes:02}m")
+    } else if minutes > 0 {
+        format!("{minutes}m {secs:02}s")
+    } else {
+        format!("{secs}s")
+    };
+    Some(formatted)
+}
+
+/// Compute the QSO duration in seconds when both start and end timestamps are present
+/// and `end > start`. Returns `None` otherwise.
+#[must_use]
+pub fn qso_duration_seconds(start: Option<&Timestamp>, end: Option<&Timestamp>) -> Option<i64> {
+    let start = start?;
+    let end = end?;
+    let delta = end.seconds.checked_sub(start.seconds)?;
+    if delta > 0 {
+        Some(delta)
+    } else {
+        None
+    }
+}
+
+/// Convenience helper: compute and format the duration of a `QsoRecord` directly.
+///
+/// `utc_timestamp` is treated as the start time and `utc_end_timestamp` as the end time
+/// (matching `proto/domain/qso_record.proto`).
+#[must_use]
+pub fn format_qso_duration(record: &QsoRecord) -> Option<String> {
+    let seconds = qso_duration_seconds(
+        record.utc_timestamp.as_ref(),
+        record.utc_end_timestamp.as_ref(),
+    )?;
+    format_duration_seconds(seconds)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ts(seconds: i64) -> Timestamp {
+        Timestamp { seconds, nanos: 0 }
+    }
+
+    #[test]
+    fn returns_none_for_non_positive_seconds() {
+        assert_eq!(format_duration_seconds(0), None);
+        assert_eq!(format_duration_seconds(-5), None);
+    }
+
+    #[test]
+    fn formats_seconds_only_under_one_minute() {
+        assert_eq!(format_duration_seconds(1).as_deref(), Some("1s"));
+        assert_eq!(format_duration_seconds(45).as_deref(), Some("45s"));
+        assert_eq!(format_duration_seconds(59).as_deref(), Some("59s"));
+    }
+
+    #[test]
+    fn formats_minutes_and_seconds_under_one_hour() {
+        assert_eq!(format_duration_seconds(60).as_deref(), Some("1m 00s"));
+        assert_eq!(format_duration_seconds(155).as_deref(), Some("2m 35s"));
+        assert_eq!(format_duration_seconds(3599).as_deref(), Some("59m 59s"));
+    }
+
+    #[test]
+    fn formats_hours_and_minutes_for_one_hour_or_more() {
+        assert_eq!(format_duration_seconds(3600).as_deref(), Some("1h 00m"));
+        assert_eq!(format_duration_seconds(4320).as_deref(), Some("1h 12m"));
+        assert_eq!(format_duration_seconds(7_265).as_deref(), Some("2h 01m"));
+        assert_eq!(format_duration_seconds(86_400).as_deref(), Some("24h 00m"));
+    }
+
+    #[test]
+    fn duration_seconds_requires_both_timestamps() {
+        assert_eq!(qso_duration_seconds(None, None), None);
+        assert_eq!(qso_duration_seconds(Some(&ts(100)), None), None);
+        assert_eq!(qso_duration_seconds(None, Some(&ts(100))), None);
+    }
+
+    #[test]
+    fn duration_seconds_requires_strictly_positive_delta() {
+        assert_eq!(qso_duration_seconds(Some(&ts(100)), Some(&ts(100))), None);
+        assert_eq!(qso_duration_seconds(Some(&ts(200)), Some(&ts(100))), None);
+        assert_eq!(
+            qso_duration_seconds(Some(&ts(100)), Some(&ts(155))),
+            Some(55)
+        );
+    }
+
+    #[test]
+    fn format_qso_duration_returns_none_when_either_timestamp_is_missing() {
+        let mut record = QsoRecord::default();
+        assert_eq!(format_qso_duration(&record), None);
+        record.utc_timestamp = Some(ts(100));
+        assert_eq!(format_qso_duration(&record), None);
+        record.utc_timestamp = None;
+        record.utc_end_timestamp = Some(ts(100));
+        assert_eq!(format_qso_duration(&record), None);
+    }
+
+    #[test]
+    fn format_qso_duration_uses_record_timestamps() {
+        let record = QsoRecord {
+            utc_timestamp: Some(ts(1_700_000_000)),
+            utc_end_timestamp: Some(ts(1_700_000_155)),
+            ..QsoRecord::default()
+        };
+        assert_eq!(format_qso_duration(&record).as_deref(), Some("2m 35s"));
+    }
+
+    #[test]
+    fn format_qso_duration_returns_none_when_end_not_after_start() {
+        let record = QsoRecord {
+            utc_timestamp: Some(ts(1_700_000_000)),
+            utc_end_timestamp: Some(ts(1_700_000_000)),
+            ..QsoRecord::default()
+        };
+        assert_eq!(format_qso_duration(&record), None);
+    }
+}

--- a/src/rust/qsoripper-core/src/domain/mod.rs
+++ b/src/rust/qsoripper-core/src/domain/mod.rs
@@ -1,5 +1,6 @@
 pub mod band;
 pub mod callsign_parser;
+pub mod duration;
 pub mod lookup;
 pub mod mode;
 pub mod qso;


### PR DESCRIPTION
Partially addresses #201. Ships shared duration formatters in both engines and wires the highest-impact UI surfaces; remaining surfaces follow up using the same helpers.

## Summary

Adds operator-friendly QSO duration display (e.g. `2m 35s` / `1h 12m`) computed from the existing `utc_timestamp` (start) and `utc_end_timestamp` fields on `QsoRecord`. **No proto schema changes.**

## Shared formatters

Identical output across all .NET surfaces and the Rust engine:

- `src/rust/qsoripper-core/src/domain/duration.rs` ΓÇö new `format_duration_seconds`, `qso_duration_seconds`, `format_qso_duration`.
- `src/dotnet/QsoRipper.EngineSelection/QsoDurationFormatter.cs` ΓÇö new `QsoDurationFormatter.FormatSeconds` and `QsoDurationFormatter.Format(start, end)` mirroring the Rust output exactly.

Both helpers return `None`/`null` when the duration is non-positive (missing end time, `end == start`, or `end < start`) so callers can render `ΓÇö` or omit the column rather than printing `0s`.

## Format conventions

- `< 1m` ΓåÆ `Ns` (e.g. `45s`)
- `< 1h` ΓåÆ `Mm SSs` (e.g. `2m 35s`)
- `>= 1h` ΓåÆ `Hh MMm` (e.g. `1h 12m`)

## Surfaces wired this PR

- **CLI `list`**: opt-in via `--show-duration` flag (preserves existing column layout for scripts). Adds a 10-char `Duration` column when enabled.
- **CLI `get`**: prints `Duration:` line whenever a positive duration can be calculated; also now prints `UTC End:` when the end timestamp is set.
- **Avalonia GUI**: new `Dur` DataGrid column (visible by default, 72px wide) bound to a new `RecentQsoItemViewModel.DurationDisplay` computed property. Shows an em dash when the duration cannot be calculated. Property change is raised when `UtcEndDisplay` is edited and again when `AcceptSavedChanges` swaps the underlying QSO.

## Test coverage

- 9 Rust unit tests in `domain::duration::tests` covering format thresholds, missing/invalid timestamps, and end-not-after-start.
- 17 .NET xUnit tests in `QsoDurationFormatterTests` mirroring the same scenarios plus fractional-second truncation.

## Surfaces left for follow-ups

Deliberately scoped out to keep this PR reviewable; using the same shared helpers:

- TUI (Rust) ΓÇö `qsoripper-tui` log entry display.
- Win32 GUI ΓÇö QSO grid column.
- DebugHost `QsoViewer` page.

## Validation (local)

- `cargo fmt` ΓÇö clean.
- `cargo clippy --all-targets -- -D warnings` ΓÇö clean.
- `cargo test --workspace --exclude qsoripper-stress --exclude qsoripper-stress-tui` ΓÇö all passing.
- `dotnet build src/dotnet/QsoRipper.slnx` ΓÇö 0 errors.
- `dotnet test src/dotnet/QsoRipper.Cli.Tests` ΓÇö 187/187 passing (includes new 17 formatter tests).
- `dotnet test src/dotnet/QsoRipper.Gui.Tests` ΓÇö 64/64 passing.