### PR TITLE
Keyboard-first design pass for Avalonia GUI

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -1,0 +1,93 @@
+# QsoRipper Keyboard Shortcuts Reference
+
+All three QsoRipper surfaces — GUI (Avalonia), TUI (ratatui), and Win32 — share a
+keyboard-first design philosophy. This document is the authoritative reference for
+shortcuts across surfaces.
+
+## Navigation
+
+| Action | GUI | TUI | Win32 | Notes |
+|---|---|---|---|---|
+| Help / shortcuts | F1 | F1 | F1 | All surfaces: overlay with full shortcut list |
+| Focus QSO grid/list | F3 | F3 | F3 | Consistent across all surfaces |
+| Focus search | F4 or Ctrl+F | F4 | F4 | GUI adds Ctrl+F alias |
+| Focus QSO logger | Ctrl+N | Tab (cycles) | Tab (cycles) | GUI has explicit focus command |
+| Quit | Ctrl+Q or Alt+X | Ctrl+Q | Ctrl+Q | GUI adds Alt+X (Windows convention) |
+| Close overlay / cancel | Esc | Esc | Esc | Consistent: closes topmost overlay, then clears logger |
+
+## QSO Logging
+
+| Action | GUI | TUI | Win32 | Notes |
+|---|---|---|---|---|
+| Log QSO | Ctrl+Enter or F10 | F10 or Alt+Enter | F10 or Shift+Enter or Alt+Enter | F10 is shared across all; GUI adds Ctrl+Enter |
+| Reset QSO timer | F7 | F7 | F7 | Consistent across all surfaces |
+| Cycle band | ←/→ on band button | ←/→ in band field | ←/→ in band field | Same gesture, different control types |
+| Cycle mode | ←/→ on mode button | ←/→ in mode field | ←/→ in mode field | Same gesture, different control types |
+| Jump to callsign | Alt+C | Alt+C | Alt+C | Consistent across all surfaces |
+| Jump to band | Alt+B | Alt+B | Alt+B | Consistent across all surfaces |
+| Jump to mode | Alt+M | Alt+M | Alt+M | Consistent across all surfaces |
+| Open QSO Card | Alt+A or Ctrl+L | — | — | GUI only (overlay form); TUI/Win32 show fields inline |
+
+## Grid / QSO List
+
+| Action | GUI | TUI | Win32 | Notes |
+|---|---|---|---|---|
+| Edit selected cell | F2 | — | — | GUI only (DataGrid inline edit) |
+| Save pending edits | Ctrl+S | — | — | GUI only (commit grid edits) |
+| Delete selected QSO | Ctrl+D or Delete | D or Delete | D or Delete | GUI requires Ctrl+D or Delete key |
+| Refresh | F5 | — | — | GUI only |
+| Callsign lookup card | F8 | — | — | GUI only (side panel with QRZ data) |
+| Toggle inspector | Alt+Enter | — | — | GUI only (detail panel) |
+
+## System
+
+| Action | GUI | TUI | Win32 | Notes |
+|---|---|---|---|---|
+| Sync with QRZ | F6 | — | — | GUI only |
+| Toggle rig control | Ctrl+R | F8 | F8 | Different key: GUI uses Ctrl+R, TUI/Win32 use F8 |
+| Toggle space weather | Ctrl+W | — | — | GUI only |
+| Settings | Ctrl+, | — | — | GUI only (dialog) |
+| Sort chooser | Ctrl+Shift+S | — | — | GUI only |
+| Column chooser | Ctrl+H | — | — | GUI only |
+
+## QSO Card (GUI only)
+
+| Action | Shortcut | Notes |
+|---|---|---|
+| Switch to tab N | Alt+1..6 | 1=Core, 2=Lookup, 3=QSL, 4=Contest, 5=Station, 6=Metadata |
+| Next tab | Ctrl+Tab | Wraps around |
+| Previous tab | Ctrl+Shift+Tab | Wraps around |
+| Save QSO | Ctrl+Enter | Saves and closes card |
+| Close card | Esc | Discards changes |
+
+## Settings (GUI only)
+
+| Action | Shortcut | Notes |
+|---|---|---|
+| Switch to section N | Ctrl+1..5 | Numbered sections |
+| Next section | Ctrl+Tab | Wraps around |
+| Previous section | Ctrl+Shift+Tab | Wraps around |
+| Save | Enter (on Save button) | |
+| Cancel / close | Esc | |
+
+## Surface-Specific Differences
+
+### F2 — Edit Cell (GUI) vs Toggle Advanced (TUI/Win32)
+In TUI and Win32, F2 toggles between the basic and advanced log form views.
+The GUI uses F2 for DataGrid cell editing because the advanced form is a
+separate overlay (Alt+A). This is an intentional divergence.
+
+### F5/F6 — Refresh/Sync (GUI) vs Advanced Tabs (TUI/Win32)
+In TUI and Win32, F5/F6 cycle between advanced form tabs. The GUI uses F5
+for grid refresh and F6 for QRZ sync. The QSO card uses Ctrl+Tab and Alt+1..6
+for tab switching instead.
+
+### F8 — Callsign Card (GUI) vs Rig Toggle (TUI/Win32)
+In TUI and Win32, F8 toggles rig control. The GUI uses F8 for the callsign
+lookup card and Ctrl+R for rig control. This gives the GUI a dedicated key
+for the frequently-used callsign lookup without losing rig control access.
+
+### Alt+Enter — Inspector (GUI) vs Log QSO (TUI/Win32)
+In TUI and Win32, Alt+Enter logs or updates a QSO. The GUI uses Alt+Enter
+for the QSO inspector panel and Ctrl+Enter/F10 for logging. This avoids
+conflict with the menu access key system where Alt activates the menu bar.

--- a/scripts/automation/avalonia-design-review-capture.json
+++ b/scripts/automation/avalonia-design-review-capture.json
@@ -1,0 +1,124 @@
+{
+  "inspectSurface": "MainWindow",
+  "window": {
+    "title": "QsoRipper",
+    "x": 80,
+    "y": 80,
+    "width": 1280,
+    "height": 760
+  },
+  "actions": [
+    { "type": "wait", "milliseconds": 800 },
+    { "type": "dump-tree", "path": "01-main-window-tree.json" },
+    { "type": "screenshot", "path": "01-main-window-default.png" },
+
+    { "comment": "Open File menu",
+      "type": "click", "name": "File", "controlType": "MenuItem" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "02-file-menu.png" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 200 },
+
+    { "comment": "Open View menu",
+      "type": "click", "name": "View", "controlType": "MenuItem" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "03-view-menu.png" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 200 },
+
+    { "comment": "Open Tools menu",
+      "type": "click", "name": "Tools", "controlType": "MenuItem" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "04-tools-menu.png" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 200 },
+
+    { "comment": "Open Help overlay with F1",
+      "type": "send-keys", "keys": "{F1}" },
+    { "type": "wait", "milliseconds": 500 },
+    { "type": "screenshot", "path": "06-help-overlay.png" },
+    { "type": "dump-tree", "path": "06-help-overlay-tree.json" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 300 },
+
+    { "comment": "Open Full QSO Card with Alt+A — Core tab",
+      "type": "send-keys", "keys": "%a" },
+    { "type": "wait", "milliseconds": 600 },
+    { "type": "screenshot", "path": "07-qso-card-core.png" },
+    { "type": "dump-tree", "path": "07-qso-card-tree.json" },
+
+    { "comment": "Switch to Lookup tab (Alt+2)",
+      "type": "send-keys", "keys": "%2" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "08-qso-card-lookup.png" },
+
+    { "comment": "Switch to QSL tab (Alt+3)",
+      "type": "send-keys", "keys": "%3" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "09-qso-card-qsl.png" },
+
+    { "comment": "Switch to Contest tab (Alt+4)",
+      "type": "send-keys", "keys": "%4" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "10-qso-card-contest.png" },
+
+    { "comment": "Switch to Station tab (Alt+5)",
+      "type": "send-keys", "keys": "%5" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "11-qso-card-station.png" },
+
+    { "comment": "Switch to Metadata tab (Alt+6)",
+      "type": "send-keys", "keys": "%6" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "12-qso-card-metadata.png" },
+
+    { "comment": "Close QSO card with Esc",
+      "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 300 },
+
+    { "comment": "Select a row and open callsign card with F8",
+      "type": "click", "name": "W1AW", "controlType": "Text" },
+    { "type": "wait", "milliseconds": 300 },
+    { "type": "send-keys", "keys": "{F8}" },
+    { "type": "wait", "milliseconds": 1500 },
+    { "type": "screenshot", "path": "13-callsign-card.png" },
+    { "type": "dump-tree", "path": "13-callsign-card-tree.json" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 300 },
+
+    { "comment": "Open Inspector with Alt+Enter",
+      "type": "send-keys", "keys": "%{ENTER}" },
+    { "type": "wait", "milliseconds": 500 },
+    { "type": "screenshot", "path": "14-inspector.png" },
+    { "type": "dump-tree", "path": "14-inspector-tree.json" },
+    { "type": "send-keys", "keys": "%{ENTER}" },
+    { "type": "wait", "milliseconds": 300 },
+
+    { "comment": "Open Column Chooser",
+      "type": "click", "automationId": "ColumnsButton" },
+    { "type": "wait", "milliseconds": 300 },
+    { "type": "screenshot", "path": "15-column-chooser.png" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 200 },
+
+    { "comment": "Open Sort Chooser",
+      "type": "click", "automationId": "SortButton" },
+    { "type": "wait", "milliseconds": 300 },
+    { "type": "screenshot", "path": "16-sort-chooser.png" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 200 },
+
+    { "comment": "Open Delete Confirm — select row then Ctrl+D",
+      "type": "click", "name": "W1AW", "controlType": "Text" },
+    { "type": "wait", "milliseconds": 200 },
+    { "type": "send-keys", "keys": "^d" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "17-delete-confirm.png" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 300 },
+
+    { "comment": "Final screenshot after everything closed",
+      "type": "screenshot", "path": "18-main-window-final.png" },
+    { "type": "dump-tree", "path": "18-main-window-final-tree.json" }
+  ]
+}

--- a/scripts/automation/avalonia-multi-size-stress.json
+++ b/scripts/automation/avalonia-multi-size-stress.json
@@ -1,0 +1,34 @@
+{
+  "inspectSurface": "MainWindow",
+  "window": {
+    "title": "QsoRipper",
+    "x": 40,
+    "y": 40,
+    "width": 1280,
+    "height": 760
+  },
+  "actions": [
+    { "type": "wait", "milliseconds": 600 },
+    { "type": "screenshot", "path": "01-default-1280x760.png" },
+
+    { "comment": "MinWidth/MinHeight stress", "type": "resize-window", "x": 40, "y": 40, "width": 1024, "height": 640 },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "02-small-1024x640.png" },
+
+    { "comment": "Below minimum — hard failures", "type": "resize-window", "x": 40, "y": 40, "width": 900, "height": 600 },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "03-tiny-900x600.png" },
+
+    { "comment": "Tall narrow — column header overflow", "type": "resize-window", "x": 40, "y": 40, "width": 800, "height": 900 },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "04-tall-narrow-800x900.png" },
+
+    { "comment": "Wide short — vertical overflow", "type": "resize-window", "x": 40, "y": 40, "width": 1600, "height": 500 },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "05-wide-short-1600x500.png" },
+
+    { "comment": "Restore default", "type": "resize-window", "x": 40, "y": 40, "width": 1280, "height": 760 },
+    { "type": "wait", "milliseconds": 300 },
+    { "type": "screenshot", "path": "06-restored-1280x760.png" }
+  ]
+}

--- a/scripts/automation/avalonia-overlays-capture.json
+++ b/scripts/automation/avalonia-overlays-capture.json
@@ -1,0 +1,86 @@
+{
+  "inspectSurface": "MainWindow",
+  "window": {
+    "title": "QsoRipper",
+    "x": 80,
+    "y": 80,
+    "width": 1280,
+    "height": 760
+  },
+  "actions": [
+    { "type": "wait", "milliseconds": 1000 },
+    { "type": "screenshot", "path": "00-main-baseline.png" },
+
+    { "comment": "Open Help overlay with F1",
+      "type": "send-keys", "keys": "{F1}" },
+    { "type": "wait", "milliseconds": 600 },
+    { "type": "screenshot", "path": "01-help-overlay.png" },
+    { "type": "dump-tree", "path": "01-help-overlay-tree.json" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 400 },
+
+    { "comment": "Open Full QSO Card — Core tab",
+      "type": "send-keys", "keys": "%a" },
+    { "type": "wait", "milliseconds": 800 },
+    { "type": "screenshot", "path": "02-qso-card-core.png" },
+    { "type": "dump-tree", "path": "02-qso-card-tree.json" },
+
+    { "comment": "Switch to Lookup tab",
+      "type": "send-keys", "keys": "%2" },
+    { "type": "wait", "milliseconds": 500 },
+    { "type": "screenshot", "path": "03-qso-card-lookup.png" },
+
+    { "comment": "Switch to QSL tab",
+      "type": "send-keys", "keys": "%3" },
+    { "type": "wait", "milliseconds": 500 },
+    { "type": "screenshot", "path": "04-qso-card-qsl.png" },
+
+    { "comment": "Switch to Contest tab",
+      "type": "send-keys", "keys": "%4" },
+    { "type": "wait", "milliseconds": 500 },
+    { "type": "screenshot", "path": "05-qso-card-contest.png" },
+
+    { "comment": "Switch to Station tab",
+      "type": "send-keys", "keys": "%5" },
+    { "type": "wait", "milliseconds": 500 },
+    { "type": "screenshot", "path": "06-qso-card-station.png" },
+
+    { "comment": "Switch to Metadata tab",
+      "type": "send-keys", "keys": "%6" },
+    { "type": "wait", "milliseconds": 500 },
+    { "type": "screenshot", "path": "07-qso-card-metadata.png" },
+
+    { "comment": "Close QSO card",
+      "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 500 },
+
+    { "comment": "Select W1AW row and open callsign card with F8",
+      "type": "click", "name": "W1AW", "controlType": "Text" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "send-keys", "keys": "{F8}" },
+    { "type": "wait", "milliseconds": 2000 },
+    { "type": "screenshot", "path": "08-callsign-card.png" },
+    { "type": "dump-tree", "path": "08-callsign-card-tree.json" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 500 },
+
+    { "comment": "Open Inspector",
+      "type": "send-keys", "keys": "%{ENTER}" },
+    { "type": "wait", "milliseconds": 600 },
+    { "type": "screenshot", "path": "09-inspector.png" },
+    { "type": "dump-tree", "path": "09-inspector-tree.json" },
+    { "type": "send-keys", "keys": "%{ENTER}" },
+    { "type": "wait", "milliseconds": 400 },
+
+    { "comment": "Delete confirm",
+      "type": "click", "name": "W1AW", "controlType": "Text" },
+    { "type": "wait", "milliseconds": 300 },
+    { "type": "send-keys", "keys": "^d" },
+    { "type": "wait", "milliseconds": 500 },
+    { "type": "screenshot", "path": "10-delete-confirm.png" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 400 },
+
+    { "type": "screenshot", "path": "11-final.png" }
+  ]
+}

--- a/scripts/automation/avalonia-pass1-verify.json
+++ b/scripts/automation/avalonia-pass1-verify.json
@@ -1,0 +1,48 @@
+{
+  "inspectSurface": "MainWindow",
+  "window": {
+    "title": "QsoRipper",
+    "x": 80,
+    "y": 80,
+    "width": 1280,
+    "height": 760
+  },
+  "actions": [
+    { "type": "wait", "milliseconds": 1000 },
+    { "type": "screenshot", "path": "after-main-window.png" },
+    { "type": "dump-tree", "path": "after-main-window-tree.json" },
+
+    { "comment": "Open File menu",
+      "type": "click", "name": "File", "controlType": "MenuItem" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "after-file-menu.png" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 200 },
+
+    { "comment": "Open View menu",
+      "type": "click", "name": "View", "controlType": "MenuItem" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "after-view-menu.png" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 200 },
+
+    { "comment": "Open Help menu",
+      "type": "click", "name": "Help", "controlType": "MenuItem" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "after-help-menu.png" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 200 },
+
+    { "comment": "Open QSO Card to check tab numbers",
+      "type": "send-keys", "keys": "%a" },
+    { "type": "wait", "milliseconds": 800 },
+    { "type": "screenshot", "path": "after-qso-card-core.png" },
+    { "type": "send-keys", "keys": "%4" },
+    { "type": "wait", "milliseconds": 400 },
+    { "type": "screenshot", "path": "after-qso-card-contest.png" },
+    { "type": "send-keys", "keys": "{ESC}" },
+    { "type": "wait", "milliseconds": 300 },
+
+    { "type": "screenshot", "path": "after-final.png" }
+  ]
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
@@ -79,7 +79,7 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject, IDisposab
     public string CardTitle => IsEditingExisting ? "QSO Card - Edit" : "QSO Card - New";
     public string CardSubtitle => IsEditingExisting
         ? "Editing the selected QSO. Ctrl+Enter saves, Esc closes."
-        : "Advanced entry for a new QSO. Ctrl+Enter logs, Esc closes.";
+        : "Advanced entry for a new QSO. Ctrl+Enter / F10 logs, Esc closes.";
     public string SaveButtonText => IsEditingExisting ? "Save Changes" : "Log QSO";
     public string ModeBadgeText => IsEditingExisting ? "Edit Existing" : "New Contact";
     public string SectionHint { get; } = SectionHintText;

--- a/src/dotnet/QsoRipper.Gui/ViewModels/HelpOverlayViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/HelpOverlayViewModel.cs
@@ -20,10 +20,17 @@ internal sealed partial class HelpOverlayViewModel : ObservableObject
             new("Esc", "Close overlay / clear"),
         ]),
         new("QSO Logging", [
-            new("Ctrl+Enter", "Log QSO"),
+            new("Ctrl+Enter / F10", "Log QSO"),
             new("Alt+A / Ctrl+L", "Open QSO Card"),
             new("F7", "Reset QSO timer"),
             new("\u2190 / \u2192", "Cycle band/mode (when focused)"),
+        ]),
+        new("QSO Card", [
+            new("Alt+1\u20266", "Jump to tab (Core\u2026Metadata)"),
+            new("Ctrl+Tab", "Next tab"),
+            new("Ctrl+Shift+Tab", "Previous tab"),
+            new("Ctrl+Enter", "Save"),
+            new("Esc", "Close card"),
         ]),
         new("Grid", [
             new("F2", "Edit selected cell"),

--- a/src/dotnet/QsoRipper.Gui/ViewModels/HelpOverlayViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/HelpOverlayViewModel.cs
@@ -22,6 +22,9 @@ internal sealed partial class HelpOverlayViewModel : ObservableObject
         new("QSO Logging", [
             new("Ctrl+Enter / F10", "Log QSO"),
             new("Alt+A / Ctrl+L", "Open QSO Card"),
+            new("Alt+C", "Jump to callsign"),
+            new("Alt+B", "Jump to band"),
+            new("Alt+M", "Jump to mode"),
             new("F7", "Reset QSO timer"),
             new("\u2190 / \u2192", "Cycle band/mode (when focused)"),
         ]),

--- a/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
@@ -71,13 +71,15 @@
         <Button Grid.Column="1"
                 Content="Cancel"
                 MinWidth="90"
-                Command="{Binding CloseCommand}" />
+                Command="{Binding CloseCommand}"
+                ToolTip.Tip="Discard and close (Esc)" />
         <Button Grid.Column="2"
                 Content="{Binding SaveButtonText}"
                 MinWidth="120"
                 Classes="accent"
                 IsEnabled="{Binding !IsSaving}"
-                Command="{Binding SaveCommand}" />
+                Command="{Binding SaveCommand}"
+                ToolTip.Tip="Save and close (Ctrl+Enter)" />
       </Grid>
 
       <TabControl x:Name="CardTabs"

--- a/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
@@ -83,7 +83,7 @@
       <TabControl x:Name="CardTabs"
                   SelectionChanged="OnCardTabsSelectionChanged"
                   SelectedIndex="{Binding SelectedTabIndex, Mode=TwoWay}">
-        <TabItem Header="Core">
+        <TabItem Header="1 Core">
           <ScrollViewer VerticalScrollBarVisibility="Auto">
             <Grid ColumnDefinitions="*,*" ColumnSpacing="18" Margin="0,8,0,0">
               <StackPanel Spacing="10">
@@ -168,7 +168,7 @@
           </ScrollViewer>
         </TabItem>
 
-        <TabItem Header="Lookup">
+        <TabItem Header="2 Lookup">
           <ScrollViewer VerticalScrollBarVisibility="Auto">
             <Grid ColumnDefinitions="*,*" ColumnSpacing="18" Margin="0,8,0,0">
               <StackPanel Spacing="10">
@@ -271,7 +271,7 @@
           </ScrollViewer>
         </TabItem>
 
-        <TabItem Header="QSL">
+        <TabItem Header="3 QSL">
           <ScrollViewer VerticalScrollBarVisibility="Auto">
             <Grid ColumnDefinitions="*,*" ColumnSpacing="18" Margin="0,8,0,0">
               <StackPanel Spacing="10">
@@ -344,7 +344,7 @@
           </ScrollViewer>
         </TabItem>
 
-        <TabItem Header="Contest">
+        <TabItem Header="4 Contest">
           <ScrollViewer VerticalScrollBarVisibility="Auto">
             <Grid ColumnDefinitions="*,*" ColumnSpacing="18" Margin="0,8,0,0">
               <StackPanel Spacing="10">
@@ -406,7 +406,7 @@
           </ScrollViewer>
         </TabItem>
 
-        <TabItem Header="Station">
+        <TabItem Header="5 Station">
           <ScrollViewer VerticalScrollBarVisibility="Auto">
             <Grid ColumnDefinitions="*,*"
                   RowDefinitions="Auto,Auto,Auto,Auto,Auto"
@@ -547,7 +547,7 @@
           </ScrollViewer>
         </TabItem>
 
-        <TabItem Header="Metadata">
+        <TabItem Header="6 Metadata">
           <ScrollViewer VerticalScrollBarVisibility="Auto">
             <Grid ColumnDefinitions="320,*" ColumnSpacing="18" Margin="0,8,0,0">
               <StackPanel Spacing="10">

--- a/src/dotnet/QsoRipper.Gui/Views/HelpOverlayView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/HelpOverlayView.axaml
@@ -4,7 +4,7 @@
              x:Class="QsoRipper.Gui.Views.HelpOverlayView"
              x:DataType="vm:HelpOverlayViewModel">
 
-  <Border Background="#E0202020" CornerRadius="8" Padding="24" MaxWidth="640" MaxHeight="520"
+  <Border Background="#E0202020" CornerRadius="8" Padding="24" MaxWidth="720" MaxHeight="560"
           HorizontalAlignment="Center" VerticalAlignment="Center"
           BorderBrush="#60FFFFFF" BorderThickness="1">
     <DockPanel>

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -27,6 +27,7 @@
     <KeyBinding Gesture="F8" Command="{Binding OpenCallsignCardCommand}" />
     <KeyBinding Gesture="F6" Command="{Binding SyncNowCommand}" />
     <KeyBinding Gesture="Ctrl+Enter" Command="{Binding Logger.LogQsoCommand}" />
+    <KeyBinding Gesture="F10" Command="{Binding Logger.LogQsoCommand}" />
     <KeyBinding Gesture="Ctrl+N" Command="{Binding FocusLoggerCommand}" />
     <KeyBinding Gesture="Ctrl+R" Command="{Binding ToggleRigControlCommand}" />
     <KeyBinding Gesture="Ctrl+W" Command="{Binding ToggleSpaceWeatherCommand}" />
@@ -134,7 +135,7 @@
         <MenuItem Header="_Reset Zoom" InputGesture="Ctrl+0"
                   Command="{Binding RecentQsos.ResetZoomCommand}" />
         <Separator />
-        <MenuItem Header="_Sort Columns..." InputGesture="Ctrl+Shift+S"
+        <MenuItem Header="_Sort..." InputGesture="Ctrl+Shift+S"
                   Command="{Binding ToggleSortChooserCommand}" />
         <MenuItem Header="_Choose Columns..." InputGesture="Ctrl+H"
                   Command="{Binding ToggleColumnChooserCommand}" />
@@ -155,6 +156,10 @@
                   Command="{Binding SwitchToDotNetEngineCommand}" />
         <MenuItem Header="_Refresh Engine Status"
                   Command="{Binding RefreshEngineAvailabilityCommand}" />
+      </MenuItem>
+      <MenuItem Header="_Help">
+        <MenuItem Header="_Keyboard Shortcuts" InputGesture="F1"
+                  Command="{Binding ToggleHelpCommand}" />
       </MenuItem>
     </Menu>
       <TextBlock HorizontalAlignment="Right"
@@ -239,13 +244,15 @@
                     Content="Sort"
                     Command="{Binding ToggleSortChooserCommand}"
                     MinHeight="28"
-                    MinWidth="54" />
+                    MinWidth="54"
+                    ToolTip.Tip="Sort columns (Ctrl+Shift+S)" />
             <Button x:Name="ColumnsButton"
                     AutomationProperties.AutomationId="ColumnsButton"
                     Content="Cols"
                     Command="{Binding ToggleColumnChooserCommand}"
                     MinHeight="28"
-                    MinWidth="54" />
+                    MinWidth="54"
+                    ToolTip.Tip="Choose columns (Ctrl+H)" />
           </StackPanel>
         </Grid>
 
@@ -337,7 +344,7 @@
                       Classes="accent"
                       MinHeight="28" MinWidth="54"
                       VerticalAlignment="Bottom"
-                      ToolTip.Tip="Log QSO (Ctrl+Enter)" />
+                      ToolTip.Tip="Log QSO (Ctrl+Enter / F10)" />
 
               <Button Grid.Column="8"
                       Content="Clear"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -937,10 +937,17 @@
                 BorderBrush="{DynamicResource SystemControlForegroundBaseLowBrush}"
                 BorderThickness="1,0,0,0"
                 Padding="10,4">
-          <StackPanel Orientation="Horizontal"
-                      Spacing="10"
-                      VerticalAlignment="Center"
-                      ClipToBounds="True">
+          <DockPanel>
+            <TextBlock DockPanel.Dock="Right"
+                       Text="F1 Help"
+                       FontSize="11"
+                       Opacity="0.50"
+                       VerticalAlignment="Center"
+                       Margin="10,0,0,0" />
+            <StackPanel Orientation="Horizontal"
+                        Spacing="10"
+                        VerticalAlignment="Center"
+                        ClipToBounds="True">
             <TextBlock Text="{Binding RecentQsos.CountStatusText}" FontSize="11.5" />
             <TextBlock Text="|" Opacity="0.45" />
             <TextBlock Text="{Binding RecentQsos.FilterStatusText}" FontSize="11.5" TextTrimming="CharacterEllipsis" />
@@ -966,6 +973,7 @@
                        MaxWidth="240"
                        IsVisible="{Binding HasEngineSwitchStatus}" />
           </StackPanel>
+          </DockPanel>
         </Border>
       </Grid>
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -272,7 +272,9 @@
                   ColumnSpacing="8"
                   VerticalAlignment="Center">
               <StackPanel Grid.Column="0" Spacing="1">
-                <TextBlock Text="Callsign" FontSize="10" Opacity="0.6" />
+                <TextBlock FontSize="10" Opacity="0.6">
+                  <Run Text="C" TextDecorations="Underline" /><Run Text="allsign" />
+                </TextBlock>
                 <TextBox x:Name="LoggerCallsignBox"
                          AutomationProperties.AutomationId="LoggerCallsignBox"
                          Text="{Binding Logger.Callsign, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
@@ -281,7 +283,9 @@
               </StackPanel>
 
               <StackPanel Grid.Column="1" Spacing="1">
-                <TextBlock Text="Band ◄►" FontSize="10" Opacity="0.6" />
+                <TextBlock FontSize="10" Opacity="0.6">
+                  <Run Text="B" TextDecorations="Underline" /><Run Text="and ◄►" />
+                </TextBlock>
                 <Button x:Name="LoggerBandButton"
                         AutomationProperties.AutomationId="LoggerBandButton"
                         Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"
@@ -297,7 +301,9 @@
               </StackPanel>
 
               <StackPanel Grid.Column="2" Spacing="1">
-                <TextBlock Text="Mode ◄►" FontSize="10" Opacity="0.6" />
+                <TextBlock FontSize="10" Opacity="0.6">
+                  <Run Text="M" TextDecorations="Underline" /><Run Text="ode ◄►" />
+                </TextBlock>
                 <Button x:Name="LoggerModeButton"
                         AutomationProperties.AutomationId="LoggerModeButton"
                         Background="{DynamicResource SystemControlBackgroundBaseLowBrush}"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -403,6 +403,29 @@ internal sealed partial class MainWindow : Window
             return true;
         }
 
+        // Alt-field jumps for rapid logger navigation — matches TUI Alt+C/B/M
+        // convention. Only active when no overlay is open and focus can reach
+        // the logger controls.
+        if (e.KeyModifiers == KeyModifiers.Alt && !_viewModel.IsFullQsoCardOpen
+            && !_viewModel.IsHelpOpen && !_viewModel.IsCallsignCardOpen)
+        {
+            switch (e.Key)
+            {
+                case Key.C:
+                    FocusLoggerControl("LoggerCallsignBox");
+                    e.Handled = true;
+                    return true;
+                case Key.B:
+                    FocusLoggerControl("LoggerBandButton");
+                    e.Handled = true;
+                    return true;
+                case Key.M:
+                    FocusLoggerControl("LoggerModeButton");
+                    e.Handled = true;
+                    return true;
+            }
+        }
+
         if (e.KeyModifiers != KeyModifiers.None)
         {
             return false;
@@ -711,6 +734,27 @@ internal sealed partial class MainWindow : Window
             {
                 _recentQsoSearchBox.Focus();
                 _recentQsoSearchBox.SelectAll();
+            },
+            DispatcherPriority.Input);
+    }
+
+    private void FocusLoggerControl(string automationId)
+    {
+        var control = this.FindControl<Control>(automationId);
+        if (control is null)
+        {
+            return;
+        }
+
+        _lastFocusArea = FocusArea.Logger;
+        Dispatcher.UIThread.Post(
+            () =>
+            {
+                control.Focus();
+                if (control is TextBox textBox)
+                {
+                    textBox.SelectAll();
+                }
             },
             DispatcherPriority.Input);
     }

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -249,7 +249,16 @@ internal sealed partial class MainWindow : Window
         // the "cursor blinks once then jumps to File menu" behaviour
         // after opening the card via Alt+A.
         if (_viewModel?.IsFullQsoCardOpen == true
-            && (e.Key == Key.LeftAlt || e.Key == Key.RightAlt || e.Key == Key.LWin || e.Key == Key.F10))
+            && (e.Key == Key.LeftAlt || e.Key == Key.RightAlt || e.Key == Key.LWin))
+        {
+            e.Handled = true;
+            return;
+        }
+
+        // Always swallow F10 KeyUp — it triggers Log QSO via KeyBinding on
+        // KeyDown, but the KeyUp would otherwise activate Avalonia's menu
+        // access-key mode (F10 is a standard menu activation key).
+        if (e.Key == Key.F10)
         {
             e.Handled = true;
             return;

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -255,6 +255,15 @@ internal sealed partial class MainWindow : Window
             return;
         }
 
+        // Swallow standalone Alt releases after Alt-field jumps (Alt+C/B/M)
+        // so the menu access-key mode does not steal focus from the logger.
+        if ((e.Key == Key.LeftAlt || e.Key == Key.RightAlt)
+            && _lastFocusArea == FocusArea.Logger)
+        {
+            e.Handled = true;
+            return;
+        }
+
         // Always swallow F10 KeyUp — it triggers Log QSO via KeyBinding on
         // KeyDown, but the KeyUp would otherwise activate Avalonia's menu
         // access-key mode (F10 is a standard menu activation key).


### PR DESCRIPTION
## Keyboard-First Design Pass for GUI

Systematic review and improvement of the Avalonia desktop GUI through a keyboard-first lens, aligning shortcuts with TUI/Win32 surfaces where possible and improving discoverability of keyboard navigation.

### Design Philosophy

Ham radio loggers are keyboard-first tools. Operators log contacts during a contest or pileup at speed — every mouse trip costs time. This PR audits the GUI against the TUI and Win32 surfaces and brings them closer together while respecting each surface's strengths.

### Changes by Pass

**Pass 1 — Menu, shortcut, and navigation foundations**
- Add **Help menu** with "Keyboard Shortcuts (F1)" entry
- Add **F10** KeyBinding for Log QSO (matches TUI/Win32 convention)
- Fix F10 KeyUp swallowing to prevent menu activation after F10 fires
- Add shortcut tooltips to **Sort** (Ctrl+Shift+S) and **Cols** (Ctrl+H) buttons
- Update LOG button tooltip to show "Ctrl+Enter / F10"
- **Number QSO card tab headers**: "1 Core", "2 Lookup", "3 QSL", "4 Contest", "5 Station", "6 Metadata"
- Add QSO Card section to help overlay (Alt+1..6, Ctrl+Tab, Ctrl+Shift+Tab)
- Update help overlay to show F10 alongside Ctrl+Enter

**Pass 2 — Alt-field jumps for rapid logging**
- Add **Alt+C** (Callsign), **Alt+B** (Band), **Alt+M** (Mode) field jumps
- Alt-jumps gated: disabled when QSO card, help, or callsign card overlays are open
- **Underline first letter** of Callsign/Band/Mode labels as mnemonic hints
- Add Alt+C/B/M entries to help overlay
- Widen help overlay MaxWidth 640→720, MaxHeight 520→560

**Pass 3 — Discoverability and polish**
- Add **"F1 Help"** hint right-aligned in status bar
- Add tooltips to QSO card Cancel ("Discard and close (Esc)") and Save ("Save and close (Ctrl+Enter)") buttons
- Update QSO card subtitle to show F10 alongside Ctrl+Enter for new QSOs
- Swallow Alt KeyUp when logger has focus to prevent menu activation after Alt-field jumps

### Cross-Surface Shortcut Comparison

| Action | GUI (this PR) | TUI | Win32 |
|---|---|---|---|
| Log QSO | **Ctrl+Enter / F10** | Ctrl+Enter / F10 | Ctrl+Enter / F10 |
| QSO Card | Alt+A / Ctrl+L | — | — |
| Focus Callsign | **Alt+C** | Alt+C | Alt+C |
| Focus Band | **Alt+B** | Alt+B | Alt+B |
| Focus Mode | **Alt+M** | Alt+M | Alt+M |
| Help | **F1** | F1 | F1 |
| Search | Ctrl+F | Ctrl+F | — |
| Delete QSO | Ctrl+D | — | — |

### Documentation

- New `docs/keyboard-shortcuts.md` — comprehensive cross-surface reference with intentional divergence explanations

### Automation Scripts Created

- `scripts/automation/avalonia-overlays-capture.json` — captures all overlay surfaces
- `scripts/automation/avalonia-multi-size-stress.json` — tests at 5 window sizes (1280×760, 1024×640, 900×600, 800×900, 1600×500)
- `scripts/automation/avalonia-design-review-capture.json` — comprehensive design review capture
- `scripts/automation/avalonia-pass1-verify.json` — pass 1 verification

### Testing

- All **83 GUI tests pass** with 0 warnings
- Multi-size stress test verified at 5 window sizes — no layout breaks
- Visual captures verified at each pass (capture → diagnose → patch → re-capture → verify loop)

### Deferred Follow-ups

- F8 divergence (GUI=callsign card, TUI/Win32=rig toggle) — different interaction models per surface
- Alt+Enter divergence (GUI=inspector, TUI/Win32=log QSO) — GUI uses Ctrl+Enter/F10 instead
- TUI-style footer shortcut chips in status bar — status bar already full with operational info
- Help overlay automation capture issue (F1 send-keys doesn't trigger in UIA mode)