### PR TITLE
fix(win32): re-fire callsign lookup after Esc clears the form

### DIFF
--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -144,6 +144,7 @@ static const int FIELD_MAX_LEN[] = {
 typedef struct {
     HWND hwnd;
     char callsign[64];
+    unsigned generation;
 } LookupThreadArg;
 
 typedef struct {
@@ -156,6 +157,7 @@ typedef struct {
     int  has_data;
     int  not_found;
     char error_msg[128];
+    unsigned generation;
 } LookupResultMsg;
 
 /* ── Rig poll message structs ──────────────────────────────────────────── */
@@ -336,6 +338,10 @@ typedef struct {
     /* Lookup debounce */
     ULONGLONG last_callsign_change;
     char last_looked_up[32];
+    /* Generation counter for in-flight lookups. Incremented when the form
+       is cleared (Esc, Log, QSO load) so any pending result whose generation
+       no longer matches is discarded and cannot poison last_looked_up. */
+    unsigned lookup_generation;
 
     /* Confirm delete dialog */
     int confirm_delete_visible;
@@ -407,6 +413,7 @@ static void OnChar(HWND hwnd, WPARAM ch);
 static void OnTimer(HWND hwnd);
 static void InitState(void);
 static void ClearForm(void);
+static void ApplyLookupResult(LookupResultMsg *res);
 static void SetStatus(const char *msg, int is_error);
 static void LogQso(void);
 static void RefreshQsoList(void);
@@ -770,6 +777,39 @@ void qsr_test_invoke_fetch_space_weather(void)
 {
     FetchSpaceWeather();
 }
+
+unsigned qsr_test_get_lookup_generation(void)
+{
+    return g_state.lookup_generation;
+}
+
+const char *qsr_test_get_last_looked_up(void)
+{
+    return g_state.last_looked_up;
+}
+
+void qsr_test_clear_form(void)
+{
+    ClearForm();
+}
+
+void qsr_test_apply_lookup_result(const char *callsign, unsigned generation, int has_data)
+{
+    LookupResultMsg *res = (LookupResultMsg *)calloc(1, sizeof(LookupResultMsg));
+    if (!res) return;
+    if (callsign) safe_strcpy(res->callsign, sizeof(res->callsign), callsign);
+    res->generation = generation;
+    res->has_data = has_data ? 1 : 0;
+    if (has_data) {
+        safe_strcpy(res->name,    sizeof(res->name),    "Test Name");
+        safe_strcpy(res->qth,     sizeof(res->qth),     "Test QTH");
+        safe_strcpy(res->grid,    sizeof(res->grid),    "FN31");
+        safe_strcpy(res->country, sizeof(res->country), "United States");
+        res->cq_zone = 5;
+    }
+    /* ApplyLookupResult takes ownership and frees res. */
+    ApplyLookupResult(res);
+}
 #endif
 
 /* Append a properly quoted Windows command-line argument to cmd.
@@ -1113,6 +1153,11 @@ static void ClearForm(void)
     g_state.qso_timer_active = 0;
     g_state.qso_started_at = 0;
     g_state.last_looked_up[0] = 0;
+    g_state.last_callsign_change = 0;
+    /* Invalidate any in-flight lookup so its result cannot resurrect
+       last_looked_up after the form is cleared. See issue #330. */
+    g_state.lookup_generation++;
+    g_state.lookup_in_progress = 0;
     SetFocusField(FIELD_CALLSIGN);
     g_state.qso_list_focused = 0;
     g_state.search_focused = 0;
@@ -1542,11 +1587,53 @@ static void ClearLookupDisplay(void)
     g_state.lookup_country[0] = 0;
     g_state.lookup_cq_zone = 0;
     g_state.last_looked_up[0] = 0;
+    /* Invalidate any in-flight lookup so a stale result cannot poison
+       last_looked_up after the user edits the callsign. See issue #330. */
+    g_state.lookup_generation++;
     /* Clear form fields that were auto-populated from lookup */
     g_state.worked_name[0] = 0;
     g_state.cursor_pos[FIELD_WORKED_NAME] = 0;
     g_state.qth[0] = 0;
     g_state.cursor_pos[FIELD_QTH] = 0;
+}
+
+/* Apply a completed lookup result. Discards results whose generation no
+   longer matches g_state.lookup_generation: those belong to a lookup that
+   was started before the form was cleared (Esc) or before the user edited
+   the callsign, and applying them would resurrect last_looked_up and
+   block the next debounce-triggered lookup. See issue #330. */
+static void ApplyLookupResult(LookupResultMsg *res)
+{
+    if (!res) return;
+    if (res->generation != g_state.lookup_generation) {
+        free(res);
+        return;
+    }
+    if (_stricmp(res->callsign, g_state.callsign) == 0) {
+        if (res->has_data) {
+            safe_strcpy(g_state.lookup_name, sizeof(g_state.lookup_name), res->name);
+            safe_strcpy(g_state.lookup_qth,  sizeof(g_state.lookup_qth),  res->qth);
+            safe_strcpy(g_state.lookup_grid, sizeof(g_state.lookup_grid), res->grid);
+            safe_strcpy(g_state.lookup_country, sizeof(g_state.lookup_country), res->country);
+            g_state.lookup_cq_zone = res->cq_zone;
+            g_state.has_lookup = 1;
+            g_state.lookup_not_found = 0;
+            g_state.lookup_error[0] = 0;
+            safe_strcpy(g_state.worked_name, sizeof(g_state.worked_name), res->name);
+            g_state.cursor_pos[FIELD_WORKED_NAME] = (int)strlen(g_state.worked_name);
+            safe_strcpy(g_state.qth, sizeof(g_state.qth), res->qth);
+            g_state.cursor_pos[FIELD_QTH] = (int)strlen(g_state.qth);
+        } else if (res->not_found) {
+            g_state.lookup_not_found = 1;
+            g_state.lookup_error[0] = 0;
+        } else if (res->error_msg[0]) {
+            g_state.lookup_not_found = 0;
+            safe_strcpy(g_state.lookup_error, sizeof(g_state.lookup_error), res->error_msg);
+        }
+        safe_strcpy(g_state.last_looked_up, sizeof(g_state.last_looked_up), res->callsign);
+    }
+    g_state.lookup_in_progress = 0;
+    free(res);
 }
 
 static unsigned __stdcall LookupThread(void *param)
@@ -1556,6 +1643,7 @@ static unsigned __stdcall LookupThread(void *param)
     if (!res) { free(arg); return 0; }
 
     safe_strcpy(res->callsign, sizeof(res->callsign), arg->callsign);
+    res->generation = arg->generation;
 
     if (g_backend.mode == BACKEND_FFI) {
         struct QsrClient *ffi_client = NULL;
@@ -3437,6 +3525,7 @@ static void OnTimer(HWND hwnd)
                 if (arg) {
                     arg->hwnd = hwnd;
                     safe_strcpy(arg->callsign, sizeof(arg->callsign), g_state.callsign);
+                    arg->generation = g_state.lookup_generation;
                     g_state.lookup_in_progress = 1;
                     uintptr_t h = _beginthreadex(NULL, 0, LookupThread, arg, 0, NULL);
                     if (h) CloseHandle((HANDLE)h);
@@ -3698,34 +3787,7 @@ static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPara
     case WM_APP_LOOKUP_DONE:
     {
         LookupResultMsg *res = (LookupResultMsg *)lParam;
-        if (res) {
-            if (_stricmp(res->callsign, g_state.callsign) == 0) {
-                if (res->has_data) {
-                    safe_strcpy(g_state.lookup_name, sizeof(g_state.lookup_name), res->name);
-                    safe_strcpy(g_state.lookup_qth,  sizeof(g_state.lookup_qth),  res->qth);
-                    safe_strcpy(g_state.lookup_grid, sizeof(g_state.lookup_grid), res->grid);
-                    safe_strcpy(g_state.lookup_country, sizeof(g_state.lookup_country), res->country);
-                    g_state.lookup_cq_zone = res->cq_zone;
-                    g_state.has_lookup = 1;
-                    g_state.lookup_not_found = 0;
-                    g_state.lookup_error[0] = 0;
-                    /* Always populate from lookup (overwrite stale data from previous callsign) */
-                    safe_strcpy(g_state.worked_name, sizeof(g_state.worked_name), res->name);
-                    g_state.cursor_pos[FIELD_WORKED_NAME] = (int)strlen(g_state.worked_name);
-                    safe_strcpy(g_state.qth, sizeof(g_state.qth), res->qth);
-                    g_state.cursor_pos[FIELD_QTH] = (int)strlen(g_state.qth);
-                } else if (res->not_found) {
-                    g_state.lookup_not_found = 1;
-                    g_state.lookup_error[0] = 0;
-                } else if (res->error_msg[0]) {
-                    g_state.lookup_not_found = 0;
-                    safe_strcpy(g_state.lookup_error, sizeof(g_state.lookup_error), res->error_msg);
-                }
-                safe_strcpy(g_state.last_looked_up, sizeof(g_state.last_looked_up), res->callsign);
-            }
-            g_state.lookup_in_progress = 0;
-            free(res);
-        }
+        ApplyLookupResult(res);
         InvalidateRect(hwnd, NULL, FALSE);
         break;
     }

--- a/src/c/qsoripper-win32/tests/win32_issue_regressions.c
+++ b/src/c/qsoripper-win32/tests/win32_issue_regressions.c
@@ -45,6 +45,10 @@ void qsr_test_invoke_log_qso(void);
 void qsr_test_invoke_load_selected_qso(void);
 void qsr_test_invoke_delete_selected_qso(void);
 void qsr_test_invoke_fetch_space_weather(void);
+unsigned qsr_test_get_lookup_generation(void);
+const char *qsr_test_get_last_looked_up(void);
+void qsr_test_clear_form(void);
+void qsr_test_apply_lookup_result(const char *callsign, unsigned generation, int has_data);
 
 static HANDLE g_log_entered = NULL;
 static HANDLE g_release_log = NULL;
@@ -308,6 +312,56 @@ static int test_issue_263_fetch_space_weather_is_non_blocking(void)
     return 0;
 }
 
+static int test_issue_330_lookup_re_fires_after_esc_clear(void)
+{
+    /* Issue #330: after the first lookup completes, pressing Esc to clear
+       the form must allow a subsequent typed callsign to re-trigger a
+       lookup. The original bug was a race: an in-flight (or just-completed)
+       lookup result would land after Esc and re-populate last_looked_up,
+       causing the debounce check (callsign != last_looked_up) to skip
+       the next lookup when the same callsign was retyped. */
+    qsr_test_reset_state();
+
+    qsr_test_set_form_basics("W1AW", NULL, NULL);
+    unsigned gen0 = qsr_test_get_lookup_generation();
+
+    /* Simulate the first lookup completing. */
+    qsr_test_apply_lookup_result("W1AW", gen0, 1);
+    if (strcmp(qsr_test_get_last_looked_up(), "W1AW") != 0) {
+        return fail("first lookup did not record last_looked_up");
+    }
+
+    /* User presses Esc — form is cleared. Generation must advance so any
+       result still in flight from the previous lookup is discarded. */
+    qsr_test_clear_form();
+    if (qsr_test_get_lookup_generation() == gen0) {
+        return fail("ClearForm did not advance lookup generation");
+    }
+    if (qsr_test_get_last_looked_up()[0] != 0) {
+        return fail("ClearForm did not reset last_looked_up");
+    }
+
+    /* User retypes the same callsign. */
+    qsr_test_set_form_basics("W1AW", NULL, NULL);
+
+    /* A stale lookup carrying the OLD generation lands now (the in-flight
+       thread that started before Esc finally completed). It must be
+       ignored — otherwise it would set last_looked_up to "W1AW" and the
+       next debounce tick would skip the new lookup. */
+    qsr_test_apply_lookup_result("W1AW", gen0, 1);
+    if (qsr_test_get_last_looked_up()[0] != 0) {
+        return fail("stale lookup result was not discarded after ClearForm");
+    }
+
+    /* A fresh lookup with the current generation is accepted. */
+    unsigned gen1 = qsr_test_get_lookup_generation();
+    qsr_test_apply_lookup_result("W1AW", gen1, 1);
+    if (strcmp(qsr_test_get_last_looked_up(), "W1AW") != 0) {
+        return fail("fresh lookup result was not applied after ClearForm");
+    }
+    return 0;
+}
+
 int main(void)
 {
     int failures = 0;
@@ -317,6 +371,7 @@ int main(void)
     if (test_issue_263_load_selected_qso_is_non_blocking() != 0) failures++;
     if (test_issue_263_delete_selected_qso_is_non_blocking() != 0) failures++;
     if (test_issue_263_fetch_space_weather_is_non_blocking() != 0) failures++;
+    if (test_issue_330_lookup_re_fires_after_esc_clear() != 0) failures++;
     if (failures != 0) {
         fprintf(stderr, "FAIL: %d regression test(s) failed\n", failures);
         return 1;


### PR DESCRIPTION
Fixes #330.

After the first callsign lookup, pressing Esc to clear the form and then typing another callsign (or even the same one) and tabbing out failed to trigger a new lookup.

Root cause: a race between ClearForm() and the async lookup thread. If a lookup result landed after Esc cleared the form, the WM_APP_LOOKUP_DONE handler still wrote res->callsign into g_state.last_looked_up. When the user retyped, the debounce in OnTimer saw callsign == last_looked_up and skipped firing.

Fix: stamp every LookupThreadArg and LookupResultMsg with a generation counter. ClearForm() and ClearLookupDisplay() bump the counter. The new ApplyLookupResult() helper drops any result whose generation does not match the current g_state.lookup_generation. ClearForm() also resets last_callsign_change and lookup_in_progress so a leftover debounce or in-flight flag cannot stall the next lookup.

Tests:
- New regression test test_issue_330_lookup_re_fires_after_esc_clear in win32_issue_regressions exercises the race directly.
- ctest --test-dir build-win32 -C Release passes all 4 suites.