### PR TITLE
feat(adif): normalize split/geo/ownership/completion fields (#92)

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -1168,10 +1168,21 @@ When DXCC data is available, cascade zone information onto the lookup result if 
    - `APP_QRZLOG_LOGID` (canonical) and the legacy alias `APP_QRZ_LOGID` → `qrz_logid`
    - `APP_QRZLOG_QSO_ID` (canonical) and the legacy alias `APP_QRZ_BOOKID` → `qrz_bookid`
    Engines MUST NOT leave these app keys in `extra_fields` once a dedicated domain field carries the value, otherwise downstream sync will treat the record as unlinked and re-upload it as a duplicate.
-4. Preserve any other unrecognized ADIF fields in the `extra_fields` map for lossless round-trip.
-5. Generate a `local_id` for each imported record.
-6. Normalize callsigns and validate required fields.
-7. Insert into storage with `sync_status = NOT_SYNCED`.
+4. Map normalized ADIF fields to their dedicated proto slots rather than `extra_fields`:
+   - `BAND_RX` → `band_rx` (Band enum)
+   - `FREQ_RX` → `frequency_rx_khz` (MHz → kHz)
+   - `LAT` / `LON` → `worked_latitude` / `worked_longitude` (parsed from `[NSEW]DDD MM.MMM` to signed decimal degrees)
+   - `ALTITUDE` → `worked_altitude_meters`
+   - `GRIDSQUARE_EXT` → `worked_gridsquare_ext`
+   - `OWNER_CALLSIGN` → `owner_callsign`
+   - `QSO_COMPLETE` → `qso_complete` (`Y`/`N`/`NIL`/`?` → `QsoCompletion` enum)
+   - `MY_ALTITUDE` → `station_snapshot.altitude_meters`
+   - `MY_GRIDSQUARE_EXT` → `station_snapshot.gridsquare_ext`
+   Unrecognized values (e.g., malformed LAT, unknown `QSO_COMPLETE` literal) fall back to `extra_fields` under the original key.
+5. Preserve any other unrecognized ADIF fields in the `extra_fields` map for lossless round-trip.
+6. Generate a `local_id` for each imported record.
+7. Normalize callsigns and validate required fields.
+8. Insert into storage with `sync_status = NOT_SYNCED`.
 
 See `docs/integrations/adif-specification.md` for the authoritative field-name table.
 
@@ -1183,8 +1194,9 @@ See `docs/integrations/adif-specification.md` for the authoritative field-name t
    - `qrz_logid` → `APP_QRZLOG_LOGID`
    - `qrz_bookid` → `APP_QRZLOG_QSO_ID`
    When iterating `extra_fields`, skip keys already covered by these dedicated emissions (`APP_QRZLOG_LOGID`, `APP_QRZ_LOGID`, `APP_QRZLOG_QSO_ID`, `APP_QRZ_BOOKID`) to avoid duplicate ADIF fields.
-4. Include other `extra_fields` to preserve data from previous imports.
-5. Output records delimited by `<eor>`.
+4. Emit the normalized ADIF fields from their dedicated proto slots whenever populated (`BAND_RX`, `FREQ_RX`, `LAT`, `LON`, `ALTITUDE`, `GRIDSQUARE_EXT`, `OWNER_CALLSIGN`, `QSO_COMPLETE`, `MY_ALTITUDE`, `MY_GRIDSQUARE_EXT`). When iterating `extra_fields`, skip these same keys so the dedicated proto value always wins and the ADIF output never contains the same field twice.
+5. Include other `extra_fields` to preserve data from previous imports.
+6. Output records delimited by `<eor>`.
 
 ### 7.6 Error Handling
 
@@ -1431,6 +1443,7 @@ A conformant engine must pass all of the following scenarios:
 | `proto/domain/sync_status.proto` | `SyncStatus` | QSO sync state |
 | `proto/domain/lookup_state.proto` | `LookupState` | Lookup result state |
 | `proto/domain/conflict_policy.proto` | `ConflictPolicy` | Sync conflict resolution policy |
+| `proto/domain/qso_completion.proto` | `QsoCompletion` | ADIF `QSO_COMPLETE` enum (Y/N/NIL/?) |
 | `proto/domain/rig_connection_status.proto` | `RigConnectionStatus` | Rig connection state |
 | `proto/domain/space_weather_status.proto` | `SpaceWeatherStatus` | Space weather data state |
 

--- a/docs/integrations/adif-specification.md
+++ b/docs/integrations/adif-specification.md
@@ -654,6 +654,16 @@ The ADIF parser (Rust-side edge adapter) converts ADIF fields to/from proto `Qso
 | EQSL_QSL_RCVD | eqsl_received | Map to bool |
 | MY_NAME | station_snapshot.operator_name | Logging-station snapshot field |
 | MY_ARRL_SECT | station_snapshot.arrl_section | Logging-station snapshot field |
+| BAND_RX | band_rx | Split-operation receiving band (Band enum) |
+| FREQ_RX | frequency_rx_khz | Split-operation RX frequency, MHz → kHz |
+| LAT | worked_latitude | Parsed from `[NSEW]DDD MM.MMM` to signed decimal degrees |
+| LON | worked_longitude | Parsed from `[NSEW]DDD MM.MMM` to signed decimal degrees |
+| ALTITUDE | worked_altitude_meters | Contacted-station altitude in meters (MSL) |
+| GRIDSQUARE_EXT | worked_gridsquare_ext | Extended grid chars 9-12 |
+| OWNER_CALLSIGN | owner_callsign | Logging-station owner callsign |
+| QSO_COMPLETE | qso_complete | Y/N/NIL/? → `QsoCompletion` enum |
+| MY_ALTITUDE | station_snapshot.altitude_meters | Logging-station altitude in meters (MSL) |
+| MY_GRIDSQUARE_EXT | station_snapshot.gridsquare_ext | Extended grid chars 9-12 |
 
 **Fields not in QsoRecord or its nested station snapshot** (such as unsupported `MY_` fields, propagation data, satellite info, etc.) are preserved in an overflow map for round-trip fidelity during ADIF import/export.
 

--- a/proto/domain/qso_completion.proto
+++ b/proto/domain/qso_completion.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package qsoripper.domain;
+
+option csharp_namespace = "QsoRipper.Domain";
+
+// ADIF QSO_COMPLETE field — indicates whether the QSO contact was completed.
+// See ADIF QSO Complete Enumeration.
+enum QsoCompletion {
+  QSO_COMPLETION_UNSPECIFIED = 0;  // No value present in source ADIF.
+  QSO_COMPLETION_YES = 1;  // Y — QSO complete (the default when the ADIF field is omitted by the source operator).
+  QSO_COMPLETION_NO = 2;  // N — QSO not complete (operator decision).
+  QSO_COMPLETION_NIL = 3;  // NIL — No QSO took place (heard but no contact).
+  QSO_COMPLETION_UNCERTAIN = 4;  // ? — Operator uncertain whether QSO completed.
+}

--- a/proto/domain/qso_record.proto
+++ b/proto/domain/qso_record.proto
@@ -7,6 +7,7 @@ option csharp_namespace = "QsoRipper.Domain";
 import "domain/band.proto";
 import "domain/mode.proto";
 import "domain/qsl_status.proto";
+import "domain/qso_completion.proto";
 import "domain/rst_report.proto";
 import "domain/station_snapshot.proto";
 import "domain/sync_status.proto";
@@ -96,4 +97,27 @@ message QsoRecord {
   // Stores ADIF fields not mapped to dedicated proto fields,
   // preserving them for lossless re-export. Key = ADIF field name (uppercase).
   map<string, string> extra_fields = 80;
+
+  // --- Worked-station geographic location (ADIF LAT/LON/ALTITUDE/GRIDSQUARE_EXT) ---
+  // Decimal degrees, signed (negative for S/W).
+  optional double worked_latitude = 100;
+  optional double worked_longitude = 101;
+  // Worked station altitude in meters above mean sea level.
+  optional double worked_altitude_meters = 102;
+  // Maidenhead grid square extension (chars 7-8 of an 8-char grid) for higher
+  // precision on top of `worked_grid`.
+  optional string worked_gridsquare_ext = 103;
+
+  // --- Split RX (ADIF FREQ_RX / BAND_RX) ---
+  // Receiver frequency in kHz when running split.
+  optional uint64 frequency_rx_khz = 104;
+  // Receiver band when running split. Defaults to BAND_UNSPECIFIED if absent.
+  Band band_rx = 105;
+
+  // --- Ownership / completion ---
+  // ADIF OWNER_CALLSIGN — owner of the station used to log the contact (may
+  // differ from STATION_CALLSIGN and OPERATOR).
+  optional string owner_callsign = 106;
+  // ADIF QSO_COMPLETE — whether the contact was completed.
+  QsoCompletion qso_complete = 107;
 }

--- a/proto/domain/station_snapshot.proto
+++ b/proto/domain/station_snapshot.proto
@@ -20,4 +20,6 @@ message StationSnapshot {
   optional double latitude = 12;  // Logging station latitude in decimal degrees
   optional double longitude = 13;  // Logging station longitude in decimal degrees
   optional string arrl_section = 14;  // Logging station ARRL section used for this QSO
+  optional double altitude_meters = 15;  // Logging station altitude in meters above mean sea level (ADIF MY_ALTITUDE)
+  optional string gridsquare_ext = 16;  // Logging station Maidenhead grid square extension (ADIF MY_GRIDSQUARE_EXT)
 }

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -624,6 +624,77 @@ public sealed class ManagedEngineStateTests : IDisposable
     }
 
     [Fact]
+    public void Adif_round_trips_normalized_split_and_geo_fields()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87"
+            }
+        });
+
+        var payload = Utf8(
+            "<STATION_CALLSIGN:5>K7RND<CALL:4>W1AW<QSO_DATE:8>20260115<TIME_ON:4>1523" +
+            "<BAND:3>20M<MODE:3>SSB<BAND_RX:3>40M<FREQ_RX:5>7.075" +
+            "<LAT:11>N041 30.000<LON:11>W071 45.500<ALTITUDE:3>150" +
+            "<GRIDSQUARE_EXT:2>ab<OWNER_CALLSIGN:4>W1AW<QSO_COMPLETE:1>Y" +
+            "<MY_ALTITUDE:3>550<MY_GRIDSQUARE_EXT:2>bb<EOR>\n");
+
+        var imported = state.ImportAdif(payload, refresh: false);
+        Assert.Equal(1u, imported.RecordsImported);
+
+        var stored = state.ListQsos(new ListQsosRequest()).Single();
+
+        Assert.Equal(Band._40M, stored.BandRx);
+        Assert.Equal(7075ul, stored.FrequencyRxKhz);
+        Assert.Equal(150.0, stored.WorkedAltitudeMeters);
+        Assert.Equal("ab", stored.WorkedGridsquareExt);
+        Assert.Equal("W1AW", stored.OwnerCallsign);
+        Assert.Equal(QsoCompletion.Yes, stored.QsoComplete);
+        Assert.True(stored.HasWorkedLatitude);
+        Assert.True(stored.HasWorkedLongitude);
+        Assert.NotNull(stored.StationSnapshot);
+        Assert.Equal(550.0, stored.StationSnapshot.AltitudeMeters);
+        Assert.Equal("bb", stored.StationSnapshot.GridsquareExt);
+
+        var exported = Encoding.UTF8.GetString(state.ExportAdif(new ExportAdifRequest()));
+
+        Assert.Contains("<BAND_RX:3>40M", exported, StringComparison.Ordinal);
+        Assert.Contains("<FREQ_RX:5>7.075", exported, StringComparison.Ordinal);
+        Assert.Contains("<ALTITUDE:3>150", exported, StringComparison.Ordinal);
+        Assert.Contains("<GRIDSQUARE_EXT:2>ab", exported, StringComparison.Ordinal);
+        Assert.Contains("<OWNER_CALLSIGN:4>W1AW", exported, StringComparison.Ordinal);
+        Assert.Contains("<QSO_COMPLETE:1>Y", exported, StringComparison.Ordinal);
+        Assert.Contains("<MY_ALTITUDE:3>550", exported, StringComparison.Ordinal);
+        Assert.Contains("<MY_GRIDSQUARE_EXT:2>bb", exported, StringComparison.Ordinal);
+        Assert.Contains("<LAT:11>N041 30.000", exported, StringComparison.Ordinal);
+        Assert.Contains("<LON:11>W071 45.500", exported, StringComparison.Ordinal);
+
+        // Each new field should be emitted exactly once (no duplicates from extra_fields).
+        AssertSingleAdifField(exported, "BAND_RX");
+        AssertSingleAdifField(exported, "FREQ_RX");
+        AssertSingleAdifField(exported, "LAT");
+        AssertSingleAdifField(exported, "LON");
+        AssertSingleAdifField(exported, "ALTITUDE");
+        AssertSingleAdifField(exported, "GRIDSQUARE_EXT");
+        AssertSingleAdifField(exported, "OWNER_CALLSIGN");
+        AssertSingleAdifField(exported, "QSO_COMPLETE");
+        AssertSingleAdifField(exported, "MY_ALTITUDE");
+        AssertSingleAdifField(exported, "MY_GRIDSQUARE_EXT");
+    }
+
+    private static void AssertSingleAdifField(string adif, string key)
+    {
+        var matches = System.Text.RegularExpressions.Regex.Matches(adif, $"<{key}:", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        Assert.True(matches.Count == 1, $"Expected exactly one <{key}:...> tag, found {matches.Count}");
+    }
+
+    [Fact]
     public void Update_qso_preserves_fields_not_present_in_partial_update()
     {
         var state = CreateState();

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedAdifCodec.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedAdifCodec.cs
@@ -310,6 +310,17 @@ internal static class ManagedAdifCodec
                     }
 
                     break;
+                case "BAND_RX":
+                    if (AdifToBand.TryGetValue(value, out var bandRx))
+                    {
+                        qso.BandRx = bandRx;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
+                    break;
                 case "MODE":
                     if (TryNormalizeModeFromAdif(value, out var mode, out var submode))
                     {
@@ -340,6 +351,18 @@ internal static class ManagedAdifCodec
                     }
 
                     break;
+                case "FREQ_RX":
+                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var mhzRx)
+                        && TryConvertMhzToKhz(mhzRx, out var khzRx))
+                    {
+                        qso.FrequencyRxKhz = khzRx;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
+                    break;
                 case "RST_SENT":
                     qso.RstSent = ParseRstReport(value);
                     break;
@@ -357,6 +380,60 @@ internal static class ManagedAdifCodec
                     break;
                 case "GRIDSQUARE":
                     qso.WorkedGrid = value;
+                    break;
+                case "GRIDSQUARE_EXT":
+                    qso.WorkedGridsquareExt = value;
+                    break;
+                case "LAT":
+                    if (TryParseAdifLocation(value, latitude: true, out var workedLatitude))
+                    {
+                        qso.WorkedLatitude = workedLatitude;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
+                    break;
+                case "LON":
+                    if (TryParseAdifLocation(value, latitude: false, out var workedLongitude))
+                    {
+                        qso.WorkedLongitude = workedLongitude;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
+                    break;
+                case "ALTITUDE":
+                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var workedAltitude)
+                        && double.IsFinite(workedAltitude))
+                    {
+                        qso.WorkedAltitudeMeters = workedAltitude;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
+                    break;
+                case "OWNER_CALLSIGN":
+                    qso.OwnerCallsign = value;
+                    break;
+                case "QSO_COMPLETE":
+                    {
+                        var completion = ParseQsoCompletion(value);
+                        if (completion == QsoCompletion.Unspecified && !string.IsNullOrEmpty(value))
+                        {
+                            qso.ExtraFields[key] = value;
+                        }
+                        else
+                        {
+                            qso.QsoComplete = completion;
+                        }
+                    }
+
                     break;
                 case "COUNTRY":
                     qso.WorkedCountry = value;
@@ -469,6 +546,21 @@ internal static class ManagedAdifCodec
                         qso.ExtraFields[key] = value;
                     }
 
+                    break;
+                case "MY_ALTITUDE":
+                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var myAltitude)
+                        && double.IsFinite(myAltitude))
+                    {
+                        (stationSnapshot ??= new StationSnapshot()).AltitudeMeters = myAltitude;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
+                    break;
+                case "MY_GRIDSQUARE_EXT":
+                    (stationSnapshot ??= new StationSnapshot()).GridsquareExt = value;
                     break;
                 case "MY_ARRL_SECT":
                     (stationSnapshot ??= new StationSnapshot()).ArrlSection = value;
@@ -662,6 +754,16 @@ internal static class ManagedAdifCodec
             fields.Add(new KeyValuePair<string, string>("FREQ", $"{qso.FrequencyKhz / 1000}.{qso.FrequencyKhz % 1000:000}"));
         }
 
+        if (qso.HasFrequencyRxKhz)
+        {
+            fields.Add(new KeyValuePair<string, string>("FREQ_RX", $"{qso.FrequencyRxKhz / 1000}.{qso.FrequencyRxKhz % 1000:000}"));
+        }
+
+        if (BandToAdif.TryGetValue(qso.BandRx, out var bandRxOut))
+        {
+            fields.Add(new KeyValuePair<string, string>("BAND_RX", bandRxOut));
+        }
+
         if (qso.RstSent is not null)
         {
             fields.Add(new KeyValuePair<string, string>("RST_SENT", qso.RstSent.Raw));
@@ -680,6 +782,28 @@ internal static class ManagedAdifCodec
         AddOptionalStringField(fields, "CONTACTED_OP", qso.WorkedOperatorCallsign);
         AddOptionalStringField(fields, "NAME", qso.WorkedOperatorName);
         AddOptionalStringField(fields, "GRIDSQUARE", qso.WorkedGrid);
+        AddOptionalStringField(fields, "GRIDSQUARE_EXT", qso.WorkedGridsquareExt);
+        if (qso.HasWorkedLatitude && TryFormatAdifLocation(qso.WorkedLatitude, latitude: true, out var workedLatOut))
+        {
+            fields.Add(new KeyValuePair<string, string>("LAT", workedLatOut));
+        }
+
+        if (qso.HasWorkedLongitude && TryFormatAdifLocation(qso.WorkedLongitude, latitude: false, out var workedLonOut))
+        {
+            fields.Add(new KeyValuePair<string, string>("LON", workedLonOut));
+        }
+
+        if (qso.HasWorkedAltitudeMeters && double.IsFinite(qso.WorkedAltitudeMeters))
+        {
+            fields.Add(new KeyValuePair<string, string>("ALTITUDE", FormatAdifAltitude(qso.WorkedAltitudeMeters)));
+        }
+
+        AddOptionalStringField(fields, "OWNER_CALLSIGN", qso.OwnerCallsign);
+        if (TryFormatQsoCompletion(qso.QsoComplete, out var qsoCompleteOut))
+        {
+            fields.Add(new KeyValuePair<string, string>("QSO_COMPLETE", qsoCompleteOut));
+        }
+
         AddOptionalStringField(fields, "COUNTRY", qso.WorkedCountry);
         if (qso.HasWorkedDxcc)
         {
@@ -735,6 +859,12 @@ internal static class ManagedAdifCodec
                 fields.Add(new KeyValuePair<string, string>("MY_LON", myLongitude));
             }
 
+            if (stationSnapshot.HasAltitudeMeters && double.IsFinite(stationSnapshot.AltitudeMeters))
+            {
+                fields.Add(new KeyValuePair<string, string>("MY_ALTITUDE", FormatAdifAltitude(stationSnapshot.AltitudeMeters)));
+            }
+
+            AddOptionalStringField(fields, "MY_GRIDSQUARE_EXT", stationSnapshot.GridsquareExt);
             AddOptionalStringField(fields, "MY_ARRL_SECT", stationSnapshot.ArrlSection);
         }
 
@@ -875,6 +1005,45 @@ internal static class ManagedAdifCodec
         };
 
         return value.Length > 0;
+    }
+
+    private static QsoCompletion ParseQsoCompletion(string value)
+    {
+        return value.Trim().ToUpperInvariant() switch
+        {
+            "Y" => QsoCompletion.Yes,
+            "N" => QsoCompletion.No,
+            "NIL" => QsoCompletion.Nil,
+            "?" => QsoCompletion.Uncertain,
+            _ => QsoCompletion.Unspecified,
+        };
+    }
+
+    private static bool TryFormatQsoCompletion(QsoCompletion status, out string value)
+    {
+        value = status switch
+        {
+            QsoCompletion.Yes => "Y",
+            QsoCompletion.No => "N",
+            QsoCompletion.Nil => "NIL",
+            QsoCompletion.Uncertain => "?",
+            _ => string.Empty,
+        };
+
+        return value.Length > 0;
+    }
+
+    private static string FormatAdifAltitude(double meters)
+    {
+        var rounded = Math.Round(meters * 1000.0, MidpointRounding.AwayFromZero) / 1000.0;
+        var formatted = rounded.ToString("0.000", CultureInfo.InvariantCulture);
+        var trimmed = formatted.TrimEnd('0').TrimEnd('.');
+        if (trimmed.Length == 0 || trimmed == "-")
+        {
+            return "0";
+        }
+
+        return trimmed;
     }
 
     private static void MapConfirmationField(QsoRecord qso, string key, string value, Action<QsoRecord, bool> setter)
@@ -1100,7 +1269,7 @@ internal static class ManagedAdifCodec
             return false;
         }
 
-        formatted = string.Format(CultureInfo.InvariantCulture, "{0}{1:000} {2:000.000}", direction, degrees, minutes);
+        formatted = string.Format(CultureInfo.InvariantCulture, "{0}{1:000} {2:00.000}", direction, degrees, minutes);
         return true;
     }
 
@@ -1174,6 +1343,16 @@ internal static class ManagedAdifCodec
             : key.Equals("MY_ARRL_SECT", StringComparison.OrdinalIgnoreCase) ? !string.IsNullOrWhiteSpace(stationSnapshot?.ArrlSection)
             : key.Equals("QSLSDATE", StringComparison.OrdinalIgnoreCase) ? qso.QslSentDate is not null && TryFormatAdifDate(qso.QslSentDate, out _)
             : key.Equals("QSLRDATE", StringComparison.OrdinalIgnoreCase) ? qso.QslReceivedDate is not null && TryFormatAdifDate(qso.QslReceivedDate, out _)
+            : key.Equals("BAND_RX", StringComparison.OrdinalIgnoreCase) ? qso.BandRx != Band.Unspecified
+            : key.Equals("FREQ_RX", StringComparison.OrdinalIgnoreCase) ? qso.HasFrequencyRxKhz
+            : key.Equals("LAT", StringComparison.OrdinalIgnoreCase) ? qso.HasWorkedLatitude
+            : key.Equals("LON", StringComparison.OrdinalIgnoreCase) ? qso.HasWorkedLongitude
+            : key.Equals("ALTITUDE", StringComparison.OrdinalIgnoreCase) ? qso.HasWorkedAltitudeMeters
+            : key.Equals("GRIDSQUARE_EXT", StringComparison.OrdinalIgnoreCase) ? !string.IsNullOrWhiteSpace(qso.WorkedGridsquareExt)
+            : key.Equals("OWNER_CALLSIGN", StringComparison.OrdinalIgnoreCase) ? !string.IsNullOrWhiteSpace(qso.OwnerCallsign)
+            : key.Equals("QSO_COMPLETE", StringComparison.OrdinalIgnoreCase) ? qso.QsoComplete != QsoCompletion.Unspecified
+            : key.Equals("MY_ALTITUDE", StringComparison.OrdinalIgnoreCase) ? stationSnapshot is not null && stationSnapshot.HasAltitudeMeters
+            : key.Equals("MY_GRIDSQUARE_EXT", StringComparison.OrdinalIgnoreCase) ? !string.IsNullOrWhiteSpace(stationSnapshot?.GridsquareExt)
             : (key.Equals("QSO_DATE_OFF", StringComparison.OrdinalIgnoreCase) || key.Equals("TIME_OFF", StringComparison.OrdinalIgnoreCase)) && qso.UtcEndTimestamp is not null;
     }
 

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedQsoParity.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedQsoParity.cs
@@ -138,6 +138,8 @@ internal static class ManagedQsoParity
             || snapshot.ItuZone > 0
             || snapshot.Latitude != 0
             || snapshot.Longitude != 0
+            || (snapshot.HasAltitudeMeters && snapshot.AltitudeMeters != 0)
+            || TrimmedNonEmpty(snapshot.GridsquareExt) is not null
             || TrimmedNonEmpty(snapshot.ArrlSection) is not null;
     }
 
@@ -527,6 +529,13 @@ internal static class ManagedQsoParity
         {
             target.Longitude = overlay.Longitude;
         }
+
+        if (overlay.HasAltitudeMeters && double.IsFinite(overlay.AltitudeMeters))
+        {
+            target.AltitudeMeters = overlay.AltitudeMeters;
+        }
+
+        MergeSnapshotOptionalString(value => target.GridsquareExt = value, overlay.GridsquareExt, clearBlankStrings);
     }
 
     private static void NormalizeStationSnapshot(StationSnapshot snapshot)
@@ -540,6 +549,7 @@ internal static class ManagedQsoParity
         snapshot.State = NormalizeOptionalString(snapshot.State);
         snapshot.Country = NormalizeOptionalString(snapshot.Country);
         snapshot.ArrlSection = NormalizeOptionalString(snapshot.ArrlSection);
+        snapshot.GridsquareExt = NormalizeOptionalString(snapshot.GridsquareExt);
 
     }
 

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/AdifCodec.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/AdifCodec.cs
@@ -264,6 +264,17 @@ internal static class AdifCodec
                     }
 
                     break;
+                case "BAND_RX":
+                    if (AdifToBand.TryGetValue(value, out var bandRx))
+                    {
+                        qso.BandRx = bandRx;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
+                    break;
                 case "MODE":
                     if (AdifToMode.TryGetValue(value, out var mode))
                     {
@@ -290,6 +301,18 @@ internal static class AdifCodec
                     }
 
                     break;
+                case "FREQ_RX":
+                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var mhzRx)
+                        && TryConvertMhzToKhz(mhzRx, out var khzRx))
+                    {
+                        qso.FrequencyRxKhz = khzRx;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
+                    break;
                 case "RST_SENT":
                     qso.RstSent = ParseRstReport(value);
                     break;
@@ -307,6 +330,60 @@ internal static class AdifCodec
                     break;
                 case "GRIDSQUARE":
                     qso.WorkedGrid = value;
+                    break;
+                case "GRIDSQUARE_EXT":
+                    qso.WorkedGridsquareExt = value;
+                    break;
+                case "LAT":
+                    if (TryParseAdifLocation(value, latitude: true, out var workedLatitude))
+                    {
+                        qso.WorkedLatitude = workedLatitude;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
+                    break;
+                case "LON":
+                    if (TryParseAdifLocation(value, latitude: false, out var workedLongitude))
+                    {
+                        qso.WorkedLongitude = workedLongitude;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
+                    break;
+                case "ALTITUDE":
+                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var workedAltitude)
+                        && double.IsFinite(workedAltitude))
+                    {
+                        qso.WorkedAltitudeMeters = workedAltitude;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
+                    break;
+                case "OWNER_CALLSIGN":
+                    qso.OwnerCallsign = value;
+                    break;
+                case "QSO_COMPLETE":
+                    {
+                        var completion = ParseQsoCompletion(value);
+                        if (completion == QsoCompletion.Unspecified && !string.IsNullOrEmpty(value))
+                        {
+                            qso.ExtraFields[key] = value;
+                        }
+                        else
+                        {
+                            qso.QsoComplete = completion;
+                        }
+                    }
+
                     break;
                 case "COUNTRY":
                     qso.WorkedCountry = value;
@@ -349,6 +426,21 @@ internal static class AdifCodec
                     break;
                 case "MY_GRIDSQUARE":
                     (stationSnapshot ??= new StationSnapshot()).Grid = value;
+                    break;
+                case "MY_GRIDSQUARE_EXT":
+                    (stationSnapshot ??= new StationSnapshot()).GridsquareExt = value;
+                    break;
+                case "MY_ALTITUDE":
+                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var myAltitude)
+                        && double.IsFinite(myAltitude))
+                    {
+                        (stationSnapshot ??= new StationSnapshot()).AltitudeMeters = myAltitude;
+                    }
+                    else
+                    {
+                        qso.ExtraFields[key] = value;
+                    }
+
                     break;
                 case "MY_CNTY":
                     (stationSnapshot ??= new StationSnapshot()).County = value;
@@ -468,6 +560,11 @@ internal static class AdifCodec
             AppendField(sb, "BAND", bandStr);
         }
 
+        if (qso.BandRx != Band.Unspecified && BandToAdif.TryGetValue(qso.BandRx, out var bandRxStr))
+        {
+            AppendField(sb, "BAND_RX", bandRxStr);
+        }
+
         if (ModeToAdif.TryGetValue(qso.Mode, out var modeStr))
         {
             AppendField(sb, "MODE", modeStr);
@@ -481,6 +578,11 @@ internal static class AdifCodec
         if (qso.HasFrequencyKhz)
         {
             AppendField(sb, "FREQ", $"{qso.FrequencyKhz / 1000}.{qso.FrequencyKhz % 1000:000}");
+        }
+
+        if (qso.HasFrequencyRxKhz)
+        {
+            AppendField(sb, "FREQ_RX", $"{qso.FrequencyRxKhz / 1000}.{qso.FrequencyRxKhz % 1000:000}");
         }
 
         if (qso.RstSent is not null)
@@ -501,6 +603,31 @@ internal static class AdifCodec
         AppendOptional(sb, "CONTACTED_OP", qso.WorkedOperatorCallsign);
         AppendOptional(sb, "NAME", qso.WorkedOperatorName);
         AppendOptional(sb, "GRIDSQUARE", qso.WorkedGrid);
+        AppendOptional(sb, "GRIDSQUARE_EXT", qso.WorkedGridsquareExt);
+
+        if (qso.HasWorkedLatitude && TryFormatAdifLocation(qso.WorkedLatitude, latitude: true, out var latStr))
+        {
+            AppendField(sb, "LAT", latStr);
+        }
+
+        if (qso.HasWorkedLongitude && TryFormatAdifLocation(qso.WorkedLongitude, latitude: false, out var lonStr))
+        {
+            AppendField(sb, "LON", lonStr);
+        }
+
+        if (qso.HasWorkedAltitudeMeters && double.IsFinite(qso.WorkedAltitudeMeters))
+        {
+            AppendField(sb, "ALTITUDE", FormatAdifAltitude(qso.WorkedAltitudeMeters));
+        }
+
+        AppendOptional(sb, "OWNER_CALLSIGN", qso.OwnerCallsign);
+
+        if (qso.QsoComplete != QsoCompletion.Unspecified
+            && TryFormatQsoCompletion(qso.QsoComplete, out var completionStr))
+        {
+            AppendField(sb, "QSO_COMPLETE", completionStr);
+        }
+
         AppendOptional(sb, "COUNTRY", qso.WorkedCountry);
 
         if (qso.HasWorkedDxcc)
@@ -539,6 +666,12 @@ internal static class AdifCodec
         {
             AppendOptional(sb, "MY_NAME", snap.OperatorName);
             AppendOptional(sb, "MY_GRIDSQUARE", snap.Grid);
+            AppendOptional(sb, "MY_GRIDSQUARE_EXT", snap.GridsquareExt);
+            if (snap.HasAltitudeMeters && double.IsFinite(snap.AltitudeMeters))
+            {
+                AppendField(sb, "MY_ALTITUDE", FormatAdifAltitude(snap.AltitudeMeters));
+            }
+
             AppendOptional(sb, "MY_CNTY", snap.County);
             AppendOptional(sb, "MY_STATE", snap.State);
             AppendOptional(sb, "MY_COUNTRY", snap.Country);
@@ -740,5 +873,133 @@ internal static class AdifCodec
 
         var value = (byte)(raw[index] - '0');
         return value >= minimum && value <= maximum ? (uint)value : 0;
+    }
+
+    private static QsoCompletion ParseQsoCompletion(string value)
+    {
+        return value.Trim().ToUpperInvariant() switch
+        {
+            "Y" => QsoCompletion.Yes,
+            "N" => QsoCompletion.No,
+            "NIL" => QsoCompletion.Nil,
+            "?" => QsoCompletion.Uncertain,
+            _ => QsoCompletion.Unspecified,
+        };
+    }
+
+    private static bool TryFormatQsoCompletion(QsoCompletion status, out string value)
+    {
+        value = status switch
+        {
+            QsoCompletion.Yes => "Y",
+            QsoCompletion.No => "N",
+            QsoCompletion.Nil => "NIL",
+            QsoCompletion.Uncertain => "?",
+            _ => string.Empty,
+        };
+
+        return value.Length > 0;
+    }
+
+    private static string FormatAdifAltitude(double meters)
+    {
+        var rounded = Math.Round(meters * 1000.0, MidpointRounding.AwayFromZero) / 1000.0;
+        var formatted = rounded.ToString("0.000", CultureInfo.InvariantCulture);
+        var trimmed = formatted.TrimEnd('0').TrimEnd('.');
+        if (trimmed.Length == 0 || trimmed == "-")
+        {
+            return "0";
+        }
+
+        return trimmed;
+    }
+
+    private static bool TryParseAdifLocation(string rawValue, bool latitude, out double value)
+    {
+        value = 0;
+        var trimmed = rawValue.Trim();
+        if (trimmed.Length != 11 || !trimmed.All(char.IsAscii))
+        {
+            return false;
+        }
+
+        var direction = char.ToUpperInvariant(trimmed[0]);
+        if (latitude)
+        {
+            if (direction is not ('N' or 'S'))
+            {
+                return false;
+            }
+        }
+        else if (direction is not ('E' or 'W'))
+        {
+            return false;
+        }
+
+        if (trimmed[4] != ' ')
+        {
+            return false;
+        }
+
+        if (!double.TryParse(trimmed.AsSpan(1, 3), NumberStyles.None, CultureInfo.InvariantCulture, out var degrees)
+            || !double.TryParse(trimmed.AsSpan(5, 6), NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var minutes))
+        {
+            return false;
+        }
+
+        if (minutes < 0 || minutes >= 60)
+        {
+            return false;
+        }
+
+        var signed = degrees + (minutes / 60.0);
+        if (direction is 'S' or 'W')
+        {
+            signed *= -1.0;
+        }
+
+        var limit = latitude ? 90.0 : 180.0;
+        if (!double.IsFinite(signed) || Math.Abs(signed) > limit)
+        {
+            return false;
+        }
+
+        value = signed;
+        return true;
+    }
+
+    private static bool TryFormatAdifLocation(double value, bool latitude, out string formatted)
+    {
+        formatted = string.Empty;
+        if (!double.IsFinite(value))
+        {
+            return false;
+        }
+
+        var limit = latitude ? 90.0 : 180.0;
+        if (Math.Abs(value) > limit)
+        {
+            return false;
+        }
+
+        var direction = latitude
+            ? (value < 0 ? 'S' : 'N')
+            : (value < 0 ? 'W' : 'E');
+        var absolute = Math.Abs(value);
+        var degrees = Math.Floor(absolute);
+        var minutes = Math.Round((absolute - degrees) * 60.0 * 1000.0, MidpointRounding.AwayFromZero) / 1000.0;
+        if (minutes >= 60.0)
+        {
+            degrees += 1.0;
+            minutes = 0.0;
+        }
+
+        if (degrees > limit)
+        {
+            return false;
+        }
+
+        formatted = string.Format(CultureInfo.InvariantCulture, "{0}{1:000} {2:00.000}", direction, degrees, minutes);
+        return true;
     }
 }

--- a/src/rust/qsoripper-core/src/adif/mapper.rs
+++ b/src/rust/qsoripper-core/src/adif/mapper.rs
@@ -8,9 +8,13 @@ use std::{borrow::Cow, fmt::Write as _};
 use crate::adif::normalize::{enrich_from_dxcc, parse_rst_report};
 use crate::domain::band::band_from_adif;
 use crate::domain::mode::normalize_mode_from_adif;
-use crate::domain::qso::{new_local_id, qsl_status_from_adif};
+use crate::domain::qso::{
+    new_local_id, qsl_status_from_adif, qso_completion_from_adif, qso_completion_to_adif,
+};
 use crate::domain::station::{effective_station_snapshot, station_snapshot_has_values};
-use crate::proto::qsoripper::domain::{Band, Mode, QsoRecord, StationSnapshot, SyncStatus};
+use crate::proto::qsoripper::domain::{
+    Band, Mode, QsoCompletion, QsoRecord, StationSnapshot, SyncStatus,
+};
 use difa::Record;
 
 /// Borrowed or owned ADIF field data suitable for ADI serialization.
@@ -80,6 +84,13 @@ impl AdifMapper {
                         qso.extra_fields.insert(key_upper, value_str.to_owned());
                     }
                 }
+                "BAND_RX" => {
+                    if let Some(band) = band_from_adif(value_str) {
+                        qso.band_rx = band.into();
+                    } else {
+                        qso.extra_fields.insert(key_upper, value_str.to_owned());
+                    }
+                }
                 "MODE" => {
                     if let Some((mode, submode)) = normalize_mode_from_adif(value_str) {
                         qso.mode = mode.into();
@@ -102,6 +113,17 @@ impl AdifMapper {
                         qso.extra_fields.insert(key_upper, value_str.to_owned());
                     }
                 }
+                "FREQ_RX" => {
+                    if let Ok(mhz) = value_str.parse::<f64>() {
+                        if let Some(khz) = mhz_to_khz(mhz) {
+                            qso.frequency_rx_khz = Some(khz);
+                        } else {
+                            qso.extra_fields.insert(key_upper, value_str.to_owned());
+                        }
+                    } else {
+                        qso.extra_fields.insert(key_upper, value_str.to_owned());
+                    }
+                }
                 // --- Signal reports ---
                 "RST_SENT" => qso.rst_sent = Some(parse_rst_report(value_str)),
                 "RST_RCVD" => qso.rst_received = Some(parse_rst_report(value_str)),
@@ -111,6 +133,41 @@ impl AdifMapper {
                 "CONTACTED_OP" => qso.worked_operator_callsign = Some(value_str.to_owned()),
                 "NAME" => qso.worked_operator_name = Some(value_str.to_owned()),
                 "GRIDSQUARE" => qso.worked_grid = Some(value_str.to_owned()),
+                "GRIDSQUARE_EXT" => qso.worked_gridsquare_ext = Some(value_str.to_owned()),
+                "LAT" => {
+                    if let Some(latitude) = parse_adif_location(value_str, true) {
+                        qso.worked_latitude = Some(latitude);
+                    } else {
+                        qso.extra_fields.insert(key_upper, value_str.to_owned());
+                    }
+                }
+                "LON" => {
+                    if let Some(longitude) = parse_adif_location(value_str, false) {
+                        qso.worked_longitude = Some(longitude);
+                    } else {
+                        qso.extra_fields.insert(key_upper, value_str.to_owned());
+                    }
+                }
+                "ALTITUDE" => {
+                    if let Ok(meters) = value_str.parse::<f64>() {
+                        if meters.is_finite() {
+                            qso.worked_altitude_meters = Some(meters);
+                        } else {
+                            qso.extra_fields.insert(key_upper, value_str.to_owned());
+                        }
+                    } else {
+                        qso.extra_fields.insert(key_upper, value_str.to_owned());
+                    }
+                }
+                "OWNER_CALLSIGN" => qso.owner_callsign = Some(value_str.to_owned()),
+                "QSO_COMPLETE" => {
+                    let parsed = qso_completion_from_adif(value_str);
+                    if matches!(parsed, QsoCompletion::Unspecified) && !value_str.is_empty() {
+                        qso.extra_fields.insert(key_upper, value_str.to_owned());
+                    } else {
+                        qso.qso_complete = parsed.into();
+                    }
+                }
                 "COUNTRY" => qso.worked_country = Some(value_str.to_owned()),
                 "DXCC" => {
                     if let Ok(code) = value_str.parse::<u32>() {
@@ -202,6 +259,24 @@ impl AdifMapper {
                     } else {
                         qso.extra_fields.insert(key_upper, value_str.to_owned());
                     }
+                }
+                "MY_ALTITUDE" => {
+                    if let Ok(meters) = value_str.parse::<f64>() {
+                        if meters.is_finite() {
+                            station_snapshot
+                                .get_or_insert_with(StationSnapshot::default)
+                                .altitude_meters = Some(meters);
+                        } else {
+                            qso.extra_fields.insert(key_upper, value_str.to_owned());
+                        }
+                    } else {
+                        qso.extra_fields.insert(key_upper, value_str.to_owned());
+                    }
+                }
+                "MY_GRIDSQUARE_EXT" => {
+                    station_snapshot
+                        .get_or_insert_with(StationSnapshot::default)
+                        .gridsquare_ext = Some(value_str.to_owned());
                 }
                 "MY_ARRL_SECT" => {
                     station_snapshot
@@ -425,6 +500,19 @@ impl AdifMapper {
                 format!("{whole_mhz}.{fractional_khz:03}"),
             );
         }
+        if let Some(khz) = qso.frequency_rx_khz {
+            let whole_mhz = khz / 1000;
+            let fractional_khz = khz % 1000;
+            push_field(
+                &mut fields,
+                "FREQ_RX",
+                format!("{whole_mhz}.{fractional_khz:03}"),
+            );
+        }
+        let band_rx = Band::try_from(qso.band_rx).unwrap_or(Band::Unspecified);
+        if let Some(band_str) = crate::domain::band::band_to_adif(band_rx) {
+            push_field(&mut fields, "BAND_RX", band_str);
+        }
 
         // Signal reports
         if let Some(ref rst) = qso.rst_sent {
@@ -446,6 +534,34 @@ impl AdifMapper {
         }
         if let Some(v) = qso.worked_grid.as_deref() {
             push_field(&mut fields, "GRIDSQUARE", v);
+        }
+        if let Some(v) = qso.worked_gridsquare_ext.as_deref() {
+            push_field(&mut fields, "GRIDSQUARE_EXT", v);
+        }
+        if let Some(latitude) = qso
+            .worked_latitude
+            .and_then(|value| format_adif_location(value, true))
+        {
+            push_field(&mut fields, "LAT", latitude);
+        }
+        if let Some(longitude) = qso
+            .worked_longitude
+            .and_then(|value| format_adif_location(value, false))
+        {
+            push_field(&mut fields, "LON", longitude);
+        }
+        if let Some(altitude) = qso.worked_altitude_meters {
+            if altitude.is_finite() {
+                push_field(&mut fields, "ALTITUDE", format_adif_altitude(altitude));
+            }
+        }
+        if let Some(v) = qso.owner_callsign.as_deref() {
+            push_field(&mut fields, "OWNER_CALLSIGN", v);
+        }
+        if let Some(s) = qso_completion_to_adif(
+            QsoCompletion::try_from(qso.qso_complete).unwrap_or(QsoCompletion::Unspecified),
+        ) {
+            push_field(&mut fields, "QSO_COMPLETE", s);
         }
         if let Some(v) = qso.worked_country.as_deref() {
             push_field(&mut fields, "COUNTRY", v);
@@ -513,6 +629,14 @@ impl AdifMapper {
                 .and_then(|value| format_adif_location(value, false))
             {
                 push_field(&mut fields, "MY_LON", longitude);
+            }
+            if let Some(altitude) = snapshot.altitude_meters {
+                if altitude.is_finite() {
+                    push_field(&mut fields, "MY_ALTITUDE", format_adif_altitude(altitude));
+                }
+            }
+            if let Some(v) = snapshot.gridsquare_ext.as_deref() {
+                push_field(&mut fields, "MY_GRIDSQUARE_EXT", v.to_string());
             }
             if let Some(v) = snapshot.arrl_section.as_deref() {
                 push_field(&mut fields, "MY_ARRL_SECT", v.to_string());
@@ -769,6 +893,23 @@ fn format_adif_location(value: f64, latitude: bool) -> Option<String> {
     Some(format!("{direction}{degrees:03.0} {minutes:06.3}"))
 }
 
+fn format_adif_altitude(meters: f64) -> String {
+    // Format as compact decimal with up to 3 fractional digits, trimming
+    // trailing zeros so integer-meter values round-trip cleanly (e.g. "100"
+    // rather than "100.000"). ADIF altitude is a Number with no fixed format.
+    let rounded = (meters * 1000.0).round() / 1000.0;
+    let formatted = format!("{rounded:.3}");
+    let trimmed = formatted
+        .trim_end_matches('0')
+        .trim_end_matches('.')
+        .to_owned();
+    if trimmed.is_empty() || trimmed == "-" {
+        "0".to_owned()
+    } else {
+        trimmed
+    }
+}
+
 fn mhz_to_khz(mhz: f64) -> Option<u64> {
     if !mhz.is_finite() || mhz.is_sign_negative() {
         return None;
@@ -817,6 +958,7 @@ fn push_confirmation_field(
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn field_is_overridden(
     qso: &QsoRecord,
     station_snapshot: Option<&StationSnapshot>,
@@ -908,6 +1050,31 @@ fn field_is_overridden(
         || key.eq_ignore_ascii_case("APP_QRZ_BOOKID")
     {
         qso.qrz_bookid.is_some()
+    } else if key.eq_ignore_ascii_case("BAND_RX") {
+        Band::try_from(qso.band_rx).unwrap_or(Band::Unspecified) != Band::Unspecified
+    } else if key.eq_ignore_ascii_case("FREQ_RX") {
+        qso.frequency_rx_khz.is_some()
+    } else if key.eq_ignore_ascii_case("LAT") {
+        qso.worked_latitude.is_some()
+    } else if key.eq_ignore_ascii_case("LON") {
+        qso.worked_longitude.is_some()
+    } else if key.eq_ignore_ascii_case("ALTITUDE") {
+        qso.worked_altitude_meters.is_some()
+    } else if key.eq_ignore_ascii_case("GRIDSQUARE_EXT") {
+        qso.worked_gridsquare_ext.is_some()
+    } else if key.eq_ignore_ascii_case("OWNER_CALLSIGN") {
+        qso.owner_callsign.is_some()
+    } else if key.eq_ignore_ascii_case("QSO_COMPLETE") {
+        QsoCompletion::try_from(qso.qso_complete).unwrap_or(QsoCompletion::Unspecified)
+            != QsoCompletion::Unspecified
+    } else if key.eq_ignore_ascii_case("MY_ALTITUDE") {
+        station_snapshot
+            .and_then(|snapshot| snapshot.altitude_meters)
+            .is_some()
+    } else if key.eq_ignore_ascii_case("MY_GRIDSQUARE_EXT") {
+        station_snapshot
+            .and_then(|snapshot| snapshot.gridsquare_ext.as_ref())
+            .is_some()
     } else {
         false
     }
@@ -1821,5 +1988,302 @@ mod tests {
             .count();
         assert_eq!(logid_count, 1, "logid should round-trip exactly once");
         assert_eq!(bookid_count, 1, "bookid should round-trip exactly once");
+    }
+
+    // --- Issue #92 ADIF normalization follow-ups ---
+
+    fn count_field(fields: &[(String, String)], key: &str) -> usize {
+        fields
+            .iter()
+            .filter(|(k, _)| k.eq_ignore_ascii_case(key))
+            .count()
+    }
+
+    fn field_value<'a>(fields: &'a [(String, String)], key: &str) -> Option<&'a str> {
+        fields
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
+            .map(|(_, v)| v.as_str())
+    }
+
+    #[test]
+    fn record_to_qso_maps_split_rx_fields() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "K1ABC").unwrap();
+        rec.insert("BAND", "20M").unwrap();
+        rec.insert("BAND_RX", "40M").unwrap();
+        rec.insert("FREQ", "14.250").unwrap();
+        rec.insert("FREQ_RX", "7.075").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+
+        assert_eq!(qso.band, Band::Band20m as i32);
+        assert_eq!(qso.band_rx, Band::Band40m as i32);
+        assert_eq!(qso.frequency_khz, Some(14250));
+        assert_eq!(qso.frequency_rx_khz, Some(7075));
+        assert!(!qso.extra_fields.contains_key("BAND_RX"));
+        assert!(!qso.extra_fields.contains_key("FREQ_RX"));
+    }
+
+    #[test]
+    fn record_to_qso_maps_worked_geo_fields() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "K1ABC").unwrap();
+        rec.insert("LAT", "N041 30.000").unwrap();
+        rec.insert("LON", "W071 45.500").unwrap();
+        rec.insert("ALTITUDE", "150").unwrap();
+        rec.insert("GRIDSQUARE", "FN41").unwrap();
+        rec.insert("GRIDSQUARE_EXT", "ab").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+
+        assert!(qso.worked_latitude.is_some());
+        assert!((qso.worked_latitude.unwrap() - 41.5).abs() < 0.0001);
+        assert!(qso.worked_longitude.is_some());
+        assert!((qso.worked_longitude.unwrap() - (-71.7583)).abs() < 0.001);
+        assert_eq!(qso.worked_altitude_meters, Some(150.0));
+        assert_eq!(qso.worked_grid.as_deref(), Some("FN41"));
+        assert_eq!(qso.worked_gridsquare_ext.as_deref(), Some("ab"));
+        assert!(!qso.extra_fields.contains_key("LAT"));
+        assert!(!qso.extra_fields.contains_key("LON"));
+        assert!(!qso.extra_fields.contains_key("ALTITUDE"));
+        assert!(!qso.extra_fields.contains_key("GRIDSQUARE_EXT"));
+    }
+
+    #[test]
+    fn record_to_qso_maps_my_altitude_and_my_gridsquare_ext() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "K1ABC").unwrap();
+        rec.insert("STATION_CALLSIGN", "AA7BQ").unwrap();
+        rec.insert("MY_GRIDSQUARE", "DM43").unwrap();
+        rec.insert("MY_GRIDSQUARE_EXT", "bb").unwrap();
+        rec.insert("MY_ALTITUDE", "550").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+        let snapshot = qso.station_snapshot.as_ref().expect("snapshot");
+
+        assert_eq!(snapshot.gridsquare_ext.as_deref(), Some("bb"));
+        assert_eq!(snapshot.altitude_meters, Some(550.0));
+        assert!(!qso.extra_fields.contains_key("MY_ALTITUDE"));
+        assert!(!qso.extra_fields.contains_key("MY_GRIDSQUARE_EXT"));
+    }
+
+    #[test]
+    fn record_to_qso_maps_owner_callsign_and_qso_complete() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "K1ABC").unwrap();
+        rec.insert("OWNER_CALLSIGN", "W1AW").unwrap();
+        rec.insert("QSO_COMPLETE", "NIL").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+
+        assert_eq!(qso.owner_callsign.as_deref(), Some("W1AW"));
+        assert_eq!(qso.qso_complete, QsoCompletion::Nil as i32);
+        assert!(!qso.extra_fields.contains_key("OWNER_CALLSIGN"));
+        assert!(!qso.extra_fields.contains_key("QSO_COMPLETE"));
+    }
+
+    #[test]
+    fn record_to_qso_qso_complete_handles_all_canonical_values() {
+        for (input, expected) in [
+            ("Y", QsoCompletion::Yes),
+            ("N", QsoCompletion::No),
+            ("NIL", QsoCompletion::Nil),
+            ("?", QsoCompletion::Uncertain),
+        ] {
+            let mut rec = Record::new();
+            rec.insert("CALL", "K1ABC").unwrap();
+            rec.insert("QSO_COMPLETE", input).unwrap();
+
+            let qso = AdifMapper::record_to_qso(&rec);
+            assert_eq!(qso.qso_complete, expected as i32, "input {input}");
+        }
+    }
+
+    #[test]
+    fn record_to_qso_qso_complete_unknown_value_falls_back_to_extra_fields() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "K1ABC").unwrap();
+        rec.insert("QSO_COMPLETE", "MAYBE").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+
+        assert_eq!(qso.qso_complete, QsoCompletion::Unspecified as i32);
+        assert_eq!(
+            qso.extra_fields.get("QSO_COMPLETE").map(String::as_str),
+            Some("MAYBE")
+        );
+    }
+
+    #[test]
+    fn record_to_qso_invalid_lat_falls_back_to_extra_fields() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "K1ABC").unwrap();
+        rec.insert("LAT", "not-a-coord").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+
+        assert!(qso.worked_latitude.is_none());
+        assert_eq!(
+            qso.extra_fields.get("LAT").map(String::as_str),
+            Some("not-a-coord")
+        );
+    }
+
+    #[test]
+    fn record_to_qso_invalid_altitude_falls_back_to_extra_fields() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "K1ABC").unwrap();
+        rec.insert("ALTITUDE", "high").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+
+        assert!(qso.worked_altitude_meters.is_none());
+        assert_eq!(
+            qso.extra_fields.get("ALTITUDE").map(String::as_str),
+            Some("high")
+        );
+    }
+
+    #[test]
+    fn qso_to_adif_emits_new_fields_exactly_once() {
+        let qso = QsoRecord {
+            worked_callsign: "K1ABC".to_string(),
+            station_callsign: "AA7BQ".to_string(),
+            band: Band::Band20m as i32,
+            band_rx: Band::Band40m as i32,
+            frequency_khz: Some(14250),
+            frequency_rx_khz: Some(7075),
+            worked_latitude: Some(41.5),
+            worked_longitude: Some(-71.7583),
+            worked_altitude_meters: Some(150.0),
+            worked_gridsquare_ext: Some("ab".to_string()),
+            owner_callsign: Some("W1AW".to_string()),
+            qso_complete: QsoCompletion::Yes as i32,
+            station_snapshot: Some(StationSnapshot {
+                station_callsign: "AA7BQ".to_string(),
+                altitude_meters: Some(550.0),
+                gridsquare_ext: Some("bb".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let fields = AdifMapper::qso_to_adif_fields(&qso);
+
+        assert_eq!(count_field(&fields, "BAND_RX"), 1);
+        assert_eq!(field_value(&fields, "BAND_RX"), Some("40M"));
+        assert_eq!(count_field(&fields, "FREQ_RX"), 1);
+        assert_eq!(field_value(&fields, "FREQ_RX"), Some("7.075"));
+        assert_eq!(count_field(&fields, "LAT"), 1);
+        assert_eq!(count_field(&fields, "LON"), 1);
+        assert_eq!(count_field(&fields, "ALTITUDE"), 1);
+        assert_eq!(field_value(&fields, "ALTITUDE"), Some("150"));
+        assert_eq!(count_field(&fields, "GRIDSQUARE_EXT"), 1);
+        assert_eq!(field_value(&fields, "GRIDSQUARE_EXT"), Some("ab"));
+        assert_eq!(count_field(&fields, "OWNER_CALLSIGN"), 1);
+        assert_eq!(count_field(&fields, "QSO_COMPLETE"), 1);
+        assert_eq!(field_value(&fields, "QSO_COMPLETE"), Some("Y"));
+        assert_eq!(count_field(&fields, "MY_ALTITUDE"), 1);
+        assert_eq!(field_value(&fields, "MY_ALTITUDE"), Some("550"));
+        assert_eq!(count_field(&fields, "MY_GRIDSQUARE_EXT"), 1);
+        assert_eq!(field_value(&fields, "MY_GRIDSQUARE_EXT"), Some("bb"));
+    }
+
+    #[test]
+    fn qso_to_adif_does_not_emit_dedicated_fields_from_extra_fields() {
+        // If a dedicated field is set AND the same key exists in extra_fields
+        // (e.g. from a malformed import), the dedicated value wins and the
+        // extra_fields copy is suppressed to prevent duplicate emission.
+        let mut qso = QsoRecord {
+            worked_callsign: "K1ABC".to_string(),
+            band_rx: Band::Band20m as i32,
+            worked_latitude: Some(0.0),
+            worked_longitude: Some(0.0),
+            worked_altitude_meters: Some(10.0),
+            worked_gridsquare_ext: Some("aa".to_string()),
+            frequency_rx_khz: Some(14000),
+            owner_callsign: Some("W1AW".to_string()),
+            qso_complete: QsoCompletion::Yes as i32,
+            ..Default::default()
+        };
+
+        for key in [
+            "BAND_RX",
+            "FREQ_RX",
+            "LAT",
+            "LON",
+            "ALTITUDE",
+            "GRIDSQUARE_EXT",
+            "OWNER_CALLSIGN",
+            "QSO_COMPLETE",
+        ] {
+            qso.extra_fields
+                .insert(key.to_string(), "stale".to_string());
+        }
+
+        let fields = AdifMapper::qso_to_adif_fields(&qso);
+
+        for key in [
+            "BAND_RX",
+            "FREQ_RX",
+            "LAT",
+            "LON",
+            "ALTITUDE",
+            "GRIDSQUARE_EXT",
+            "OWNER_CALLSIGN",
+            "QSO_COMPLETE",
+        ] {
+            assert_eq!(
+                count_field(&fields, key),
+                1,
+                "{key} should be emitted exactly once"
+            );
+            assert_ne!(
+                field_value(&fields, key),
+                Some("stale"),
+                "{key} should not be emitted from extra_fields when a dedicated value is set"
+            );
+        }
+    }
+
+    #[test]
+    fn qso_round_trips_new_fields_through_adi() {
+        let qso = QsoRecord {
+            worked_callsign: "K1ABC".to_string(),
+            station_callsign: "AA7BQ".to_string(),
+            band: Band::Band20m as i32,
+            band_rx: Band::Band40m as i32,
+            frequency_rx_khz: Some(7075),
+            worked_altitude_meters: Some(150.0),
+            worked_gridsquare_ext: Some("ab".to_string()),
+            owner_callsign: Some("W1AW".to_string()),
+            qso_complete: QsoCompletion::Nil as i32,
+            ..Default::default()
+        };
+
+        let adi = AdifMapper::qso_to_adi(&qso);
+        let mut record = Record::new();
+        for line in adi.lines() {
+            if line.is_empty() || line.eq_ignore_ascii_case("<eor>") {
+                continue;
+            }
+            // Parse simple <KEY:LEN>VALUE lines; reuse difa::Record by hand.
+            if let Some(end_tag) = line.find('>') {
+                let tag = &line[1..end_tag];
+                let value = &line[end_tag + 1..];
+                if let Some((key, _)) = tag.split_once(':') {
+                    record.insert(key, value).unwrap();
+                }
+            }
+        }
+        let parsed = AdifMapper::record_to_qso(&record);
+
+        assert_eq!(parsed.band_rx, Band::Band40m as i32);
+        assert_eq!(parsed.frequency_rx_khz, Some(7075));
+        assert_eq!(parsed.worked_altitude_meters, Some(150.0));
+        assert_eq!(parsed.worked_gridsquare_ext.as_deref(), Some("ab"));
+        assert_eq!(parsed.owner_callsign.as_deref(), Some("W1AW"));
+        assert_eq!(parsed.qso_complete, QsoCompletion::Nil as i32);
     }
 }

--- a/src/rust/qsoripper-core/src/domain/qso.rs
+++ b/src/rust/qsoripper-core/src/domain/qso.rs
@@ -1,6 +1,8 @@
 //! `QsoRecord` helpers: construction, QSL status mapping, and ADIF field mapping.
 
-use crate::proto::qsoripper::domain::{Band, Mode, QslStatus, QsoRecord, SyncStatus};
+use crate::proto::qsoripper::domain::{
+    Band, Mode, QslStatus, QsoCompletion, QsoRecord, SyncStatus,
+};
 use uuid::Uuid;
 
 /// Map an ADIF QSL Sent/Received status character to the `QslStatus` enum.
@@ -26,6 +28,30 @@ pub fn qsl_status_to_adif(status: QslStatus) -> Option<&'static str> {
         QslStatus::Queued => Some("Q"),
         QslStatus::Ignore => Some("I"),
         QslStatus::Unspecified => None,
+    }
+}
+
+/// Map an ADIF `QSO_COMPLETE` value to the `QsoCompletion` enum.
+#[must_use]
+pub fn qso_completion_from_adif(s: &str) -> QsoCompletion {
+    match s.to_uppercase().as_str() {
+        "Y" => QsoCompletion::Yes,
+        "N" => QsoCompletion::No,
+        "NIL" => QsoCompletion::Nil,
+        "?" => QsoCompletion::Uncertain,
+        _ => QsoCompletion::Unspecified,
+    }
+}
+
+/// Convert the `QsoCompletion` enum to its ADIF `QSO_COMPLETE` representation.
+#[must_use]
+pub fn qso_completion_to_adif(status: QsoCompletion) -> Option<&'static str> {
+    match status {
+        QsoCompletion::Yes => Some("Y"),
+        QsoCompletion::No => Some("N"),
+        QsoCompletion::Nil => Some("NIL"),
+        QsoCompletion::Uncertain => Some("?"),
+        QsoCompletion::Unspecified => None,
     }
 }
 

--- a/src/rust/qsoripper-core/src/domain/station.rs
+++ b/src/rust/qsoripper-core/src/domain/station.rs
@@ -19,6 +19,8 @@ pub fn station_snapshot_from_profile(profile: &StationProfile) -> Option<Station
         itu_zone: profile.itu_zone.filter(|value| *value > 0),
         latitude: profile.latitude,
         longitude: profile.longitude,
+        altitude_meters: None,
+        gridsquare_ext: None,
         arrl_section: normalize_optional_string(profile.arrl_section.as_deref()),
     };
     normalize_station_snapshot(&mut snapshot);
@@ -186,6 +188,12 @@ pub fn station_snapshot_has_values(snapshot: &StationSnapshot) -> bool {
         || snapshot.itu_zone.is_some()
         || snapshot.latitude.is_some()
         || snapshot.longitude.is_some()
+        || snapshot.altitude_meters.is_some()
+        || snapshot
+            .gridsquare_ext
+            .as_deref()
+            .and_then(trimmed_non_empty)
+            .is_some()
         || snapshot
             .arrl_section
             .as_deref()
@@ -248,6 +256,14 @@ fn merge_station_snapshot(
     if let Some(longitude) = overlay.longitude {
         base.longitude = Some(longitude);
     }
+    if let Some(altitude) = overlay.altitude_meters {
+        base.altitude_meters = Some(altitude);
+    }
+    merge_optional_string(
+        &mut base.gridsquare_ext,
+        overlay.gridsquare_ext.as_deref(),
+        clear_blank_strings,
+    );
     merge_optional_string(
         &mut base.arrl_section,
         overlay.arrl_section.as_deref(),
@@ -267,6 +283,7 @@ fn normalize_station_snapshot(snapshot: &mut StationSnapshot) {
     snapshot.dxcc = snapshot.dxcc.filter(|value| *value > 0);
     snapshot.cq_zone = snapshot.cq_zone.filter(|value| *value > 0);
     snapshot.itu_zone = snapshot.itu_zone.filter(|value| *value > 0);
+    snapshot.gridsquare_ext = normalize_optional_string(snapshot.gridsquare_ext.as_deref());
     snapshot.arrl_section = normalize_optional_string(snapshot.arrl_section.as_deref());
 }
 


### PR DESCRIPTION
Closes #92.

Promote 10 ADIF fields from generic xtra_fields to dedicated proto slots so ADIF round-trips preserve typed semantics.

## New dedicated fields

**QsoRecord** (fields 100-107):
- `BAND_RX` → `band_rx` (Band enum)
- `FREQ_RX` → `frequency_rx_khz`
- `LAT` / `LON` → `worked_latitude` / `worked_longitude` (signed decimal degrees)
- `ALTITUDE` → `worked_altitude_meters`
- `GRIDSQUARE_EXT` → `worked_gridsquare_ext`
- `OWNER_CALLSIGN` → `owner_callsign`
- `QSO_COMPLETE` → `qso_complete` (new `QsoCompletion` enum)

**StationSnapshot** (fields 15-16):
- `MY_ALTITUDE` → `station_snapshot.altitude_meters`
- `MY_GRIDSQUARE_EXT` → `station_snapshot.gridsquare_ext`

New proto file: `proto/domain/qso_completion.proto` (1-1-1 compliant, mirrors `qsl_status.proto` pattern with `Y/N/NIL/?` → `YES/NO/NIL/UNCERTAIN`).

## Lockstep engine work

Both engines treat these as typed fields now, with `extra_fields` fallback reserved for unrecognized values (malformed `LAT`, unknown `QSO_COMPLETE` literals):

- Rust `qsoripper-core/src/adif/mapper.rs` — parse + emit + `field_is_overridden` + 10 new unit tests covering parse, fallback, no-duplicate-emission, and ADI round-trip.
- .NET `ManagedAdifCodec` — import/export codec + override suppression + new round-trip test in `ManagedEngineStateTests`.
- .NET `QrzLogbook/AdifCodec` — QRZ upload/download parity.
- `ManagedQsoParity` — new snapshot fields added to `MergeStationSnapshot` / `NormalizeStationSnapshot` / `StationSnapshotHasValues`.

## Incidental bugfix

Pre-existing bug in `TryFormatAdifLocation` in both `ManagedAdifCodec.cs` and `QrzLogbook/AdifCodec.cs`: format string `{2:000.000}` emitted 12-char `LAT`/`LON` values (`N041 030.000`) instead of the ADIF-spec 11-char format. Fixed to `{2:00.000}` → `N041 30.000`. Rust was already correct.

## Docs

- `docs/architecture/engine-specification.md` §7.5 (ADIF import/export) + Appendix A (new `QsoCompletion` entry).
- `docs/integrations/adif-specification.md` QsoRecord mapping table.

## Validation

- `cargo fmt` / `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test --workspace --exclude qsoripper-stress --exclude qsoripper-stress-tui` — green.
- `buf lint` — clean.
- `dotnet test src/dotnet/QsoRipper.slnx` — all suites green (Engine.DotNet 32, QrzLogbook 96, CLI 187, GUI 64, etc.).