### PR TITLE
feat: add frequency_hz fields for sub-kHz precision in ADIF export

### DIFF
--- a/docs/api/logbook-service.md
+++ b/docs/api/logbook-service.md
@@ -287,7 +287,7 @@ rpc ImportAdif(stream ImportAdifRequest) returns (ImportAdifResponse)
 - The server accumulates chunks and parses the complete ADIF payload after the client closes the send side.
 - Imported `STATION_CALLSIGN`, `OPERATOR`, and `MY_*` fields are preserved through `station_snapshot`; the current active station profile does **not** overwrite imported local-station history.
 - If an ADIF record has no local-station context at all, the server uses the current active station profile as an explicit fallback and adds a warning describing that fallback.
-- Duplicate policy: a record is skipped when it matches an existing QSO on `station_callsign`, `worked_callsign`, `utc_timestamp`, `band`, `mode`, and compatible `submode` / `frequency_khz`.
+- Duplicate policy: a record is skipped when it matches an existing QSO on `station_callsign`, `worked_callsign`, `utc_timestamp`, `band`, `mode`, and compatible `submode` / `frequency_hz`.
 - Invalid core ADIF values such as unknown `BAND`, unknown `MODE`, or invalid `QSO_DATE` / `TIME_ON` combinations are skipped with warnings. Raw ADIF values are still retained in `extra_fields` so later exports stay predictable.
 
 **Response:** `ImportAdifResponse`
@@ -353,7 +353,7 @@ rpc ExportAdif(ExportAdifRequest) returns (stream ExportAdifResponse)
 | `utc_end_timestamp` | Optional | UTC end time of the contact when known |
 | `band` | Required | Frequency band (see `Band` enum) |
 | `mode` | Required | Operating mode (see `Mode` enum) |
-| `frequency_khz` | Optional | Precise frequency in kHz |
+| `frequency_hz` | Optional | Precise frequency in Hz (e.g., 28075730 for 28.07573 MHz) |
 | `submode` | Optional | ADIF submode string (e.g., `"USB"`, `"PSK31"`) |
 | `rst_sent` / `rst_received` | Optional | RST signal reports |
 | `sync_status` | Set by engine | `LOCAL_ONLY → SYNCED → MODIFIED → CONFLICT` |

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -88,7 +88,7 @@ Normalized representation of a ham radio operator/station. Derived from QRZ XML 
 The core QSO (contact) entity. Every logged contact is a QsoRecord.
 
 - **Identity**: local_id (UUID assigned by QsoRipper), qrz_logid (from QRZ sync)
-- **Core**: station_callsign, worked_callsign, utc_timestamp, utc_end_timestamp, band, mode, submode, frequency_khz
+- **Core**: station_callsign, worked_callsign, utc_timestamp, utc_end_timestamp, band, mode, submode, frequency_hz
 - **Signal**: rst_sent, rst_received (structured RstReport), tx_power
 - **QSL**: sent/received status for card, LoTW, eQSL
 - **Enrichment**: worked_operator_name, worked_grid, worked_country, worked_dxcc, worked_continent

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -1176,7 +1176,7 @@ When DXCC data is available, cascade zone information onto the lookup result if 
    Engines MUST NOT leave these app keys in `extra_fields` once a dedicated domain field carries the value, otherwise downstream sync will treat the record as unlinked and re-upload it as a duplicate.
 4. Map normalized ADIF fields to their dedicated proto slots rather than `extra_fields`:
    - `BAND_RX` → `band_rx` (Band enum)
-   - `FREQ_RX` → `frequency_rx_khz` (MHz → kHz)
+   - `FREQ_RX` → `frequency_rx_hz` (MHz → Hz via string math for sub-kHz precision)
    - `LAT` / `LON` → `worked_latitude` / `worked_longitude` (parsed from `[NSEW]DDD MM.MMM` to signed decimal degrees)
    - `ALTITUDE` → `worked_altitude_meters`
    - `GRIDSQUARE_EXT` → `worked_gridsquare_ext`

--- a/docs/integrations/adif-specification.md
+++ b/docs/integrations/adif-specification.md
@@ -621,7 +621,7 @@ The ADIF parser (Rust-side edge adapter) converts ADIF fields to/from proto `Qso
 | QSO_DATE_OFF + TIME_OFF | utc_end_timestamp | End date falls back to QSO_DATE when ADIF omits QSO_DATE_OFF |
 | BAND | band | Map string to Band enum |
 | MODE + SUBMODE | mode | Map to Mode enum; store submode separately if needed |
-| FREQ | frequency_khz | Convert MHz → kHz (multiply by 1000) |
+| FREQ | frequency_hz | Convert MHz → Hz via string/decimal math for sub-kHz precision |
 | RST_SENT | rst_sent | Parse into RstReport |
 | RST_RCVD | rst_received | Parse into RstReport |
 | TX_PWR | tx_power | — |
@@ -655,7 +655,7 @@ The ADIF parser (Rust-side edge adapter) converts ADIF fields to/from proto `Qso
 | MY_NAME | station_snapshot.operator_name | Logging-station snapshot field |
 | MY_ARRL_SECT | station_snapshot.arrl_section | Logging-station snapshot field |
 | BAND_RX | band_rx | Split-operation receiving band (Band enum) |
-| FREQ_RX | frequency_rx_khz | Split-operation RX frequency, MHz → kHz |
+| FREQ_RX | frequency_rx_hz | Split-operation RX frequency, MHz → Hz via string math |
 | LAT | worked_latitude | Parsed from `[NSEW]DDD MM.MMM` to signed decimal degrees |
 | LON | worked_longitude | Parsed from `[NSEW]DDD MM.MMM` to signed decimal degrees |
 | ALTITUDE | worked_altitude_meters | Contacted-station altitude in meters (MSL) |

--- a/proto/domain/qso_record.proto
+++ b/proto/domain/qso_record.proto
@@ -26,7 +26,8 @@ message QsoRecord {
   google.protobuf.Timestamp utc_timestamp = 12;
   Band band = 13;
   Mode mode = 14;
-  optional uint64 frequency_khz = 15;  // Precise frequency in kHz
+  optional uint64 frequency_khz = 15 [deprecated = true];  // Deprecated: use frequency_hz for sub-kHz precision
+  optional uint64 frequency_hz = 116;  // Precise frequency in Hz (e.g., 28075730 for 28.075730 MHz)
   optional string submode = 16;  // ADIF submode string (e.g., "USB", "PSK31")
   optional StationSnapshot station_snapshot = 17;  // Materialized local-station values used at log time
   optional google.protobuf.Timestamp utc_end_timestamp = 18;  // QSO end timestamp when known
@@ -109,8 +110,10 @@ message QsoRecord {
   optional string worked_gridsquare_ext = 103;
 
   // --- Split RX (ADIF FREQ_RX / BAND_RX) ---
-  // Receiver frequency in kHz when running split.
-  optional uint64 frequency_rx_khz = 104;
+  // Deprecated: use frequency_rx_hz for sub-kHz precision.
+  optional uint64 frequency_rx_khz = 104 [deprecated = true];
+  // Receiver frequency in Hz when running split.
+  optional uint64 frequency_rx_hz = 117;
   // Receiver band when running split. Defaults to BAND_UNSPECIFIED if absent.
   Band band_rx = 105;
 

--- a/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
@@ -12,7 +12,7 @@ public sealed class CommandHelperTests
     {
         var success = LogQsoCommand.TryBuildQso(
             "W1AW",
-            ["20m", "FT8", "--station", "k7abv", "--rst-sent", "59", "--rst-rcvd", "57", "--freq", "14074", "--comment", "Strong copy", "--notes", "Worked on dipole"],
+            ["20m", "FT8", "--station", "k7abv", "--rst-sent", "59", "--rst-rcvd", "57", "--freq", "14.074", "--comment", "Strong copy", "--notes", "Worked on dipole"],
             out var qso,
             out _,
             out var error);
@@ -24,7 +24,7 @@ public sealed class CommandHelperTests
         Assert.Equal("K7ABV", qso.StationCallsign);
         Assert.Equal(Band._20M, qso.Band);
         Assert.Equal(Mode.Ft8, qso.Mode);
-        Assert.Equal((ulong)14074, qso.FrequencyKhz);
+        Assert.Equal((ulong)14_074_000, qso.FrequencyHz);
         Assert.Equal((uint)5, qso.RstSent!.Readability);
         Assert.Equal((uint)9, qso.RstSent.Strength);
         Assert.Equal((uint)5, qso.RstReceived!.Readability);
@@ -35,7 +35,7 @@ public sealed class CommandHelperTests
     }
 
     [Theory]
-    [InlineData("--freq", "nope", "Invalid value for --freq: nope")]
+    [InlineData("--freq", "nope", "Invalid value for --freq: nope. Use MHz such as 14.074.")]
     [InlineData("--rst-sent", "ab", "Invalid value for --rst-sent: ab. Expected 2 or 3 digits.")]
     [InlineData("--rst-rcvd", "1", "Invalid value for --rst-rcvd: 1. Expected 2 or 3 digits.")]
     public void TryBuildQso_rejects_invalid_optional_values(string option, string value, string expectedError)
@@ -296,7 +296,7 @@ public sealed class CommandHelperTests
         var enrich = false;
 
         var success = UpdateQsoCommand.TryApplyUpdates(
-            ["--grid", "FN31", "--freq", "14035", "--comment", "Nice signal"],
+            ["--grid", "FN31", "--freq", "14.035", "--comment", "Nice signal"],
             qso,
             ref enrich,
             out var error);
@@ -304,7 +304,7 @@ public sealed class CommandHelperTests
         Assert.True(success);
         Assert.Null(error);
         Assert.Equal("FN31", qso.WorkedGrid);
-        Assert.Equal((ulong)14035, qso.FrequencyKhz);
+        Assert.Equal((ulong)14_035_000, qso.FrequencyHz);
         Assert.Equal("Nice signal", qso.Comment);
         Assert.False(enrich);
     }

--- a/src/dotnet/QsoRipper.Cli/Commands/GetQsoCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/GetQsoCommand.cs
@@ -45,9 +45,16 @@ internal static class GetQsoCommand
             Console.WriteLine($"Duration:         {duration}");
         }
 
-        if (qso.HasFrequencyKhz)
         {
-            Console.WriteLine($"Frequency:        {qso.FrequencyKhz} kHz");
+            ulong? freqHz = qso.HasFrequencyHz ? qso.FrequencyHz
+#pragma warning disable CS0612
+                : qso.HasFrequencyKhz ? qso.FrequencyKhz * 1000
+#pragma warning restore CS0612
+                : null;
+            if (freqHz.HasValue)
+            {
+                Console.WriteLine($"Frequency:        {FormatFrequencyMhz(freqHz.Value)} MHz");
+            }
         }
 
         if (qso.RstSent is not null)
@@ -66,5 +73,17 @@ internal static class GetQsoCommand
         }
 
         return 0;
+    }
+
+    private static string FormatFrequencyMhz(ulong hz)
+    {
+        ulong whole = hz / 1_000_000;
+        ulong frac = hz % 1_000_000;
+        string full = $"{whole}.{frac:000000}";
+        int dotPos = full.IndexOf('.', StringComparison.Ordinal);
+        int minLen = dotPos + 4;
+        var trimmed = full.AsSpan().TrimEnd('0');
+        int end = Math.Max(trimmed.Length, minLen);
+        return full[..end];
     }
 }

--- a/src/dotnet/QsoRipper.Cli/Commands/ListQsosCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ListQsosCommand.cs
@@ -113,7 +113,12 @@ internal static class ListQsosCommand
             row += $" {FormatRst(qso.RstSent),-6} {FormatRst(qso.RstReceived),-6}";
         }
 
-        var freq = qso.HasFrequencyKhz ? $"{qso.FrequencyKhz / 1000.0:F3}" : "";
+        ulong? freqHz = qso.HasFrequencyHz ? qso.FrequencyHz
+#pragma warning disable CS0612
+            : qso.HasFrequencyKhz ? qso.FrequencyKhz * 1000
+#pragma warning restore CS0612
+            : null;
+        var freq = freqHz.HasValue ? FormatFrequencyMhz(freqHz.Value) : "";
         var grid = qso.HasWorkedGrid ? qso.WorkedGrid : "";
         row += $" {freq,-10} {grid,-8}";
 
@@ -271,6 +276,18 @@ internal static class ListQsosCommand
         }
 
         return $"{sanitized[..(CommentColumnWidth - 3)]}...";
+    }
+
+    private static string FormatFrequencyMhz(ulong hz)
+    {
+        ulong whole = hz / 1_000_000;
+        ulong frac = hz % 1_000_000;
+        string full = $"{whole}.{frac:000000}";
+        int dotPos = full.IndexOf('.', StringComparison.Ordinal);
+        int minLen = dotPos + 4;
+        var trimmed = full.AsSpan().TrimEnd('0');
+        int end = Math.Max(trimmed.Length, minLen);
+        return full[..end];
     }
 }
 

--- a/src/dotnet/QsoRipper.Cli/Commands/LogQsoCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/LogQsoCommand.cs
@@ -224,13 +224,20 @@ internal static class LogQsoCommand
                     return false;
                 case "--freq" when i < args.Length - 1:
                     var freqValue = args[++i];
-                    if (!ulong.TryParse(freqValue, out var freq))
+                    if (!double.TryParse(freqValue, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var freqMhz) || freqMhz <= 0)
                     {
-                        error = $"Invalid value for --freq: {freqValue}";
+                        error = $"Invalid value for --freq: {freqValue}. Use MHz such as 14.074.";
                         return false;
                     }
 
-                    qso.FrequencyKhz = freq;
+                    {
+                        var hz = (ulong)Math.Round(freqMhz * 1_000_000.0, MidpointRounding.AwayFromZero);
+                        qso.FrequencyHz = hz;
+#pragma warning disable CS0612
+                        qso.FrequencyKhz = (hz + 500) / 1000;
+#pragma warning restore CS0612
+                    }
+
                     break;
                 case "--freq":
                     error = "Missing value for --freq.";
@@ -446,9 +453,12 @@ internal static class LogQsoCommand
                 qso.Mode = snapshot.Mode;
             }
 
-            if (qso.FrequencyKhz == 0 && snapshot.FrequencyHz > 0)
+            if (!qso.HasFrequencyHz && snapshot.FrequencyHz > 0)
             {
+                qso.FrequencyHz = snapshot.FrequencyHz;
+#pragma warning disable CS0612
                 qso.FrequencyKhz = (snapshot.FrequencyHz + 500) / 1000;
+#pragma warning restore CS0612
             }
 
             if (!qso.HasSubmode && snapshot.HasSubmode)

--- a/src/dotnet/QsoRipper.Cli/Commands/UpdateQsoCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/UpdateQsoCommand.cs
@@ -94,13 +94,20 @@ internal static class UpdateQsoCommand
                     return false;
                 case "--freq" when i < args.Length - 1:
                     var freqValue = args[++i];
-                    if (!ulong.TryParse(freqValue, out var freq))
+                    if (!double.TryParse(freqValue, System.Globalization.NumberStyles.Float, System.Globalization.CultureInfo.InvariantCulture, out var freqMhz) || freqMhz <= 0)
                     {
-                        error = $"Invalid value for --freq: {freqValue}";
+                        error = $"Invalid value for --freq: {freqValue}. Use MHz such as 14.074.";
                         return false;
                     }
 
-                    qso.FrequencyKhz = freq;
+                    {
+                        var hz = (ulong)Math.Round(freqMhz * 1_000_000.0, MidpointRounding.AwayFromZero);
+                        qso.FrequencyHz = hz;
+#pragma warning disable CS0612
+                        qso.FrequencyKhz = (hz + 500) / 1000;
+#pragma warning restore CS0612
+                    }
+
                     break;
                 case "--freq":
                     error = "Missing value for --freq.";

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/QsoViewer.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/QsoViewer.razor
@@ -125,7 +125,7 @@
                                 <td>@FormatTimestamp(qso.UtcTimestamp)</td>
                                 <td>@FormatBand(qso.Band)</td>
                                 <td>@FormatMode(qso.Mode)</td>
-                                <td>@(qso.HasFrequencyKhz ? qso.FrequencyKhz.ToString("N0") : "—")</td>
+                                <td>@FormatFrequency(qso)</td>
                                 <td>@(qso.RstSent?.Raw ?? "—")</td>
                                 <td>@(qso.RstReceived?.Raw ?? "—")</td>
                                 <td>@qso.StationCallsign</td>
@@ -291,5 +291,23 @@
     private static string FormatMode(QsoRipper.Domain.Mode mode)
     {
         return ProtoEnumDisplay.ForMode(mode);
+    }
+
+    private static string FormatFrequency(QsoRipper.Domain.QsoRecord qso)
+    {
+        ulong? hz = qso.HasFrequencyHz ? qso.FrequencyHz
+#pragma warning disable CS0612
+            : qso.HasFrequencyKhz ? qso.FrequencyKhz * 1000
+#pragma warning restore CS0612
+            : null;
+        if (!hz.HasValue) return "—";
+        ulong whole = hz.Value / 1_000_000;
+        ulong frac = hz.Value % 1_000_000;
+        string full = $"{whole}.{frac:000000}";
+        int dotPos = full.IndexOf('.', StringComparison.Ordinal);
+        int minLen = dotPos + 4;
+        var trimmed = full.AsSpan().TrimEnd('0');
+        int end = Math.Max(trimmed.Length, minLen);
+        return full[..end];
     }
 }

--- a/src/dotnet/QsoRipper.DebugHost/Services/SampleProtoFactory.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Services/SampleProtoFactory.cs
@@ -111,7 +111,7 @@ internal sealed class SampleProtoFactory
         var utcNow = DateTime.SpecifyKind(DateTime.UtcNow, DateTimeKind.Utc);
         var normalizedCallsign = NormalizeCallsign(workedCallsign);
         var sampleRst = CreateSampleRst(options.Mode);
-        var frequencyKhz = GetSampleFrequencyKhz(options.Band);
+        var frequencyHz = GetSampleFrequencyHz(options.Band);
         var submode = GetSampleSubmode(options.Band, options.Mode);
         var record = new QsoRecord
         {
@@ -121,7 +121,7 @@ internal sealed class SampleProtoFactory
             UtcTimestamp = Timestamp.FromDateTime(utcNow),
             Band = options.Band,
             Mode = options.Mode,
-            FrequencyKhz = frequencyKhz,
+            FrequencyHz = frequencyHz,
             RstSent = sampleRst.Sent,
             RstReceived = sampleRst.Received,
             TxPower = "100",
@@ -662,7 +662,8 @@ internal sealed class SampleProtoFactory
     {
         return field.Name switch
         {
-            "frequency_khz" => checked((long)(GetSampleFrequencyKhz(context.Options.Band) + (ulong)SampleGenerationContext.NextInt(0, 25))),
+            "frequency_hz" => checked((long)(GetSampleFrequencyHz(context.Options.Band) + (ulong)SampleGenerationContext.NextInt(0, 25) * 1000)),
+            "frequency_khz" => checked((long)((GetSampleFrequencyHz(context.Options.Band) + 500) / 1000 + (ulong)SampleGenerationContext.NextInt(0, 25))),
             _ => CreateSampleInt32(field, context)
         };
     }
@@ -747,7 +748,7 @@ internal sealed class SampleProtoFactory
     private static QsoRecord CreateSampleQsoRecord(SampleGenerationContext context)
     {
         var sampleRst = CreateSampleRst(context.Options.Mode);
-        var frequencyKhz = GetSampleFrequencyKhz(context.Options.Band) + (ulong)SampleGenerationContext.NextInt(0, 25);
+        var frequencyHz = GetSampleFrequencyHz(context.Options.Band) + (ulong)SampleGenerationContext.NextInt(0, 25) * 1000;
         var submode = GetSampleSubmode(context.Options.Band, context.Options.Mode);
         var record = new QsoRecord
         {
@@ -757,7 +758,7 @@ internal sealed class SampleProtoFactory
             UtcTimestamp = Timestamp.FromDateTime(context.GeneratedAtUtc),
             Band = context.Options.Band,
             Mode = context.Options.Mode,
-            FrequencyKhz = frequencyKhz,
+            FrequencyHz = frequencyHz,
             RstSent = sampleRst.Sent,
             RstReceived = sampleRst.Received,
             TxPower = context.TxPower,
@@ -854,23 +855,23 @@ internal sealed class SampleProtoFactory
         };
     }
 
-    private static ulong GetSampleFrequencyKhz(Band band)
+    private static ulong GetSampleFrequencyHz(Band band)
     {
         return band switch
         {
-            Band._160M => 1900,
-            Band._80M => 3900,
-            Band._40M => 7100,
-            Band._30M => 10136,
-            Band._20M => 14250,
-            Band._17M => 18100,
-            Band._15M => 21250,
-            Band._12M => 24940,
-            Band._10M => 28400,
-            Band._6M => 50125,
-            Band._2M => 146520,
-            Band._70Cm => 446000,
-            _ => 14250
+            Band._160M => 1_900_000,
+            Band._80M => 3_900_000,
+            Band._40M => 7_100_000,
+            Band._30M => 10_136_000,
+            Band._20M => 14_250_000,
+            Band._17M => 18_100_000,
+            Band._15M => 21_250_000,
+            Band._12M => 24_940_000,
+            Band._10M => 28_400_000,
+            Band._6M => 50_125_000,
+            Band._2M => 146_520_000,
+            Band._70Cm => 446_000_000,
+            _ => 14_250_000
         };
     }
 

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -651,7 +651,7 @@ public sealed class ManagedEngineStateTests : IDisposable
         var stored = state.ListQsos(new ListQsosRequest()).Single();
 
         Assert.Equal(Band._40M, stored.BandRx);
-        Assert.Equal(7075ul, stored.FrequencyRxKhz);
+        Assert.Equal(7_075_000ul, stored.FrequencyRxHz);
         Assert.Equal(150.0, stored.WorkedAltitudeMeters);
         Assert.Equal("ab", stored.WorkedGridsquareExt);
         Assert.Equal("W1AW", stored.OwnerCallsign);
@@ -721,7 +721,7 @@ public sealed class ManagedEngineStateTests : IDisposable
                 RstSent = new RstReport { Raw = "59" },
                 RstReceived = new RstReport { Raw = "57" },
                 Notes = "Initial notes",
-                FrequencyKhz = 14074,
+                FrequencyHz = 14_074_000,
             }
         });
 
@@ -748,7 +748,7 @@ public sealed class ManagedEngineStateTests : IDisposable
         Assert.Equal("59", stored.RstSent?.Raw);
         Assert.Equal("57", stored.RstReceived?.Raw);
         Assert.Equal("Initial notes", stored.Notes);
-        Assert.Equal(14074UL, stored.FrequencyKhz);
+        Assert.Equal(14_074_000UL, stored.FrequencyHz);
     }
 
     [Fact]

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedAdifCodec.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedAdifCodec.cs
@@ -340,10 +340,12 @@ internal static class ManagedAdifCodec
                     qso.Submode = value;
                     break;
                 case "FREQ":
-                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var mhz)
-                        && TryConvertMhzToKhz(mhz, out var khz))
+                    if (TryConvertMhzToHz(value, out var hz))
                     {
-                        qso.FrequencyKhz = khz;
+                        qso.FrequencyHz = hz;
+#pragma warning disable CS0612 // Type or member is obsolete
+                        qso.FrequencyKhz = (hz + 500) / 1000;
+#pragma warning restore CS0612
                     }
                     else
                     {
@@ -352,10 +354,12 @@ internal static class ManagedAdifCodec
 
                     break;
                 case "FREQ_RX":
-                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var mhzRx)
-                        && TryConvertMhzToKhz(mhzRx, out var khzRx))
+                    if (TryConvertMhzToHz(value, out var hzRx))
                     {
-                        qso.FrequencyRxKhz = khzRx;
+                        qso.FrequencyRxHz = hzRx;
+#pragma warning disable CS0612 // Type or member is obsolete
+                        qso.FrequencyRxKhz = (hzRx + 500) / 1000;
+#pragma warning restore CS0612
                     }
                     else
                     {
@@ -749,14 +753,14 @@ internal static class ManagedAdifCodec
             fields.Add(new KeyValuePair<string, string>("SUBMODE", qso.Submode));
         }
 
-        if (qso.HasFrequencyKhz)
+        if (TryFormatHzAsMhz(qso, freq: true, out var freqStr))
         {
-            fields.Add(new KeyValuePair<string, string>("FREQ", $"{qso.FrequencyKhz / 1000}.{qso.FrequencyKhz % 1000:000}"));
+            fields.Add(new KeyValuePair<string, string>("FREQ", freqStr));
         }
 
-        if (qso.HasFrequencyRxKhz)
+        if (TryFormatHzAsMhz(qso, freq: false, out var freqRxStr))
         {
-            fields.Add(new KeyValuePair<string, string>("FREQ_RX", $"{qso.FrequencyRxKhz / 1000}.{qso.FrequencyRxKhz % 1000:000}"));
+            fields.Add(new KeyValuePair<string, string>("FREQ_RX", freqRxStr));
         }
 
         if (BandToAdif.TryGetValue(qso.BandRx, out var bandRxOut))
@@ -1273,22 +1277,126 @@ internal static class ManagedAdifCodec
         return true;
     }
 
-    private static bool TryConvertMhzToKhz(double mhz, out ulong khz)
+    /// <summary>
+    /// Parse an ADIF MHz string into Hz using string/decimal math for cross-engine
+    /// parity with the Rust implementation. Supports up to 6 decimal places.
+    /// </summary>
+    private static bool TryConvertMhzToHz(string mhzStr, out ulong hz)
     {
-        khz = 0;
-        if (!double.IsFinite(mhz) || mhz < 0)
+        hz = 0;
+        var trimmed = mhzStr.AsSpan().Trim();
+        if (trimmed.IsEmpty || trimmed[0] == '-')
         {
             return false;
         }
 
-        var rounded = Math.Round(mhz * 1000.0, MidpointRounding.AwayFromZero);
-        if (rounded < 0 || rounded > ulong.MaxValue)
+        int dotIndex = trimmed.IndexOf('.');
+        ReadOnlySpan<char> intPart;
+        ReadOnlySpan<char> fracPart;
+        if (dotIndex >= 0)
+        {
+            intPart = trimmed[..dotIndex];
+            fracPart = trimmed[(dotIndex + 1)..];
+        }
+        else
+        {
+            intPart = trimmed;
+            fracPart = [];
+        }
+
+        if (!ulong.TryParse(intPart, NumberStyles.None, CultureInfo.InvariantCulture, out var wholeMhz))
         {
             return false;
         }
 
-        khz = (ulong)rounded;
+        // Pad or truncate fractional part to exactly 6 digits (1 Hz resolution).
+        int fracLen = Math.Min(fracPart.Length, 6);
+        Span<char> fracBuf = stackalloc char[6];
+        fracPart[..fracLen].CopyTo(fracBuf);
+        for (int i = fracLen; i < 6; i++)
+        {
+            fracBuf[i] = '0';
+        }
+
+        if (!ulong.TryParse(fracBuf, NumberStyles.None, CultureInfo.InvariantCulture, out var fracHz))
+        {
+            return false;
+        }
+
+        // Round if more than 6 decimal places.
+        if (fracPart.Length > 6 && fracPart[6] >= '5')
+        {
+            fracHz++;
+        }
+
+        hz = wholeMhz * 1_000_000 + fracHz;
         return true;
+    }
+
+    /// <summary>
+    /// Format Hz as an ADIF-compliant MHz string with full precision.
+    /// Up to 6 decimal places, trailing zeros trimmed, minimum 3 places.
+    /// Prefers FrequencyHz; falls back to deprecated FrequencyKhz.
+    /// </summary>
+    private static bool TryFormatHzAsMhz(QsoRecord qso, bool freq, out string result)
+    {
+        result = string.Empty;
+        ulong hz;
+
+        if (freq)
+        {
+#pragma warning disable CS0612
+            if (qso.HasFrequencyHz)
+            {
+                hz = qso.FrequencyHz;
+            }
+            else if (qso.HasFrequencyKhz)
+            {
+                hz = qso.FrequencyKhz * 1000;
+            }
+            else
+            {
+                return false;
+            }
+#pragma warning restore CS0612
+        }
+        else
+        {
+#pragma warning disable CS0612
+            if (qso.HasFrequencyRxHz)
+            {
+                hz = qso.FrequencyRxHz;
+            }
+            else if (qso.HasFrequencyRxKhz)
+            {
+                hz = qso.FrequencyRxKhz * 1000;
+            }
+            else
+            {
+                return false;
+            }
+#pragma warning restore CS0612
+        }
+
+        result = FormatHzAsMhz(hz);
+        return true;
+    }
+
+    /// <summary>
+    /// Format a frequency in Hz as MHz with up to 6 decimal places,
+    /// trailing zeros trimmed, minimum 3 decimal places.
+    /// </summary>
+    internal static string FormatHzAsMhz(ulong hz)
+    {
+        ulong whole = hz / 1_000_000;
+        ulong frac = hz % 1_000_000;
+        string full = $"{whole}.{frac:000000}";
+        // Trim trailing zeros but keep at least 3 decimal places.
+        int dotPos = full.IndexOf('.', StringComparison.Ordinal);
+        int minLen = dotPos + 1 + 3;
+        var trimmed = full.AsSpan().TrimEnd('0');
+        int end = Math.Max(trimmed.Length, minLen);
+        return full[..end];
     }
 
     private static void EnrichFromDxcc(QsoRecord qso)
@@ -1344,7 +1452,10 @@ internal static class ManagedAdifCodec
             : key.Equals("QSLSDATE", StringComparison.OrdinalIgnoreCase) ? qso.QslSentDate is not null && TryFormatAdifDate(qso.QslSentDate, out _)
             : key.Equals("QSLRDATE", StringComparison.OrdinalIgnoreCase) ? qso.QslReceivedDate is not null && TryFormatAdifDate(qso.QslReceivedDate, out _)
             : key.Equals("BAND_RX", StringComparison.OrdinalIgnoreCase) ? qso.BandRx != Band.Unspecified
-            : key.Equals("FREQ_RX", StringComparison.OrdinalIgnoreCase) ? qso.HasFrequencyRxKhz
+            : key.Equals("FREQ_RX", StringComparison.OrdinalIgnoreCase) ? qso.HasFrequencyRxHz
+#pragma warning disable CS0612
+                || qso.HasFrequencyRxKhz
+#pragma warning restore CS0612
             : key.Equals("LAT", StringComparison.OrdinalIgnoreCase) ? qso.HasWorkedLatitude
             : key.Equals("LON", StringComparison.OrdinalIgnoreCase) ? qso.HasWorkedLongitude
             : key.Equals("ALTITUDE", StringComparison.OrdinalIgnoreCase) ? qso.HasWorkedAltitudeMeters

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedQsoParity.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedQsoParity.cs
@@ -273,7 +273,7 @@ internal static class ManagedQsoParity
             && StringsEqualIgnoreAsciiCase(existing.StationCallsign, candidate.StationCallsign)
             && StringsEqualIgnoreAsciiCase(existing.WorkedCallsign, candidate.WorkedCallsign)
             && OptionalStringsCompatible(existing.HasSubmode ? existing.Submode : null, candidate.HasSubmode ? candidate.Submode : null)
-            && OptionalUInt64Compatible(existing.HasFrequencyKhz ? existing.FrequencyKhz : null, candidate.HasFrequencyKhz ? candidate.FrequencyKhz : null);
+            && FrequenciesCompatible(existing, candidate);
     }
 
     /// <summary>
@@ -316,7 +316,10 @@ internal static class ManagedQsoParity
             merged.Mode = incoming.Mode;
         }
 
+#pragma warning disable CS0612
         MergeOptionalUInt64(incoming.HasFrequencyKhz, incoming.FrequencyKhz, value => merged.FrequencyKhz = value);
+#pragma warning restore CS0612
+        MergeOptionalUInt64(incoming.HasFrequencyHz, incoming.FrequencyHz, value => merged.FrequencyHz = value);
         MergeOptionalString(incoming.HasSubmode ? incoming.Submode : null, value => merged.Submode = value);
         if (incoming.UtcEndTimestamp is not null)
         {
@@ -431,7 +434,10 @@ internal static class ManagedQsoParity
         merged.Band = import.Band;
         merged.Mode = import.Mode;
 
+#pragma warning disable CS0612
         MergeOptionalUInt64(import.HasFrequencyKhz, import.FrequencyKhz, value => merged.FrequencyKhz = value);
+#pragma warning restore CS0612
+        MergeOptionalUInt64(import.HasFrequencyHz, import.FrequencyHz, value => merged.FrequencyHz = value);
         MergeOptionalString(import.HasSubmode ? import.Submode : null, value => merged.Submode = value);
         if (import.UtcEndTimestamp is not null)
         {
@@ -614,6 +620,24 @@ internal static class ManagedQsoParity
     private static bool OptionalUInt64Compatible(ulong? left, ulong? right)
     {
         return left is null || right is null || left.Value == right.Value;
+    }
+
+    /// <summary>
+    /// Compare frequencies for duplicate matching. When both sides have Hz fields,
+    /// compare exactly. When one or both lack Hz, fall back to kHz compatibility.
+    /// </summary>
+    private static bool FrequenciesCompatible(QsoRecord existing, QsoRecord candidate)
+    {
+        if (existing.HasFrequencyHz && candidate.HasFrequencyHz)
+        {
+            return existing.FrequencyHz == candidate.FrequencyHz;
+        }
+
+#pragma warning disable CS0612
+        return OptionalUInt64Compatible(
+            existing.HasFrequencyKhz ? existing.FrequencyKhz : null,
+            candidate.HasFrequencyKhz ? candidate.FrequencyKhz : null);
+#pragma warning restore CS0612
     }
 
     private static string NormalizeOptionalString(string? value)

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/AdifCodecTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/AdifCodecTests.cs
@@ -78,7 +78,7 @@ public sealed class AdifCodecTests
         var qsos = AdifCodec.ParseAdif(adif);
 
         Assert.Single(qsos);
-        Assert.Equal(14074UL, qsos[0].FrequencyKhz);
+        Assert.Equal(14_074_000UL, qsos[0].FrequencyHz);
     }
 
     [Fact]
@@ -226,7 +226,7 @@ public sealed class AdifCodecTests
             Band = Band._40M,
             Mode = Mode.Cw,
             UtcTimestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2024, 3, 10, 14, 0, 0, TimeSpan.Zero)),
-            FrequencyKhz = 7030,
+            FrequencyHz = 7_030_000,
             RstSent = new RstReport { Readability = 5, Strength = 9, Tone = 9, Raw = "599" },
             Notes = "Test note",
         };
@@ -240,7 +240,7 @@ public sealed class AdifCodecTests
         Assert.Equal("K7RND", q.StationCallsign);
         Assert.Equal(Band._40M, q.Band);
         Assert.Equal(Mode.Cw, q.Mode);
-        Assert.Equal(7030UL, q.FrequencyKhz);
+        Assert.Equal(7_030_000UL, q.FrequencyHz);
         Assert.Equal("599", q.RstSent!.Raw);
         Assert.Equal("Test note", q.Notes);
     }

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/AdifCodec.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/AdifCodec.cs
@@ -290,10 +290,12 @@ internal static class AdifCodec
                     qso.Submode = value;
                     break;
                 case "FREQ":
-                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var mhz)
-                        && TryConvertMhzToKhz(mhz, out var khz))
+                    if (TryConvertMhzToHz(value, out var hz))
                     {
-                        qso.FrequencyKhz = khz;
+                        qso.FrequencyHz = hz;
+#pragma warning disable CS0612
+                        qso.FrequencyKhz = (hz + 500) / 1000;
+#pragma warning restore CS0612
                     }
                     else
                     {
@@ -302,10 +304,12 @@ internal static class AdifCodec
 
                     break;
                 case "FREQ_RX":
-                    if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var mhzRx)
-                        && TryConvertMhzToKhz(mhzRx, out var khzRx))
+                    if (TryConvertMhzToHz(value, out var hzRx))
                     {
-                        qso.FrequencyRxKhz = khzRx;
+                        qso.FrequencyRxHz = hzRx;
+#pragma warning disable CS0612
+                        qso.FrequencyRxKhz = (hzRx + 500) / 1000;
+#pragma warning restore CS0612
                     }
                     else
                     {
@@ -575,14 +579,22 @@ internal static class AdifCodec
             AppendField(sb, "SUBMODE", qso.Submode);
         }
 
-        if (qso.HasFrequencyKhz)
+        if (qso.HasFrequencyHz
+#pragma warning disable CS0612
+            || qso.HasFrequencyKhz)
         {
-            AppendField(sb, "FREQ", $"{qso.FrequencyKhz / 1000}.{qso.FrequencyKhz % 1000:000}");
+            ulong freqHz = qso.HasFrequencyHz ? qso.FrequencyHz : qso.FrequencyKhz * 1000;
+#pragma warning restore CS0612
+            AppendField(sb, "FREQ", FormatHzAsMhz(freqHz));
         }
 
-        if (qso.HasFrequencyRxKhz)
+        if (qso.HasFrequencyRxHz
+#pragma warning disable CS0612
+            || qso.HasFrequencyRxKhz)
         {
-            AppendField(sb, "FREQ_RX", $"{qso.FrequencyRxKhz / 1000}.{qso.FrequencyRxKhz % 1000:000}");
+            ulong freqRxHz = qso.HasFrequencyRxHz ? qso.FrequencyRxHz : qso.FrequencyRxKhz * 1000;
+#pragma warning restore CS0612
+            AppendField(sb, "FREQ_RX", FormatHzAsMhz(freqRxHz));
         }
 
         if (qso.RstSent is not null)
@@ -840,16 +852,73 @@ internal static class AdifCodec
         }
     }
 
-    private static bool TryConvertMhzToKhz(double mhz, out ulong khz)
+    /// <summary>
+    /// Parse an ADIF MHz string into Hz using string/decimal math.
+    /// Mirror of <c>ManagedAdifCodec.TryConvertMhzToHz</c> for cross-engine parity.
+    /// </summary>
+    private static bool TryConvertMhzToHz(string mhzStr, out ulong hz)
     {
-        khz = 0;
-        if (mhz <= 0)
+        hz = 0;
+        var trimmed = mhzStr.AsSpan().Trim();
+        if (trimmed.IsEmpty || trimmed[0] == '-')
         {
             return false;
         }
 
-        khz = (ulong)Math.Round(mhz * 1000, MidpointRounding.AwayFromZero);
+        int dotIndex = trimmed.IndexOf('.');
+        ReadOnlySpan<char> intPart;
+        ReadOnlySpan<char> fracPart;
+        if (dotIndex >= 0)
+        {
+            intPart = trimmed[..dotIndex];
+            fracPart = trimmed[(dotIndex + 1)..];
+        }
+        else
+        {
+            intPart = trimmed;
+            fracPart = [];
+        }
+
+        if (!ulong.TryParse(intPart, NumberStyles.None, CultureInfo.InvariantCulture, out var wholeMhz))
+        {
+            return false;
+        }
+
+        int fracLen = Math.Min(fracPart.Length, 6);
+        Span<char> fracBuf = stackalloc char[6];
+        fracPart[..fracLen].CopyTo(fracBuf);
+        for (int i = fracLen; i < 6; i++)
+        {
+            fracBuf[i] = '0';
+        }
+
+        if (!ulong.TryParse(fracBuf, NumberStyles.None, CultureInfo.InvariantCulture, out var fracHz))
+        {
+            return false;
+        }
+
+        if (fracPart.Length > 6 && fracPart[6] >= '5')
+        {
+            fracHz++;
+        }
+
+        hz = wholeMhz * 1_000_000 + fracHz;
         return true;
+    }
+
+    /// <summary>
+    /// Format Hz as MHz with up to 6 decimal places, trailing zeros trimmed, minimum 3.
+    /// </summary>
+    private static string FormatHzAsMhz(ulong hz)
+    {
+        ulong whole = hz / 1_000_000;
+        ulong frac = hz % 1_000_000;
+        string full = $"{whole}.{frac:000000}";
+        int dotPos = full.IndexOf('.', StringComparison.Ordinal);
+        int minLen = dotPos + 1 + 3;
+        var trimmedSpan = full.AsSpan().TrimEnd('0');
+        int end = Math.Max(trimmedSpan.Length, minLen);
+        return full[..end];
     }
 
     private static RstReport ParseRstReport(string raw)

--- a/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
@@ -105,7 +105,7 @@ public sealed class MainWindowViewModelTests
             UtcTimestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2026, 4, 13, 22, 15, 0, TimeSpan.Zero)),
             Band = Band._20M,
             Mode = Mode.Cw,
-            FrequencyKhz = 14025,
+            FrequencyHz = 14_025_000,
             WorkedGrid = "CN87",
             Comment = "Loaded",
             Notes = string.Empty,

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoItemViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoItemViewModelTests.cs
@@ -38,19 +38,19 @@ public sealed class RecentQsoItemViewModelTests
             UtcEndTimestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2026, 4, 13, 22, 25, 0, TimeSpan.Zero)),
             Band = Band._20M,
             Mode = Mode.Cw,
-            FrequencyKhz = 14025,
+            FrequencyHz = 14_025_000,
             WorkedDxcc = 291,
             RstSent = new RstReport { Raw = "59" },
             RstReceived = new RstReport { Raw = "57" },
         });
 
         item.UtcDisplay = "2026-04-14T01:02:03Z";
-        item.Frequency = "14250";
+        item.Frequency = "14.250";
         item.Dxcc = "110";
         item.UtcEndDisplay = "2026-04-14T01:12:03Z";
 
         Assert.Equal(new DateTimeOffset(2026, 4, 14, 1, 2, 3, TimeSpan.Zero), item.UtcSortKey);
-        Assert.Equal((ulong)14250, item.FrequencySortKey);
+        Assert.Equal((ulong)14_250_000, item.FrequencySortKey);
         Assert.Equal((uint)110, item.DxccSortKey);
         Assert.Equal(new DateTimeOffset(2026, 4, 14, 1, 12, 3, TimeSpan.Zero), item.UtcEndSortKey);
     }

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
@@ -21,7 +21,7 @@ public class RecentQsoListViewModelTests
                     "W1AW",
                     Band._40M,
                     Mode.Cw,
-                    7025,
+                    7_025_000,
                     "CN87",
                     "First recent QSO",
                     operatorName: "Alice",
@@ -36,7 +36,7 @@ public class RecentQsoListViewModelTests
                     "K7RND",
                     Band._20M,
                     Mode.Ft8,
-                    14074,
+                    14_074_000,
                     "CN88",
                     "Second recent QSO",
                     operatorName: "Bob",
@@ -85,7 +85,7 @@ public class RecentQsoListViewModelTests
                     "W1AW",
                     Band._20M,
                     Mode.Ft8,
-                    14074,
+                    14_074_000,
                     "CN87",
                     "CQ test",
                     operatorName: "Alice",
@@ -98,7 +98,7 @@ public class RecentQsoListViewModelTests
                     "VE7ABC",
                     Band._40M,
                     Mode.Ssb,
-                    7185,
+                    7_185_000,
                     "CN88",
                     "Morning ragchew",
                     operatorName: "Bob",
@@ -123,7 +123,7 @@ public class RecentQsoListViewModelTests
     [Fact]
     public async Task SaveEditsAsyncUpdatesDirtyRowsAndClearsPendingEdits()
     {
-        var original = CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States");
+        var original = CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14_025_000, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States");
         var updated = original.Clone();
         updated.Notes = "Updated note";
 
@@ -159,7 +159,7 @@ public class RecentQsoListViewModelTests
         {
             RecentQsos =
             [
-                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States")
+                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14_025_000, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States")
             ]
         };
 
@@ -185,7 +185,7 @@ public class RecentQsoListViewModelTests
         {
             RecentQsos =
             [
-                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States")
+                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14_025_000, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States")
             ]
         };
 
@@ -209,7 +209,7 @@ public class RecentQsoListViewModelTests
                 "W1AW",
                 Band._40M,
                 Mode.Cw,
-                7025,
+                7_025_000,
                 "CN87",
                 "Evening CW",
                 operatorName: "Alice",
@@ -229,8 +229,8 @@ public class RecentQsoListViewModelTests
         {
             RecentQsos =
             [
-                CreateQso("qso-2", "VE7ABC", Band._40M, Mode.Ssb, 7185, "CN88", "Second", operatorName: "Bob", state: "BC", country: "Canada"),
-                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "First", operatorName: "Alice", state: "WA", country: "United States")
+                CreateQso("qso-2", "VE7ABC", Band._40M, Mode.Ssb, 7_185_000, "CN88", "Second", operatorName: "Bob", state: "BC", country: "Canada"),
+                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14_025_000, "CN87", "First", operatorName: "Alice", state: "WA", country: "United States")
             ]
         };
 
@@ -253,8 +253,8 @@ public class RecentQsoListViewModelTests
         {
             RecentQsos =
             [
-                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "First", operatorName: "Alice", state: "WA", country: "United States"),
-                CreateQso("qso-2", "K7RND", Band._40M, Mode.Ssb, 7185, "CN88", "Second", operatorName: "Bob", state: "BC", country: "Canada")
+                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14_025_000, "CN87", "First", operatorName: "Alice", state: "WA", country: "United States"),
+                CreateQso("qso-2", "K7RND", Band._40M, Mode.Ssb, 7_185_000, "CN88", "Second", operatorName: "Bob", state: "BC", country: "Canada")
             ]
         };
 
@@ -275,10 +275,10 @@ public class RecentQsoListViewModelTests
         {
             RecentQsos =
             [
-                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "First", syncStatus: SyncStatus.LocalOnly),
-                CreateQso("qso-2", "K7RND", Band._40M, Mode.Ssb, 7185, "CN88", "Second", syncStatus: SyncStatus.Modified),
-                CreateQso("qso-3", "VE7ABC", Band._15M, Mode.Ft8, 21074, "CN89", "Third", syncStatus: SyncStatus.Conflict),
-                CreateQso("qso-4", "N0CALL", Band._10M, Mode.Ssb, 28450, "EN34", "Fourth", syncStatus: SyncStatus.Synced),
+                CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14_025_000, "CN87", "First", syncStatus: SyncStatus.LocalOnly),
+                CreateQso("qso-2", "K7RND", Band._40M, Mode.Ssb, 7_185_000, "CN88", "Second", syncStatus: SyncStatus.Modified),
+                CreateQso("qso-3", "VE7ABC", Band._15M, Mode.Ft8, 21_074_000, "CN89", "Third", syncStatus: SyncStatus.Conflict),
+                CreateQso("qso-4", "N0CALL", Band._10M, Mode.Ssb, 28_450_000, "EN34", "Fourth", syncStatus: SyncStatus.Synced),
             ]
         };
 
@@ -293,7 +293,7 @@ public class RecentQsoListViewModelTests
     public void CancelEditRestoresSnapshotAndClearsDirtyState()
     {
         var item = RecentQsoItemViewModel.FromQso(
-            CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14025, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States"));
+            CreateQso("qso-1", "W1AW", Band._20M, Mode.Cw, 14_025_000, "CN87", "Loaded", operatorName: "Alice", state: "WA", country: "United States"));
 
         item.BeginEdit();
         item.WorkedCallsign = "VE7ABC";
@@ -342,7 +342,7 @@ public class RecentQsoListViewModelTests
         string workedCallsign,
         Band band,
         Mode mode,
-        ulong frequencyKhz,
+        ulong frequencyHz,
         string grid,
         string comment,
         string? operatorName = null,
@@ -363,7 +363,7 @@ public class RecentQsoListViewModelTests
             UtcTimestamp = Timestamp.FromDateTimeOffset(utcTimestamp ?? new DateTimeOffset(2026, 4, 13, 22, 15, 0, TimeSpan.Zero)),
             Band = band,
             Mode = mode,
-            FrequencyKhz = frequencyKhz,
+            FrequencyHz = frequencyHz,
             WorkedGrid = grid,
             Comment = comment,
             Notes = notes ?? string.Empty,

--- a/src/dotnet/QsoRipper.Gui/Inspection/UxCaptureFixture.cs
+++ b/src/dotnet/QsoRipper.Gui/Inspection/UxCaptureFixture.cs
@@ -219,7 +219,7 @@ internal sealed record UxCaptureFixture
             UtcTimestamp = new DateTimeOffset(2026, 4, 13, 22, 16, 0, TimeSpan.Zero),
             Band = "40M",
             Mode = "CW",
-            FrequencyKhz = 7025,
+            FrequencyHz = 7_025_000,
             WorkedGrid = "FN31",
             Comment = "Evening CW run with strong signal reports and a narrow note field.",
             WorkedOperatorName = "ARRL HQ",
@@ -239,7 +239,7 @@ internal sealed record UxCaptureFixture
             UtcTimestamp = new DateTimeOffset(2026, 4, 13, 22, 15, 0, TimeSpan.Zero),
             Band = "20M",
             Mode = "FT8",
-            FrequencyKhz = 14074,
+            FrequencyHz = 14_074_000,
             WorkedGrid = "CN87",
             Comment = "Portable park activation exchange with a longer operator note to exercise truncation.",
             WorkedOperatorName = "Randy",
@@ -259,7 +259,7 @@ internal sealed record UxCaptureFixture
             UtcTimestamp = new DateTimeOffset(2026, 4, 13, 22, 12, 0, TimeSpan.Zero),
             Band = "15M",
             Mode = "SSB",
-            FrequencyKhz = 21295,
+            FrequencyHz = 21_295_000,
             WorkedGrid = "CN89",
             Comment = "Late-afternoon SSB contact with a country column long enough to ellipsize cleanly.",
             WorkedOperatorName = "Jordan",
@@ -279,7 +279,7 @@ internal sealed record UxCaptureFixture
             UtcTimestamp = new DateTimeOffset(2026, 4, 13, 22, 8, 0, TimeSpan.Zero),
             Band = "10M",
             Mode = "SSB",
-            FrequencyKhz = 28485,
+            FrequencyHz = 28_485_000,
             WorkedGrid = "JO62",
             Comment = "DX opening note for visual density capture.",
             WorkedOperatorName = "Marta",
@@ -319,7 +319,7 @@ internal sealed record UxCaptureFixture
             UtcTimestamp = Timestamp.FromDateTimeOffset(item.UtcTimestamp),
             Band = band,
             Mode = mode,
-            FrequencyKhz = item.FrequencyKhz,
+            FrequencyHz = item.FrequencyHz,
             WorkedGrid = item.WorkedGrid ?? string.Empty,
             Comment = item.Comment ?? string.Empty,
             Notes = item.Notes ?? string.Empty,
@@ -350,7 +350,7 @@ internal sealed record UxCaptureQsoFixtureItem
 
     public string Mode { get; init; } = "FT8";
 
-    public ulong FrequencyKhz { get; init; } = 14074;
+    public ulong FrequencyHz { get; init; } = 14_074_000;
 
     public string? WorkedGrid { get; init; }
 

--- a/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
@@ -496,8 +496,10 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject, IDisposab
         SelectedBand = ProtoEnumDisplay.ForBand(qso.Band);
         SelectedMode = ProtoEnumDisplay.ForMode(qso.Mode);
         Submode = qso.Submode ?? string.Empty;
-        FrequencyMhz = qso.HasFrequencyKhz
-            ? (qso.FrequencyKhz / 1000.0).ToString("0.###", CultureInfo.InvariantCulture)
+        FrequencyMhz = qso.HasFrequencyHz ? FormatFrequencyMhz(qso.FrequencyHz)
+#pragma warning disable CS0612
+            : qso.HasFrequencyKhz ? FormatFrequencyMhz(qso.FrequencyKhz * 1000)
+#pragma warning restore CS0612
             : string.Empty;
         RstSent = FormatRst(qso.RstSent);
         RstReceived = FormatRst(qso.RstReceived);
@@ -815,8 +817,20 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject, IDisposab
                 out error)
             || !TryApplyFrequency(
                 FrequencyMhz,
-                value => working.FrequencyKhz = value,
-                working.ClearFrequencyKhz,
+                hz =>
+                {
+                    working.FrequencyHz = hz;
+#pragma warning disable CS0612
+                    working.FrequencyKhz = (hz + 500) / 1000;
+#pragma warning restore CS0612
+                },
+                () =>
+                {
+                    working.ClearFrequencyHz();
+#pragma warning disable CS0612
+                    working.ClearFrequencyKhz();
+#pragma warning restore CS0612
+                },
                 out error)
             || !TryApplyOptionalRst(
                 RstSent,
@@ -1016,12 +1030,24 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject, IDisposab
 
         if (double.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out var mhz) && mhz > 0)
         {
-            setter((ulong)Math.Round(mhz * 1000.0, MidpointRounding.AwayFromZero));
+            setter((ulong)Math.Round(mhz * 1_000_000.0, MidpointRounding.AwayFromZero));
             return true;
         }
 
         error = $"Invalid frequency: {value}. Use MHz such as 14.074.";
         return false;
+    }
+
+    private static string FormatFrequencyMhz(ulong hz)
+    {
+        ulong whole = hz / 1_000_000;
+        ulong frac = hz % 1_000_000;
+        string full = $"{whole}.{frac:000000}";
+        int dotPos = full.IndexOf('.', StringComparison.Ordinal);
+        int minLen = dotPos + 4; // dot + 3 digits minimum
+        var trimmed = full.AsSpan().TrimEnd('0');
+        int end = Math.Max(trimmed.Length, minLen);
+        return full[..end];
     }
 
     private static bool TryApplyOptionalRst(

--- a/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
@@ -255,7 +255,11 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
         if (double.TryParse(FrequencyMhz, NumberStyles.Float, CultureInfo.InvariantCulture, out var freqMhz)
             && freqMhz > 0)
         {
-            qso.FrequencyKhz = (ulong)(freqMhz * 1000.0);
+            var hz = (ulong)Math.Round(freqMhz * 1_000_000.0, MidpointRounding.AwayFromZero);
+            qso.FrequencyHz = hz;
+#pragma warning disable CS0612
+            qso.FrequencyKhz = (hz + 500) / 1000;
+#pragma warning restore CS0612
         }
 
         if (!string.IsNullOrWhiteSpace(Comment))

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
@@ -612,15 +612,21 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
     {
         error = null;
 
-        if (TryParseFrequency(Frequency, out var frequency))
+        if (TryParseFrequencyHz(Frequency, out var hz))
         {
-            updated.FrequencyKhz = frequency;
+            updated.FrequencyHz = hz;
+#pragma warning disable CS0612
+            updated.FrequencyKhz = (hz + 500) / 1000;
+#pragma warning restore CS0612
             return true;
         }
 
         if (string.IsNullOrWhiteSpace(Frequency) || Frequency == "-")
         {
+            updated.ClearFrequencyHz();
+#pragma warning disable CS0612
             updated.ClearFrequencyKhz();
+#pragma warning restore CS0612
             return true;
         }
 
@@ -767,7 +773,7 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         DisplayOrDash(qso.WorkedCallsign),
         ProtoEnumDisplay.ForBand(qso.Band),
         ProtoEnumDisplay.ForMode(qso.Mode),
-        qso.HasFrequencyKhz ? qso.FrequencyKhz.ToString(CultureInfo.InvariantCulture) : "-",
+        FormatFrequencyMhzOrDash(qso),
         BuildCombinedReport(FormatRst(qso.RstSent), FormatRst(qso.RstReceived)),
         BuildDxcc(qso),
         BuildCountry(qso),
@@ -802,8 +808,8 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
 
     private static ulong ParseFrequencySortKey(string? value)
     {
-        return TryParseFrequency(value, out var frequency)
-            ? frequency
+        return TryParseFrequencyHz(value, out var hz)
+            ? hz
             : 0;
     }
 
@@ -978,20 +984,44 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
                    out timestamp);
     }
 
-    private static bool TryParseFrequency(string? value, out ulong frequency)
+    private static bool TryParseFrequencyHz(string? value, out ulong hz)
     {
-        frequency = 0;
+        hz = 0;
         var normalized = NoteOrNull(value);
         if (normalized is null || normalized == "-")
         {
             return false;
         }
 
-        return ulong.TryParse(
-            normalized.Replace(",", string.Empty, StringComparison.Ordinal),
-            NumberStyles.None,
-            CultureInfo.InvariantCulture,
-            out frequency);
+        if (double.TryParse(normalized, NumberStyles.Float, CultureInfo.InvariantCulture, out var mhz) && mhz > 0)
+        {
+            hz = (ulong)Math.Round(mhz * 1_000_000.0, MidpointRounding.AwayFromZero);
+            return true;
+        }
+
+        return false;
+    }
+
+    private static string FormatFrequencyMhzOrDash(QsoRecord qso)
+    {
+        ulong? hz = qso.HasFrequencyHz ? qso.FrequencyHz
+#pragma warning disable CS0612
+            : qso.HasFrequencyKhz ? qso.FrequencyKhz * 1000
+#pragma warning restore CS0612
+            : null;
+        return hz.HasValue ? FormatFrequencyMhz(hz.Value) : "-";
+    }
+
+    private static string FormatFrequencyMhz(ulong hz)
+    {
+        ulong whole = hz / 1_000_000;
+        ulong frac = hz % 1_000_000;
+        string full = $"{whole}.{frac:000000}";
+        int dotPos = full.IndexOf('.', StringComparison.Ordinal);
+        int minLen = dotPos + 4; // dot + 3 digits minimum
+        var trimmed = full.AsSpan().TrimEnd('0');
+        int end = Math.Max(trimmed.Length, minLen);
+        return full[..end];
     }
 
     private static bool TryParseOptionalUInt(string? value, out uint parsed)

--- a/src/rust/qsoripper-core/src/adif/mapper.rs
+++ b/src/rust/qsoripper-core/src/adif/mapper.rs
@@ -103,22 +103,22 @@ impl AdifMapper {
                 }
                 "SUBMODE" => qso.submode = Some(value_str.to_owned()),
                 "FREQ" => {
-                    if let Ok(mhz) = value_str.parse::<f64>() {
-                        if let Some(khz) = mhz_to_khz(mhz) {
-                            qso.frequency_khz = Some(khz);
-                        } else {
-                            qso.extra_fields.insert(key_upper, value_str.to_owned());
+                    if let Some(hz) = mhz_str_to_hz(value_str) {
+                        qso.frequency_hz = Some(hz);
+                        #[allow(deprecated)]
+                        {
+                            qso.frequency_khz = Some((hz + 500) / 1000);
                         }
                     } else {
                         qso.extra_fields.insert(key_upper, value_str.to_owned());
                     }
                 }
                 "FREQ_RX" => {
-                    if let Ok(mhz) = value_str.parse::<f64>() {
-                        if let Some(khz) = mhz_to_khz(mhz) {
-                            qso.frequency_rx_khz = Some(khz);
-                        } else {
-                            qso.extra_fields.insert(key_upper, value_str.to_owned());
+                    if let Some(hz) = mhz_str_to_hz(value_str) {
+                        qso.frequency_rx_hz = Some(hz);
+                        #[allow(deprecated)]
+                        {
+                            qso.frequency_rx_khz = Some((hz + 500) / 1000);
                         }
                     } else {
                         qso.extra_fields.insert(key_upper, value_str.to_owned());
@@ -490,24 +490,15 @@ impl AdifMapper {
             push_field(&mut fields, "SUBMODE", sub.as_str());
         }
 
-        // Frequency
-        if let Some(khz) = qso.frequency_khz {
-            let whole_mhz = khz / 1000;
-            let fractional_khz = khz % 1000;
-            push_field(
-                &mut fields,
-                "FREQ",
-                format!("{whole_mhz}.{fractional_khz:03}"),
-            );
-        }
-        if let Some(khz) = qso.frequency_rx_khz {
-            let whole_mhz = khz / 1000;
-            let fractional_khz = khz % 1000;
-            push_field(
-                &mut fields,
-                "FREQ_RX",
-                format!("{whole_mhz}.{fractional_khz:03}"),
-            );
+        // Frequency — prefer Hz field, fall back to deprecated kHz.
+        #[allow(deprecated)]
+        {
+            if let Some(freq_str) = hz_to_mhz_str(qso.frequency_hz, qso.frequency_khz) {
+                push_field(&mut fields, "FREQ", freq_str);
+            }
+            if let Some(freq_str) = hz_to_mhz_str(qso.frequency_rx_hz, qso.frequency_rx_khz) {
+                push_field(&mut fields, "FREQ_RX", freq_str);
+            }
         }
         let band_rx = Band::try_from(qso.band_rx).unwrap_or(Band::Unspecified);
         if let Some(band_str) = crate::domain::band::band_to_adif(band_rx) {
@@ -910,17 +901,74 @@ fn format_adif_altitude(meters: f64) -> String {
     }
 }
 
-fn mhz_to_khz(mhz: f64) -> Option<u64> {
-    if !mhz.is_finite() || mhz.is_sign_negative() {
+/// Parse an ADIF MHz string into Hz using string/decimal math to avoid float
+/// precision drift. Supports up to 6 decimal places (1 Hz resolution).
+///
+/// Examples: `"28.07573"` = `28_075_730`, `"14.074"` = `14_074_000`, `"7.0385"` = `7_038_500`
+fn mhz_str_to_hz(s: &str) -> Option<u64> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() || trimmed.starts_with('-') {
         return None;
     }
 
-    let rounded = (mhz * 1000.0).round();
-    if rounded < 0.0 {
-        return None;
+    let (integer_part, fractional_part) = match trimmed.split_once('.') {
+        Some((int_s, frac_s)) => (int_s, frac_s),
+        None => (trimmed, ""),
+    };
+
+    let whole_mhz: u64 = integer_part.parse().ok()?;
+
+    // Pad or truncate fractional part to exactly 6 digits (1 Hz resolution).
+    let frac_len = fractional_part.len().min(6);
+    let frac_digits = &fractional_part[..frac_len];
+    let mut frac_hz: u64 = frac_digits.parse().ok()?;
+    // Scale up to 6 digits: e.g., "07573" (5 digits) → 75730
+    for _ in 0..(6 - frac_len) {
+        frac_hz *= 10;
     }
 
-    format!("{rounded:.0}").parse().ok()
+    // Handle rounding if there are more than 6 decimal places.
+    if fractional_part.len() > 6 {
+        let next_digit = fractional_part.as_bytes().get(6).and_then(|&b| {
+            if b.is_ascii_digit() {
+                Some(b - b'0')
+            } else {
+                None
+            }
+        });
+        if let Some(d) = next_digit {
+            if d >= 5 {
+                frac_hz += 1;
+            }
+        }
+    }
+
+    Some(whole_mhz * 1_000_000 + frac_hz)
+}
+
+/// Format Hz as an ADIF MHz string with full precision.
+/// Uses up to 6 decimal places, trims trailing zeros, keeps minimum 3 places.
+///
+/// Prefers `frequency_hz` when present; falls back to deprecated `frequency_khz * 1000`.
+#[allow(deprecated)]
+fn hz_to_mhz_str(hz: Option<u64>, khz_fallback: Option<u64>) -> Option<String> {
+    let hz = hz.or_else(|| khz_fallback.map(|k| k * 1000))?;
+    Some(format_hz_as_mhz(hz))
+}
+
+/// Format a frequency in Hz as an ADIF-compliant MHz string.
+/// Up to 6 decimal places, trailing zeros trimmed, minimum 3 decimal places.
+fn format_hz_as_mhz(hz: u64) -> String {
+    let whole = hz / 1_000_000;
+    let frac = hz % 1_000_000;
+    let full = format!("{whole}.{frac:06}");
+    // Trim trailing zeros but keep at least 3 decimal places.
+    // The format always contains a '.', so indexing is safe.
+    let dot_pos = whole.to_string().len(); // position of '.' in the formatted string
+    let min_len = dot_pos + 1 + 3; // "X." + 3 digits
+    let trimmed = full.trim_end_matches('0');
+    let end = trimmed.len().max(min_len);
+    full[..end].to_owned()
 }
 
 fn parse_confirmation_bool(value: &str) -> Option<bool> {
@@ -1053,7 +1101,12 @@ fn field_is_overridden(
     } else if key.eq_ignore_ascii_case("BAND_RX") {
         Band::try_from(qso.band_rx).unwrap_or(Band::Unspecified) != Band::Unspecified
     } else if key.eq_ignore_ascii_case("FREQ_RX") {
-        qso.frequency_rx_khz.is_some()
+        qso.frequency_rx_hz.is_some() || {
+            #[allow(deprecated)]
+            {
+                qso.frequency_rx_khz.is_some()
+            }
+        }
     } else if key.eq_ignore_ascii_case("LAT") {
         qso.worked_latitude.is_some()
     } else if key.eq_ignore_ascii_case("LON") {
@@ -1116,7 +1169,11 @@ mod tests {
         assert_eq!(qso.station_callsign, "AA7BQ");
         assert_eq!(qso.band, Band::Band20m as i32);
         assert_eq!(qso.mode, Mode::Rtty as i32);
-        assert_eq!(qso.frequency_khz, Some(14085));
+        assert_eq!(qso.frequency_hz, Some(14_085_000));
+        #[allow(deprecated)]
+        {
+            assert_eq!(qso.frequency_khz, Some(14085));
+        }
         assert!(qso.utc_timestamp.is_some());
         assert_eq!(
             qso.station_snapshot
@@ -1280,7 +1337,11 @@ mod tests {
         assert!(qso.utc_timestamp.is_none());
         assert_eq!(qso.band, Band::Unspecified as i32);
         assert_eq!(qso.mode, Mode::Unspecified as i32);
-        assert_eq!(qso.frequency_khz, None);
+        assert_eq!(qso.frequency_hz, None);
+        #[allow(deprecated)]
+        {
+            assert_eq!(qso.frequency_khz, None);
+        }
         assert_eq!(
             qso.extra_fields.get("QSO_DATE").map(String::as_str),
             Some("2025ABCD")
@@ -1736,23 +1797,67 @@ mod tests {
     }
 
     #[test]
-    fn frequency_to_khz_conversion() {
+    fn frequency_to_hz_conversion() {
         let mut rec = Record::new();
         rec.insert("CALL", "W1AW").unwrap();
         rec.insert("FREQ", "14.074").unwrap();
 
         let qso = AdifMapper::record_to_qso(&rec);
-        assert_eq!(qso.frequency_khz, Some(14074));
+        assert_eq!(qso.frequency_hz, Some(14_074_000));
+        #[allow(deprecated)]
+        {
+            assert_eq!(qso.frequency_khz, Some(14074));
+        }
     }
 
     #[test]
-    fn frequency_to_khz_precise() {
+    fn frequency_to_hz_precise() {
         let mut rec = Record::new();
         rec.insert("CALL", "W1AW").unwrap();
         rec.insert("FREQ", "7.0385").unwrap();
 
         let qso = AdifMapper::record_to_qso(&rec);
-        assert_eq!(qso.frequency_khz, Some(7039)); // 7038.5 rounds to 7039
+        assert_eq!(qso.frequency_hz, Some(7_038_500));
+        #[allow(deprecated)]
+        {
+            assert_eq!(qso.frequency_khz, Some(7039)); // 7038.5 kHz rounds to 7039
+        }
+    }
+
+    #[test]
+    fn frequency_sub_khz_precision_preserved() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "W1AW").unwrap();
+        rec.insert("FREQ", "28.07573").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+        assert_eq!(qso.frequency_hz, Some(28_075_730));
+        #[allow(deprecated)]
+        {
+            assert_eq!(qso.frequency_khz, Some(28076)); // 28075.73 kHz rounds to 28076
+        }
+    }
+
+    #[test]
+    fn frequency_hz_round_trips_through_adif() {
+        // Parse → serialize → parse should preserve Hz precision.
+        let mut rec = Record::new();
+        rec.insert("CALL", "W1AW").unwrap();
+        rec.insert("BAND", "20M").unwrap();
+        rec.insert("MODE", "FT8").unwrap();
+        rec.insert("QSO_DATE", "20260417").unwrap();
+        rec.insert("TIME_ON", "194345").unwrap();
+        rec.insert("FREQ", "28.07573").unwrap();
+        rec.insert("STATION_CALLSIGN", "KC7AVA").unwrap();
+
+        let qso = AdifMapper::record_to_qso(&rec);
+        assert_eq!(qso.frequency_hz, Some(28_075_730));
+
+        let adif_out = AdifMapper::qso_to_adi(&qso);
+        assert!(
+            adif_out.contains("<FREQ:8>28.07573"),
+            "ADIF output should preserve sub-kHz precision: {adif_out}"
+        );
     }
 
     #[test]
@@ -1763,7 +1868,7 @@ mod tests {
 
         let qso = AdifMapper::record_to_qso(&rec);
         assert_eq!(
-            qso.frequency_khz, None,
+            qso.frequency_hz, None,
             "Negative frequency should be rejected, not mapped to 0"
         );
     }
@@ -2019,8 +2124,13 @@ mod tests {
 
         assert_eq!(qso.band, Band::Band20m as i32);
         assert_eq!(qso.band_rx, Band::Band40m as i32);
-        assert_eq!(qso.frequency_khz, Some(14250));
-        assert_eq!(qso.frequency_rx_khz, Some(7075));
+        assert_eq!(qso.frequency_hz, Some(14_250_000));
+        assert_eq!(qso.frequency_rx_hz, Some(7_075_000));
+        #[allow(deprecated)]
+        {
+            assert_eq!(qso.frequency_khz, Some(14250));
+            assert_eq!(qso.frequency_rx_khz, Some(7075));
+        }
         assert!(!qso.extra_fields.contains_key("BAND_RX"));
         assert!(!qso.extra_fields.contains_key("FREQ_RX"));
     }
@@ -2152,8 +2262,8 @@ mod tests {
             station_callsign: "AA7BQ".to_string(),
             band: Band::Band20m as i32,
             band_rx: Band::Band40m as i32,
-            frequency_khz: Some(14250),
-            frequency_rx_khz: Some(7075),
+            frequency_hz: Some(14_250_000),
+            frequency_rx_hz: Some(7_075_000),
             worked_latitude: Some(41.5),
             worked_longitude: Some(-71.7583),
             worked_altitude_meters: Some(150.0),
@@ -2202,7 +2312,7 @@ mod tests {
             worked_longitude: Some(0.0),
             worked_altitude_meters: Some(10.0),
             worked_gridsquare_ext: Some("aa".to_string()),
-            frequency_rx_khz: Some(14000),
+            frequency_rx_hz: Some(14_000_000),
             owner_callsign: Some("W1AW".to_string()),
             qso_complete: QsoCompletion::Yes as i32,
             ..Default::default()
@@ -2254,7 +2364,7 @@ mod tests {
             station_callsign: "AA7BQ".to_string(),
             band: Band::Band20m as i32,
             band_rx: Band::Band40m as i32,
-            frequency_rx_khz: Some(7075),
+            frequency_rx_hz: Some(7_075_000),
             worked_altitude_meters: Some(150.0),
             worked_gridsquare_ext: Some("ab".to_string()),
             owner_callsign: Some("W1AW".to_string()),
@@ -2280,7 +2390,7 @@ mod tests {
         let parsed = AdifMapper::record_to_qso(&record);
 
         assert_eq!(parsed.band_rx, Band::Band40m as i32);
-        assert_eq!(parsed.frequency_rx_khz, Some(7075));
+        assert_eq!(parsed.frequency_rx_hz, Some(7_075_000));
         assert_eq!(parsed.worked_altitude_meters, Some(150.0));
         assert_eq!(parsed.worked_gridsquare_ext.as_deref(), Some("ab"));
         assert_eq!(parsed.owner_callsign.as_deref(), Some("W1AW"));

--- a/src/rust/qsoripper-core/src/application/logbook.rs
+++ b/src/rust/qsoripper-core/src/application/logbook.rs
@@ -589,7 +589,7 @@ fn qsos_match_for_duplicate(existing: &QsoRecord, candidate: &QsoRecord) -> bool
             candidate.worked_callsign.as_str(),
         )
         && optional_strings_compatible(existing.submode.as_deref(), candidate.submode.as_deref())
-        && optional_u64_compatible(existing.frequency_khz, candidate.frequency_khz)
+        && frequencies_compatible(existing, candidate)
 }
 
 /// Merge import data onto an existing record for refresh mode.
@@ -608,7 +608,9 @@ fn merge_qso_for_refresh(mut existing: QsoRecord, import: &QsoRecord) -> QsoReco
     existing.band = import.band;
     existing.mode = import.mode;
 
+    #[allow(deprecated)]
     merge_optional_u64(&mut existing.frequency_khz, import.frequency_khz);
+    merge_optional_u64(&mut existing.frequency_hz, import.frequency_hz);
     merge_optional_str(&mut existing.submode, import.submode.as_deref());
     merge_optional_timestamp(&mut existing.utc_end_timestamp, import.utc_end_timestamp);
 
@@ -738,6 +740,17 @@ fn optional_u64_compatible(left: Option<u64>, right: Option<u64>) -> bool {
     match (left, right) {
         (Some(left), Some(right)) => left == right,
         _ => true,
+    }
+}
+
+/// Compare frequencies for duplicate matching.
+/// When both sides have Hz fields, compare exactly.
+/// When one or both lack Hz, fall back to kHz compatibility.
+#[allow(deprecated)]
+fn frequencies_compatible(existing: &QsoRecord, candidate: &QsoRecord) -> bool {
+    match (existing.frequency_hz, candidate.frequency_hz) {
+        (Some(a), Some(b)) => a == b,
+        _ => optional_u64_compatible(existing.frequency_khz, candidate.frequency_khz),
     }
 }
 

--- a/src/rust/qsoripper-core/src/domain/qso.rs
+++ b/src/rust/qsoripper-core/src/domain/qso.rs
@@ -96,9 +96,25 @@ impl QsoRecordBuilder {
     }
 
     #[must_use]
-    /// Set the transmit frequency in kHz.
+    /// Set the transmit frequency in kHz (deprecated — prefer `frequency_hz`).
+    #[deprecated(note = "use frequency_hz() for sub-kHz precision")]
     pub fn frequency_khz(mut self, khz: u64) -> Self {
-        self.record.frequency_khz = Some(khz);
+        #[allow(deprecated)]
+        {
+            self.record.frequency_khz = Some(khz);
+        }
+        self.record.frequency_hz = Some(khz * 1000);
+        self
+    }
+
+    #[must_use]
+    /// Set the transmit frequency in Hz for full sub-kHz precision.
+    pub fn frequency_hz(mut self, hz: u64) -> Self {
+        self.record.frequency_hz = Some(hz);
+        #[allow(deprecated)]
+        {
+            self.record.frequency_khz = Some((hz + 500) / 1000);
+        }
         self
     }
 
@@ -192,7 +208,7 @@ mod tests {
         let record = QsoRecordBuilder::new("AA7BQ", "VK9NS")
             .band(Band::Band20m)
             .mode(Mode::Ft8)
-            .frequency_khz(14_074)
+            .frequency_hz(14_074_000)
             .comment("Great signal".to_string())
             .build();
 
@@ -200,7 +216,11 @@ mod tests {
         assert_eq!(record.worked_callsign, "VK9NS");
         assert_eq!(record.band, Band::Band20m as i32);
         assert_eq!(record.mode, Mode::Ft8 as i32);
-        assert_eq!(record.frequency_khz, Some(14_074));
+        assert_eq!(record.frequency_hz, Some(14_074_000));
+        #[allow(deprecated)]
+        {
+            assert_eq!(record.frequency_khz, Some(14_074));
+        }
         assert_eq!(record.comment.as_deref(), Some("Great signal"));
         assert_eq!(record.sync_status, SyncStatus::LocalOnly as i32);
         assert!(!record.local_id.is_empty());
@@ -263,7 +283,7 @@ mod tests {
         let record = QsoRecordBuilder::new("W1AW", "JA1ABC")
             .band(Band::Band40m)
             .mode(Mode::Cw)
-            .frequency_khz(7_030)
+            .frequency_hz(7_030_000)
             .comment("CW contest")
             .extra_field("CHECK", "73")
             .build();
@@ -279,7 +299,11 @@ mod tests {
         assert_eq!(decoded.worked_callsign, "JA1ABC");
         assert_eq!(decoded.band, Band::Band40m as i32);
         assert_eq!(decoded.mode, Mode::Cw as i32);
-        assert_eq!(decoded.frequency_khz, Some(7_030));
+        assert_eq!(decoded.frequency_hz, Some(7_030_000));
+        #[allow(deprecated)]
+        {
+            assert_eq!(decoded.frequency_khz, Some(7_030));
+        }
         assert_eq!(decoded.comment.as_deref(), Some("CW contest"));
         assert_eq!(
             decoded.extra_fields.get("CHECK").map(String::as_str),

--- a/src/rust/qsoripper-core/tests/adif_integration.rs
+++ b/src/rust/qsoripper-core/tests/adif_integration.rs
@@ -38,7 +38,7 @@ async fn parse_basic_qsos_file() {
     assert_eq!(q1.station_callsign, "AA7BQ");
     assert_eq!(q1.band, Band::Band20m as i32);
     assert_eq!(q1.mode, Mode::Rtty as i32);
-    assert_eq!(q1.frequency_khz, Some(14085));
+    assert_eq!(q1.frequency_hz, Some(14_085_000));
     assert_eq!(q1.rst_sent.as_ref().unwrap().raw, "59");
     assert_eq!(q1.rst_received.as_ref().unwrap().raw, "57");
     assert_eq!(q1.comment.as_deref(), Some("Good signal!"));
@@ -68,7 +68,7 @@ async fn parse_basic_qsos_file() {
     assert_eq!(q2.band, Band::Band40m as i32);
     assert_eq!(q2.mode, Mode::Ssb as i32);
     assert_eq!(q2.submode.as_deref(), Some("USB"));
-    assert_eq!(q2.frequency_khz, Some(7180));
+    assert_eq!(q2.frequency_hz, Some(7_180_000));
     assert_eq!(q2.contest_id.as_deref(), Some("CQ-WW-SSB"));
     assert_eq!(q2.serial_received.as_deref(), Some("142"));
     assert_eq!(q2.serial_sent.as_deref(), Some("033"));
@@ -101,7 +101,7 @@ async fn parse_basic_qsos_file() {
     assert_eq!(q3.worked_callsign, "JA1ABC");
     assert_eq!(q3.band, Band::Band15m as i32);
     assert_eq!(q3.mode, Mode::Ft8 as i32);
-    assert_eq!(q3.frequency_khz, Some(21074));
+    assert_eq!(q3.frequency_hz, Some(21_074_000));
     assert_eq!(q3.worked_grid.as_deref(), Some("PM95vk"));
     assert_eq!(q3.worked_country.as_deref(), Some("Japan"));
     assert_eq!(q3.worked_dxcc, Some(339));
@@ -219,7 +219,7 @@ async fn round_trip_qso_through_adif() {
     assert_eq!(round_tripped.station_callsign, original.station_callsign);
     assert_eq!(round_tripped.band, original.band);
     assert_eq!(round_tripped.mode, original.mode);
-    assert_eq!(round_tripped.frequency_khz, original.frequency_khz);
+    assert_eq!(round_tripped.frequency_hz, original.frequency_hz);
     assert_eq!(
         round_tripped.rst_sent.as_ref().map(|r| r.raw.as_str()),
         original.rst_sent.as_ref().map(|r| r.raw.as_str())

--- a/src/rust/qsoripper-ffi/src/client.rs
+++ b/src/rust/qsoripper-ffi/src/client.rs
@@ -358,7 +358,11 @@ fn build_qso_record(req: &QsrLogQsoRequest) -> Result<QsoRecord, String> {
     }
 
     if req.freq_khz > 0 {
-        qso.frequency_khz = Some(req.freq_khz);
+        qso.frequency_hz = Some(req.freq_khz * 1000);
+        #[allow(deprecated)]
+        {
+            qso.frequency_khz = Some(req.freq_khz);
+        }
     }
 
     set_optional_str(&req.comment, |s| qso.comment = Some(s.to_string()));
@@ -748,11 +752,13 @@ fn populate_qso_detail(qso: &QsoRecord, out: &mut QsrQsoDetail) {
         str_to_buf(&time_str, &mut out.time);
     }
 
-    // Frequency
-    if let Some(freq_khz) = qso.frequency_khz {
-        if freq_khz > 0 {
-            let mhz = freq_khz as f64 / 1000.0;
-            let freq_str = format!("{mhz:.5}");
+    // Frequency — prefer Hz field, fall back to deprecated kHz
+    #[allow(deprecated)]
+    let freq_hz = qso.frequency_hz.or(qso.frequency_khz.map(|k| k * 1000));
+    if let Some(hz) = freq_hz {
+        if hz > 0 {
+            let mhz = hz as f64 / 1_000_000.0;
+            let freq_str = format!("{mhz:.6}");
             str_to_buf(&freq_str, &mut out.freq_mhz);
         }
     }

--- a/src/rust/qsoripper-tui/src/grpc.rs
+++ b/src/rust/qsoripper-tui/src/grpc.rs
@@ -52,7 +52,7 @@ pub(crate) async fn log_qso(
         parse_timestamp(&form.date, &form.time_off).ok()
     };
 
-    let frequency_khz = form.frequency_mhz.parse::<f64>().ok().map(mhz_to_khz);
+    let frequency_hz = form.frequency_mhz.parse::<f64>().ok().map(mhz_to_hz);
 
     let (worked_grid, worked_country, worked_cq_zone, worked_dxcc) =
         lookup.unwrap_or((None, None, None, None));
@@ -63,7 +63,7 @@ pub(crate) async fn log_qso(
         mode: i32::from(mode),
         utc_timestamp,
         utc_end_timestamp,
-        frequency_khz,
+        frequency_hz,
         submode: if form.submode_override.is_empty() {
             submode.map(str::to_string)
         } else {
@@ -325,7 +325,7 @@ pub(crate) async fn update_qso(
     } else {
         parse_timestamp(&form.date, &form.time_off).ok()
     };
-    let frequency_khz = form.frequency_mhz.parse::<f64>().ok().map(mhz_to_khz);
+    let frequency_hz = form.frequency_mhz.parse::<f64>().ok().map(mhz_to_hz);
 
     let (worked_grid, worked_country, worked_cq_zone, worked_dxcc) =
         lookup.unwrap_or((None, None, None, None));
@@ -339,7 +339,7 @@ pub(crate) async fn update_qso(
     qso.mode = i32::from(mode);
     qso.utc_timestamp = utc_timestamp;
     qso.utc_end_timestamp = utc_end_timestamp;
-    qso.frequency_khz = frequency_khz;
+    qso.frequency_hz = frequency_hz;
     qso.submode = if form.submode_override.is_empty() {
         submode.map(str::to_string)
     } else {
@@ -389,16 +389,16 @@ pub(crate) async fn delete_qso(channel: Channel, local_id: &str) -> anyhow::Resu
     Ok(())
 }
 
-/// Convert a frequency in MHz to kHz as a `u64`.
-fn mhz_to_khz(mhz: f64) -> u64 {
-    let khz = mhz * 1_000.0_f64;
+/// Convert a frequency in MHz to Hz as a `u64`.
+fn mhz_to_hz(mhz: f64) -> u64 {
+    let hz = mhz * 1_000_000.0_f64;
     #[expect(
         clippy::cast_possible_truncation,
         clippy::cast_sign_loss,
         reason = "frequency is always a small positive value well within u64 range"
     )]
     {
-        khz as u64
+        hz.round() as u64
     }
 }
 

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -749,7 +749,35 @@ fn load_qso_into_form(app: &mut App, local_id: &str, lookup_tx: &watch::Sender<S
     let src = &qso.source_record;
     app.form.comment = src.comment.clone().unwrap_or_default();
     app.form.notes = src.notes.clone().unwrap_or_default();
-    if let Some(khz) = src.frequency_khz {
+    if let Some(hz) = src.frequency_hz {
+        #[expect(
+            clippy::cast_precision_loss,
+            reason = "ham radio frequencies are well within f64 mantissa range"
+        )]
+        {
+            app.form.frequency_mhz = format!("{:.6}", hz as f64 / 1_000_000.0)
+                .trim_end_matches('0')
+                .trim_end_matches('.')
+                .to_string();
+            // Ensure at least 3 decimal places
+            let dot = app
+                .form
+                .frequency_mhz
+                .find('.')
+                .unwrap_or(app.form.frequency_mhz.len());
+            let decimals = app.form.frequency_mhz.len() - dot - 1;
+            if decimals < 3 {
+                for _ in 0..(3 - decimals) {
+                    app.form.frequency_mhz.push('0');
+                }
+            }
+        }
+    } else if let Some(khz) = {
+        #[allow(deprecated)]
+        {
+            src.frequency_khz
+        }
+    } {
         #[expect(
             clippy::cast_precision_loss,
             reason = "ham radio frequencies are well within f64 mantissa range"


### PR DESCRIPTION
## Problem

When exporting QSOs to ADIF and processing through TQSL, LoTW detects previously-uploaded QSOs as "new" — 790 false positives in one case. The root cause is frequency precision loss: frequencies were stored as integer kHz (`frequency_khz: uint64`), truncating sub-kHz values. For example, an FT8 QSO at 28.07573 MHz was stored as 28076 kHz and exported as `28.076` — a different frequency than what LoTW already had on file.

## Solution

Add `frequency_hz` (field 116) and `frequency_rx_hz` (field 117) as `uint64` fields to `QsoRecord`, storing frequencies in Hz for full sub-kHz precision. The old `frequency_khz` and `frequency_rx_khz` fields are deprecated but still dual-written for backward compatibility.

### Key design decisions

- **String-based MHz→Hz parsing** in both Rust and .NET to avoid float precision drift between engines
- **Exact Hz matching** for duplicate detection when both sides have Hz; kHz-level fallback otherwise
- **Legacy kHz down-conversion**: `(hz + 500) / 1000` (round, never truncate)
- **Dual-write**: always populate both Hz and kHz fields so older clients still work
- **ADIF output**: up to 6 decimal places, trailing zeros trimmed, minimum 3 decimals

### Scope (31 files)

| Layer | Changes |
|-------|---------|
| **Proto** | Added `frequency_hz`/`frequency_rx_hz`, deprecated old kHz fields |
| **Rust engine** | ADIF mapper, domain builder, logbook duplicate matching & merge |
| **Rust TUI/FFI** | Hz read/write with kHz fallback |
| **.NET engine** | ManagedAdifCodec, QrzLogbook AdifCodec, ManagedQsoParity |
| **.NET consumers** | GUI, CLI, DebugHost — all display/edit paths |
| **Tests** | Updated across both engines |
| **Docs** | engine-spec, data-model, ADIF spec, logbook API |

### Validation

- `cargo fmt --check` ✅
- `cargo clippy -D warnings` ✅
- `cargo test` — 372 passed ✅
- `dotnet test` — 354 passed ✅
- `buf lint` ✅