### PR TITLE
Fix stale proto comments; add QSO duration to TUI and DebugHost

### DIFF
--- a/proto/services/logbook_service.proto
+++ b/proto/services/logbook_service.proto
@@ -28,8 +28,8 @@ import "services/update_qso_response.proto";
 // Core logbook operations. Covers local QSO CRUD, QRZ logbook sync, and ADIF import/export.
 //
 // Implementation status:
-//   LogQso        — implemented for local storage; optional QRZ sync still reports unimplemented
-//   UpdateQso     — implemented for local storage; optional QRZ sync still reports unimplemented
+//   LogQso        — implemented; optional per-operation QRZ sync implemented (sync_to_qrz=true)
+//   UpdateQso     — implemented; optional per-operation QRZ sync implemented (sync_to_qrz=true)
 //   DeleteQso     — implemented for local storage; QRZ delete supported when delete_from_qrz=true
 //   GetQso        — implemented for local storage
 //   ListQsos      — implemented for local storage

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/QsoViewer.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/QsoViewer.razor
@@ -1,4 +1,5 @@
 @page "/qso-viewer"
+@using QsoRipper.EngineSelection
 @inject DebugWorkbenchState WorkbenchState
 @inject RuntimeConfigWorkbenchService RuntimeConfigWorkbenchService
 @inject QsoViewerService QsoViewerService
@@ -112,6 +113,7 @@
                             <th>RST Rcvd</th>
                             <th>Station</th>
                             <th>Grid</th>
+                            <th>Dur</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -130,11 +132,12 @@
                                 <td>@(qso.RstReceived?.Raw ?? "—")</td>
                                 <td>@qso.StationCallsign</td>
                                 <td>@(qso.WorkedGrid ?? "—")</td>
+                                <td>@(QsoDurationFormatter.Format(qso.UtcTimestamp?.ToDateTimeOffset(), qso.UtcEndTimestamp?.ToDateTimeOffset()) ?? "—")</td>
                             </tr>
                             @if (isExpanded)
                             {
                                 <tr>
-                                    <td colspan="10" class="p-3 bg-light">
+                                    <td colspan="11" class="p-3 bg-light">
                                         <div class="row g-3">
                                             <div class="col-xl-6">
                                                 <PayloadCard Title="QSO record"

--- a/src/rust/qsoripper-tui/src/app.rs
+++ b/src/rust/qsoripper-tui/src/app.rs
@@ -85,6 +85,8 @@ pub(crate) struct RecentQso {
     pub(crate) grid: Option<String>,
     /// Worked operator name.
     pub(crate) name: Option<String>,
+    /// Calculated QSO duration (e.g. "2m 35s"), or `None` when end time is absent.
+    pub(crate) duration: Option<String>,
     /// Full proto record from the engine, preserved for lossless round-trip during edits.
     pub(crate) source_record: QsoRecord,
 }
@@ -354,6 +356,7 @@ mod tests {
             country: None,
             grid: None,
             name: None,
+            duration: None,
             source_record: QsoRecord {
                 local_id: id.to_string(),
                 worked_callsign: callsign.to_string(),
@@ -575,6 +578,7 @@ mod tests {
             country: Some("United States".to_string()),
             grid: Some("CN87".to_string()),
             name: Some("John".to_string()),
+            duration: None,
             source_record: QsoRecord::default(),
         };
         assert!(qso.matches_search("40m"));
@@ -604,6 +608,7 @@ mod tests {
             country: None,
             grid: None,
             name: None,
+            duration: None,
             source_record: QsoRecord::default(),
         };
         assert!(!qso.matches_search("united"));

--- a/src/rust/qsoripper-tui/src/grpc.rs
+++ b/src/rust/qsoripper-tui/src/grpc.rs
@@ -5,6 +5,7 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use tonic::transport::{Channel, Endpoint};
 
 use qsoripper_core::domain::band::{band_from_adif, band_to_adif};
+use qsoripper_core::domain::duration::format_qso_duration;
 use qsoripper_core::domain::mode::{mode_from_adif, mode_to_adif};
 use qsoripper_core::proto::qsoripper::domain::{Band, LookupState, Mode, RstReport};
 use qsoripper_core::proto::qsoripper::services::{
@@ -158,6 +159,7 @@ pub(crate) async fn list_recent_qsos(
             country: qso.worked_country.clone(),
             grid: qso.worked_grid.clone(),
             name: qso.worked_operator_name.clone(),
+            duration: format_qso_duration(&qso),
             source_record: qso,
         });
     }

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -1081,6 +1081,7 @@ mod tests {
             country: None,
             grid: None,
             name: None,
+            duration: None,
             source_record: QsoRecord {
                 local_id: id.to_string(),
                 worked_callsign: callsign.to_string(),
@@ -1651,6 +1652,7 @@ mod tests {
             country: None,
             grid: None,
             name: Some("John".to_string()),
+            duration: None,
             source_record: QsoRecord {
                 local_id: "q1".to_string(),
                 worked_callsign: "K7ABC".to_string(),
@@ -1707,6 +1709,7 @@ mod tests {
             country: Some("United States".to_string()),
             grid: Some("FN31pr".to_string()),
             name: Some("Hiram".to_string()),
+            duration: None,
             source_record: QsoRecord {
                 local_id: "adv1".to_string(),
                 worked_callsign: "W1AW".to_string(),

--- a/src/rust/qsoripper-tui/src/ui/mod.rs
+++ b/src/rust/qsoripper-tui/src/ui/mod.rs
@@ -113,6 +113,7 @@ mod tests {
             country: Some("United States".to_string()),
             grid: Some("CN87".to_string()),
             name: Some("John Smith".to_string()),
+            duration: None,
             source_record: QsoRecord {
                 local_id: id.to_string(),
                 worked_callsign: callsign.to_string(),

--- a/src/rust/qsoripper-tui/src/ui/recent_qsos.rs
+++ b/src/rust/qsoripper-tui/src/ui/recent_qsos.rs
@@ -101,6 +101,7 @@ fn render_table(app: &App, filtered: &[&crate::app::RecentQso], frame: &mut Fram
         "Mode",
         "RST\u{2191}",
         "RST\u{2193}",
+        "Dur",
         "Country",
         "Grid",
     ]
@@ -132,6 +133,7 @@ fn render_table(app: &App, filtered: &[&crate::app::RecentQso], frame: &mut Fram
             Cell::from(qso.mode.as_str()),
             Cell::from(qso.rst_sent.as_str()),
             Cell::from(qso.rst_rcvd.as_str()),
+            Cell::from(qso.duration.as_deref().unwrap_or("")),
             Cell::from(qso.country.as_deref().unwrap_or("")),
             Cell::from(qso.grid.as_deref().unwrap_or("")),
         ])
@@ -146,6 +148,7 @@ fn render_table(app: &App, filtered: &[&crate::app::RecentQso], frame: &mut Fram
         Constraint::Length(6),
         Constraint::Length(5),
         Constraint::Length(5),
+        Constraint::Length(9),
         Constraint::Fill(1),
         Constraint::Length(7),
     ];


### PR DESCRIPTION
Addresses issue #176 item 4 and two remaining surfaces from issue #201.

Fix stale implementation-status comments in logbook_service.proto. LogQso and UpdateQso comments said per-operation QRZ sync still reports unimplemented, but run_per_op_qrz_sync has been fully wired for some time.

Add a Dur column to the TUI recent QSOs table. RecentQso gains a duration field populated from the existing format_qso_duration helper in qsoripper-core. The CLI, Avalonia GUI, and Win32 GUI already showed duration; this brings the TUI to parity.

Add a Dur column to the DebugHost QsoViewer page using QsoDurationFormatter from QsoRipper.EngineSelection.

All quality gates pass: buf lint, cargo fmt/clippy/test (208 TUI tests), dotnet build, dotnet test (0 failures).