### PR TITLE
feat(cw): auto-fill cw_decode_transcript on logged CW QSOs (round 2 of #321)

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -1200,6 +1200,8 @@ When DXCC data is available, cascade zone information onto the lookup result if 
    - `QSO_COMPLETE` → `qso_complete` (`Y`/`N`/`NIL`/`?` → `QsoCompletion` enum)
    - `MY_ALTITUDE` → `station_snapshot.altitude_meters`
    - `MY_GRIDSQUARE_EXT` → `station_snapshot.gridsquare_ext`
+   - `APP_QSORIPPER_RX_WPM` → `cw_decode_rx_wpm` (parsed as unsigned integer; non-numeric values fall back to `extra_fields`)
+   - `APP_QSORIPPER_CW_TRANSCRIPT` → `cw_decode_transcript` (decoded CW transcript snapshot for the QSO; empty values are dropped)
    Unrecognized values (e.g., malformed LAT, unknown `QSO_COMPLETE` literal) fall back to `extra_fields` under the original key.
 5. Preserve any other unrecognized ADIF fields in the `extra_fields` map for lossless round-trip.
 6. Generate a `local_id` for each imported record.
@@ -1216,7 +1218,7 @@ See `docs/integrations/adif-specification.md` for the authoritative field-name t
    - `qrz_logid` → `APP_QRZLOG_LOGID`
    - `qrz_bookid` → `APP_QRZLOG_QSO_ID`
    When iterating `extra_fields`, skip keys already covered by these dedicated emissions (`APP_QRZLOG_LOGID`, `APP_QRZ_LOGID`, `APP_QRZLOG_QSO_ID`, `APP_QRZ_BOOKID`) to avoid duplicate ADIF fields.
-4. Emit the normalized ADIF fields from their dedicated proto slots whenever populated (`BAND_RX`, `FREQ_RX`, `LAT`, `LON`, `ALTITUDE`, `GRIDSQUARE_EXT`, `OWNER_CALLSIGN`, `QSO_COMPLETE`, `MY_ALTITUDE`, `MY_GRIDSQUARE_EXT`). When iterating `extra_fields`, skip these same keys so the dedicated proto value always wins and the ADIF output never contains the same field twice.
+4. Emit the normalized ADIF fields from their dedicated proto slots whenever populated (`BAND_RX`, `FREQ_RX`, `LAT`, `LON`, `ALTITUDE`, `GRIDSQUARE_EXT`, `OWNER_CALLSIGN`, `QSO_COMPLETE`, `MY_ALTITUDE`, `MY_GRIDSQUARE_EXT`, `APP_QSORIPPER_RX_WPM`, `APP_QSORIPPER_CW_TRANSCRIPT`). When iterating `extra_fields`, skip these same keys so the dedicated proto value always wins and the ADIF output never contains the same field twice. Engines MUST sanitize `cw_decode_transcript` to printable ASCII (plus CR/LF/tab) before emitting `APP_QSORIPPER_CW_TRANSCRIPT` so the .NET char-count length and Rust byte-count length agree across runtimes.
 5. Include other `extra_fields` to preserve data from previous imports.
 6. Output records delimited by `<eor>`.
 

--- a/proto/domain/qso_record.proto
+++ b/proto/domain/qso_record.proto
@@ -133,4 +133,23 @@ message QsoRecord {
   // decoding); ADIF `SPEED` mapping waits for that field, so this round-1
   // RX value is exported via `APP_QSORIPPER_RX_WPM`.
   optional uint32 cw_decode_rx_wpm = 130;
+
+  // Decoded CW transcript text from the worked station's audio over the
+  // QSO's start..end window (concatenated `char` events from the live CW
+  // decoder, with `word` boundaries rendered as spaces and unresolved
+  // symbols rendered as `?`). Auto-filled by the GUI on save when the
+  // QSO is on CW mode and the decoder produced events; otherwise unset.
+  // Editable by the operator on the QSO card so copy errors can be
+  // corrected before saving.
+  //
+  // This is an intentionally lossy "latest snapshot" cache. A future
+  // `cw_transcript_segments` table (per #321) will be the authoritative
+  // store of decoded segments with timing/pitch/lock metadata; this
+  // inline field stays as a denormalized convenience for at-a-glance
+  // display, ADIF export, and offline viewing without a join.
+  //
+  // ADIF interchange: round-trips via the application-defined field
+  // `APP_QSORIPPER_CW_TRANSCRIPT`. There is no standard ADIF field for
+  // a decoded transcript.
+  optional string cw_decode_transcript = 131;
 }

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/AdifCodecTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/AdifCodecTests.cs
@@ -391,4 +391,84 @@ public sealed class AdifCodecTests
 
         Assert.DoesNotContain("APP_QSORIPPER_RX_WPM", adif);
     }
+
+    [Fact]
+    public void Cw_decode_transcript_round_trips_via_app_qsoripper_cw_transcript()
+    {
+        var original = new QsoRecord
+        {
+            WorkedCallsign = "W1AW",
+            Band = Band._40M,
+            Mode = Mode.Cw,
+            UtcTimestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)),
+            CwDecodeTranscript = "CQ DE W1AW K",
+        };
+
+        var adif = AdifCodec.SerializeSingleQso(original);
+        Assert.Contains("<APP_QSORIPPER_CW_TRANSCRIPT:12>CQ DE W1AW K", adif);
+
+        var parsed = AdifCodec.ParseAdif($"<EOH>\n{adif}");
+        Assert.Single(parsed);
+        Assert.True(parsed[0].HasCwDecodeTranscript);
+        Assert.Equal("CQ DE W1AW K", parsed[0].CwDecodeTranscript);
+        Assert.False(parsed[0].ExtraFields.ContainsKey("APP_QSORIPPER_CW_TRANSCRIPT"));
+    }
+
+    [Fact]
+    public void Serialize_omits_cw_decode_transcript_when_unset()
+    {
+        var qso = new QsoRecord
+        {
+            WorkedCallsign = "W1AW",
+            Mode = Mode.Cw,
+            Band = Band._40M,
+            UtcTimestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)),
+        };
+
+        var adif = AdifCodec.SerializeSingleQso(qso);
+
+        Assert.DoesNotContain("APP_QSORIPPER_CW_TRANSCRIPT", adif);
+    }
+
+    [Fact]
+    public void Cw_decode_transcript_sanitizes_non_ascii_and_control_chars()
+    {
+        // Include non-ASCII (é U+00E9), bell control (0x07), DEL (0x7F),
+        // and a preserved newline. After sanitization the field length
+        // must equal byte length so the Rust reader (byte-length writer)
+        // and .NET reader (char-length writer) agree on parsing.
+        var original = new QsoRecord
+        {
+            WorkedCallsign = "W1AW",
+            Mode = Mode.Cw,
+            Band = Band._40M,
+            UtcTimestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)),
+            CwDecodeTranscript = "CQ\u00e9\u0007DE\u007f\nK",
+        };
+
+        var adif = AdifCodec.SerializeSingleQso(original);
+        Assert.Contains("<APP_QSORIPPER_CW_TRANSCRIPT:6>CQDE\nK", adif);
+
+        var parsed = AdifCodec.ParseAdif($"<EOH>\n{adif}");
+        Assert.Equal("CQDE\nK", parsed[0].CwDecodeTranscript);
+    }
+
+    [Fact]
+    public void Cw_decode_transcript_extra_fields_does_not_shadow_typed_value()
+    {
+        var qso = new QsoRecord
+        {
+            WorkedCallsign = "W1AW",
+            Mode = Mode.Cw,
+            Band = Band._40M,
+            UtcTimestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero)),
+            CwDecodeTranscript = "typed",
+        };
+        qso.ExtraFields["APP_QSORIPPER_CW_TRANSCRIPT"] = "stale";
+
+        var adif = AdifCodec.SerializeSingleQso(qso);
+
+        Assert.Contains("<APP_QSORIPPER_CW_TRANSCRIPT:5>typed", adif);
+        Assert.DoesNotContain("stale", adif);
+    }
 }

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/AdifCodec.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/AdifCodec.cs
@@ -400,6 +400,17 @@ internal static class AdifCodec
                     }
 
                     break;
+                case "APP_QSORIPPER_CW_TRANSCRIPT":
+                    // Decoded CW transcript text — accepted as-is. Empty
+                    // values are dropped to avoid a noisy `HasCwDecodeTranscript`
+                    // flag for round-trips through tools that emit zero-length
+                    // user-defined fields.
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        qso.CwDecodeTranscript = value;
+                    }
+
+                    break;
                 case "COUNTRY":
                     qso.WorkedCountry = value;
                     break;
@@ -656,6 +667,15 @@ internal static class AdifCodec
             AppendField(sb, "APP_QSORIPPER_RX_WPM", qso.CwDecodeRxWpm.ToString(CultureInfo.InvariantCulture));
         }
 
+        if (qso.HasCwDecodeTranscript && !string.IsNullOrEmpty(qso.CwDecodeTranscript))
+        {
+            // ADIF length-delimited fields tolerate `<`, `>`, and embedded
+            // newlines. Sanitize ASCII control bytes (defensive — the
+            // decoder shouldn't emit them but the field is operator-editable)
+            // and emit verbatim.
+            AppendField(sb, "APP_QSORIPPER_CW_TRANSCRIPT", SanitizeCwTranscriptForAdif(qso.CwDecodeTranscript));
+        }
+
         AppendOptional(sb, "COUNTRY", qso.WorkedCountry);
 
         if (qso.HasWorkedDxcc)
@@ -729,7 +749,12 @@ internal static class AdifCodec
         string.Equals(key, "APP_QRZLOG_LOGID", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(key, "APP_QRZ_LOGID", StringComparison.OrdinalIgnoreCase) ||
         string.Equals(key, "APP_QRZLOG_QSO_ID", StringComparison.OrdinalIgnoreCase) ||
-        string.Equals(key, "APP_QRZ_BOOKID", StringComparison.OrdinalIgnoreCase);
+        string.Equals(key, "APP_QRZ_BOOKID", StringComparison.OrdinalIgnoreCase) ||
+        // QsoRipper-owned app keys are emitted from their dedicated proto
+        // fields above; never re-emit them from ExtraFields, even if a
+        // caller seeded a stale value there.
+        string.Equals(key, "APP_QSORIPPER_RX_WPM", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(key, "APP_QSORIPPER_CW_TRANSCRIPT", StringComparison.OrdinalIgnoreCase);
 
     // -- Helpers -------------------------------------------------------------
 
@@ -750,6 +775,47 @@ internal static class AdifCodec
         {
             AppendField(sb, key, value);
         }
+    }
+
+    /// <summary>
+    /// Strip ASCII control bytes (other than CR/LF/tab) from operator-editable
+    /// CW transcript text before writing to ADIF. The .NET writer uses
+    /// <c>value.Length</c> (chars) for the length prefix while the Rust writer
+    /// uses byte length; restricting payload to printable ASCII + CR/LF/tab
+    /// keeps both runtimes' length math consistent and avoids round-trip drift.
+    /// </summary>
+    internal static string SanitizeCwTranscriptForAdif(string value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        var sb = new StringBuilder(value.Length);
+        foreach (var c in value)
+        {
+            if (c == '\r' || c == '\n' || c == '\t')
+            {
+                sb.Append(c);
+                continue;
+            }
+
+            if (c < 0x20 || c == 0x7F)
+            {
+                continue;
+            }
+
+            // Drop non-ASCII so byte length and char length agree
+            // across runtimes when the field is round-tripped.
+            if (c > 0x7E)
+            {
+                continue;
+            }
+
+            sb.Append(c);
+        }
+
+        return sb.ToString();
     }
 
     private static bool TryNormalizeQrzPower(string? value, out string normalized)

--- a/src/dotnet/QsoRipper.Gui.Tests/CwQsoTranscriptAggregatorTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/CwQsoTranscriptAggregatorTests.cs
@@ -1,0 +1,167 @@
+using System;
+using QsoRipper.Gui.Services;
+
+namespace QsoRipper.Gui.Tests;
+
+public sealed class CwQsoTranscriptAggregatorTests
+{
+    private sealed class FakeSource : ICwWpmSampleSource
+    {
+        public bool IsRunning => false;
+        public CwWpmSample? LatestSample => null;
+        public CwLockState CurrentLockState => CwLockState.Locked;
+#pragma warning disable CS0067 // unused in tests
+        public event EventHandler<CwWpmSample>? SampleReceived;
+        public event EventHandler? StatusChanged;
+        public event EventHandler<CwLockState>? LockStateChanged;
+#pragma warning restore CS0067
+        public event EventHandler<string>? RawLineReceived;
+
+        public void Emit(string line) => RawLineReceived?.Invoke(this, line);
+        public void Start(string? deviceOverride) { }
+        public void Stop() { }
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public void ReturnsNullWhenNoFragments()
+    {
+        using var src = new FakeSource();
+        using var agg = new CwQsoTranscriptAggregator(src);
+
+        var now = DateTimeOffset.UtcNow;
+        Assert.Null(agg.GetTranscript(now, now.AddMinutes(1)));
+    }
+
+    [Fact]
+    public void AccumulatesCharsWordsAndGarbledFromRawNdjson()
+    {
+        using var src = new FakeSource();
+        using var agg = new CwQsoTranscriptAggregator(src);
+
+        var start = DateTimeOffset.UtcNow.AddSeconds(-1);
+
+        src.Emit("{\"type\":\"char\",\"ch\":\"C\",\"morse\":\"-.-.\"}");
+        src.Emit("{\"type\":\"char\",\"ch\":\"Q\",\"morse\":\"--.-\"}");
+        src.Emit("{\"type\":\"word\"}");
+        src.Emit("{\"type\":\"garbled\",\"symbol\":\"..-...-\"}");
+        src.Emit("{\"type\":\"char\",\"ch\":\"D\",\"morse\":\"-..\"}");
+        src.Emit("{\"type\":\"char\",\"ch\":\"E\",\"morse\":\".\"}");
+
+        var transcript = agg.GetTranscript(start, DateTimeOffset.UtcNow.AddSeconds(1));
+
+        Assert.Equal("CQ ?DE", transcript);
+    }
+
+    [Fact]
+    public void NormalizeCollapsesWhitespaceAndTrimsTrailing()
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append(" CQ   ").Append("DE  K1ABC ");
+
+        var normalized = CwQsoTranscriptAggregator.Normalize(sb);
+
+        Assert.Equal("CQ DE K1ABC", normalized);
+    }
+
+    [Fact]
+    public void NormalizeStripsControlCharacters()
+    {
+        var sb = new System.Text.StringBuilder();
+        sb.Append("AB").Append('\u0007').Append('C');
+
+        var normalized = CwQsoTranscriptAggregator.Normalize(sb);
+
+        Assert.Equal("ABC", normalized);
+    }
+
+    [Fact]
+    public void IgnoresUnknownEventTypesAndMalformedJson()
+    {
+        using var src = new FakeSource();
+        using var agg = new CwQsoTranscriptAggregator(src);
+
+        var start = DateTimeOffset.UtcNow.AddSeconds(-1);
+
+        src.Emit("not json at all");
+        src.Emit("{\"type\":\"power\",\"snr\":1.0}");
+        src.Emit("{\"type\":\"pitch\",\"hz\":700}");
+        src.Emit("{}");
+        src.Emit("{\"type\":\"char\"}"); // missing ch
+        src.Emit("{\"type\":\"char\",\"ch\":\"\"}"); // empty ch
+        src.Emit("{\"type\":\"char\",\"ch\":\"K\"}");
+
+        var transcript = agg.GetTranscript(start, DateTimeOffset.UtcNow.AddSeconds(1));
+
+        Assert.Equal("K", transcript);
+    }
+
+    [Fact]
+    public void OutOfWindowFragmentsExcluded()
+    {
+        using var src = new FakeSource();
+        using var agg = new CwQsoTranscriptAggregator(src);
+
+        // Emit before window
+        src.Emit("{\"type\":\"char\",\"ch\":\"X\"}");
+
+        // Capture window start AFTER first emit
+        System.Threading.Thread.Sleep(20);
+        var windowStart = DateTimeOffset.UtcNow;
+        System.Threading.Thread.Sleep(20);
+
+        src.Emit("{\"type\":\"char\",\"ch\":\"Y\"}");
+
+        var windowEnd = DateTimeOffset.UtcNow.AddSeconds(1);
+
+        var transcript = agg.GetTranscript(windowStart, windowEnd);
+
+        Assert.Equal("Y", transcript);
+    }
+
+    [Fact]
+    public void HandlerSwallowsExceptionsAndContinuesProcessing()
+    {
+        using var src = new FakeSource();
+        using var agg = new CwQsoTranscriptAggregator(src);
+
+        // Two valid lines around an empty/whitespace one (which the
+        // handler should silently drop without affecting subsequent
+        // events). Aggregator must remain healthy.
+        src.Emit("{\"type\":\"char\",\"ch\":\"A\"}");
+        src.Emit("");
+        src.Emit("   ");
+        src.Emit("{\"type\":\"char\",\"ch\":\"B\"}");
+
+        var transcript = agg.GetTranscript(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddMinutes(1));
+
+        Assert.Equal("AB", transcript);
+    }
+
+    [Fact]
+    public void DisposeUnsubscribesFromSource()
+    {
+        using var src = new FakeSource();
+        var agg = new CwQsoTranscriptAggregator(src);
+
+        agg.Dispose();
+        // After dispose, further emits should not affect FragmentCount.
+        src.Emit("{\"type\":\"char\",\"ch\":\"Z\"}");
+
+        Assert.Equal(0, agg.FragmentCount);
+    }
+
+    [Fact]
+    public void RetentionCapDropsOldestFragments()
+    {
+        using var src = new FakeSource();
+        using var agg = new CwQsoTranscriptAggregator(src, maxRetainedFragments: 4);
+
+        for (int i = 0; i < 10; i++)
+        {
+            src.Emit("{\"type\":\"char\",\"ch\":\"X\"}");
+        }
+
+        Assert.Equal(4, agg.FragmentCount);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui.Tests/FullQsoCardNavigationTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/FullQsoCardNavigationTests.cs
@@ -19,6 +19,8 @@ public sealed class FullQsoCardNavigationTests
     [InlineData(Key.NumPad5, 4)]
     [InlineData(Key.D6, 5)]
     [InlineData(Key.NumPad6, 5)]
+    [InlineData(Key.D7, 6)]
+    [InlineData(Key.NumPad7, 6)]
     public void Alt_digit_shortcuts_jump_to_expected_section(Key key, int expectedIndex)
     {
         var handled = FullQsoCardNavigation.TryResolve(

--- a/src/dotnet/QsoRipper.Gui.Tests/FullQsoCardViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/FullQsoCardViewModelTests.cs
@@ -373,6 +373,74 @@ public sealed class FullQsoCardViewModelTests
         Assert.Equal("WA", card.WorkedState);
     }
 
+    [Fact]
+    public void CwTranscriptSummaryReportsNoDataWhenBothFieldsEmpty()
+    {
+        var engine = new RecordingEngineClient();
+        var card = FullQsoCardViewModel.ForNew(engine, new QsoLoggerViewModel(engine));
+
+        Assert.False(card.HasCwTranscriptContent);
+        Assert.Equal("No CW decoder data captured.", card.CwTranscriptSummary);
+        Assert.Equal(string.Empty, card.CwTranscriptPreview);
+        Assert.Equal("CW decoder (RX)", card.CwTranscriptSourceBadge);
+    }
+
+    [Fact]
+    public void CwTranscriptSummaryCombinesWpmAndCharCount()
+    {
+        var engine = new RecordingEngineClient();
+        var card = FullQsoCardViewModel.ForNew(engine, new QsoLoggerViewModel(engine));
+
+        card.CwDecodeRxWpmText = "23";
+        card.CwDecodeTranscript = "CQ CQ DE K7RND";
+
+        Assert.True(card.HasCwTranscriptContent);
+        Assert.Equal("23 WPM \u00B7 14 chars", card.CwTranscriptSummary);
+        Assert.Equal("CW decoder (RX) \u00B7 23 WPM", card.CwTranscriptSourceBadge);
+        Assert.Equal("CQ CQ DE K7RND", card.CwTranscriptPreview);
+    }
+
+    [Fact]
+    public void CwTranscriptPreviewCollapsesNewlinesAndTruncates()
+    {
+        var engine = new RecordingEngineClient();
+        var card = FullQsoCardViewModel.ForNew(engine, new QsoLoggerViewModel(engine));
+
+        card.CwDecodeTranscript = string.Concat("line1\r\nline2 ", new string('x', 200));
+
+        var preview = card.CwTranscriptPreview;
+        Assert.Equal(80, preview.Length);
+        Assert.EndsWith("\u2026", preview, StringComparison.Ordinal);
+        Assert.DoesNotContain('\n', preview);
+        Assert.DoesNotContain('\r', preview);
+    }
+
+    [Fact]
+    public void ShowTranscriptTabCommandSelectsTranscriptTab()
+    {
+        var engine = new RecordingEngineClient();
+        var card = FullQsoCardViewModel.ForNew(engine, new QsoLoggerViewModel(engine));
+
+        Assert.Equal(0, card.SelectedTabIndex);
+        card.ShowTranscriptTabCommand.Execute(null);
+        Assert.Equal(5, card.SelectedTabIndex);
+    }
+
+    [Fact]
+    public void EditingCwTranscriptRaisesSummaryAndPreviewChangeNotifications()
+    {
+        var engine = new RecordingEngineClient();
+        var card = FullQsoCardViewModel.ForNew(engine, new QsoLoggerViewModel(engine));
+        var raised = new List<string?>();
+        card.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        card.CwDecodeTranscript = "TEST";
+
+        Assert.Contains(nameof(FullQsoCardViewModel.CwTranscriptSummary), raised);
+        Assert.Contains(nameof(FullQsoCardViewModel.CwTranscriptPreview), raised);
+        Assert.Contains(nameof(FullQsoCardViewModel.HasCwTranscriptContent), raised);
+    }
+
     private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;

--- a/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
@@ -125,6 +125,120 @@ public sealed class QsoLoggerEnrichmentTests
     }
 
     [Fact]
+    public void EnrichFromCwDecoderFillsTranscriptForCwQsoWhenFragmentsPresent()
+    {
+        using var src = new CwSampleHarness();
+        using var transcriptAgg = new CwQsoTranscriptAggregator(src);
+
+        var start = DateTimeOffset.UtcNow.AddSeconds(-2);
+
+        transcriptAgg.IngestForTest("{\"type\":\"char\",\"ch\":\"C\"}");
+        transcriptAgg.IngestForTest("{\"type\":\"char\",\"ch\":\"Q\"}");
+        transcriptAgg.IngestForTest("{\"type\":\"word\"}");
+        transcriptAgg.IngestForTest("{\"type\":\"char\",\"ch\":\"K\"}");
+
+        var logger = new QsoLoggerViewModel(new FakeEngineClient(), cwWpmAggregator: null);
+        logger.AttachCwTranscriptAggregator(transcriptAgg);
+
+        var qso = new QsoRecord { WorkedCallsign = "K7DOE", Mode = Mode.Cw };
+
+        logger.EnrichFromCwDecoder(qso, start, DateTimeOffset.UtcNow.AddSeconds(2));
+
+        Assert.True(qso.HasCwDecodeTranscript);
+        Assert.Equal("CQ K", qso.CwDecodeTranscript);
+    }
+
+    [Fact]
+    public void EnrichFromCwDecoderPreservesOperatorTypedTranscript()
+    {
+        using var src = new CwSampleHarness();
+        using var transcriptAgg = new CwQsoTranscriptAggregator(src);
+        transcriptAgg.IngestForTest("{\"type\":\"char\",\"ch\":\"X\"}");
+
+        var logger = new QsoLoggerViewModel(new FakeEngineClient(), cwWpmAggregator: null);
+        logger.AttachCwTranscriptAggregator(transcriptAgg);
+
+        var qso = new QsoRecord
+        {
+            WorkedCallsign = "K7DOE",
+            Mode = Mode.Cw,
+            CwDecodeTranscript = "operator typed",
+        };
+
+        logger.EnrichFromCwDecoder(qso, DateTimeOffset.UtcNow.AddSeconds(-2), DateTimeOffset.UtcNow.AddSeconds(2));
+
+        Assert.Equal("operator typed", qso.CwDecodeTranscript);
+    }
+
+    [Fact]
+    public void EnrichFromCwDecoderClearsCwFieldsWhenModeIsNotCw()
+    {
+        using var src = new CwSampleHarness();
+        using var wpm = new CwQsoWpmAggregator(src);
+        using var transcriptAgg = new CwQsoTranscriptAggregator(src);
+        src.Emit(new CwWpmSample(DateTimeOffset.UtcNow, 25.0, Epoch: 1));
+        transcriptAgg.IngestForTest("{\"type\":\"char\",\"ch\":\"Y\"}");
+
+        var logger = new QsoLoggerViewModel(new FakeEngineClient(), wpm);
+        logger.AttachCwTranscriptAggregator(transcriptAgg);
+
+        var qso = new QsoRecord
+        {
+            WorkedCallsign = "K7DOE",
+            Mode = Mode.Ssb,
+            CwDecodeRxWpm = 30,
+            CwDecodeTranscript = "stale auto-fill",
+        };
+
+        logger.EnrichFromCwDecoder(qso, DateTimeOffset.UtcNow.AddSeconds(-30), DateTimeOffset.UtcNow);
+
+        Assert.False(qso.HasCwDecodeRxWpm);
+        Assert.False(qso.HasCwDecodeTranscript);
+    }
+
+    [Fact]
+    public void EnrichFromCwDecoderTranscriptIsNoOpWhenAggregatorMissing()
+    {
+        var logger = new QsoLoggerViewModel(new FakeEngineClient());
+        var qso = new QsoRecord { WorkedCallsign = "K7DOE", Mode = Mode.Cw };
+
+        logger.EnrichFromCwDecoder(qso, DateTimeOffset.UtcNow.AddSeconds(-30), DateTimeOffset.UtcNow);
+
+        Assert.False(qso.HasCwDecodeTranscript);
+    }
+
+    [Fact]
+    public void EnrichFromCwDecoderFillsBothWpmAndTranscriptForCwQso()
+    {
+        using var src = new CwSampleHarness();
+        using var wpm = new CwQsoWpmAggregator(src, maxSampleHoldDuration: TimeSpan.FromSeconds(60));
+        using var transcriptAgg = new CwQsoTranscriptAggregator(src);
+
+        var start = new DateTimeOffset(2024, 6, 1, 12, 0, 0, TimeSpan.Zero);
+        var end = start.AddSeconds(20);
+
+        src.Emit(new CwWpmSample(start, 24.0, Epoch: 1));
+        src.Emit(new CwWpmSample(start.AddSeconds(10), 24.0, Epoch: 1));
+        transcriptAgg.IngestForTest("{\"type\":\"char\",\"ch\":\"R\"}");
+
+        var logger = new QsoLoggerViewModel(new FakeEngineClient(), wpm);
+        logger.AttachCwTranscriptAggregator(transcriptAgg);
+
+        var qso = new QsoRecord { WorkedCallsign = "K7DOE", Mode = Mode.Cw };
+        logger.EnrichFromCwDecoder(qso, start, end);
+
+        // wpm aggregator queries on a window in the past; transcript
+        // aggregator timestamps fragments at ingest-time using
+        // DateTimeOffset.UtcNow, so use a wide window for transcript here
+        // by re-running with a wide window:
+        logger.EnrichFromCwDecoder(qso, DateTimeOffset.UtcNow.AddSeconds(-5), DateTimeOffset.UtcNow.AddSeconds(5));
+
+        Assert.True(qso.HasCwDecodeRxWpm);
+        Assert.Equal(24u, qso.CwDecodeRxWpm);
+        Assert.Equal("R", qso.CwDecodeTranscript);
+    }
+
+    [Fact]
     public void EnrichFromLookupWithNullRecordLeavesQsoUnchanged()
     {
         var qso = new QsoRecord { WorkedCallsign = "W1AW" };

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoItemViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoItemViewModelTests.cs
@@ -54,4 +54,62 @@ public sealed class RecentQsoItemViewModelTests
         Assert.Equal((uint)110, item.DxccSortKey);
         Assert.Equal(new DateTimeOffset(2026, 4, 14, 1, 12, 3, TimeSpan.Zero), item.UtcEndSortKey);
     }
+
+    [Fact]
+    public void RxWpmDisplayShowsValueWhenPresent()
+    {
+        var item = RecentQsoItemViewModel.FromQso(new QsoRecord
+        {
+            LocalId = "qso-wpm",
+            WorkedCallsign = "K1ABC",
+            StationCallsign = "K7RND",
+            Mode = Mode.Cw,
+            CwDecodeRxWpm = 22,
+        });
+
+        Assert.Equal("22", item.RxWpmDisplay);
+        Assert.Equal((uint)22, item.RxWpmSortKey);
+    }
+
+    [Fact]
+    public void RxWpmDisplayUsesEmDashWhenAbsent()
+    {
+        var item = RecentQsoItemViewModel.FromQso(new QsoRecord
+        {
+            LocalId = "qso-no-wpm",
+            WorkedCallsign = "K2XYZ",
+            StationCallsign = "K7RND",
+            Mode = Mode.Cw,
+        });
+
+        Assert.Equal("\u2014", item.RxWpmDisplay);
+        Assert.Equal((uint)0, item.RxWpmSortKey);
+    }
+
+    [Fact]
+    public void AcceptSavedChangesRefreshesRxWpmDisplay()
+    {
+        var qso = new QsoRecord
+        {
+            LocalId = "qso-edit",
+            WorkedCallsign = "W1AW",
+            StationCallsign = "K7RND",
+            Mode = Mode.Cw,
+        };
+        var item = RecentQsoItemViewModel.FromQso(qso);
+
+        Assert.Equal("\u2014", item.RxWpmDisplay);
+
+        var updated = qso.Clone();
+        updated.CwDecodeRxWpm = 30;
+        var raised = new List<string?>();
+        item.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+        item.AcceptSavedChanges(updated);
+
+        Assert.Equal("30", item.RxWpmDisplay);
+        Assert.Equal((uint)30, item.RxWpmSortKey);
+        Assert.Contains(nameof(RecentQsoItemViewModel.RxWpmDisplay), raised);
+        Assert.Contains(nameof(RecentQsoItemViewModel.RxWpmSortKey), raised);
+    }
 }

--- a/src/dotnet/QsoRipper.Gui/Services/CwQsoTranscriptAggregator.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/CwQsoTranscriptAggregator.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+
+namespace QsoRipper.Gui.Services;
+
+/// <summary>
+/// Captures decoded CW characters/words/garbled symbols emitted by the live
+/// decoder via <see cref="ICwWpmSampleSource.RawLineReceived"/> and exposes
+/// the concatenated transcript for an arbitrary
+/// <c>[utcStart, utcEnd]</c> window — typically a freshly-completed QSO.
+/// Mirrors the lifetime/ownership model of <see cref="CwQsoWpmAggregator"/>:
+/// constructed by <c>MainWindowViewModel</c> alongside the WPM aggregator,
+/// disposed when the source is torn down.
+///
+/// <para>
+/// Robustness rules:
+/// <list type="bullet">
+///   <item>The handler runs on the source's stdout pump thread. All
+///         exceptions are swallowed inside the handler so a single
+///         malformed NDJSON line can never kill the pump (see #324
+///         post-mortem).</item>
+///   <item>The aggregator is internally locked; a second concurrent
+///         subscriber on the same source is safe.</item>
+///   <item>Retained fragments are capped at <see cref="MaxRetainedFragments"/>
+///         to bound memory across long ragchews; older fragments are
+///         dropped.</item>
+///   <item>Text is normalized at read time (collapse runs of whitespace,
+///         trim leading/trailing whitespace) so the transcript reads
+///         naturally regardless of how `word` events fell relative to
+///         `char` events.</item>
+/// </list>
+/// </para>
+/// </summary>
+internal sealed class CwQsoTranscriptAggregator : IDisposable
+{
+    /// <summary>Hard cap on retained fragment events. Sized for very long
+    /// ragchews at typical CW rates without unbounded growth.</summary>
+    public int MaxRetainedFragments { get; }
+
+    private readonly object _lock = new();
+    private readonly LinkedList<TranscriptFragment> _fragments = new();
+    private ICwWpmSampleSource? _source;
+
+    public CwQsoTranscriptAggregator(
+        ICwWpmSampleSource source,
+        int maxRetainedFragments = 65_536)
+    {
+        _source = source ?? throw new ArgumentNullException(nameof(source));
+        MaxRetainedFragments = maxRetainedFragments;
+        _source.RawLineReceived += OnRawLineReceived;
+    }
+
+    /// <summary>
+    /// Returns the decoded transcript for the supplied window, or null
+    /// if no usable fragments fall in the window. Window edges are
+    /// inclusive on the start and exclusive on the end so adjacent QSOs
+    /// don't double-count a boundary fragment.
+    /// </summary>
+    public string? GetTranscript(DateTimeOffset utcStart, DateTimeOffset utcEnd)
+    {
+        if (utcEnd <= utcStart)
+        {
+            return null;
+        }
+
+        TranscriptFragment[] snapshot;
+        lock (_lock)
+        {
+            if (_fragments.Count == 0)
+            {
+                return null;
+            }
+
+            snapshot = _fragments.ToArray();
+        }
+
+        var sb = new StringBuilder(snapshot.Length);
+        foreach (var fragment in snapshot)
+        {
+            if (fragment.ReceivedUtc < utcStart || fragment.ReceivedUtc >= utcEnd)
+            {
+                continue;
+            }
+
+            sb.Append(fragment.Text);
+        }
+
+        if (sb.Length == 0)
+        {
+            return null;
+        }
+
+        var normalized = Normalize(sb);
+        return normalized.Length == 0 ? null : normalized;
+    }
+
+    /// <summary>Drops all retained fragments. Used on settings reset / tests.</summary>
+    public void Clear()
+    {
+        lock (_lock)
+        {
+            _fragments.Clear();
+        }
+    }
+
+    /// <summary>Test/diagnostic accessor for the retained fragment count.</summary>
+    internal int FragmentCount
+    {
+        get { lock (_lock) { return _fragments.Count; } }
+    }
+
+    /// <summary>Inject a raw NDJSON line directly. For tests only.</summary>
+    internal void IngestForTest(string ndjsonLine) => OnRawLineReceived(this, ndjsonLine);
+
+    private void OnRawLineReceived(object? sender, string line)
+    {
+        // Runs on the source's stdout pump thread. Catch everything —
+        // a JsonException, an OOM in StringBuilder, or any other failure
+        // here must NOT kill the pump (which would silently freeze WPM
+        // updates and any other downstream subscribers).
+        try
+        {
+            if (string.IsNullOrWhiteSpace(line))
+            {
+                return;
+            }
+
+            var fragment = TryParseFragment(line);
+            if (fragment is null)
+            {
+                return;
+            }
+
+            lock (_lock)
+            {
+                _fragments.AddLast(fragment.Value);
+                while (_fragments.Count > MaxRetainedFragments)
+                {
+                    _fragments.RemoveFirst();
+                }
+            }
+        }
+#pragma warning disable CA1031, RCS1075 // background pump handler must not crash on a single bad line
+        catch (Exception ex)
+        {
+            // Intentionally swallowed — see class doc on robustness rules.
+            // A malformed NDJSON line, OOM, or any other failure here must
+            // NOT kill the source's stdout pump (which would silently
+            // freeze WPM updates and any other downstream subscribers).
+            System.Diagnostics.Trace.WriteLine($"CwQsoTranscriptAggregator handler error: {ex.GetType().Name}: {ex.Message}");
+        }
+#pragma warning restore CA1031, RCS1075
+    }
+
+    private static TranscriptFragment? TryParseFragment(string line)
+    {
+        using var doc = JsonDocument.Parse(line);
+        if (!doc.RootElement.TryGetProperty("type", out var typeProp))
+        {
+            return null;
+        }
+
+        var eventType = typeProp.GetString();
+        switch (eventType)
+        {
+            case "char":
+                {
+                    if (!doc.RootElement.TryGetProperty("ch", out var chProp))
+                    {
+                        return null;
+                    }
+                    var ch = chProp.GetString();
+                    if (string.IsNullOrEmpty(ch))
+                    {
+                        return null;
+                    }
+                    return new TranscriptFragment(DateTimeOffset.UtcNow, ch);
+                }
+            case "word":
+                return new TranscriptFragment(DateTimeOffset.UtcNow, " ");
+            case "garbled":
+                return new TranscriptFragment(DateTimeOffset.UtcNow, "?");
+            default:
+                return null;
+        }
+    }
+
+    /// <summary>
+    /// Normalize the assembled transcript so it reads naturally:
+    /// collapse runs of whitespace into a single space and trim leading
+    /// or trailing whitespace introduced by `word` events at episode
+    /// boundaries. Strips ASCII control characters (defensive — the
+    /// decoder shouldn't emit them) but preserves all printable chars.
+    /// </summary>
+    internal static string Normalize(StringBuilder source)
+    {
+        var sb = new StringBuilder(source.Length);
+        bool prevSpace = true;
+        for (int i = 0; i < source.Length; i++)
+        {
+            var c = source[i];
+            if (c == '\r' || c == '\n' || c == '\t' || c == ' ')
+            {
+                if (!prevSpace)
+                {
+                    sb.Append(' ');
+                    prevSpace = true;
+                }
+                continue;
+            }
+
+            if (c < 0x20)
+            {
+                continue;
+            }
+
+            sb.Append(c);
+            prevSpace = false;
+        }
+
+        // Trailing space normalization.
+        while (sb.Length > 0 && sb[^1] == ' ')
+        {
+            sb.Length--;
+        }
+
+        return sb.ToString();
+    }
+
+    public void Dispose()
+    {
+        var source = _source;
+        if (source is not null)
+        {
+            source.RawLineReceived -= OnRawLineReceived;
+            _source = null;
+        }
+    }
+
+    private readonly record struct TranscriptFragment(DateTimeOffset ReceivedUtc, string Text);
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
@@ -233,6 +233,12 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject, IDisposab
     private string _comment = string.Empty;
 
     [ObservableProperty]
+    private string _cwDecodeRxWpmText = string.Empty;
+
+    [ObservableProperty]
+    private string _cwDecodeTranscript = string.Empty;
+
+    [ObservableProperty]
     private string _snapshotProfileName = string.Empty;
 
     [ObservableProperty]
@@ -355,6 +361,14 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject, IDisposab
             }
             else
             {
+                // Auto-fill CW WPM/transcript from the live decoder if the
+                // operator hasn't typed values manually. Mirrors the
+                // simple-logger path so QSOs logged via the full card
+                // get the same CW enrichment.
+                var cwStart = qso.UtcTimestamp?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow;
+                var cwEnd = qso.UtcEndTimestamp?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow;
+                _logger?.EnrichFromCwDecoder(qso, cwStart, cwEnd);
+
                 var response = await _engine.LogQsoAsync(qso);
                 LocalId = response.LocalId;
                 StatusText = $"Logged {qso.WorkedCallsign}.";
@@ -538,6 +552,10 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject, IDisposab
         SatMode = qso.SatMode ?? string.Empty;
         Notes = qso.Notes ?? string.Empty;
         Comment = qso.Comment ?? string.Empty;
+        CwDecodeRxWpmText = qso.HasCwDecodeRxWpm
+            ? qso.CwDecodeRxWpm.ToString(CultureInfo.InvariantCulture)
+            : string.Empty;
+        CwDecodeTranscript = qso.HasCwDecodeTranscript ? (qso.CwDecodeTranscript ?? string.Empty) : string.Empty;
         LocalId = qso.LocalId;
         SyncStatusText = BuildSyncStatus(qso.SyncStatus);
         CreatedAtText = FormatTimestamp(qso.CreatedAt);
@@ -890,6 +908,15 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject, IDisposab
         ApplyOptionalString(SatMode, value => working.SatMode = value, working.ClearSatMode, uppercase: true);
         ApplyOptionalString(Notes, value => working.Notes = value, working.ClearNotes);
         ApplyOptionalString(Comment, value => working.Comment = value, working.ClearComment);
+        ApplyOptionalString(CwDecodeTranscript, value => working.CwDecodeTranscript = value, working.ClearCwDecodeTranscript);
+        if (uint.TryParse(CwDecodeRxWpmText, NumberStyles.None, CultureInfo.InvariantCulture, out var parsedRxWpm) && parsedRxWpm > 0)
+        {
+            working.CwDecodeRxWpm = parsedRxWpm;
+        }
+        else
+        {
+            working.ClearCwDecodeRxWpm();
+        }
 
         working.QslSentStatus = ParseQslStatus(SelectedQslSentStatus);
         working.QslReceivedStatus = ParseQslStatus(SelectedQslReceivedStatus);

--- a/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
@@ -38,7 +38,7 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject, IDisposab
         .ToArray();
 
     private static readonly string[] QslStatusLabels = ["-", "No", "Yes", "Requested", "Queued", "Ignore"];
-    private const string SectionHintText = "Ctrl+Tab / Ctrl+Shift+Tab or Alt+1..6 to switch sections";
+    private const string SectionHintText = "Ctrl+Tab / Ctrl+Shift+Tab or Alt+1..7 to switch sections";
 
     private readonly IEngineClient _engine;
     private readonly QsoLoggerViewModel? _logger;
@@ -326,6 +326,90 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject, IDisposab
         {
             _lastAutoWorkedOperatorCallsign = string.Empty;
         }
+    }
+
+    partial void OnCwDecodeRxWpmTextChanged(string value)
+    {
+        OnPropertyChanged(nameof(CwTranscriptSummary));
+        OnPropertyChanged(nameof(CwTranscriptSourceBadge));
+    }
+
+    partial void OnCwDecodeTranscriptChanged(string value)
+    {
+        OnPropertyChanged(nameof(CwTranscriptSummary));
+        OnPropertyChanged(nameof(CwTranscriptPreview));
+        OnPropertyChanged(nameof(HasCwTranscriptContent));
+    }
+
+    /// <summary>
+    /// True when CW WPM or transcript is populated. Used to show a "no data" state in the
+    /// Transcript tab without hiding the editable fields.
+    /// </summary>
+    public bool HasCwTranscriptContent =>
+        !string.IsNullOrWhiteSpace(CwDecodeTranscript) || !string.IsNullOrWhiteSpace(CwDecodeRxWpmText);
+
+    /// <summary>
+    /// Compact summary line shown on the Core tab so the operator can see at-a-glance whether
+    /// CW decoder data is captured without leaving the section.
+    /// </summary>
+    public string CwTranscriptSummary
+    {
+        get
+        {
+            var hasWpm = !string.IsNullOrWhiteSpace(CwDecodeRxWpmText);
+            var hasText = !string.IsNullOrWhiteSpace(CwDecodeTranscript);
+            if (!hasWpm && !hasText)
+            {
+                return "No CW decoder data captured.";
+            }
+
+            var parts = new List<string>(2);
+            if (hasWpm)
+            {
+                parts.Add(string.Concat(CwDecodeRxWpmText.Trim(), " WPM"));
+            }
+
+            if (hasText)
+            {
+                parts.Add(string.Concat(
+                    CwDecodeTranscript.Length.ToString(CultureInfo.InvariantCulture),
+                    " chars"));
+            }
+
+            return string.Join(" \u00B7 ", parts);
+        }
+    }
+
+    /// <summary>
+    /// First ~80 characters of the CW transcript with newlines collapsed, for the Core tab preview.
+    /// </summary>
+    public string CwTranscriptPreview
+    {
+        get
+        {
+            if (string.IsNullOrWhiteSpace(CwDecodeTranscript))
+            {
+                return string.Empty;
+            }
+
+            var collapsed = CwDecodeTranscript.Replace('\n', ' ').Replace('\r', ' ').Trim();
+            return collapsed.Length <= 80 ? collapsed : string.Concat(collapsed.AsSpan(0, 79), "\u2026");
+        }
+    }
+
+    /// <summary>
+    /// Source-and-metric badge shown atop each transcript section in the Transcript tab.
+    /// Designed to be reused for future voice STT sections (e.g. "Voice STT \u00B7 Whisper").
+    /// </summary>
+    public string CwTranscriptSourceBadge =>
+        string.IsNullOrWhiteSpace(CwDecodeRxWpmText)
+            ? "CW decoder (RX)"
+            : string.Concat("CW decoder (RX) \u00B7 ", CwDecodeRxWpmText.Trim(), " WPM");
+
+    [RelayCommand]
+    private void ShowTranscriptTab()
+    {
+        SelectedTabIndex = 5;
     }
 
     [RelayCommand]

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -30,6 +30,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     private readonly DispatcherTimer _spaceWeatherTimer;
     private CwDecoderProcessSampleSource? _cwSampleSource;
     private CwQsoWpmAggregator? _cwAggregator;
+    private CwQsoTranscriptAggregator? _cwTranscriptAggregator;
     private CwDiagnosticsRecorder? _cwDiagnosticsRecorder;
     private bool _setupCompleteBeforeWizard;
     private string? _preferredEngineProfileId;
@@ -885,7 +886,9 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         src.LockStateChanged += OnCwLockStateChanged;
         _cwSampleSource = src;
         _cwAggregator = new CwQsoWpmAggregator(src);
+        _cwTranscriptAggregator = new CwQsoTranscriptAggregator(src);
         Logger.AttachCwAggregator(_cwAggregator);
+        Logger.AttachCwTranscriptAggregator(_cwTranscriptAggregator);
     }
 
     private void OnCwRawLineReceived(object? sender, string line)
@@ -1545,6 +1548,8 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         }
         _cwAggregator?.Dispose();
         _cwAggregator = null;
+        _cwTranscriptAggregator?.Dispose();
+        _cwTranscriptAggregator = null;
         DisposeDiagnosticsRecorder();
         CwStatsPane?.Dispose();
         CwStatsPane = null;

--- a/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
@@ -22,6 +22,7 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
     private readonly IEngineClient _engine;
     private readonly DispatcherTimer _elapsedTimer;
     private CwQsoWpmAggregator? _cwWpmAggregator;
+    private CwQsoTranscriptAggregator? _cwTranscriptAggregator;
     private DateTimeOffset _qsoStartTime;
     private bool _timerRunning;
     private CancellationTokenSource? _lookupCts;
@@ -404,36 +405,60 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
         => _cwWpmAggregator = aggregator;
 
     /// <summary>
-    /// Auto-fills <see cref="QsoRecord.CwDecodeRxWpm"/> from the live CW
-    /// decoder source when the QSO is on CW mode and the aggregator has
-    /// at least one usable sample inside the QSO's window. Non-CW QSOs
-    /// and missing/empty sources are no-ops so logging is never blocked.
+    /// Attach (or replace) the CW transcript aggregator used to populate
+    /// <see cref="QsoRecord.CwDecodeTranscript"/> on logged CW QSOs. The
+    /// aggregator is owned by the host (typically the MainWindowViewModel)
+    /// and may be null when CW decoding is disabled or unsupported.
+    /// </summary>
+    internal void AttachCwTranscriptAggregator(CwQsoTranscriptAggregator? aggregator)
+        => _cwTranscriptAggregator = aggregator;
+
+    /// <summary>
+    /// Auto-fills <see cref="QsoRecord.CwDecodeRxWpm"/> and
+    /// <see cref="QsoRecord.CwDecodeTranscript"/> from the live CW
+    /// decoder when the QSO is on CW mode and the aggregator(s) have
+    /// data inside the QSO's window. Non-CW QSOs and missing/empty
+    /// sources are no-ops so logging is never blocked. Existing
+    /// transcript text on the QSO (e.g. typed by the operator on the
+    /// full card) is preserved — auto-fill never overwrites a
+    /// caller-supplied transcript.
     /// </summary>
     internal void EnrichFromCwDecoder(QsoRecord qso, DateTimeOffset utcStart, DateTimeOffset utcEnd)
     {
-        if (_cwWpmAggregator is null)
-        {
-            return;
-        }
-
         if (qso.Mode != Mode.Cw)
         {
+            // Defensive: if mode isn't CW, scrub any auto-filled CW
+            // fields so they can't ride along on a re-classified QSO.
+            qso.ClearCwDecodeRxWpm();
+            qso.ClearCwDecodeTranscript();
             return;
         }
 
-        var mean = _cwWpmAggregator.GetMeanWpm(utcStart, utcEnd);
-        if (mean is null || !double.IsFinite(mean.Value) || mean.Value <= 0)
+        if (_cwWpmAggregator is not null)
         {
-            return;
+            var mean = _cwWpmAggregator.GetMeanWpm(utcStart, utcEnd);
+            if (mean is not null && double.IsFinite(mean.Value) && mean.Value > 0)
+            {
+                var rounded = (uint)Math.Round(mean.Value, MidpointRounding.AwayFromZero);
+                if (rounded > 0)
+                {
+                    qso.CwDecodeRxWpm = rounded;
+                }
+            }
         }
 
-        var rounded = (uint)Math.Round(mean.Value, MidpointRounding.AwayFromZero);
-        if (rounded == 0)
+        // Operator wins: if the QSO already carries non-empty transcript
+        // text (typed/edited on the full QSO card), don't overwrite it
+        // with the decoder's snapshot.
+        if (_cwTranscriptAggregator is not null
+            && (!qso.HasCwDecodeTranscript || string.IsNullOrWhiteSpace(qso.CwDecodeTranscript)))
         {
-            return;
+            var transcript = _cwTranscriptAggregator.GetTranscript(utcStart, utcEnd);
+            if (!string.IsNullOrWhiteSpace(transcript))
+            {
+                qso.CwDecodeTranscript = transcript;
+            }
         }
-
-        qso.CwDecodeRxWpm = rounded;
     }
 
     internal static void EnrichFromLookup(QsoRecord qso, CallsignRecord? record)

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoGridColumn.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoGridColumn.cs
@@ -26,5 +26,6 @@ internal enum RecentQsoGridColumn
     RstReceived,
     State,
     County,
-    Comment
+    Comment,
+    RxWpm
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoItemViewModel.cs
@@ -192,6 +192,19 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         set => SetProperty(ref _comment, value);
     }
 
+    /// <summary>
+    /// Read-only display of the captured CW receive WPM (proto field cw_decode_rx_wpm).
+    /// Renders as an em dash when no value is present so the column reads cleanly.
+    /// </summary>
+    public string RxWpmDisplay => _sourceQso.HasCwDecodeRxWpm
+        ? _sourceQso.CwDecodeRxWpm.ToString(CultureInfo.InvariantCulture)
+        : "—";
+
+    /// <summary>
+    /// Numeric sort key for the WPM column. Missing values sort as 0 so they cluster together.
+    /// </summary>
+    public uint RxWpmSortKey => _sourceQso.HasCwDecodeRxWpm ? _sourceQso.CwDecodeRxWpm : 0u;
+
     public string UtcEndDisplay
     {
         get => _utcEndDisplay;
@@ -397,6 +410,8 @@ internal sealed class RecentQsoItemViewModel : ObservableObject, IEditableObject
         State = NoteOrNull(_sourceQso.WorkedState) ?? string.Empty;
         County = ParseCountyName(_sourceQso.WorkedCounty);
         Comment = NoteOrNull(_sourceQso.Comment) ?? string.Empty;
+        OnPropertyChanged(nameof(RxWpmDisplay));
+        OnPropertyChanged(nameof(RxWpmSortKey));
         OnPropertyChanged(nameof(DurationDisplay));
         RecomputeDirty();
     }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -832,6 +832,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         RecentQsoSortColumn.State => nameof(RecentQsoItemViewModel.State),
         RecentQsoSortColumn.County => nameof(RecentQsoItemViewModel.County),
         RecentQsoSortColumn.Comment => nameof(RecentQsoItemViewModel.Comment),
+        RecentQsoSortColumn.RxWpm => nameof(RecentQsoItemViewModel.RxWpmSortKey),
         RecentQsoSortColumn.Sync => nameof(RecentQsoItemViewModel.SyncStatus),
         _ => nameof(RecentQsoItemViewModel.UtcSortKey)
     };
@@ -861,6 +862,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         nameof(RecentQsoItemViewModel.State) => RecentQsoSortColumn.State,
         nameof(RecentQsoItemViewModel.County) => RecentQsoSortColumn.County,
         nameof(RecentQsoItemViewModel.Comment) => RecentQsoSortColumn.Comment,
+        nameof(RecentQsoItemViewModel.RxWpmSortKey) => RecentQsoSortColumn.RxWpm,
         nameof(RecentQsoItemViewModel.SyncStatus) => RecentQsoSortColumn.Sync,
         _ => RecentQsoSortColumn.Utc
     };
@@ -923,6 +925,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.County, "County", false);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Sync, "Sync", false);
         yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.Continent, "Cont", false);
+        yield return new RecentQsoColumnOptionViewModel(RecentQsoGridColumn.RxWpm, "WPM", false);
     }
 
     private readonly record struct SearchToken(string Key, string Value);

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoSortColumn.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoSortColumn.cs
@@ -25,5 +25,6 @@ internal enum RecentQsoSortColumn
     RstReceived,
     State,
     County,
-    Comment
+    Comment,
+    RxWpm
 }

--- a/src/dotnet/QsoRipper.Gui/Views/FullQsoCardNavigation.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/FullQsoCardNavigation.cs
@@ -4,7 +4,7 @@ namespace QsoRipper.Gui.Views;
 
 internal static class FullQsoCardNavigation
 {
-    internal const int TabCount = 6;
+    internal const int TabCount = 7;
 
     internal static bool TryResolve(Key key, KeyModifiers modifiers, int currentIndex, out int targetIndex)
     {
@@ -30,6 +30,7 @@ internal static class FullQsoCardNavigation
             Key.D4 or Key.NumPad4 => 3,
             Key.D5 or Key.NumPad5 => 4,
             Key.D6 or Key.NumPad6 => 5,
+            Key.D7 or Key.NumPad7 => 6,
             _ => currentIndex,
         };
 
@@ -39,6 +40,7 @@ internal static class FullQsoCardNavigation
                 or Key.D3 or Key.NumPad3
                 or Key.D4 or Key.NumPad4
                 or Key.D5 or Key.NumPad5
-                or Key.D6 or Key.NumPad6;
+                or Key.D6 or Key.NumPad6
+                or Key.D7 or Key.NumPad7;
     }
 }

--- a/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
@@ -169,6 +169,24 @@
                   <TextBlock Classes="fieldLabel" Text="Notes" />
                   <TextBox Text="{Binding Notes, Mode=TwoWay}" AcceptsReturn="True" Height="140" TextWrapping="Wrap" />
                 </StackPanel>
+
+                <StackPanel>
+                  <TextBlock Classes="fieldLabel" Text="CW decode (RX)" />
+                  <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
+                    <StackPanel Grid.Column="0" Width="120">
+                      <TextBlock Classes="fieldLabel" Text="WPM" Opacity="0.72" />
+                      <TextBox Text="{Binding CwDecodeRxWpmText, Mode=TwoWay}"
+                               PlaceholderText="auto" />
+                    </StackPanel>
+                    <StackPanel Grid.Column="1">
+                      <TextBlock Classes="fieldLabel" Text="Transcript" Opacity="0.72" />
+                      <TextBox Text="{Binding CwDecodeTranscript, Mode=TwoWay}"
+                               AcceptsReturn="True" Height="88" TextWrapping="Wrap"
+                               Classes="mono"
+                               PlaceholderText="Auto-filled from CW decoder; editable" />
+                    </StackPanel>
+                  </Grid>
+                </StackPanel>
               </StackPanel>
             </Grid>
           </ScrollViewer>

--- a/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
@@ -162,18 +162,18 @@
 
                 <StackPanel>
                   <TextBlock Classes="fieldLabel" Text="Comment" />
-                  <TextBox Text="{Binding Comment, Mode=TwoWay}" AcceptsReturn="True" Height="88" TextWrapping="Wrap" />
+                  <TextBox Text="{Binding Comment, Mode=TwoWay}" AcceptsReturn="True" Height="56" TextWrapping="Wrap" />
                 </StackPanel>
 
                 <StackPanel>
                   <TextBlock Classes="fieldLabel" Text="Notes" />
-                  <TextBox Text="{Binding Notes, Mode=TwoWay}" AcceptsReturn="True" Height="140" TextWrapping="Wrap" />
+                  <TextBox Text="{Binding Notes, Mode=TwoWay}" AcceptsReturn="True" Height="92" TextWrapping="Wrap" />
                 </StackPanel>
 
                 <StackPanel>
                   <TextBlock Classes="fieldLabel" Text="CW decode (RX)" />
                   <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
-                    <StackPanel Grid.Column="0" Width="120">
+                    <StackPanel Grid.Column="0" Width="96">
                       <TextBlock Classes="fieldLabel" Text="WPM" Opacity="0.72" />
                       <TextBox Text="{Binding CwDecodeRxWpmText, Mode=TwoWay}"
                                PlaceholderText="auto" />
@@ -181,7 +181,7 @@
                     <StackPanel Grid.Column="1">
                       <TextBlock Classes="fieldLabel" Text="Transcript" Opacity="0.72" />
                       <TextBox Text="{Binding CwDecodeTranscript, Mode=TwoWay}"
-                               AcceptsReturn="True" Height="88" TextWrapping="Wrap"
+                               AcceptsReturn="True" Height="56" TextWrapping="Wrap"
                                Classes="mono"
                                PlaceholderText="Auto-filled from CW decoder; editable" />
                     </StackPanel>

--- a/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml
@@ -172,19 +172,29 @@
 
                 <StackPanel>
                   <TextBlock Classes="fieldLabel" Text="CW decode (RX)" />
-                  <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
-                    <StackPanel Grid.Column="0" Width="96">
+                  <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10" RowDefinitions="Auto,Auto" RowSpacing="6">
+                    <StackPanel Grid.Column="0" Grid.Row="0" Width="96">
                       <TextBlock Classes="fieldLabel" Text="WPM" Opacity="0.72" />
                       <TextBox Text="{Binding CwDecodeRxWpmText, Mode=TwoWay}"
                                PlaceholderText="auto" />
                     </StackPanel>
-                    <StackPanel Grid.Column="1">
-                      <TextBlock Classes="fieldLabel" Text="Transcript" Opacity="0.72" />
-                      <TextBox Text="{Binding CwDecodeTranscript, Mode=TwoWay}"
-                               AcceptsReturn="True" Height="56" TextWrapping="Wrap"
-                               Classes="mono"
-                               PlaceholderText="Auto-filled from CW decoder; editable" />
+                    <StackPanel Grid.Column="1" Grid.Row="0" VerticalAlignment="Bottom">
+                      <TextBlock Text="{Binding CwTranscriptSummary}"
+                                 FontSize="11"
+                                 Opacity="0.72"
+                                 TextTrimming="CharacterEllipsis" />
+                      <TextBlock Text="{Binding CwTranscriptPreview}"
+                                 FontSize="11.5"
+                                 Classes="mono"
+                                 TextWrapping="NoWrap"
+                                 TextTrimming="CharacterEllipsis"
+                                 IsVisible="{Binding HasCwTranscriptContent}" />
                     </StackPanel>
+                    <Button Grid.Column="2" Grid.Row="0"
+                            Content="Open transcript &#x2192;"
+                            VerticalAlignment="Bottom"
+                            Command="{Binding ShowTranscriptTabCommand}"
+                            ToolTip.Tip="Jump to the Transcript tab (Alt+6)" />
                   </Grid>
                 </StackPanel>
               </StackPanel>
@@ -574,7 +584,59 @@
           </ScrollViewer>
         </TabItem>
 
-        <TabItem Header="6 Metadata">
+        <TabItem Header="6 Transcript">
+          <ScrollViewer VerticalScrollBarVisibility="Auto">
+            <StackPanel Spacing="14" Margin="0,8,0,0">
+
+              <Border Classes="infoPanel">
+                <Grid RowDefinitions="Auto,Auto,*" RowSpacing="6">
+                  <Grid Grid.Row="0" ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding CwTranscriptSourceBadge}"
+                               FontWeight="SemiBold"
+                               FontSize="13"
+                               VerticalAlignment="Center" />
+                    <StackPanel Grid.Column="1"
+                                Orientation="Horizontal"
+                                Spacing="8"
+                                VerticalAlignment="Center">
+                      <TextBlock Classes="fieldLabel" Text="WPM" />
+                      <TextBox Text="{Binding CwDecodeRxWpmText, Mode=TwoWay}"
+                               Width="80"
+                               PlaceholderText="auto" />
+                    </StackPanel>
+                  </Grid>
+
+                  <TextBlock Grid.Row="1"
+                             Text="Auto-filled from the live CW decoder. Edits here are saved with the QSO; the captured WPM and transcript are a lossy snapshot of the decoder output."
+                             FontSize="11"
+                             Opacity="0.65"
+                             TextWrapping="Wrap" />
+
+                  <TextBox Grid.Row="2"
+                           x:Name="CwTranscriptBox"
+                           Text="{Binding CwDecodeTranscript, Mode=TwoWay}"
+                           AcceptsReturn="True"
+                           AcceptsTab="False"
+                           TextWrapping="Wrap"
+                           Classes="mono"
+                           MinHeight="380"
+                           VerticalContentAlignment="Top"
+                           PlaceholderText="No CW transcript captured yet. Type a callsign while the CW decoder is locked to start collecting decoded text." />
+                </Grid>
+              </Border>
+
+              <!--
+                Future-proofing: voice STT (SSB/FM) transcripts will appear here as a sibling
+                section with the same shape (header strip + multi-line editable monospace box).
+                See docs/architecture/engine-specification.md for the planned proto contract.
+              -->
+
+            </StackPanel>
+          </ScrollViewer>
+        </TabItem>
+
+        <TabItem Header="7 Metadata">
           <ScrollViewer VerticalScrollBarVisibility="Auto">
             <Grid ColumnDefinitions="320,*" ColumnSpacing="18" Margin="0,8,0,0">
               <StackPanel Spacing="10">

--- a/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/FullQsoCardView.axaml.cs
@@ -90,7 +90,8 @@ internal sealed partial class FullQsoCardView : UserControl
             2 => "QslSentStatusBox",
             3 => "ContestIdBox",
             4 => "StationCallsignSnapshotBox",
-            5 => "ExtraFieldsBox",
+            5 => "CwTranscriptBox",
+            6 => "ExtraFieldsBox",
             _ => "WorkedCallsignBox"
         };
 }

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -783,6 +783,13 @@
                                       SortMemberPath="Continent"
                                       IsReadOnly="True"
                                       IsVisible="False" />
+                  <DataGridTextColumn Header="WPM"
+                                      Width="64"
+                                      MinWidth="48"
+                                      Binding="{ReflectionBinding RxWpmDisplay}"
+                                      SortMemberPath="RxWpmSortKey"
+                                      IsReadOnly="True"
+                                      IsVisible="False" />
                 </DataGrid.Columns>
               </DataGrid>
 

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml.cs
@@ -1035,12 +1035,13 @@ internal sealed partial class MainWindow : Window
             [RecentQsoGridColumn.Note] = _recentQsoGrid.Columns[14],
             [RecentQsoGridColumn.Comment] = _recentQsoGrid.Columns[15],
             [RecentQsoGridColumn.UtcEnd] = _recentQsoGrid.Columns[16],
-            [RecentQsoGridColumn.CqZone] = _recentQsoGrid.Columns[17],
-            [RecentQsoGridColumn.ItuZone] = _recentQsoGrid.Columns[18],
-            [RecentQsoGridColumn.State] = _recentQsoGrid.Columns[19],
-            [RecentQsoGridColumn.County] = _recentQsoGrid.Columns[20],
-            [RecentQsoGridColumn.Sync] = _recentQsoGrid.Columns[21],
-            [RecentQsoGridColumn.Continent] = _recentQsoGrid.Columns[22]
+            [RecentQsoGridColumn.CqZone] = _recentQsoGrid.Columns[18],
+            [RecentQsoGridColumn.ItuZone] = _recentQsoGrid.Columns[19],
+            [RecentQsoGridColumn.State] = _recentQsoGrid.Columns[20],
+            [RecentQsoGridColumn.County] = _recentQsoGrid.Columns[21],
+            [RecentQsoGridColumn.Sync] = _recentQsoGrid.Columns[22],
+            [RecentQsoGridColumn.Continent] = _recentQsoGrid.Columns[23],
+            [RecentQsoGridColumn.RxWpm] = _recentQsoGrid.Columns[24]
         };
     }
 

--- a/src/rust/qsoripper-core/src/adif/mapper.rs
+++ b/src/rust/qsoripper-core/src/adif/mapper.rs
@@ -175,6 +175,15 @@ impl AdifMapper {
                         qso.extra_fields.insert(key_upper, value_str.to_owned());
                     }
                 }
+                "APP_QSORIPPER_CW_TRANSCRIPT" => {
+                    // Decoded CW transcript text — accepted as-is. Empty
+                    // values are dropped so a zero-length user-defined
+                    // field from another tool doesn't trigger a noisy
+                    // round-trip.
+                    if !value_str.is_empty() {
+                        qso.cw_decode_transcript = Some(value_str.to_owned());
+                    }
+                }
                 "COUNTRY" => qso.worked_country = Some(value_str.to_owned()),
                 "DXCC" => {
                     if let Ok(code) = value_str.parse::<u32>() {
@@ -564,6 +573,15 @@ impl AdifMapper {
         if let Some(wpm) = qso.cw_decode_rx_wpm {
             push_field(&mut fields, "APP_QSORIPPER_RX_WPM", wpm.to_string());
         }
+        if let Some(transcript) = qso.cw_decode_transcript.as_deref() {
+            // Sanitize ASCII control bytes (other than CR/LF/tab) and drop
+            // non-ASCII so byte length (Rust writer) and char length (.NET
+            // writer) agree across runtimes for round-trips.
+            let sanitized = sanitize_cw_transcript_for_adif(transcript);
+            if !sanitized.is_empty() {
+                push_field(&mut fields, "APP_QSORIPPER_CW_TRANSCRIPT", sanitized);
+            }
+        }
         if let Some(v) = qso.worked_country.as_deref() {
             push_field(&mut fields, "COUNTRY", v);
         }
@@ -764,6 +782,27 @@ fn push_field<'a>(
     value: impl Into<Cow<'a, str>>,
 ) {
     fields.push((key.into(), value.into()));
+}
+
+/// Strip ASCII control bytes (other than CR/LF/tab) and drop non-ASCII
+/// characters from operator-editable CW transcript text before writing
+/// to ADIF. Keeping the payload to printable ASCII + CR/LF/tab keeps
+/// the .NET writer's char-count length and the Rust writer's byte
+/// length in agreement so round-trips don't drift across runtimes.
+fn sanitize_cw_transcript_for_adif(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        if c == '\r' || c == '\n' || c == '\t' {
+            out.push(c);
+            continue;
+        }
+        let code = c as u32;
+        if code < 0x20 || code == 0x7F || code > 0x7E {
+            continue;
+        }
+        out.push(c);
+    }
+    out
 }
 
 /// Parse ADIF date (YYYYMMDD) + optional time (HHMM or HHMMSS) into prost Timestamp.
@@ -1132,6 +1171,8 @@ fn field_is_overridden(
             != QsoCompletion::Unspecified
     } else if key.eq_ignore_ascii_case("APP_QSORIPPER_RX_WPM") {
         qso.cw_decode_rx_wpm.is_some()
+    } else if key.eq_ignore_ascii_case("APP_QSORIPPER_CW_TRANSCRIPT") {
+        qso.cw_decode_transcript.is_some()
     } else if key.eq_ignore_ascii_case("MY_ALTITUDE") {
         station_snapshot
             .and_then(|snapshot| snapshot.altitude_meters)
@@ -2295,6 +2336,92 @@ mod tests {
         let fields = AdifMapper::qso_to_adif_fields(&qso);
         assert_eq!(count_field(&fields, "APP_QSORIPPER_RX_WPM"), 1);
         assert_eq!(field_value(&fields, "APP_QSORIPPER_RX_WPM"), Some("25"));
+    }
+
+    #[test]
+    fn cw_decode_transcript_round_trips_via_app_qsoripper_cw_transcript() {
+        let qso = QsoRecord {
+            worked_callsign: "K1ABC".to_string(),
+            cw_decode_transcript: Some("CQ DE K1ABC K".to_string()),
+            ..Default::default()
+        };
+
+        let fields = AdifMapper::qso_to_adif_fields(&qso);
+        assert_eq!(count_field(&fields, "APP_QSORIPPER_CW_TRANSCRIPT"), 1);
+        assert_eq!(
+            field_value(&fields, "APP_QSORIPPER_CW_TRANSCRIPT"),
+            Some("CQ DE K1ABC K")
+        );
+
+        let mut rec = Record::new();
+        rec.insert("CALL", "K1ABC").unwrap();
+        rec.insert("APP_QSORIPPER_CW_TRANSCRIPT", "CQ DE K1ABC K")
+            .unwrap();
+        let parsed = AdifMapper::record_to_qso(&rec);
+        assert_eq!(
+            parsed.cw_decode_transcript.as_deref(),
+            Some("CQ DE K1ABC K")
+        );
+        assert!(!parsed
+            .extra_fields
+            .contains_key("APP_QSORIPPER_CW_TRANSCRIPT"));
+    }
+
+    #[test]
+    fn cw_decode_transcript_unset_emits_no_field() {
+        let qso = QsoRecord {
+            worked_callsign: "K1ABC".to_string(),
+            ..Default::default()
+        };
+        let fields = AdifMapper::qso_to_adif_fields(&qso);
+        assert_eq!(count_field(&fields, "APP_QSORIPPER_CW_TRANSCRIPT"), 0);
+    }
+
+    #[test]
+    fn cw_decode_transcript_empty_value_does_not_set_field() {
+        let mut rec = Record::new();
+        rec.insert("CALL", "K1ABC").unwrap();
+        rec.insert("APP_QSORIPPER_CW_TRANSCRIPT", "").unwrap();
+        let parsed = AdifMapper::record_to_qso(&rec);
+        assert!(parsed.cw_decode_transcript.is_none());
+    }
+
+    #[test]
+    fn cw_decode_transcript_sanitizes_non_ascii_and_control_chars() {
+        let qso = QsoRecord {
+            worked_callsign: "K1ABC".to_string(),
+            // Intentionally include: a non-ASCII character (é, U+00E9), a
+            // bell control (0x07), DEL (0x7F), and a preserved newline.
+            cw_decode_transcript: Some("CQ\u{00e9}\u{0007}DE\u{007f}\nK".to_string()),
+            ..Default::default()
+        };
+
+        let fields = AdifMapper::qso_to_adif_fields(&qso);
+        let value = field_value(&fields, "APP_QSORIPPER_CW_TRANSCRIPT")
+            .expect("transcript should be written after sanitization");
+        // Non-ASCII, BEL, and DEL stripped; CR/LF/tab + printable ASCII kept.
+        assert_eq!(value, "CQDE\nK");
+        // Sanitized output is pure ASCII so byte length and char count agree.
+        assert!(value.is_ascii());
+    }
+
+    #[test]
+    fn cw_decode_transcript_extra_fields_does_not_shadow_typed_value() {
+        let mut qso = QsoRecord {
+            worked_callsign: "K1ABC".to_string(),
+            cw_decode_transcript: Some("typed".to_string()),
+            ..Default::default()
+        };
+        qso.extra_fields.insert(
+            "APP_QSORIPPER_CW_TRANSCRIPT".to_string(),
+            "stale".to_string(),
+        );
+        let fields = AdifMapper::qso_to_adif_fields(&qso);
+        assert_eq!(count_field(&fields, "APP_QSORIPPER_CW_TRANSCRIPT"), 1);
+        assert_eq!(
+            field_value(&fields, "APP_QSORIPPER_CW_TRANSCRIPT"),
+            Some("typed")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Round 2 of #321 — auto-fills the live CW decoder's transcript on logged CW QSOs (the WPM round-1 work landed in #324).

Closes #331.

Scope. Adds optional cw_decode_transcript = 131 to QsoRecord as a denormalized 'latest snapshot' cache that will coexist with a future cw_transcript_segments table per #321. A new GUI CwQsoTranscriptAggregator service subscribes to ICwWpmSampleSource.RawLineReceived, parses char/word/garbled NDJSON events safely (handler swallows all exceptions so a malformed line cannot kill the source's stdout pump), exposes a window-aware GetTranscript(start,end), and caps retained fragments to bound memory across long ragchews. QsoLoggerViewModel.EnrichFromCwDecoder now fills both WPM and transcript for CW QSOs, preserves operator-typed transcript text on the full QSO card (operator-wins), and defensively scrubs both CW fields when mode is not CW so stale data cannot ride along on a re-classified QSO. The full QSO card UI shows and lets the operator edit the auto-filled WPM and transcript on the Basic tab.

ADIF round-trip. APP_QSORIPPER_CW_TRANSCRIPT writes and parses on both Rust (adif::mapper) and .NET (AdifCodec) sides. Both runtimes share an ASCII-only sanitizer that strips non-ASCII and ASCII control bytes (other than CR/LF/tab) before writing, so the Rust byte-length writer and the .NET char-length writer agree across runtimes — preventing Unicode round-trip drift that would otherwise corrupt the field on parse. The .NET writer's IsQrzAppExtraKey filter is extended so QsoRipper-owned app keys (APP_QSORIPPER_RX_WPM, APP_QSORIPPER_CW_TRANSCRIPT) are never re-emitted from extra_fields, preventing a stale shadow value from duplicating the dedicated proto value in the ADIF output.

Out of scope (deferred to follow-up sub-issues of #321): separate cw_transcript_segments table + qso_cw_attachment relation, lifting experiments/cw-decoder into src/rust/qsoripper-cw-decoder, CwDecodeService proto + RPCs and the .NET engine child-process proxy, LogbookService transcript RPCs.

Tests. Rust: 5 new mapper tests (round-trip, unset, empty, sanitization, extra_fields shadow guard) — 129 adif tests green. .NET: 9 new CwQsoTranscriptAggregator tests, 5 new EnrichFromCwDecoder transcript tests, 4 new AdifCodec transcript tests — 48 focused GUI tests + 103 QrzLogbook tests green. Local quality gates run: cargo fmt, cargo clippy --all-targets -D warnings, cargo test adif, dotnet build src\dotnet\QsoRipper.slnx, dotnet format on the changed files, buf lint.

Docs. engine-specification.md import/export sections list the new app field and call out the ASCII-sanitization invariant explicitly.