### PR TITLE
feat: CLI trash view, restore command, and sync delete counters (#294)

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -131,6 +131,7 @@ The primary QSO CRUD and sync surface. This is the most critical service in the 
 | `LogQso` | `LogQsoRequest` | `LogQsoResponse` | Unary |
 | `UpdateQso` | `UpdateQsoRequest` | `UpdateQsoResponse` | Unary |
 | `DeleteQso` | `DeleteQsoRequest` | `DeleteQsoResponse` | Unary |
+| `RestoreQso` | `RestoreQsoRequest` | `RestoreQsoResponse` | Unary |
 | `GetQso` | `GetQsoRequest` | `GetQsoResponse` | Unary |
 | `ListQsos` | `ListQsosRequest` | `stream ListQsosResponse` | Server-streaming |
 | `SyncWithQrz` | `SyncWithQrzRequest` | `stream SyncWithQrzResponse` | Server-streaming |
@@ -230,6 +231,21 @@ The sync follows a three-phase lifecycle:
 3. **Metadata phase** — Update the `sync_metadata` record with the current QRZ QSO count, last sync timestamp, and logbook owner callsign.
 
 Stream progress messages throughout all phases so clients can display real-time sync state.
+
+**Response fields (`SyncWithQrzResponse`):**
+
+| Field | Type | Description |
+|---|---|---|
+| `total_records` | `uint32` | Total records in scope for the sync pass. |
+| `processed_records` | `uint32` | Records processed so far. |
+| `uploaded_records` | `uint32` | Records successfully uploaded to QRZ. |
+| `downloaded_records` | `uint32` | Records downloaded (inserted or merged) from QRZ. |
+| `conflict_records` | `uint32` | Records flagged for conflict resolution. |
+| `current_action` | `string` (optional) | Human-readable status string for progress display. |
+| `complete` | `bool` | `true` on the terminal message; `false` on intermediate progress. |
+| `error` | `string` (optional) | Accumulated error summary if any phase encountered failures. |
+| `remote_deletes_pushed` | `uint32` | Number of pending remote deletes successfully pushed to QRZ (Phase 2.5). |
+| `deletes_skipped_remote` | `uint32` | Number of download records skipped because they matched a soft-deleted local row (Phase 1). |
 
 **Error semantics:**
 - `FAILED_PRECONDITION` — QRZ logbook credentials not configured.

--- a/proto/services/sync_with_qrz_response.proto
+++ b/proto/services/sync_with_qrz_response.proto
@@ -13,4 +13,8 @@ message SyncWithQrzResponse {
   optional string current_action = 6;  // Human-readable status
   bool complete = 7;
   optional string error = 8;
+  // Number of pending remote deletes successfully pushed to QRZ (Phase 2.5).
+  uint32 remote_deletes_pushed = 9;
+  // Number of QRZ download records skipped because they matched a soft-deleted local row (Phase 1).
+  uint32 deletes_skipped_remote = 10;
 }

--- a/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliUtilityTests.cs
@@ -215,5 +215,45 @@ public sealed class CliUtilityTests
         Assert.DoesNotContain("QSORIPPER_QRZ_USERNAME", help, StringComparison.Ordinal);
         Assert.DoesNotContain("QSORIPPER_QRZ_PASSWORD", help, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public void UsesPrimaryArgument_restore_is_true()
+    {
+        Assert.True(CliCommandMetadata.UsesPrimaryArgument("restore"));
+        Assert.True(CliCommandMetadata.RequiresPrimaryArgument("restore"));
+    }
+
+    [Fact]
+    public void GetGeneralHelp_includes_restore_command()
+    {
+        var help = CliHelpText.GetGeneralHelp();
+
+        Assert.Contains("restore <local-id>", help, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetCommandHelp_restore_shows_usage()
+    {
+        var help = CliHelpText.GetCommandHelp("restore");
+
+        Assert.Contains("Usage: restore <local-id>", help, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetCommandHelp_delete_mentions_restore()
+    {
+        var help = CliHelpText.GetCommandHelp("delete");
+
+        Assert.Contains("restore", help, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GetCommandHelp_list_includes_deleted_flags()
+    {
+        var help = CliHelpText.GetCommandHelp("list");
+
+        Assert.Contains("--deleted", help, StringComparison.Ordinal);
+        Assert.Contains("--include-deleted", help, StringComparison.Ordinal);
+    }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
@@ -463,5 +463,48 @@ public sealed class CommandHelperTests
         var reconstructed = requests.SelectMany(static request => request.Chunk!.Data.ToByteArray()).ToArray();
         Assert.Equal(bytes, reconstructed);
     }
+
+    [Fact]
+    public void TryParseArgs_deleted_flag_sets_deleted_only_filter()
+    {
+        var success = ListQsosCommand.TryParseArgs(["--deleted"], out var request, out var displayOptions, out var error);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.Equal(DeletedRecordsFilter.DeletedOnly, request.DeletedFilter);
+        Assert.True(displayOptions.ShowDeletedAt);
+    }
+
+    [Fact]
+    public void TryParseArgs_include_deleted_flag_sets_all_filter()
+    {
+        var success = ListQsosCommand.TryParseArgs(["--include-deleted"], out var request, out var displayOptions, out var error);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.Equal(DeletedRecordsFilter.All, request.DeletedFilter);
+        Assert.True(displayOptions.ShowDeletedAt);
+    }
+
+    [Fact]
+    public void TryParseArgs_combining_deleted_and_include_deleted_is_rejected()
+    {
+        var success = ListQsosCommand.TryParseArgs(["--deleted", "--include-deleted"], out _, out _, out var error);
+
+        Assert.False(success);
+        Assert.NotNull(error);
+        Assert.Contains("--deleted", error, StringComparison.Ordinal);
+        Assert.Contains("--include-deleted", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryParseArgs_no_delete_flag_uses_default_filter()
+    {
+        var success = ListQsosCommand.TryParseArgs([], out var request, out var displayOptions, out _);
+
+        Assert.True(success);
+        Assert.Equal(DeletedRecordsFilter.Unspecified, request.DeletedFilter);
+        Assert.False(displayOptions.ShowDeletedAt);
+    }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli/CliCommandMetadata.cs
+++ b/src/dotnet/QsoRipper.Cli/CliCommandMetadata.cs
@@ -4,7 +4,7 @@ internal static class CliCommandMetadata
 {
     public static bool UsesPrimaryArgument(string? command)
     {
-        return command is "lookup" or "stream-lookup" or "cache-check" or "log" or "get" or "update" or "delete" or "import";
+        return command is "lookup" or "stream-lookup" or "cache-check" or "log" or "get" or "update" or "delete" or "restore" or "import";
     }
 
     public static bool RequiresPrimaryArgument(string? command)

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -14,7 +14,8 @@ internal static class CliHelpText
               get <local-id>                   Get a QSO by ID
               list [filters]                   List QSOs (--callsign, --band, --mode, --limit)
               update <local-id> [fields]       Update a QSO (--grid, --freq, --enrich, etc.)
-              delete <local-id>                Delete a QSO
+              delete <local-id>                Soft-delete a QSO (recoverable via restore)
+              restore <local-id>               Restore a soft-deleted QSO
 
             ADIF:
               import <file>                    Import QSOs from an ADIF file
@@ -85,7 +86,7 @@ internal static class CliHelpText
             "list" => """
                 Usage: list [options]
 
-                List QSOs with optional filters.
+                List QSOs with optional filters. By default shows only active (non-deleted) QSOs.
 
                   --callsign <call>    Filter by worked callsign
                   --band <band>        Filter by band (e.g., 20m)
@@ -96,6 +97,8 @@ internal static class CliHelpText
                   --show-id            Include the QSO local ID column
                   --show-rst           Include RST sent/received columns
                   --show-comment       Include comment/notes column (default)
+                  --deleted            Show only soft-deleted QSOs (trash view)
+                  --include-deleted    Show all QSOs including soft-deleted ones
                 """,
             "update" => """
                 Usage: update <local-id> [options]
@@ -122,7 +125,17 @@ internal static class CliHelpText
             "delete" => """
                 Usage: delete <local-id>
 
-                Delete a QSO by its local ID.
+                Soft-delete a QSO by its local ID. The QSO is moved to trash and hidden from
+                normal list output, but remains recoverable via the restore command until purged.
+                Use --show-id on the list command to find local IDs.
+                """,
+            "restore" => """
+                Usage: restore <local-id>
+
+                Restore a soft-deleted QSO by its local ID. Clears deleted_at and cancels any
+                pending remote delete so the QSO reappears in normal list output.
+                If the QRZ copy was already deleted, the QSO is re-queued for upload on the
+                next sync. Use list --deleted --show-id to find local IDs of trashed QSOs.
                 """,
             "import" => """
                 Usage: import <file-path> [--refresh]
@@ -204,7 +217,8 @@ internal static class CliHelpText
             "sync" => """
                 Usage: sync [--force]
 
-                Trigger a sync with the QRZ logbook. Shows streaming progress updates.
+                Trigger a sync with the QRZ logbook. Shows streaming progress updates and
+                a summary including downloaded, uploaded, conflict, and delete counters.
 
                   --force              Run a full sync instead of incremental
                 """,

--- a/src/dotnet/QsoRipper.Cli/Commands/ListQsosCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ListQsosCommand.cs
@@ -92,6 +92,11 @@ internal static class ListQsosCommand
             header += $" {"Comment",-40}";
         }
 
+        if (options.ShowDeletedAt)
+        {
+            header += $" {"Deleted",-22} {"Pending QRZ Delete",-18}";
+        }
+
         Console.WriteLine(header);
         Console.WriteLine(new string('-', header.Length));
     }
@@ -133,6 +138,13 @@ internal static class ListQsosCommand
             row += $" {FormatCommentPreview(qso),-40}";
         }
 
+        if (options.ShowDeletedAt)
+        {
+            var deletedAt = qso.DeletedAt is not null ? qso.DeletedAt.ToDateTime().ToString("u") : "";
+            var pendingRemoteDelete = qso.PendingRemoteDelete ? "yes" : "";
+            row += $" {deletedAt,-22} {pendingRemoteDelete,-18}";
+        }
+
         Console.WriteLine(row);
     }
 
@@ -141,6 +153,9 @@ internal static class ListQsosCommand
         request = new ListQsosRequest { Limit = 20 };
         displayOptions = new ListDisplayOptions();
         error = null;
+
+        var hasDeleted = false;
+        var hasIncludeDeleted = false;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -157,6 +172,12 @@ internal static class ListQsosCommand
                     break;
                 case "--show-duration":
                     displayOptions.ShowDuration = true;
+                    break;
+                case "--deleted":
+                    hasDeleted = true;
+                    break;
+                case "--include-deleted":
+                    hasIncludeDeleted = true;
                     break;
                 case "--callsign" when i < args.Length - 1:
                     request.CallsignFilter = args[++i].ToUpperInvariant();
@@ -239,6 +260,23 @@ internal static class ListQsosCommand
             }
         }
 
+        if (hasDeleted && hasIncludeDeleted)
+        {
+            error = "--deleted and --include-deleted cannot be combined. Use --deleted for trash-only or --include-deleted for all records.";
+            return false;
+        }
+
+        if (hasDeleted)
+        {
+            request.DeletedFilter = DeletedRecordsFilter.DeletedOnly;
+            displayOptions.ShowDeletedAt = true;
+        }
+        else if (hasIncludeDeleted)
+        {
+            request.DeletedFilter = DeletedRecordsFilter.All;
+            displayOptions.ShowDeletedAt = true;
+        }
+
         return true;
     }
 
@@ -300,4 +338,6 @@ internal sealed class ListDisplayOptions
     public bool ShowId { get; set; }
 
     public bool ShowRst { get; set; }
+
+    public bool ShowDeletedAt { get; set; }
 }

--- a/src/dotnet/QsoRipper.Cli/Commands/RestoreQsoCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/RestoreQsoCommand.cs
@@ -1,0 +1,25 @@
+using Grpc.Net.Client;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli.Commands;
+
+internal static class RestoreQsoCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel, string localId)
+    {
+        var client = new LogbookService.LogbookServiceClient(channel);
+        var response = await client.RestoreQsoAsync(new RestoreQsoRequest { LocalId = localId });
+
+        if (response.Success)
+        {
+            Console.WriteLine($"Restored QSO: {localId}");
+        }
+        else
+        {
+            Console.Error.WriteLine($"Failed to restore QSO: {response.Error}");
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/src/dotnet/QsoRipper.Cli/Commands/SyncCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SyncCommand.cs
@@ -46,6 +46,16 @@ internal static class SyncCommand
         Console.WriteLine($"Conflicts:   {last.ConflictRecords}");
         Console.WriteLine($"Total:       {last.TotalRecords}");
 
+        if (last.RemoteDeletesPushed > 0)
+        {
+            Console.WriteLine($"Deleted (remote): {last.RemoteDeletesPushed}");
+        }
+
+        if (last.DeletesSkippedRemote > 0)
+        {
+            Console.WriteLine($"Skipped (trashed): {last.DeletesSkippedRemote}");
+        }
+
         return 0;
     }
 }

--- a/src/dotnet/QsoRipper.Cli/Program.cs
+++ b/src/dotnet/QsoRipper.Cli/Program.cs
@@ -57,6 +57,7 @@ try
             "list" => await ListQsosCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput, cancellationSource.Token),
             "update" => await UpdateQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.RemainingArgs),
             "delete" => await DeleteQsoCommand.RunAsync(channel, arguments.Callsign!),
+            "restore" => await RestoreQsoCommand.RunAsync(channel, arguments.Callsign!),
             "import" => await ImportAdifCommand.RunAsync(channel, arguments.Callsign ?? arguments.RemainingArgs.FirstOrDefault() ?? "", arguments.Refresh, cancellationSource.Token),
             "export" => await ExportAdifCommand.RunAsync(channel, arguments.RemainingArgs, cancellationSource.Token),
             "config" => await ConfigCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput),

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -1015,6 +1015,44 @@ public sealed class ManagedEngineStateTests : IDisposable
         });
     }
 
+    [Fact]
+    public void SyncWithQrz_populates_remote_deletes_pushed_counter()
+    {
+        var state = CreateStateWithSync();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            QrzLogbookApiKey = "api-key",
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87",
+            },
+        });
+        var loggedResp = state.LogQso(new LogQsoRequest
+        {
+            SyncToQrz = false,
+            Qso = new QsoRecord
+            {
+                WorkedCallsign = "W1AW",
+                Band = Band._20M,
+                Mode = Mode.Ft8,
+                UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+        });
+        state.SyncWithQrz();
+        var synced = state.GetQso(loggedResp.LocalId)!;
+        Assert.False(string.IsNullOrEmpty(synced.QrzLogid));
+
+        state.DeleteQso(synced.LocalId, queueRemoteDelete: true);
+        var secondSync = state.SyncWithQrz();
+
+        Assert.True(secondSync.Complete);
+        Assert.Equal(1u, secondSync.RemoteDeletesPushed);
+        Assert.Equal(0u, secondSync.DeletesSkippedRemote);
+    }
+
     private static void EnsureStationConfigured(ManagedEngineState state)
     {
         state.SaveSetup(new SaveSetupRequest

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -687,6 +687,8 @@ internal sealed class ManagedEngineState
                     ProcessedRecords = result.DownloadedCount + result.UploadedCount,
                     CurrentAction = "Sync completed.",
                     Complete = true,
+                    RemoteDeletesPushed = result.RemoteDeletesPushed,
+                    DeletesSkippedRemote = result.DeletesSkippedRemote,
                 };
 
                 if (result.ErrorSummary is not null)

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -186,6 +186,8 @@ pub(crate) async fn execute_sync(
         counters.downloaded,
         counters.uploaded,
         counters.conflicts,
+        counters.remote_deletes_pushed,
+        counters.deletes_skipped_remote,
         error_summary,
     )
     .await;
@@ -231,6 +233,8 @@ async fn download_phase(
                 0,
                 0,
                 0,
+                0,
+                0,
                 Some(format!("Failed to load local QSOs: {err}")),
             )
             .await;
@@ -262,6 +266,8 @@ async fn download_phase(
         Err(err) => {
             send_complete(
                 progress_tx,
+                0,
+                0,
                 0,
                 0,
                 0,
@@ -892,6 +898,8 @@ async fn send_progress(
             current_action: Some(action.to_string()),
             complete: false,
             error: None,
+            remote_deletes_pushed: 0,
+            deletes_skipped_remote: 0,
         }))
         .await,
     );
@@ -902,6 +910,8 @@ async fn send_complete(
     downloaded: u32,
     uploaded: u32,
     conflicts: u32,
+    remote_deletes_pushed: u32,
+    deletes_skipped_remote: u32,
     error: Option<String>,
 ) {
     drop(
@@ -914,6 +924,8 @@ async fn send_complete(
             current_action: Some("Sync complete".to_string()),
             complete: true,
             error,
+            remote_deletes_pushed,
+            deletes_skipped_remote,
         }))
         .await,
     );


### PR DESCRIPTION
Implements the CLI portion of issue #294.

qso list gets --deleted (show only soft-deleted QSOs) and --include-deleted (show all). Combining both is rejected. Either flag enables a deleted_at column and a pending QRZ delete indicator.

A new restore subcommand calls the RestoreQso gRPC RPC and reports success or failure.

qso sync now prints remote delete counters (deleted to QRZ, skipped on download) when non-zero.

Two new SyncWithQrzResponse proto fields (remote_deletes_pushed, deletes_skipped_remote) back the counter display. Both Rust and .NET engines populate them from their existing SyncCounters/SyncResult tracking.

Engine spec updated: RestoreQso added to the LogbookService RPC table, SyncWithQrzResponse fields documented.

Closes #294