### PR TITLE
feat: add purge affordances to CLI, GUI, TUI, and Debug Host

### DIFF
--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -16,6 +16,7 @@ internal static class CliHelpText
               update <local-id> [fields]       Update a QSO (--grid, --freq, --enrich, etc.)
               delete <local-id>                Soft-delete a QSO (recoverable via restore)
               restore <local-id>               Restore a soft-deleted QSO
+              purge [options]                  Permanently delete soft-deleted QSOs
 
             ADIF:
               import <file>                    Import QSOs from an ADIF file
@@ -136,6 +137,25 @@ internal static class CliHelpText
                 pending remote delete so the QSO reappears in normal list output.
                 If the QRZ copy was already deleted, the QSO is re-queued for upload on the
                 next sync. Use list --deleted --show-id to find local IDs of trashed QSOs.
+                """,
+            "purge" => """
+                Usage: purge [options]
+
+                Permanently remove soft-deleted QSOs from storage ("empty trash").
+                This is non-recoverable. By default, prompts for confirmation.
+
+                  --older-than <duration>    Only purge QSOs deleted before this duration
+                                             (e.g., 7.days, 30.days, 1.hours)
+                  --ids <id1,id2,...>         Only purge specific local IDs (comma-separated)
+                  --include-pending-remote-deletes
+                                             Include QSOs with pending QRZ remote deletes
+                  --confirm                  Skip interactive confirmation prompt
+
+                Examples:
+                  purge                              Purge all deleted QSOs (with confirmation)
+                  purge --older-than 30.days         Purge QSOs deleted more than 30 days ago
+                  purge --ids abc123,def456          Purge specific QSOs
+                  purge --confirm                    Skip confirmation prompt
                 """,
             "import" => """
                 Usage: import <file-path> [--refresh]

--- a/src/dotnet/QsoRipper.Cli/Commands/PurgeCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/PurgeCommand.cs
@@ -1,0 +1,105 @@
+using Grpc.Net.Client;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli.Commands;
+
+internal static class PurgeCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel, string[] remainingArgs)
+    {
+        if (!TryParseArgs(remainingArgs, out var request, out var error))
+        {
+            Console.Error.WriteLine(error);
+            return 1;
+        }
+
+        if (!request.Confirm)
+        {
+            Console.Write("This will permanently delete soft-deleted QSOs. Type YES to confirm: ");
+            var input = Console.ReadLine();
+
+            if (input != "YES")
+            {
+                Console.WriteLine("Purge canceled.");
+                return 1;
+            }
+
+            request.Confirm = true;
+        }
+
+        var client = new LogbookService.LogbookServiceClient(channel);
+        var response = await client.PurgeDeletedQsosAsync(request);
+
+        Console.WriteLine($"Purged {response.PurgedCount} QSOs.");
+
+        if (response.RemoteDeletesPushed > 0 || response.RemoteDeletesFailed > 0)
+        {
+            Console.WriteLine($"Remote deletes: {response.RemoteDeletesPushed} pushed, {response.RemoteDeletesFailed} failed.");
+        }
+
+        if (!string.IsNullOrEmpty(response.ErrorSummary))
+        {
+            Console.Error.WriteLine(response.ErrorSummary);
+        }
+
+        return 0;
+    }
+
+    private static bool TryParseArgs(string[] args, out PurgeDeletedQsosRequest request, out string? error)
+    {
+        request = new PurgeDeletedQsosRequest();
+        error = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--older-than":
+                    if (i + 1 >= args.Length)
+                    {
+                        error = "--older-than requires a duration value (e.g., 7.days)";
+                        return false;
+                    }
+
+                    var timestamp = TimeParser.Parse(args[++i]);
+
+                    if (timestamp is null)
+                    {
+                        error = $"Invalid duration for --older-than: '{args[i]}'. Use formats like 7.days, 30.days, 1.hours.";
+                        return false;
+                    }
+
+                    request.OlderThan = timestamp;
+                    break;
+                case "--ids":
+                    if (i + 1 >= args.Length)
+                    {
+                        error = "--ids requires a comma-separated list of local IDs";
+                        return false;
+                    }
+
+                    var ids = args[++i].Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+                    if (ids.Length == 0)
+                    {
+                        error = "--ids requires at least one ID";
+                        return false;
+                    }
+
+                    request.LocalIds.AddRange(ids);
+                    break;
+                case "--include-pending-remote-deletes":
+                    request.IncludePendingRemoteDeletes = true;
+                    break;
+                case "--confirm":
+                    request.Confirm = true;
+                    break;
+                default:
+                    error = $"Unknown option: {args[i]}";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/dotnet/QsoRipper.Cli/Program.cs
+++ b/src/dotnet/QsoRipper.Cli/Program.cs
@@ -58,6 +58,7 @@ try
             "update" => await UpdateQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.RemainingArgs),
             "delete" => await DeleteQsoCommand.RunAsync(channel, arguments.Callsign!),
             "restore" => await RestoreQsoCommand.RunAsync(channel, arguments.Callsign!),
+            "purge" => await PurgeCommand.RunAsync(channel, arguments.RemainingArgs),
             "import" => await ImportAdifCommand.RunAsync(channel, arguments.Callsign ?? arguments.RemainingArgs.FirstOrDefault() ?? "", arguments.Refresh, cancellationSource.Token),
             "export" => await ExportAdifCommand.RunAsync(channel, arguments.RemainingArgs, cancellationSource.Token),
             "config" => await ConfigCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput),

--- a/src/dotnet/QsoRipper.DebugHost/Components/Pages/StorageWorkbench.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Pages/StorageWorkbench.razor
@@ -1,4 +1,5 @@
 @page "/storage-workbench"
+@using QsoRipper.Services
 @inject DebugWorkbenchState WorkbenchState
 @inject RuntimeConfigWorkbenchService RuntimeConfigWorkbenchService
 @inject StorageWorkbenchService StorageWorkbenchService
@@ -87,6 +88,48 @@
         {
             <div><code>@variable.Key=@variable.Value</code></div>
         }
+    </div>
+</div>
+
+<div class="card shadow-sm mt-4">
+    <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h2 class="h5 mb-0">Purge deleted QSOs</h2>
+            @if (purgeResponse is not null)
+            {
+                <span class="badge text-bg-info">
+                    Purged @purgeResponse.PurgedCount
+                </span>
+            }
+        </div>
+        <p class="text-muted">
+            Permanently remove all soft-deleted (trashed) QSOs from local storage. This action cannot be undone.
+        </p>
+        @if (!string.IsNullOrWhiteSpace(purgeError))
+        {
+            <div class="alert alert-danger">@purgeError</div>
+        }
+        @if (purgeResponse is not null && string.IsNullOrWhiteSpace(purgeError))
+        {
+            <div class="alert alert-success">
+                Purged @purgeResponse.PurgedCount QSO(s).
+                @if (purgeResponse.RemoteDeletesPushed > 0)
+                {
+                    <span> Remote deletes pushed: @purgeResponse.RemoteDeletesPushed.</span>
+                }
+                @if (purgeResponse.RemoteDeletesFailed > 0)
+                {
+                    <span class="text-warning"> Remote deletes failed: @purgeResponse.RemoteDeletesFailed.</span>
+                }
+                @if (!string.IsNullOrWhiteSpace(purgeResponse.ErrorSummary))
+                {
+                    <div class="mt-1 text-warning">@purgeResponse.ErrorSummary</div>
+                }
+            </div>
+        }
+        <button class="btn btn-outline-danger" @onclick="RunPurgeAsync" disabled="@isPurging">
+            @(isPurging ? "Purging…" : "Purge All Deleted")
+        </button>
     </div>
 </div>
 
@@ -195,6 +238,9 @@
     private ProtoPayloadView? syncStatusPayload;
     private ProtoPayloadView? deleteResponsePayload;
     private List<ProtoPayloadView> listedPayloads = [];
+    private PurgeDeletedQsosResponse? purgeResponse;
+    private string? purgeError;
+    private bool isPurging;
 
     protected override async Task OnInitializedAsync()
     {
@@ -233,6 +279,32 @@
         syncStatusPayload = result.SyncStatus is null ? null : ProtoJsonService.Describe(result.SyncStatus);
         deleteResponsePayload = result.DeleteResponse is null ? null : ProtoJsonService.Describe(result.DeleteResponse);
         listedPayloads = result.ListedQsos.Select(ProtoJsonService.Describe).ToList();
+    }
+
+    private async Task RunPurgeAsync()
+    {
+        isPurging = true;
+        purgeError = null;
+        purgeResponse = null;
+
+        try
+        {
+            purgeResponse = await StorageWorkbenchService.PurgeDeletedQsosAsync();
+        }
+        catch (Grpc.Core.RpcException ex)
+        {
+            purgeError = string.IsNullOrWhiteSpace(ex.Status.Detail)
+                ? $"Purge failed ({ex.StatusCode})."
+                : ex.Status.Detail;
+        }
+        catch (OperationCanceledException ex)
+        {
+            purgeError = ex.Message;
+        }
+        finally
+        {
+            isPurging = false;
+        }
     }
 
     private static string DescribeActiveStation(StationProfile profile)

--- a/src/dotnet/QsoRipper.DebugHost/Services/StorageWorkbenchService.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Services/StorageWorkbenchService.cs
@@ -180,6 +180,15 @@ internal sealed class StorageWorkbenchService
         }
     }
 
+    public async Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(CancellationToken cancellationToken = default)
+    {
+        var client = _clientFactory.CreateLogbookClient();
+
+        return await client.PurgeDeletedQsosAsync(
+            new PurgeDeletedQsosRequest { Confirm = true },
+            cancellationToken: cancellationToken);
+    }
+
     internal static QsoRecord BuildUpdatedQso(QsoRecord source)
     {
         ArgumentNullException.ThrowIfNull(source);

--- a/src/dotnet/QsoRipper.Gui.Tests/FullQsoCardViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/FullQsoCardViewModelTests.cs
@@ -479,5 +479,6 @@ public sealed class FullQsoCardViewModelTests
 
         public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default) =>
             Task.FromResult(new GetCurrentSpaceWeatherResponse());
+        public Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(IReadOnlyList<string>? localIds = null, Timestamp? olderThan = null, bool includePendingRemoteDeletes = false, CancellationToken ct = default) => throw new NotImplementedException();
     }
 }

--- a/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
@@ -172,5 +172,6 @@ public sealed class MainWindowViewModelTests
 
         public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default) =>
             Task.FromResult(new GetCurrentSpaceWeatherResponse());
+        public Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(IReadOnlyList<string>? localIds = null, Timestamp? olderThan = null, bool includePendingRemoteDeletes = false, CancellationToken ct = default) => throw new NotImplementedException();
     }
 }

--- a/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
@@ -1,3 +1,4 @@
+using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
 using QsoRipper.Gui.Services;
 using QsoRipper.Gui.ViewModels;
@@ -236,6 +237,7 @@ public sealed class QsoLoggerEnrichmentTests
 
         public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default) =>
             throw new NotImplementedException();
+        public Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(IReadOnlyList<string>? localIds = null, Timestamp? olderThan = null, bool includePendingRemoteDeletes = false, CancellationToken ct = default) => throw new NotImplementedException();
     }
 
     private sealed class CapturingEngineClient : IEngineClient
@@ -292,5 +294,6 @@ public sealed class QsoLoggerEnrichmentTests
 
         public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default) =>
             throw new NotImplementedException();
+        public Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(IReadOnlyList<string>? localIds = null, Timestamp? olderThan = null, bool includePendingRemoteDeletes = false, CancellationToken ct = default) => throw new NotImplementedException();
     }
 }

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
@@ -447,5 +447,6 @@ public class RecentQsoListViewModelTests
 
         public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default) =>
             throw new NotImplementedException();
+        public Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(IReadOnlyList<string>? localIds = null, Timestamp? olderThan = null, bool includePendingRemoteDeletes = false, CancellationToken ct = default) => throw new NotImplementedException();
     }
 }

--- a/src/dotnet/QsoRipper.Gui.Tests/SwitchableEngineClientTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/SwitchableEngineClientTests.cs
@@ -1,3 +1,4 @@
+using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
 using QsoRipper.Domain;
 using QsoRipper.EngineSelection;
@@ -126,6 +127,9 @@ public sealed class SwitchableEngineClientTests
             string localId,
             bool deleteFromQrz = false,
             CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(IReadOnlyList<string>? localIds = null, Google.Protobuf.WellKnownTypes.Timestamp? olderThan = null, bool includePendingRemoteDeletes = false, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
         public Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) =>

--- a/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
@@ -418,6 +418,15 @@ internal sealed class UxFixtureEngineClient : IEngineClient
         }
     }
 
+    public Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(
+        IReadOnlyList<string>? localIds = null,
+        Google.Protobuf.WellKnownTypes.Timestamp? olderThan = null,
+        bool includePendingRemoteDeletes = false,
+        CancellationToken ct = default)
+    {
+        return Task.FromResult(new PurgeDeletedQsosResponse { PurgedCount = 0 });
+    }
+
     public Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default)
     {
         return Task.FromResult(new LogQsoResponse { LocalId = Guid.NewGuid().ToString() });

--- a/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
@@ -169,6 +169,31 @@ internal sealed class EngineGrpcService : IEngineClient, IDisposable
             cancellationToken: ct);
     }
 
+    public async Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(
+        IReadOnlyList<string>? localIds = null,
+        Google.Protobuf.WellKnownTypes.Timestamp? olderThan = null,
+        bool includePendingRemoteDeletes = false,
+        CancellationToken ct = default)
+    {
+        var request = new PurgeDeletedQsosRequest
+        {
+            Confirm = true,
+            IncludePendingRemoteDeletes = includePendingRemoteDeletes
+        };
+
+        if (localIds is not null)
+        {
+            request.LocalIds.AddRange(localIds);
+        }
+
+        if (olderThan is not null)
+        {
+            request.OlderThan = olderThan;
+        }
+
+        return await _logbookClient.PurgeDeletedQsosAsync(request, cancellationToken: ct);
+    }
+
     public async Task<LogQsoResponse> LogQsoAsync(
         QsoRecord qso,
         bool syncToQrz = false,

--- a/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
@@ -44,6 +44,8 @@ internal interface IEngineClient
 
     Task<DeleteQsoResponse> DeleteQsoAsync(string localId, bool deleteFromQrz = false, CancellationToken ct = default);
 
+    Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(IReadOnlyList<string>? localIds = null, Google.Protobuf.WellKnownTypes.Timestamp? olderThan = null, bool includePendingRemoteDeletes = false, CancellationToken ct = default);
+
     Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default);
 
     Task<GetRigSnapshotResponse> GetRigSnapshotAsync(CancellationToken ct = default);

--- a/src/dotnet/QsoRipper.Gui/Services/SwitchableEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/SwitchableEngineClient.cs
@@ -204,6 +204,13 @@ internal sealed class SwitchableEngineClient : IEngineClient, IDisposable
         CancellationToken ct = default) =>
         SnapshotClient().DeleteQsoAsync(localId, deleteFromQrz, ct);
 
+    public Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(
+        IReadOnlyList<string>? localIds = null,
+        Google.Protobuf.WellKnownTypes.Timestamp? olderThan = null,
+        bool includePendingRemoteDeletes = false,
+        CancellationToken ct = default) =>
+        SnapshotClient().PurgeDeletedQsosAsync(localIds, olderThan, includePendingRemoteDeletes, ct);
+
     public Task<LogQsoResponse> LogQsoAsync(
         QsoRecord qso,
         bool syncToQrz = false,

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -373,6 +373,61 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         DeleteConfirmCallsign = string.Empty;
     }
 
+    [ObservableProperty]
+    private bool _isPurgePending;
+
+    [ObservableProperty]
+    private string _purgeConfirmText = string.Empty;
+
+    [RelayCommand]
+    internal void RequestPurge()
+    {
+        IsPurgePending = true;
+        PurgeConfirmText = string.Empty;
+    }
+
+    [RelayCommand]
+    private void CancelPurge()
+    {
+        IsPurgePending = false;
+        PurgeConfirmText = string.Empty;
+    }
+
+    [RelayCommand]
+    internal async Task ConfirmPurgeAsync()
+    {
+        if (!string.Equals(PurgeConfirmText, "YES", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        IsPurgePending = false;
+        PurgeConfirmText = string.Empty;
+
+        try
+        {
+            var response = await _engine.PurgeDeletedQsosAsync();
+            if (response.PurgedCount > 0)
+            {
+                ErrorMessage = $"Purged {response.PurgedCount} deleted QSO(s).";
+            }
+            else
+            {
+                ErrorMessage = "No deleted QSOs to purge.";
+            }
+
+            NotifyStatusPropertiesChanged();
+            await RefreshAsync();
+        }
+        catch (RpcException ex)
+        {
+            ErrorMessage = string.IsNullOrWhiteSpace(ex.Status.Detail)
+                ? $"Purge failed ({ex.StatusCode})."
+                : ex.Status.Detail;
+            NotifyStatusPropertiesChanged();
+        }
+    }
+
     [RelayCommand]
     private void ZoomIn()
     {

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -1083,6 +1083,51 @@
         </Border>
       </Border>
 
+      <!-- Purge confirmation overlay -->
+      <Border x:Name="PurgeConfirmOverlay"
+              AutomationProperties.AutomationId="PurgeConfirmOverlay"
+              IsVisible="{Binding RecentQsos.IsPurgePending}"
+              Background="#80000000">
+        <Border Background="{DynamicResource SystemControlBackgroundAltHighBrush}"
+                CornerRadius="8"
+                Padding="24"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                BoxShadow="0 8 24 0 #40000000"
+                MinWidth="360">
+          <StackPanel Spacing="16">
+            <TextBlock Text="Purge All Deleted QSOs?"
+                       FontSize="16"
+                       FontWeight="SemiBold" />
+            <TextBlock FontSize="13"
+                       TextWrapping="Wrap"
+                       Text="This will permanently remove all trashed QSOs from local storage. This action cannot be undone." />
+            <StackPanel Spacing="6">
+              <TextBlock FontSize="12"
+                         Opacity="0.72"
+                         Text="Type YES to confirm:" />
+              <TextBox Text="{Binding RecentQsos.PurgeConfirmText, Mode=TwoWay}"
+                       PlaceholderText="YES"
+                       MaxWidth="200"
+                       HorizontalAlignment="Left" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal"
+                        Spacing="10"
+                        HorizontalAlignment="Right">
+              <Button Content="Cancel"
+                      MinWidth="80"
+                      Foreground="{DynamicResource SystemControlForegroundBaseHighBrush}"
+                      Command="{Binding RecentQsos.CancelPurgeCommand}" />
+              <Button Content="Purge"
+                      MinWidth="80"
+                      Foreground="White"
+                      Classes="accent"
+                      Command="{Binding RecentQsos.ConfirmPurgeCommand}" />
+            </StackPanel>
+          </StackPanel>
+        </Border>
+      </Border>
+
       <!-- Full QSO Card overlay -->
       <ContentControl Content="{Binding FullQsoCard}">
         <ContentControl.DataTemplates>

--- a/src/rust/qsoripper-tui/src/app.rs
+++ b/src/rust/qsoripper-tui/src/app.rs
@@ -43,6 +43,8 @@ pub(crate) enum View {
     Help,
     /// Confirmation dialog before deleting a QSO.
     ConfirmDeleteQso,
+    /// Confirmation dialog before purging all soft-deleted QSOs.
+    ConfirmPurge,
 }
 
 /// Resolved callsign information from a QRZ lookup (used for field auto-population).

--- a/src/rust/qsoripper-tui/src/events.rs
+++ b/src/rust/qsoripper-tui/src/events.rs
@@ -36,6 +36,10 @@ pub(crate) enum AppEvent {
     QsoDeleted(String),
     /// A QSO deletion attempt failed; value is the human-readable error message.
     QsoDeleteFailed(String),
+    /// All soft-deleted QSOs were permanently purged; value is the purged count.
+    PurgeComplete(u32),
+    /// A purge attempt failed; value is the human-readable error message.
+    PurgeFailed(String),
     /// Refreshed snapshot of recent QSOs.
     RecentQsos(Vec<RecentQso>),
     /// Background name enrichment result for one QSO in the recent list.

--- a/src/rust/qsoripper-tui/src/grpc.rs
+++ b/src/rust/qsoripper-tui/src/grpc.rs
@@ -13,7 +13,7 @@ use qsoripper_core::proto::qsoripper::services::{
     rig_control_service_client::RigControlServiceClient,
     space_weather_service_client::SpaceWeatherServiceClient, DeleteQsoRequest,
     GetCurrentSpaceWeatherRequest, GetRigSnapshotRequest, ListQsosRequest, LogQsoRequest,
-    LookupRequest, UpdateQsoRequest,
+    LookupRequest, PurgeDeletedQsosRequest, UpdateQsoRequest,
 };
 
 use crate::app::{CallsignInfo, RecentQso, RigInfo, RigStatus, SpaceWeatherInfo};
@@ -389,6 +389,19 @@ pub(crate) async fn delete_qso(channel: Channel, local_id: &str) -> anyhow::Resu
     };
     client.delete_qso(request).await?;
     Ok(())
+}
+
+/// Permanently purge all soft-deleted QSOs and return the number of records removed.
+pub(crate) async fn purge_deleted_qsos(channel: Channel) -> anyhow::Result<u32> {
+    let mut client = LogbookServiceClient::new(channel);
+    let request = PurgeDeletedQsosRequest {
+        local_ids: vec![],
+        older_than: None,
+        include_pending_remote_deletes: false,
+        confirm: true,
+    };
+    let response = client.purge_deleted_qsos(request).await?.into_inner();
+    Ok(response.purged_count)
 }
 
 /// Convert a frequency in MHz to Hz as a `u64`.

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -180,6 +180,10 @@ async fn run<B: ratatui::backend::Backend>(
 }
 
 /// Dispatch a single [`AppEvent`] to the appropriate handler.
+#[expect(
+    clippy::too_many_lines,
+    reason = "top-level event dispatch; splitting would obscure the routing logic"
+)]
 fn handle_event_with_channel(
     app: &mut App,
     event: AppEvent,
@@ -247,6 +251,17 @@ fn handle_event_with_channel(
         AppEvent::QsoDeleteFailed(err) => {
             app.set_error(format!("Delete failed: {err}"));
             app.delete_candidate_id = None;
+            app.view = app::View::LogEntry;
+        }
+        AppEvent::PurgeComplete(count) => {
+            app.set_status(format!("Purged {count} QSOs"));
+            app.view = app::View::LogEntry;
+            app.qso_list_focused = false;
+            app.qso_selected = None;
+            refresh_recent_qsos(event_tx, channel);
+        }
+        AppEvent::PurgeFailed(err) => {
+            app.set_error(format!("Purge failed: {err}"));
             app.view = app::View::LogEntry;
         }
         AppEvent::RecentQsos(qsos) => {
@@ -376,6 +391,11 @@ fn handle_key_with_channel(
         return;
     }
 
+    if matches!(app.view, app::View::ConfirmPurge) {
+        handle_confirm_purge_key(app, key, event_tx, channel);
+        return;
+    }
+
     if app.search_focused {
         handle_search_key(app, key);
         return;
@@ -408,7 +428,7 @@ fn handle_key_with_channel(
                 app.form.focused = Field::Callsign;
                 app.form.field_selected = true;
             }
-            app::View::Help | app::View::ConfirmDeleteQso => {}
+            app::View::Help | app::View::ConfirmDeleteQso | app::View::ConfirmPurge => {}
         },
         KeyCode::F(3) => {
             if !app.filtered_qsos().is_empty() {
@@ -449,7 +469,7 @@ fn handle_key_with_channel(
                 app.editing_local_id = None;
                 app.reset_timer();
             }
-            app::View::Help | app::View::ConfirmDeleteQso => {}
+            app::View::Help | app::View::ConfirmDeleteQso | app::View::ConfirmPurge => {}
         },
         KeyCode::Left if app.form.is_cycle_field() => cycle_left(app),
         KeyCode::Right if app.form.is_cycle_field() => cycle_right(app),
@@ -590,6 +610,9 @@ fn handle_qso_list_key(
                 app.view = app::View::ConfirmDeleteQso;
             }
         }
+        KeyCode::Char('p' | 'P') => {
+            app.view = app::View::ConfirmPurge;
+        }
         KeyCode::Esc | KeyCode::F(3) => {
             app.qso_list_focused = false;
             app.qso_selected = None;
@@ -636,6 +659,44 @@ fn spawn_delete_qso(
             }
             Err(e) => {
                 let _ = tx.send(AppEvent::QsoDeleteFailed(e.to_string()));
+            }
+        }
+    });
+}
+
+/// Handle key input while the purge-confirmation dialog is showing.
+fn handle_confirm_purge_key(
+    app: &mut App,
+    key: crossterm::event::KeyEvent,
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    channel: &tonic::transport::Channel,
+) {
+    use crossterm::event::KeyCode;
+    match key.code {
+        KeyCode::Char('y' | 'Y') | KeyCode::Enter => {
+            spawn_purge_deleted_qsos(event_tx, channel);
+        }
+        KeyCode::Char('n' | 'N') | KeyCode::Esc => {
+            app.view = app::View::LogEntry;
+        }
+        _ => {}
+    }
+}
+
+/// Spawn a task to purge all soft-deleted QSOs and forward the result to the event channel.
+fn spawn_purge_deleted_qsos(
+    event_tx: &mpsc::UnboundedSender<AppEvent>,
+    channel: &tonic::transport::Channel,
+) {
+    let tx = event_tx.clone();
+    let channel = channel.clone();
+    tokio::spawn(async move {
+        match grpc::purge_deleted_qsos(channel).await {
+            Ok(count) => {
+                let _ = tx.send(AppEvent::PurgeComplete(count));
+            }
+            Err(e) => {
+                let _ = tx.send(AppEvent::PurgeFailed(e.to_string()));
             }
         }
     });
@@ -2715,5 +2776,105 @@ mod tests {
         });
         apply_rig_snapshot(&mut app, rig);
         assert_eq!(app.form.frequency_mhz, original_freq); // unchanged
+    }
+
+    #[test]
+    fn handle_qso_list_key_p_sets_confirm_purge_view() {
+        let (lookup_tx, _rx) = make_watch();
+        let mut app = make_app();
+        app.recent_qsos.push(make_qso("1", "K7ABC"));
+        app.qso_list_focused = true;
+        app.qso_selected = Some(0);
+        handle_qso_list_key(&mut app, make_key(KeyCode::Char('p')), &lookup_tx);
+        assert!(matches!(app.view, View::ConfirmPurge));
+    }
+
+    #[test]
+    fn handle_qso_list_key_upper_p_sets_confirm_purge_view() {
+        let (lookup_tx, _rx) = make_watch();
+        let mut app = make_app();
+        app.recent_qsos.push(make_qso("1", "K7ABC"));
+        app.qso_list_focused = true;
+        app.qso_selected = Some(0);
+        handle_qso_list_key(&mut app, make_key(KeyCode::Char('P')), &lookup_tx);
+        assert!(matches!(app.view, View::ConfirmPurge));
+    }
+
+    #[tokio::test]
+    async fn handle_key_confirm_purge_n_cancels() {
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let (lookup_tx, _lookup_rx) = make_watch();
+        let (rig_tx, _rig_rx) = make_rig_watch();
+        let mut app = make_app();
+        app.view = View::ConfirmPurge;
+        handle_key(
+            &mut app,
+            make_key(KeyCode::Char('n')),
+            &tx,
+            &lookup_tx,
+            &rig_tx,
+            "",
+        );
+        assert!(matches!(app.view, View::LogEntry));
+    }
+
+    #[tokio::test]
+    async fn handle_key_confirm_purge_esc_cancels() {
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let (lookup_tx, _lookup_rx) = make_watch();
+        let (rig_tx, _rig_rx) = make_rig_watch();
+        let mut app = make_app();
+        app.view = View::ConfirmPurge;
+        handle_key(
+            &mut app,
+            make_key(KeyCode::Esc),
+            &tx,
+            &lookup_tx,
+            &rig_tx,
+            "",
+        );
+        assert!(matches!(app.view, View::LogEntry));
+    }
+
+    #[tokio::test]
+    async fn handle_event_purge_complete_sets_status() {
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let (lookup_tx, _lookup_rx) = make_watch();
+        let (rig_tx, _rig_rx) = make_rig_watch();
+        let mut app = make_app();
+        app.view = View::ConfirmPurge;
+        handle_event(
+            &mut app,
+            AppEvent::PurgeComplete(5),
+            &tx,
+            &lookup_tx,
+            &rig_tx,
+            "",
+        );
+        assert!(matches!(app.view, View::LogEntry));
+        let msg = app.status_message.as_ref().unwrap();
+        assert!(!msg.is_error);
+        assert!(msg.text.contains('5'));
+    }
+
+    #[tokio::test]
+    async fn handle_event_purge_failed_sets_error() {
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let (lookup_tx, _lookup_rx) = make_watch();
+        let (rig_tx, _rig_rx) = make_rig_watch();
+        let mut app = make_app();
+        app.view = View::ConfirmPurge;
+        handle_event(
+            &mut app,
+            AppEvent::PurgeFailed("connection refused".to_string()),
+            &tx,
+            &lookup_tx,
+            &rig_tx,
+            "",
+        );
+        assert!(matches!(app.view, View::LogEntry));
+        let msg = app.status_message.as_ref().unwrap();
+        assert!(msg.is_error);
+        assert!(msg.text.contains("connection refused"));
     }
 }

--- a/src/rust/qsoripper-tui/src/ui/confirm_dialog.rs
+++ b/src/rust/qsoripper-tui/src/ui/confirm_dialog.rs
@@ -60,6 +60,47 @@ pub(super) fn render(app: &App, frame: &mut Frame) {
     frame.render_widget(paragraph, popup_area);
 }
 
+/// Render a purge confirmation popup over whatever is already drawn.
+pub(super) fn render_purge(frame: &mut Frame) {
+    let popup_area = centered_rect(50, 9, frame.area());
+
+    let block = Block::bordered()
+        .title(" Purge Deleted QSOs ")
+        .title_style(Style::default().fg(Color::Red).add_modifier(Modifier::BOLD))
+        .border_style(Style::default().fg(Color::Red));
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Permanently delete ALL trashed QSOs?",
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            "  This cannot be undone.",
+            Style::default().fg(Color::Red),
+        )),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                "  [ Y / Enter: Confirm ]",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw("   "),
+            Span::styled("[ N / Esc: Cancel ]", Style::default().fg(Color::Green)),
+        ]),
+        Line::from(""),
+    ];
+
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .alignment(Alignment::Left);
+
+    frame.render_widget(Clear, popup_area);
+    frame.render_widget(paragraph, popup_area);
+}
+
 /// Return a [`Rect`] centered within `area` with the given percentage width and fixed height.
 fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
     let vertical = Layout::vertical([

--- a/src/rust/qsoripper-tui/src/ui/help.rs
+++ b/src/rust/qsoripper-tui/src/ui/help.rs
@@ -87,6 +87,8 @@ pub(super) fn render(frame: &mut Frame, area: Rect) {
         "Navigate QSO entries",
     ));
     lines.push(binding("Enter            ", "Load selected QSO into form"));
+    lines.push(binding("D / Delete       ", "Delete selected QSO"));
+    lines.push(binding("P                ", "Purge all trashed QSOs"));
     lines.push(binding("Esc / F3         ", "Return focus to form"));
     lines.push(Line::raw(""));
 

--- a/src/rust/qsoripper-tui/src/ui/mod.rs
+++ b/src/rust/qsoripper-tui/src/ui/mod.rs
@@ -58,6 +58,10 @@ pub(crate) fn render_ui(app: &App, frame: &mut Frame) {
     if matches!(app.view, View::ConfirmDeleteQso) {
         confirm_dialog::render(app, frame);
     }
+
+    if matches!(app.view, View::ConfirmPurge) {
+        confirm_dialog::render_purge(frame);
+    }
 }
 
 /// Render the status bar (QSO log / error feedback).
@@ -196,6 +200,14 @@ mod tests {
         app.recent_qsos.push(make_qso("del-id", "K7ABC"));
         app.view = View::ConfirmDeleteQso;
         app.delete_candidate_id = Some("del-id".to_string());
+        terminal.draw(|f| super::render_ui(&app, f)).unwrap();
+    }
+
+    #[test]
+    fn render_confirm_purge_view() {
+        let mut terminal = make_terminal();
+        let mut app = make_app();
+        app.view = View::ConfirmPurge;
         terminal.draw(|f| super::render_ui(&app, f)).unwrap();
     }
 


### PR DESCRIPTION
## Summary

Adds purge affordances across all four client surfaces so operators can invoke the `PurgeDeletedQsos` RPC added in PR #314.

Fixes #315

## Changes

### CLI (`qsoripper purge`)
- New `purge` command with `--older-than`, `--ids`, `--include-pending-remote-deletes`, `--confirm`
- Interactive `YES` confirmation when `--confirm` not passed
- Reuses existing `TimeParser` for duration parsing (e.g., `7.days`, `30.days`)
- Help text with usage examples

### GUI (Avalonia)
- `PurgeDeletedQsosAsync` added to `IEngineClient` + all implementations
- Purge confirmation overlay with `YES` text input (matches delete confirm pattern)
- `RecentQsoListViewModel`: `RequestPurge`/`ConfirmPurge`/`CancelPurge` flow
- Fixed `Watermark` → `PlaceholderText` deprecation warning

### TUI
- `P` keybinding in QSO list to trigger purge
- `ConfirmPurge` view with `Y`/`Enter` confirm, `N`/`Esc` cancel
- Async gRPC call with `PurgeComplete`/`PurgeFailed` events
- Status message on success/failure, auto-refreshes list
- 7 new tests covering key handling, events, and rendering
- Help screen updated with `P` keybinding

### Debug Host
- `PurgeDeletedQsosAsync` on `StorageWorkbenchService`
- Purge card on `StorageWorkbench` page with result display

## Validation
- `dotnet build` — 0 errors
- `dotnet test` — 756 tests passed
- `dotnet format --verify-no-changes` — clean
- `cargo fmt --check` — clean
- `cargo clippy --all-targets -D warnings` — clean
- `cargo test -p qsoripper-tui` — 215 tests passed (7 new)

Note: `qsoripper-ffi` has a pre-existing test failure on main (`log_list_get_delete_round_trip`) unrelated to this change.