### PR TITLE
fix(gui): resolve DataGrid editing crash from missing System.ComponentModel.Annotations binding

### DIFF
--- a/src/dotnet/QsoRipper.Gui.Tests/FrameworkAssemblyResolverTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/FrameworkAssemblyResolverTests.cs
@@ -1,0 +1,53 @@
+using System.Reflection;
+using QsoRipper.Gui.Utilities;
+
+namespace QsoRipper.Gui.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+
+// Regression test for issue #318:
+// In published Release builds, Avalonia.Controls.DataGrid's editing path can fail to bind
+// the System.ComponentModel.Annotations identity it was compiled against
+// (Version=10.0.0.0, PublicKeyToken=b03f5f7f11d50a3a). FrameworkAssemblyResolver is the
+// defensive bridge that satisfies that load by returning the shared-framework copy.
+public sealed class FrameworkAssemblyResolverTests
+{
+    [Fact]
+    public void Resolver_returns_framework_copy_for_crash_assembly_identity()
+    {
+        // The exact identity from the crash log in issue #318.
+        var requested = new AssemblyName(
+            "System.ComponentModel.Annotations, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a");
+
+        var resolved = FrameworkAssemblyResolver.Resolve(requested);
+
+        Assert.NotNull(resolved);
+        Assert.Equal("System.ComponentModel.Annotations", resolved!.GetName().Name);
+
+        // Sanity: the resolved assembly must actually contain the EditableAttribute type
+        // that DataGrid reflects on. If this is missing, the resolver returned the wrong
+        // assembly and the underlying crash would still occur.
+        var editable = resolved.GetType("System.ComponentModel.DataAnnotations.EditableAttribute");
+        Assert.NotNull(editable);
+    }
+
+    [Fact]
+    public void Resolver_returns_null_for_unrelated_assembly_requests()
+    {
+        var requested = new AssemblyName("Some.Unrelated.Assembly, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
+
+        var resolved = FrameworkAssemblyResolver.Resolve(requested);
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void Register_is_idempotent_and_safe_to_call_repeatedly()
+    {
+        // Should not throw or double-register. Verifying via repeated invocation; the resolver
+        // itself uses Interlocked to guard the AppDomain hookup.
+        FrameworkAssemblyResolver.Register();
+        FrameworkAssemblyResolver.Register();
+        FrameworkAssemblyResolver.Register();
+    }
+}

--- a/src/dotnet/QsoRipper.Gui.Tests/FrameworkAssemblyResolverTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/FrameworkAssemblyResolverTests.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using System.Reflection;
 using QsoRipper.Gui.Utilities;
 
@@ -12,6 +13,15 @@ namespace QsoRipper.Gui.Tests;
 // defensive bridge that satisfies that load by returning the shared-framework copy.
 public sealed class FrameworkAssemblyResolverTests
 {
+    // Model deliberately uses [Editable] - the exact attribute Avalonia.Controls.DataGrid
+    // reflects on in GetPropertyIsReadOnly. Reflecting on it forces a runtime load of
+    // System.ComponentModel.Annotations, which is what triggered the production crash.
+    private sealed class EditableSampleRow
+    {
+        [Editable(allowEdit: false)]
+        public string Callsign { get; set; } = "K1ABC";
+    }
+
     [Fact]
     public void Resolver_returns_framework_copy_for_crash_assembly_identity()
     {
@@ -50,4 +60,32 @@ public sealed class FrameworkAssemblyResolverTests
         FrameworkAssemblyResolver.Register();
         FrameworkAssemblyResolver.Register();
     }
+
+    [Fact]
+    public void DataGrid_style_attribute_reflection_does_not_throw_with_resolver_registered()
+    {
+        // This mirrors the exact reflection call Avalonia.Controls.DataGrid.DataGridDataConnection
+        // makes inside GetPropertyIsReadOnly: it asks a bound property for its [Editable]
+        // attributes. JIT-time resolution of typeof(EditableAttribute) plus the reflection call
+        // forces a runtime load of System.ComponentModel.Annotations, which is the load that
+        // failed with FileNotFoundException in issue #318.
+        FrameworkAssemblyResolver.Register();
+
+        var prop = typeof(EditableSampleRow).GetProperty(nameof(EditableSampleRow.Callsign));
+        Assert.NotNull(prop);
+
+        // The act of calling GetCustomAttributes with typeof(EditableAttribute) is what
+        // triggered the crashing assembly load in production.
+        var attrs = prop!.GetCustomAttributes(typeof(EditableAttribute), inherit: true);
+
+        Assert.Single(attrs);
+        var editable = Assert.IsType<EditableAttribute>(attrs[0]);
+        Assert.False(editable.AllowEdit);
+
+        // EditableAttribute lives in System.ComponentModel.Annotations - confirm the load
+        // succeeded and the resolved assembly is the shared-framework copy.
+        var hostingAssembly = typeof(EditableAttribute).Assembly;
+        Assert.Equal("System.ComponentModel.Annotations", hostingAssembly.GetName().Name);
+    }
 }
+

--- a/src/dotnet/QsoRipper.Gui/Program.cs
+++ b/src/dotnet/QsoRipper.Gui/Program.cs
@@ -14,6 +14,7 @@ internal static class Program
     [STAThread]
     public static void Main(string[] args)
     {
+        FrameworkAssemblyResolver.Register();
         GuiPerformanceTrace.Write(nameof(Main) + ".start");
         if (!UxCaptureOptions.TryParse(args, out var options, out var error))
         {

--- a/src/dotnet/QsoRipper.Gui/Utilities/FrameworkAssemblyResolver.cs
+++ b/src/dotnet/QsoRipper.Gui/Utilities/FrameworkAssemblyResolver.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Reflection;
+
+namespace QsoRipper.Gui.Utilities;
+
+// Issue #318: Avalonia.Controls.DataGrid (compiled against the .NETStandard reference of
+// System.ComponentModel.Annotations, PublicKeyToken=b03f5f7f11d50a3a) can fail to bind to
+// the .NET shared-framework copy of that assembly in published Release builds, throwing
+// FileNotFoundException the first time DataGridDataConnection.GetPropertyIsReadOnly runs
+// (i.e., the moment a user clicks a DataGrid cell to begin editing). The shared framework
+// always ships System.ComponentModel.Annotations under the Microsoft public key, so we can
+// satisfy the request by loading it by simple name and returning that instance.
+//
+// This is defensive: if the runtime would have resolved the request itself, the handler is
+// never invoked. If the runtime fails to bind, the handler unblocks the load and prevents
+// the crash.
+internal static class FrameworkAssemblyResolver
+{
+    private static readonly string[] FrameworkSimpleNames =
+    {
+        "System.ComponentModel.Annotations",
+    };
+
+    private static readonly ConcurrentDictionary<string, Assembly> Cache = new(StringComparer.OrdinalIgnoreCase);
+
+    private static int _registered;
+
+    public static void Register()
+    {
+        if (System.Threading.Interlocked.Exchange(ref _registered, 1) != 0)
+        {
+            return;
+        }
+
+        AppDomain.CurrentDomain.AssemblyResolve += OnAssemblyResolve;
+    }
+
+    internal static Assembly? Resolve(AssemblyName requested)
+    {
+        ArgumentNullException.ThrowIfNull(requested);
+
+        var simpleName = requested.Name;
+        if (string.IsNullOrEmpty(simpleName))
+        {
+            return null;
+        }
+
+        if (Array.IndexOf(FrameworkSimpleNames, simpleName) < 0)
+        {
+            return null;
+        }
+
+        return Cache.GetOrAdd(simpleName, static name =>
+        {
+            // Load by simple name; the runtime resolves to the shared-framework copy regardless
+            // of the original request's PublicKeyToken/Version, which is exactly what we want
+            // when the original strong-name binding fails.
+            return Assembly.Load(new AssemblyName(name));
+        });
+    }
+
+    private static Assembly? OnAssemblyResolve(object? sender, ResolveEventArgs args)
+    {
+        try
+        {
+            return Resolve(new AssemblyName(args.Name));
+        }
+        catch (FileNotFoundException)
+        {
+            return null;
+        }
+        catch (FileLoadException)
+        {
+            return null;
+        }
+        catch (BadImageFormatException)
+        {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Fixes a hard crash in QsoRipper.Gui that occurs the moment a user clicks any DataGrid cell to begin inline editing in published Release builds. The crash was reproduced on Windows 11 with .NET 10.0.6 and traced via the Application Event Log (issue #318).

Root cause:
Avalonia.Controls.DataGrid 12.0.0 is compiled against the .NETStandard reference of System.ComponentModel.Annotations (Version=10.0.0.0, PublicKeyToken=b03f5f7f11d50a3a, the ECMA token, verified by inspecting the assembly references in the restored package). When DataGridDataConnection.GetPropertyIsReadOnly runs during BeginCellEdit, it triggers a load of that exact identity. The shared framework ships System.ComponentModel.Annotations under the Microsoft public key, and in this scenario the runtime fails to bridge the two identities, raising FileNotFoundException with no chance for the app to recover.

Fix:
Adds a small FrameworkAssemblyResolver utility that hooks AppDomain.CurrentDomain.AssemblyResolve and, for the affected simple name, returns the shared-framework copy by loading it by simple name. This bypasses the strong-name mismatch without requiring NuGet PackageReference workarounds (which are silently elided by NuGet for framework-provided assemblies in net10 and therefore have no effect on deps.json closure - I tried that first and confirmed it does nothing). The handler is registered in Program.Main before AppBuilder runs, only fires when the runtime would otherwise fail, and is a no-op for unrelated assemblies.

Tests (FrameworkAssemblyResolverTests, 4 cases):
- Resolver returns the shared-framework copy of System.ComponentModel.Annotations when asked for the exact AssemblyName from the crash log, and the returned assembly contains EditableAttribute.
- Resolver returns null for unrelated assembly requests (no overreach).
- Register is idempotent and safe to call repeatedly.
- DataGrid-style attribute reflection - the exact GetCustomAttributes(typeof(EditableAttribute), inherit: true) call that Avalonia DataGridDataConnection.GetPropertyIsReadOnly makes - succeeds without throwing on a property decorated with [Editable]. This forces the same runtime assembly load that crashed in production and is the closest in-process reproduction available.

Verification limitation (transparent):
The crash environment was .NET 10.0.6; this machine is now on 10.0.7, where the runtime resolves the problematic identity natively. As a result, the test suite cannot manufacture a "fails before fix, passes after fix" repro on the current host - the assembly load succeeds either way. The tests instead lock in the contract of the defensive resolver and exercise the same reflection path Avalonia uses, so they will catch any future regression where the load again fails. Adding a true headless Avalonia DataGrid edit smoke test was attempted but Avalonia.Headless.XUnit 12.x requires xunit v3, which conflicts with the project's existing xunit v2 test suite; that migration is out of scope for this fix.

Validation:
- dotnet build src/dotnet/QsoRipper.slnx (clean)
- dotnet test src/dotnet/QsoRipper.Gui.Tests (87/87 passing, including the 4 new tests)
- dotnet format --verify-no-changes (clean)

Closes #318
