### PR TITLE
fix: force callsign fields to uppercase in GUI

### DIFF
--- a/src/dotnet/QsoRipper.Gui/Utilities/UpperCaseBehavior.cs
+++ b/src/dotnet/QsoRipper.Gui/Utilities/UpperCaseBehavior.cs
@@ -1,0 +1,59 @@
+using Avalonia;
+using Avalonia.Controls;
+
+namespace QsoRipper.Gui.Utilities;
+
+/// <summary>
+/// Attached behavior that forces a TextBox value to uppercase.
+/// Usage: &lt;TextBox util:UpperCaseBehavior.IsEnabled="True" /&gt;
+/// </summary>
+internal static class UpperCaseBehavior
+{
+    public static readonly AttachedProperty<bool> IsEnabledProperty =
+        AvaloniaProperty.RegisterAttached<TextBox, bool>("IsEnabled", typeof(UpperCaseBehavior));
+
+    static UpperCaseBehavior()
+    {
+        IsEnabledProperty.Changed.AddClassHandler<TextBox>(OnIsEnabledChanged);
+    }
+
+    public static bool GetIsEnabled(TextBox textBox)
+    {
+        ArgumentNullException.ThrowIfNull(textBox);
+        return textBox.GetValue(IsEnabledProperty);
+    }
+
+    public static void SetIsEnabled(TextBox textBox, bool value)
+    {
+        ArgumentNullException.ThrowIfNull(textBox);
+        textBox.SetValue(IsEnabledProperty, value);
+    }
+
+    private static void OnIsEnabledChanged(TextBox textBox, AvaloniaPropertyChangedEventArgs e)
+    {
+        if (e.NewValue is true)
+        {
+            textBox.TextChanged += OnTextChanged;
+        }
+        else
+        {
+            textBox.TextChanged -= OnTextChanged;
+        }
+    }
+
+    private static void OnTextChanged(object? sender, TextChangedEventArgs e)
+    {
+        if (sender is not TextBox textBox || textBox.Text is null)
+        {
+            return;
+        }
+
+        var upper = textBox.Text.ToUpperInvariant();
+        if (upper != textBox.Text)
+        {
+            var caretIndex = textBox.CaretIndex;
+            textBox.Text = upper;
+            textBox.CaretIndex = caretIndex;
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:QsoRipper.Gui.ViewModels"
+             xmlns:util="using:QsoRipper.Gui.Utilities"
              x:Class="QsoRipper.Gui.Views.FullQsoCardView"
              x:DataType="vm:FullQsoCardViewModel">
   <UserControl.KeyBindings>
@@ -96,7 +97,8 @@
                            Text="{Binding WorkedCallsign, Mode=TwoWay}"
                            FontSize="18"
                            FontWeight="SemiBold"
-                           Classes="mono" />
+                           Classes="mono"
+                           util:UpperCaseBehavior.IsEnabled="True" />
                 </StackPanel>
 
                 <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
@@ -149,7 +151,8 @@
               <StackPanel Grid.Column="1" Spacing="10">
                 <StackPanel>
                   <TextBlock Classes="fieldLabel" Text="Station callsign" />
-                  <TextBox Text="{Binding StationCallsign, Mode=TwoWay}" Classes="mono" />
+                  <TextBox Text="{Binding StationCallsign, Mode=TwoWay}" Classes="mono"
+                           util:UpperCaseBehavior.IsEnabled="True" />
                 </StackPanel>
 
                 <StackPanel>
@@ -180,7 +183,8 @@
                     <TextBlock Classes="fieldLabel" Text="Worked operator callsign" />
                     <TextBox x:Name="LookupOperatorCallsignBox"
                              Text="{Binding WorkedOperatorCallsign, Mode=TwoWay}"
-                             Classes="mono" />
+                             Classes="mono"
+                             util:UpperCaseBehavior.IsEnabled="True" />
                   </StackPanel>
                   <Button Grid.Column="1"
                           VerticalAlignment="Bottom"
@@ -452,11 +456,13 @@
                   <TextBlock Classes="fieldLabel" Text="Snapshot station callsign" />
                   <TextBox x:Name="StationCallsignSnapshotBox"
                            Text="{Binding SnapshotStationCallsign, Mode=TwoWay}"
-                           Classes="mono" />
+                           Classes="mono"
+                           util:UpperCaseBehavior.IsEnabled="True" />
                 </StackPanel>
                 <StackPanel Grid.Column="1">
                   <TextBlock Classes="fieldLabel" Text="Snapshot operator callsign" />
-                  <TextBox Text="{Binding SnapshotOperatorCallsign, Mode=TwoWay}" Classes="mono" />
+                  <TextBox Text="{Binding SnapshotOperatorCallsign, Mode=TwoWay}" Classes="mono"
+                           util:UpperCaseBehavior.IsEnabled="True" />
                 </StackPanel>
               </Grid>
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:QsoRipper.Gui.ViewModels"
         xmlns:v="using:QsoRipper.Gui.Views"
+        xmlns:util="using:QsoRipper.Gui.Utilities"
         x:Class="QsoRipper.Gui.Views.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         AutomationProperties.AutomationId="MainWindow"
@@ -307,7 +308,8 @@
                          Width="110" Height="28"
                          FontWeight="SemiBold"
                          FontFamily="Cascadia Mono, Consolas, monospace"
-                         Foreground="#00d4ff" />
+                         Foreground="#00d4ff"
+                         util:UpperCaseBehavior.IsEnabled="True" />
               </StackPanel>
 
               <StackPanel Grid.Column="1" Spacing="1">
@@ -473,7 +475,8 @@
                       <DataTemplate x:DataType="vm:RecentQsoItemViewModel">
                         <TextBox Text="{Binding WorkedCallsign, Mode=TwoWay}"
                                  BorderThickness="0"
-                                 Background="Transparent" />
+                                 Background="Transparent"
+                                 util:UpperCaseBehavior.IsEnabled="True" />
                       </DataTemplate>
                     </DataGridTemplateColumn.CellEditingTemplate>
                   </DataGridTemplateColumn>

--- a/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:QsoRipper.Gui.ViewModels"
         xmlns:v="using:QsoRipper.Gui.Views"
+        xmlns:util="using:QsoRipper.Gui.Utilities"
         x:Class="QsoRipper.Gui.Views.SettingsView"
         x:Name="SettingsWindow"
         x:DataType="vm:SettingsViewModel"
@@ -114,7 +115,8 @@
                        AutomationProperties.AutomationId="SettingsCallsignBox"
                        Grid.Row="0" Grid.Column="1"
                        Text="{Binding Callsign, Mode=TwoWay}"
-                       PlaceholderText="e.g. W1AW" />
+                       PlaceholderText="e.g. W1AW"
+                       util:UpperCaseBehavior.IsEnabled="True" />
 
               <TextBlock Grid.Row="0" Grid.Column="2" Text="Grid Square:" VerticalAlignment="Center" />
               <TextBox x:Name="SettingsGridSquareBox"
@@ -133,7 +135,8 @@
               <TextBox x:Name="SettingsOperatorCallsignBox"
                        AutomationProperties.AutomationId="SettingsOperatorCallsignBox"
                        Grid.Row="1" Grid.Column="3"
-                       Text="{Binding OperatorCallsign, Mode=TwoWay}" />
+                       Text="{Binding OperatorCallsign, Mode=TwoWay}"
+                       util:UpperCaseBehavior.IsEnabled="True" />
 
               <TextBlock Grid.Row="2" Grid.Column="0" Text="Profile Name:" VerticalAlignment="Center" />
               <TextBox x:Name="SettingsProfileNameBox"

--- a/src/dotnet/QsoRipper.Gui/Views/StationProfileStepView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/StationProfileStepView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="using:QsoRipper.Gui.ViewModels"
+             xmlns:util="using:QsoRipper.Gui.Utilities"
              x:Class="QsoRipper.Gui.Views.StationProfileStepView"
              x:DataType="vm:StationProfileStepViewModel">
 
@@ -26,13 +27,15 @@
         <TextBox x:Name="WizardStationCallsignBox"
                  AutomationProperties.AutomationId="WizardStationCallsignBox"
                   Text="{Binding Callsign, Mode=TwoWay}"
-                  PlaceholderText="e.g. W1AW" />
+                  PlaceholderText="e.g. W1AW"
+                  util:UpperCaseBehavior.IsEnabled="True" />
 
         <TextBlock Text="Operator Callsign (required):" FontWeight="SemiBold" />
         <TextBox x:Name="WizardOperatorCallsignBox"
                  AutomationProperties.AutomationId="WizardOperatorCallsignBox"
                   Text="{Binding OperatorCallsign, Mode=TwoWay}"
-                  PlaceholderText="e.g. W1AW (or personal call if different)" />
+                  PlaceholderText="e.g. W1AW (or personal call if different)"
+                  util:UpperCaseBehavior.IsEnabled="True" />
 
         <TextBlock Text="Operator Name:" />
         <TextBox x:Name="WizardOperatorNameBox"


### PR DESCRIPTION
## Summary

Fixes #307 — Callsign input fields in the GUI now automatically convert text to uppercase as the user types.

## Changes

**New file:** `UpperCaseBehavior.cs` — An Avalonia attached property that hooks `TextChanged` to uppercase the value while preserving caret position.

**Updated views** (added `util:UpperCaseBehavior.IsEnabled="True"`):
- `MainWindow.axaml` — Logger callsign box + inline-edit callsign in DataGrid
- `FullQsoCardView.axaml` — Worked callsign, station callsign, operator callsign, snapshot station/operator callsigns
- `SettingsView.axaml` — Station callsign, operator callsign
- `StationProfileStepView.axaml` — Wizard station and operator callsigns

## Testing

- Build passes with zero warnings/errors
- Behavior is a simple `ToUpperInvariant()` on `TextChanged` with caret preservation