### PR TITLE
fix(win32): populate QSO duration when editing existing contact

### DIFF
--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -448,6 +448,36 @@ static void safe_strcat(char *dst, size_t dstsz, const char *src)
     safe_strcpy(dst + cur, avail, src);
 }
 
+/* Parse "HH:MM" into seconds since midnight, or -1 on error. */
+static int parse_hhmm_to_seconds(const char *s)
+{
+    if (!s) return -1;
+    if (!(s[0] >= '0' && s[0] <= '9')) return -1;
+    if (!(s[1] >= '0' && s[1] <= '9')) return -1;
+    if (s[2] != ':') return -1;
+    if (!(s[3] >= '0' && s[3] <= '9')) return -1;
+    if (!(s[4] >= '0' && s[4] <= '9')) return -1;
+    if (s[5] != 0) return -1;
+    int h = (s[0] - '0') * 10 + (s[1] - '0');
+    int m = (s[3] - '0') * 10 + (s[4] - '0');
+    if (h > 23 || m > 59) return -1;
+    return h * 3600 + m * 60;
+}
+
+/* Compute duration in seconds between two "HH:MM" timestamps.
+   Returns -1 if either input cannot be parsed. If time_off is earlier
+   than time_on (e.g. a QSO that crossed midnight) the result wraps by
+   adding 24 hours so the displayed duration is non-negative. */
+static int qso_duration_seconds(const char *time_on, const char *time_off)
+{
+    int on = parse_hhmm_to_seconds(time_on);
+    int off = parse_hhmm_to_seconds(time_off);
+    if (on < 0 || off < 0) return -1;
+    int diff = off - on;
+    if (diff < 0) diff += 24 * 3600;
+    return diff;
+}
+
 /* Convert raw MHz decimal string to radio-style: "14.22500" -> "14.225.00" */
 static void freq_to_radio_style(const char *mhz_str, char *out, size_t outsz)
 {
@@ -769,6 +799,11 @@ void qsr_test_invoke_delete_selected_qso(void)
 void qsr_test_invoke_fetch_space_weather(void)
 {
     FetchSpaceWeather();
+}
+
+int qsr_test_qso_duration_seconds(const char *time_on, const char *time_off)
+{
+    return qso_duration_seconds(time_on, time_off);
 }
 #endif
 
@@ -2268,7 +2303,7 @@ static int PaintLogForm(HDC hdc, int y_start, int w)
 
     /* Row 6: QSO Duration */
     {
-        char dur[32];
+        char dur[48];
         if (g_state.qso_timer_active) {
             ULONGLONG elapsed = GetTickCount64() - g_state.qso_started_at;
             int secs = (int)(elapsed / 1000);
@@ -2277,7 +2312,15 @@ static int PaintLogForm(HDC hdc, int y_start, int w)
             snprintf(dur, sizeof(dur), "QSO Duration: %02d:%02d", mins, secs);
             DrawText_A(hdc, pad, y + 3, CLR_GREEN, dur);
         } else {
-            DrawText_A(hdc, pad, y + 3, CLR_DARKGRAY, "QSO Duration: 00:00");
+            int total = qso_duration_seconds(g_state.time_str, g_state.time_off);
+            if (total >= 0) {
+                int mins = total / 60;
+                int secs = total % 60;
+                snprintf(dur, sizeof(dur), "QSO Duration: %02d:%02d", mins, secs);
+                DrawText_A(hdc, pad, y + 3, CLR_DARKGRAY, dur);
+            } else {
+                DrawText_A(hdc, pad, y + 3, CLR_DARKGRAY, "QSO Duration: 00:00");
+            }
         }
     }
     y += row_h;

--- a/src/c/qsoripper-win32/tests/win32_issue_regressions.c
+++ b/src/c/qsoripper-win32/tests/win32_issue_regressions.c
@@ -45,6 +45,7 @@ void qsr_test_invoke_log_qso(void);
 void qsr_test_invoke_load_selected_qso(void);
 void qsr_test_invoke_delete_selected_qso(void);
 void qsr_test_invoke_fetch_space_weather(void);
+int qsr_test_qso_duration_seconds(const char *time_on, const char *time_off);
 
 static HANDLE g_log_entered = NULL;
 static HANDLE g_release_log = NULL;
@@ -308,6 +309,41 @@ static int test_issue_263_fetch_space_weather_is_non_blocking(void)
     return 0;
 }
 
+static int test_issue_329_qso_duration_uses_time_off(void)
+{
+    /* Normal case: 03:04 -> 03:19 = 15 minutes */
+    int d = qsr_test_qso_duration_seconds("03:04", "03:19");
+    if (d != 15 * 60) {
+        return fail("duration for 03:04 -> 03:19 was not 15 minutes");
+    }
+
+    /* Same minute */
+    d = qsr_test_qso_duration_seconds("12:30", "12:30");
+    if (d != 0) {
+        return fail("duration for identical times was not zero");
+    }
+
+    /* Wrap across midnight: 23:55 -> 00:05 = 10 minutes */
+    d = qsr_test_qso_duration_seconds("23:55", "00:05");
+    if (d != 10 * 60) {
+        return fail("duration that crosses midnight was not 10 minutes");
+    }
+
+    /* Empty / unset time_off should report no duration */
+    d = qsr_test_qso_duration_seconds("12:00", "");
+    if (d != -1) {
+        return fail("missing time_off should yield -1");
+    }
+
+    /* Malformed input should report no duration */
+    d = qsr_test_qso_duration_seconds("12:00", "bogus");
+    if (d != -1) {
+        return fail("malformed time_off should yield -1");
+    }
+
+    return 0;
+}
+
 int main(void)
 {
     int failures = 0;
@@ -317,6 +353,7 @@ int main(void)
     if (test_issue_263_load_selected_qso_is_non_blocking() != 0) failures++;
     if (test_issue_263_delete_selected_qso_is_non_blocking() != 0) failures++;
     if (test_issue_263_fetch_space_weather_is_non_blocking() != 0) failures++;
+    if (test_issue_329_qso_duration_uses_time_off() != 0) failures++;
     if (failures != 0) {
         fprintf(stderr, "FAIL: %d regression test(s) failed\n", failures);
         return 1;


### PR DESCRIPTION
The Win32 app's QSO Duration row only displayed the live elapsed timer, otherwise rendering 00:00. Loading an existing QSO for editing always showed a zero duration even when both TIME_ON and TIME_OFF were stored on the record.

Root cause: the duration draw block in src/c/qsoripper-win32/src/main.c only checked g_state.qso_timer_active and never derived a value from the loaded TIME_ON / TIME_OFF fields that LoadSelectedQso copies from the FFI's QsoDetail.

Fix: when the live timer is not active, compute the duration from the form's HH:MM time_str and time_off. Midnight wrap is handled by adding 24h when time_off precedes time_on. Empty or malformed values fall back to the original 00:00 placeholder.

Adds a regression test (test_issue_329_qso_duration_uses_time_off) covering normal, zero-length, midnight wrap, missing, and malformed inputs via a new qsr_test_qso_duration_seconds export.

Verification:
- cmake --build build-win32 --config Release: succeeds
- ctest --test-dir build-win32 -C Release: 4/4 passed

Fixes #329