### PR TITLE
UI tools: clear indicator when the qsoripper engine server is not running

### DIFF
--- a/src/dotnet/QsoRipper.Cli.Tests/EngineReachabilityTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/EngineReachabilityTests.cs
@@ -1,0 +1,73 @@
+using Grpc.Net.Client;
+using QsoRipper.Cli;
+using QsoRipper.EngineSelection;
+
+namespace QsoRipper.Cli.Tests;
+
+public sealed class EngineReachabilityTests
+{
+    [Fact]
+    public void SuggestedCommandReturnsCargoForRustProfile()
+    {
+        var command = EngineReachability.SuggestedCommand(EngineCatalog.RustProfile);
+
+        Assert.Equal("cargo run --manifest-path src/rust/Cargo.toml -p qsoripper-server", command);
+    }
+
+    [Fact]
+    public void SuggestedCommandReturnsDotnetForDotNetProfile()
+    {
+        var command = EngineReachability.SuggestedCommand(EngineCatalog.DotNetProfile);
+
+        Assert.Equal("dotnet run --project src/dotnet/QsoRipper.Engine.DotNet", command);
+    }
+
+    [Fact]
+    public void SuggestedCommandReturnsGenericForUnknownProfile()
+    {
+        var profile = new EngineTargetProfile(
+            "remote-cluster",
+            "remote",
+            "Remote Cluster Engine",
+            "http://example.test:50051",
+            ["remote-cluster"],
+            LocalLaunchRecipe: null);
+
+        var command = EngineReachability.SuggestedCommand(profile);
+
+        Assert.Equal("the engine binary for this profile", command);
+    }
+
+    [Fact]
+    public void FormatUnreachableMessageIncludesEndpointProfileNameAndSuggestedCommand()
+    {
+        var profile = EngineCatalog.RustProfile;
+        var endpoint = "http://127.0.0.1:50051";
+
+        var message = EngineReachability.FormatUnreachableMessage(profile, endpoint);
+
+        Assert.Contains(profile.DisplayName, message, StringComparison.Ordinal);
+        Assert.Contains(endpoint, message, StringComparison.Ordinal);
+        Assert.Contains(EngineReachability.SuggestedCommand(profile), message, StringComparison.Ordinal);
+        Assert.Contains("Make sure the engine is running", message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ProbeAsyncReportsUnreachableForClosedPort()
+    {
+        using var channel = GrpcChannel.ForAddress("http://127.0.0.1:1");
+        var profile = EngineCatalog.RustProfile;
+        var endpoint = "http://127.0.0.1:1";
+
+        var result = await EngineReachability.ProbeAsync(
+            channel,
+            profile,
+            endpoint,
+            deadline: TimeSpan.FromMilliseconds(500));
+
+        Assert.False(result.IsReachable);
+        Assert.NotNull(result.ErrorMessage);
+        Assert.Contains(endpoint, result.ErrorMessage, StringComparison.Ordinal);
+        Assert.Contains(profile.DisplayName, result.ErrorMessage, StringComparison.Ordinal);
+    }
+}

--- a/src/dotnet/QsoRipper.Cli/EngineReachability.cs
+++ b/src/dotnet/QsoRipper.Cli/EngineReachability.cs
@@ -1,0 +1,119 @@
+using Grpc.Core;
+using Grpc.Net.Client;
+using QsoRipper.EngineSelection;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli;
+
+internal readonly record struct EngineReachabilityResult(
+    bool IsReachable,
+    string? ErrorMessage,
+    StatusCode? StatusCode);
+
+internal static class EngineReachability
+{
+    private static readonly TimeSpan DefaultDeadline = TimeSpan.FromMilliseconds(1500);
+
+    public static async Task<EngineReachabilityResult> ProbeAsync(
+        GrpcChannel channel,
+        EngineTargetProfile profile,
+        string endpoint,
+        TimeSpan? deadline = null,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(channel);
+        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        var effectiveDeadline = deadline ?? DefaultDeadline;
+        var deadlineUtc = DateTime.UtcNow.Add(effectiveDeadline);
+
+        try
+        {
+            var engineClient = new EngineService.EngineServiceClient(channel);
+            await engineClient
+                .GetEngineInfoAsync(new GetEngineInfoRequest(), deadline: deadlineUtc, cancellationToken: ct)
+                .ResponseAsync
+                .ConfigureAwait(false);
+            return new EngineReachabilityResult(true, null, null);
+        }
+        catch (RpcException ex) when (ex.StatusCode == Grpc.Core.StatusCode.Unimplemented)
+        {
+            return await ProbeWithLogbookAsync(channel, profile, endpoint, deadlineUtc, ct).ConfigureAwait(false);
+        }
+        catch (RpcException ex) when (IsUnreachable(ex.StatusCode))
+        {
+            return new EngineReachabilityResult(
+                false,
+                FormatUnreachableMessage(profile, endpoint),
+                ex.StatusCode);
+        }
+        catch (RpcException ex)
+        {
+            return new EngineReachabilityResult(false, ex.Status.Detail, ex.StatusCode);
+        }
+    }
+
+    public static string FormatUnreachableMessage(EngineTargetProfile profile, string endpoint)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(endpoint);
+
+        return $"Could not connect to {profile.DisplayName} at {endpoint}.\nMake sure the engine is running. Suggested start command:\n  {SuggestedCommand(profile)}";
+    }
+
+    public static string SuggestedCommand(EngineTargetProfile profile)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+
+        if (string.Equals(profile.ProfileId, KnownEngineProfiles.LocalRust, StringComparison.OrdinalIgnoreCase)
+            || profile.Matches("rust"))
+        {
+            return "cargo run --manifest-path src/rust/Cargo.toml -p qsoripper-server";
+        }
+
+        if (string.Equals(profile.ProfileId, KnownEngineProfiles.LocalDotNet, StringComparison.OrdinalIgnoreCase)
+            || profile.Matches("dotnet"))
+        {
+            return "dotnet run --project src/dotnet/QsoRipper.Engine.DotNet";
+        }
+
+        return "the engine binary for this profile";
+    }
+
+    private static async Task<EngineReachabilityResult> ProbeWithLogbookAsync(
+        GrpcChannel channel,
+        EngineTargetProfile profile,
+        string endpoint,
+        DateTime deadlineUtc,
+        CancellationToken ct)
+    {
+        try
+        {
+            var logbookClient = new LogbookService.LogbookServiceClient(channel);
+            await logbookClient
+                .GetSyncStatusAsync(new GetSyncStatusRequest(), deadline: deadlineUtc, cancellationToken: ct)
+                .ResponseAsync
+                .ConfigureAwait(false);
+            return new EngineReachabilityResult(true, null, null);
+        }
+        catch (RpcException ex) when (IsUnreachable(ex.StatusCode))
+        {
+            return new EngineReachabilityResult(
+                false,
+                FormatUnreachableMessage(profile, endpoint),
+                ex.StatusCode);
+        }
+        catch (RpcException ex)
+        {
+            return new EngineReachabilityResult(false, ex.Status.Detail, ex.StatusCode);
+        }
+    }
+
+    private static bool IsUnreachable(StatusCode statusCode)
+    {
+        return statusCode is Grpc.Core.StatusCode.Unavailable
+            or Grpc.Core.StatusCode.DeadlineExceeded
+            or Grpc.Core.StatusCode.Internal;
+    }
+}

--- a/src/dotnet/QsoRipper.Cli/Program.cs
+++ b/src/dotnet/QsoRipper.Cli/Program.cs
@@ -77,9 +77,7 @@ try
 }
 catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable)
 {
-    Console.Error.WriteLine(
-        $"Could not connect to {arguments.EngineProfile.DisplayName} at {arguments.Endpoint}");
-    Console.Error.WriteLine("Make sure the engine is running.");
+    Console.Error.WriteLine(EngineReachability.FormatUnreachableMessage(arguments.EngineProfile, arguments.Endpoint));
     return 1;
 }
 catch (RpcException ex)

--- a/src/dotnet/QsoRipper.DebugHost.Tests/EngineConnectivityWatcherTests.cs
+++ b/src/dotnet/QsoRipper.DebugHost.Tests/EngineConnectivityWatcherTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Options;
+using QsoRipper.DebugHost.Models;
+using QsoRipper.DebugHost.Services;
+
+namespace QsoRipper.DebugHost.Tests;
+
+#pragma warning disable CA1707
+public class EngineConnectivityWatcherTests
+{
+    [Fact]
+    public void Initial_state_is_reachable_with_resolved_endpoint()
+    {
+        using var watcher = CreateWatcher((_, _) => Task.FromResult(new EngineProbeOutcome(true, null)));
+
+        Assert.False(watcher.IsEngineUnreachable);
+        Assert.Null(watcher.LastError);
+        Assert.False(string.IsNullOrWhiteSpace(watcher.LastEndpoint));
+    }
+
+    [Fact]
+    public async Task Failed_probe_sets_unreachable_and_fires_state_changed_once()
+    {
+        using var watcher = CreateWatcher((_, _) => Task.FromResult(new EngineProbeOutcome(false, "boom")));
+        var fires = 0;
+        watcher.StateChanged += (_, _) => Interlocked.Increment(ref fires);
+
+        await watcher.ProbeNowAsync();
+
+        Assert.True(watcher.IsEngineUnreachable);
+        Assert.Equal("boom", watcher.LastError);
+        Assert.NotEqual(default, watcher.LastProbeUtc);
+        Assert.Equal(1, fires);
+
+        await watcher.ProbeNowAsync();
+        Assert.Equal(1, fires);
+    }
+
+    [Fact]
+    public async Task Recovery_after_failure_flips_state_back_and_fires_again()
+    {
+        var reachable = false;
+        using var watcher = CreateWatcher((_, _) => Task.FromResult(new EngineProbeOutcome(reachable, reachable ? null : "down")));
+        var fires = 0;
+        watcher.StateChanged += (_, _) => Interlocked.Increment(ref fires);
+
+        await watcher.ProbeNowAsync();
+        Assert.True(watcher.IsEngineUnreachable);
+        Assert.Equal(1, fires);
+
+        reachable = true;
+        await watcher.ProbeNowAsync();
+
+        Assert.False(watcher.IsEngineUnreachable);
+        Assert.Null(watcher.LastError);
+        Assert.Equal(2, fires);
+    }
+
+    [Fact]
+    public async Task Probe_delegate_exception_is_captured_as_error()
+    {
+        using var watcher = CreateWatcher((_, _) => throw new InvalidOperationException("kaboom"));
+
+        await watcher.ProbeNowAsync();
+
+        Assert.True(watcher.IsEngineUnreachable);
+        Assert.Equal("kaboom", watcher.LastError);
+    }
+
+    [Fact]
+    public async Task Probe_receives_resolved_endpoint()
+    {
+        string? captured = null;
+        using var watcher = CreateWatcher((endpoint, _) =>
+        {
+            captured = endpoint;
+            return Task.FromResult(new EngineProbeOutcome(true, null));
+        }, endpoint: "http://localhost:54321");
+
+        await watcher.ProbeNowAsync();
+
+        Assert.Equal("http://localhost:54321", captured);
+        Assert.Equal("http://localhost:54321", watcher.LastEndpoint);
+    }
+
+    private static EngineConnectivityWatcher CreateWatcher(
+        EngineConnectivityWatcher.ProbeDelegate probe,
+        string endpoint = "http://localhost:60051")
+    {
+        var options = Options.Create(new DebugWorkbenchOptions
+        {
+            DefaultEngineEndpoint = endpoint,
+            ProbeTimeoutSeconds = 1,
+        });
+        return new EngineConnectivityWatcher(options, logger: null, probe: probe, interval: TimeSpan.FromMinutes(5));
+    }
+}

--- a/src/dotnet/QsoRipper.DebugHost/Components/Layout/EngineUnreachableBanner.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Layout/EngineUnreachableBanner.razor
@@ -1,0 +1,57 @@
+@implements IDisposable
+@inject EngineConnectivityWatcher Watcher
+
+@if (Watcher.IsEngineUnreachable)
+{
+    <div class="text-bg-danger px-3 py-2 d-flex align-items-center gap-3 small">
+        <strong>Engine unreachable.</strong>
+        <span>Endpoint: <code class="text-bg-danger">@(Watcher.LastEndpoint ?? "(unset)")</code></span>
+        @if (!string.IsNullOrWhiteSpace(Watcher.LastError))
+        {
+            <span class="opacity-75">@Watcher.LastError</span>
+        }
+        <button type="button"
+                class="btn btn-sm btn-light ms-auto"
+                disabled="@_retrying"
+                @onclick="RetryAsync">
+            @(_retrying ? "Probing..." : "Retry probe")
+        </button>
+    </div>
+}
+
+@code {
+    private bool _retrying;
+
+    protected override void OnInitialized()
+    {
+        Watcher.StateChanged += HandleStateChanged;
+    }
+
+    public void Dispose()
+    {
+        Watcher.StateChanged -= HandleStateChanged;
+    }
+
+    private void HandleStateChanged(object? sender, EventArgs e)
+    {
+        _ = InvokeAsync(StateHasChanged);
+    }
+
+    private async Task RetryAsync()
+    {
+        if (_retrying)
+        {
+            return;
+        }
+
+        _retrying = true;
+        try
+        {
+            await Watcher.ProbeNowAsync();
+        }
+        finally
+        {
+            _retrying = false;
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.DebugHost/Components/Layout/MainLayout.razor
+++ b/src/dotnet/QsoRipper.DebugHost/Components/Layout/MainLayout.razor
@@ -9,6 +9,7 @@
     </div>
 
     <main>
+        <EngineUnreachableBanner />
         <div class="top-row px-4">
             <div>
                 <strong>QsoRipper Debug Workbench</strong>

--- a/src/dotnet/QsoRipper.DebugHost/Program.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Program.cs
@@ -24,6 +24,8 @@ builder.Services.AddScoped<SetupWorkbenchService>();
 builder.Services.AddScoped<StationProfileWorkbenchService>();
 builder.Services.AddScoped<RigControlWorkbenchService>();
 builder.Services.AddScoped<DebugCommandService>();
+builder.Services.AddSingleton<EngineConnectivityWatcher>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<EngineConnectivityWatcher>());
 
 var app = builder.Build();
 

--- a/src/dotnet/QsoRipper.DebugHost/Services/EngineConnectivityWatcher.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Services/EngineConnectivityWatcher.cs
@@ -1,0 +1,232 @@
+using System.Net.Sockets;
+using Grpc.Core;
+using Grpc.Net.Client;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using QsoRipper.DebugHost.Models;
+using QsoRipper.EngineSelection;
+using QsoRipper.Services;
+
+namespace QsoRipper.DebugHost.Services;
+
+internal sealed class EngineConnectivityWatcher : BackgroundService
+{
+    internal delegate Task<EngineProbeOutcome> ProbeDelegate(string endpoint, CancellationToken cancellationToken);
+
+    private static readonly TimeSpan DefaultInterval = TimeSpan.FromSeconds(5);
+
+    private readonly DebugWorkbenchOptions _options;
+    private readonly ILogger<EngineConnectivityWatcher>? _logger;
+    private readonly ProbeDelegate _probe;
+    private readonly TimeSpan _interval;
+    private readonly SemaphoreSlim _gate = new(1, 1);
+    private bool _hasProbed;
+
+    public EngineConnectivityWatcher(IOptions<DebugWorkbenchOptions> options, ILogger<EngineConnectivityWatcher> logger)
+        : this(options, logger, probe: null, interval: null)
+    {
+    }
+
+    internal EngineConnectivityWatcher(
+        IOptions<DebugWorkbenchOptions> options,
+        ILogger<EngineConnectivityWatcher>? logger,
+        ProbeDelegate? probe,
+        TimeSpan? interval)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        _options = options.Value;
+        _logger = logger;
+        _probe = probe ?? DefaultProbeAsync;
+        _interval = interval ?? DefaultInterval;
+        LastEndpoint = ResolveEndpoint();
+    }
+
+    public bool IsEngineUnreachable { get; private set; }
+
+    public string? LastError { get; private set; }
+
+    public string? LastEndpoint { get; private set; }
+
+    public DateTimeOffset LastProbeUtc { get; private set; }
+
+    public event EventHandler? StateChanged;
+
+    public async Task ProbeNowAsync(CancellationToken cancellationToken = default)
+    {
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var endpoint = ResolveEndpoint();
+            LastEndpoint = endpoint;
+
+            EngineProbeOutcome outcome;
+            try
+            {
+                outcome = await _probe(endpoint, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+#pragma warning disable CA1031
+            catch (Exception ex)
+            {
+                outcome = new EngineProbeOutcome(false, ex.Message);
+            }
+#pragma warning restore CA1031
+
+            LastProbeUtc = DateTimeOffset.UtcNow;
+            var previouslyUnreachable = IsEngineUnreachable;
+            var nowUnreachable = !outcome.IsReachable;
+            LastError = outcome.IsReachable ? null : outcome.Error;
+            IsEngineUnreachable = nowUnreachable;
+
+            if (!_hasProbed || previouslyUnreachable != nowUnreachable)
+            {
+                _hasProbed = true;
+                RaiseStateChanged();
+            }
+        }
+        finally
+        {
+            _gate.Release();
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProbeNowAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+#pragma warning disable CA1031
+            catch (Exception ex)
+            {
+                LogProbeFailure(_logger, ex);
+            }
+#pragma warning restore CA1031
+
+            try
+            {
+                await Task.Delay(_interval, stoppingToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+        }
+    }
+
+    public override void Dispose()
+    {
+        _gate.Dispose();
+        base.Dispose();
+    }
+
+    private static readonly Action<ILogger, Exception?> LogProbeFailureCore =
+        LoggerMessage.Define(LogLevel.Debug, new EventId(1, nameof(EngineConnectivityWatcher)), "Engine connectivity probe threw unexpectedly.");
+
+    private static void LogProbeFailure(ILogger? logger, Exception ex)
+    {
+        if (logger is not null)
+        {
+            LogProbeFailureCore(logger, ex);
+        }
+    }
+
+    private void RaiseStateChanged()
+    {
+        StateChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    private string ResolveEndpoint()
+    {
+        var configuredProfile = string.IsNullOrWhiteSpace(_options.DefaultEngineProfile)
+            ? _options.DefaultEngineImplementation
+            : _options.DefaultEngineProfile;
+        var profile = EngineCatalog.ResolveProfile(configuredProfile);
+        return EngineCatalog.ResolveEndpoint(profile, _options.DefaultEngineEndpoint);
+    }
+
+    private async Task<EngineProbeOutcome> DefaultProbeAsync(string endpoint, CancellationToken cancellationToken)
+    {
+        if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var endpointUri))
+        {
+            return new EngineProbeOutcome(false, "Endpoint is not a valid absolute URI.");
+        }
+
+        var port = endpointUri.IsDefaultPort
+            ? endpointUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase) ? 443 : 80
+            : endpointUri.Port;
+
+        var timeout = TimeSpan.FromSeconds(Math.Max(1, _options.ProbeTimeoutSeconds));
+
+        try
+        {
+            using var tcpTimeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            tcpTimeoutSource.CancelAfter(timeout);
+
+            using var tcpClient = new TcpClient();
+            await tcpClient.ConnectAsync(endpointUri.Host, port, tcpTimeoutSource.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            return new EngineProbeOutcome(false, "TCP connection timed out.");
+        }
+        catch (SocketException ex)
+        {
+            return new EngineProbeOutcome(false, $"TCP connection failed: {ex.Message}");
+        }
+        catch (IOException ex)
+        {
+            return new EngineProbeOutcome(false, $"TCP connection failed: {ex.Message}");
+        }
+
+        var channel = GrpcChannel.ForAddress(endpointUri);
+        try
+        {
+            using var grpcTimeoutSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            grpcTimeoutSource.CancelAfter(timeout);
+
+            var callOptions = new CallOptions(cancellationToken: grpcTimeoutSource.Token);
+            var client = new LogbookService.LogbookServiceClient(channel);
+            await client.GetSyncStatusAsync(new GetSyncStatusRequest(), callOptions);
+            return new EngineProbeOutcome(true, null);
+        }
+        catch (RpcException ex) when (ex.StatusCode == StatusCode.Unimplemented)
+        {
+            return new EngineProbeOutcome(true, null);
+        }
+        catch (RpcException ex)
+        {
+            return new EngineProbeOutcome(false, $"gRPC call failed ({ex.StatusCode}): {ex.Status.Detail}");
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            return new EngineProbeOutcome(false, "gRPC call timed out.");
+        }
+        finally
+        {
+            await channel.ShutdownAsync().ConfigureAwait(false);
+            channel.Dispose();
+        }
+    }
+}
+
+internal readonly record struct EngineProbeOutcome(bool IsReachable, string? Error);

--- a/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelEngineReachabilityTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelEngineReachabilityTests.cs
@@ -1,0 +1,142 @@
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using QsoRipper.Domain;
+using QsoRipper.EngineSelection;
+using QsoRipper.Gui.Services;
+using QsoRipper.Gui.ViewModels;
+using QsoRipper.Services;
+
+namespace QsoRipper.Gui.Tests;
+
+public sealed class MainWindowViewModelEngineReachabilityTests
+{
+    [Fact]
+    public async Task CheckFirstRunAsyncMarksEngineUnreachableWhenRpcFails()
+    {
+        var endpoint = "http://localhost:50121";
+        var profile = EngineCatalog.GetProfile(KnownEngineProfiles.LocalRust);
+        var failingInner = new FakeEngineClient
+        {
+            FailWithRpcException = true,
+        };
+        using var switchable = new SwitchableEngineClient(
+            profile,
+            endpoint,
+            _ => failingInner);
+        using var viewModel = new MainWindowViewModel(switchable);
+
+        await viewModel.CheckFirstRunAsync();
+
+        Assert.True(viewModel.IsEngineUnreachable);
+        Assert.Contains(endpoint, viewModel.EngineUnreachableMessage, StringComparison.Ordinal);
+        Assert.Contains("Make sure the engine is running", viewModel.EngineUnreachableMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CheckFirstRunAsyncLeavesEngineReachableWhenCallsSucceed()
+    {
+        var engine = new FakeEngineClient
+        {
+            SetupStatus = new GetSetupStatusResponse
+            {
+                Status = new SetupStatus
+                {
+                    SetupComplete = true,
+                    IsFirstRun = false,
+                },
+            },
+        };
+
+        using var viewModel = new MainWindowViewModel(engine);
+
+        await viewModel.CheckFirstRunAsync();
+
+        Assert.False(viewModel.IsEngineUnreachable);
+    }
+
+    private sealed class FakeEngineClient : IEngineClient
+    {
+        public GetSetupStatusResponse SetupStatus { get; init; } = new()
+        {
+            Status = new SetupStatus
+            {
+                SetupComplete = true,
+                IsFirstRun = false,
+            },
+        };
+
+        public bool FailWithRpcException { get; init; }
+
+        public Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default) =>
+            Task.FromResult(new GetSetupWizardStateResponse { Status = SetupStatus.Status ?? new SetupStatus() });
+
+        public Task<ValidateSetupStepResponse> ValidateStepAsync(ValidateSetupStepRequest request, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<TestQrzCredentialsResponse> TestQrzCredentialsAsync(string username, string password, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<SaveSetupResponse> SaveSetupAsync(SaveSetupRequest request, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default)
+        {
+            if (FailWithRpcException)
+            {
+                throw new RpcException(new Status(StatusCode.Unavailable, "engine offline"));
+            }
+
+            return Task.FromResult(SetupStatus);
+        }
+
+        public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default)
+        {
+            if (FailWithRpcException)
+            {
+                throw new RpcException(new Status(StatusCode.Unavailable, "engine offline"));
+            }
+
+            return Task.FromResult<IReadOnlyList<QsoRecord>>([]);
+        }
+
+        public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default) =>
+            Task.FromResult(new SyncWithQrzResponse());
+
+        public Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default)
+        {
+            if (FailWithRpcException)
+            {
+                throw new RpcException(new Status(StatusCode.Unavailable, "engine offline"));
+            }
+
+            return Task.FromResult(new GetSyncStatusResponse());
+        }
+
+        public Task<LookupResponse> LookupCallsignAsync(string callsign, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<DeleteQsoResponse> DeleteQsoAsync(string localId, bool deleteFromQrz = false, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+
+        public Task<GetRigSnapshotResponse> GetRigSnapshotAsync(CancellationToken ct = default) =>
+            Task.FromResult(new GetRigSnapshotResponse());
+
+        public Task<GetRigStatusResponse> GetRigStatusAsync(CancellationToken ct = default) =>
+            Task.FromResult(new GetRigStatusResponse());
+
+        public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default) =>
+            Task.FromResult(new GetCurrentSpaceWeatherResponse());
+
+        public Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(IReadOnlyList<string>? localIds = null, Timestamp? olderThan = null, bool includePendingRemoteDeletes = false, CancellationToken ct = default) =>
+            throw new NotImplementedException();
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -2,8 +2,10 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Grpc.Core;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
@@ -22,12 +24,16 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     private static readonly TimeSpan PreferredEngineSwitchTimeout = TimeSpan.FromSeconds(1.5);
     private static readonly TimeSpan SpaceWeatherRefreshInterval = TimeSpan.FromHours(1);
     private static readonly TimeSpan RigPollInterval = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan EngineHealthPollInterval = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan EngineHealthProbeTimeout = TimeSpan.FromMilliseconds(1500);
 
     private readonly IEngineClient _engine;
     private readonly SwitchableEngineClient? _switchableEngine;
     private readonly DispatcherTimer _utcTimer;
     private readonly DispatcherTimer _rigTimer;
     private readonly DispatcherTimer _spaceWeatherTimer;
+    private readonly DispatcherTimer _engineHealthTimer;
+    private bool _engineHealthProbeInFlight;
     private bool _setupCompleteBeforeWizard;
     private string? _preferredEngineProfileId;
     private string? _preferredEngineEndpoint;
@@ -135,6 +141,12 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     [ObservableProperty]
     private string _contextHintText = "F3 grid · F4 search · Ctrl+N logger · Alt+A card · F1 help";
 
+    [ObservableProperty]
+    private bool _isEngineUnreachable;
+
+    [ObservableProperty]
+    private string _engineUnreachableMessage = string.Empty;
+
     internal MainWindowViewModel(EngineTargetProfile engineProfile, string endpoint)
     {
         ArgumentNullException.ThrowIfNull(engineProfile);
@@ -154,6 +166,8 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         _rigTimer.Tick += OnRigTimerTick;
         _spaceWeatherTimer = new DispatcherTimer { Interval = SpaceWeatherRefreshInterval };
         _spaceWeatherTimer.Tick += OnSpaceWeatherTimerTick;
+        _engineHealthTimer = new DispatcherTimer { Interval = EngineHealthPollInterval };
+        _engineHealthTimer.Tick += OnEngineHealthTimerTick;
     }
 
     internal MainWindowViewModel(IEngineClient engine)
@@ -183,6 +197,8 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         _rigTimer.Tick += OnRigTimerTick;
         _spaceWeatherTimer = new DispatcherTimer { Interval = SpaceWeatherRefreshInterval };
         _spaceWeatherTimer.Tick += OnSpaceWeatherTimerTick;
+        _engineHealthTimer = new DispatcherTimer { Interval = EngineHealthPollInterval };
+        _engineHealthTimer.Tick += OnEngineHealthTimerTick;
     }
 
     public RecentQsoListViewModel RecentQsos { get; }
@@ -255,10 +271,14 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 
             Dispatcher.UIThread.Post(UpdateAvailableEngineSummary, DispatcherPriority.Background);
             GuiPerformanceTrace.Write(nameof(CheckFirstRunAsync) + ".complete");
+            MarkEngineReachable();
+            StartEngineHealthTimer();
         }
-        catch (Grpc.Core.RpcException)
+        catch (RpcException)
         {
             StatusMessage = "Engine unavailable";
+            MarkEngineUnreachable();
+            StartEngineHealthTimer();
         }
     }
 
@@ -300,10 +320,12 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
             var down = response.DownloadedRecords;
             SyncStatusText = $"Synced: \u2191{up} \u2193{down}";
             await RecentQsos.RefreshAsync();
+            MarkEngineReachable();
         }
         catch (Grpc.Core.RpcException ex)
         {
             SyncStatusText = $"Sync failed: {ex.Status.Detail}";
+            MarkEngineUnreachable();
         }
         finally
         {
@@ -320,6 +342,14 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         SyncNowCommand.NotifyCanExecuteChanged();
         SwitchToRustEngineCommand.NotifyCanExecuteChanged();
         SwitchToDotNetEngineCommand.NotifyCanExecuteChanged();
+        if (value)
+        {
+            _engineHealthTimer.Stop();
+        }
+        else if (!_engineHealthTimer.IsEnabled)
+        {
+            _engineHealthTimer.Start();
+        }
     }
 
     [RelayCommand(CanExecute = nameof(CanSwitchEngines))]
@@ -768,10 +798,12 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         try
         {
             await RecentQsos.RefreshAsync();
+            MarkEngineReachable();
         }
         catch (Grpc.Core.RpcException)
         {
             StatusMessage = "Ready (refresh failed)";
+            MarkEngineUnreachable();
         }
         catch (ObjectDisposedException)
         {
@@ -811,6 +843,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         catch (Grpc.Core.RpcException)
         {
             RigStatusText = "Rig: error";
+            MarkEngineUnreachable();
         }
         catch (ObjectDisposedException)
         {
@@ -833,6 +866,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         catch (Grpc.Core.RpcException)
         {
             // Transient network failure — keep existing weather data.
+            MarkEngineUnreachable();
         }
         catch (InvalidOperationException)
         {
@@ -873,6 +907,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         catch (Grpc.Core.RpcException) when (!preserveOnFailure)
         {
             SpaceWeatherText = "Weather: error";
+            MarkEngineUnreachable();
         }
     }
 
@@ -939,6 +974,9 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 
         _spaceWeatherTimer.Stop();
         _spaceWeatherTimer.Tick -= OnSpaceWeatherTimerTick;
+
+        _engineHealthTimer.Stop();
+        _engineHealthTimer.Tick -= OnEngineHealthTimerTick;
 
         if (_switchableEngine is not null)
         {
@@ -1056,10 +1094,12 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         try
         {
             ApplySetupContext((await _engine.GetSetupStatusAsync()).Status);
+            MarkEngineReachable();
         }
         catch (Grpc.Core.RpcException)
         {
             StatusMessage = "Engine unavailable";
+            MarkEngineUnreachable();
         }
     }
 
@@ -1138,6 +1178,82 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         catch (Grpc.Core.RpcException)
         {
             // Sync status unavailable — leave current text unchanged.
+            MarkEngineUnreachable();
+        }
+    }
+
+    private string BuildEngineUnreachableMessage()
+    {
+        var endpoint = _switchableEngine?.CurrentEndpoint;
+        if (string.IsNullOrWhiteSpace(endpoint))
+        {
+            return "QsoRipper engine unreachable. Make sure the engine is running.";
+        }
+
+        return $"QsoRipper engine unreachable at {endpoint}. Make sure the engine is running.";
+    }
+
+    private void MarkEngineUnreachable()
+    {
+        EngineUnreachableMessage = BuildEngineUnreachableMessage();
+        IsEngineUnreachable = true;
+    }
+
+    private void MarkEngineReachable()
+    {
+        if (IsEngineUnreachable)
+        {
+            IsEngineUnreachable = false;
+        }
+    }
+
+    private void StartEngineHealthTimer()
+    {
+        if (IsWizardOpen || _engineHealthTimer.IsEnabled)
+        {
+            return;
+        }
+
+        _engineHealthTimer.Start();
+    }
+
+    private async void OnEngineHealthTimerTick(object? sender, EventArgs e)
+    {
+        if (_engineHealthProbeInFlight || IsWizardOpen)
+        {
+            return;
+        }
+
+        _engineHealthProbeInFlight = true;
+        using var cts = new CancellationTokenSource(EngineHealthProbeTimeout);
+        try
+        {
+            await _engine.GetSyncStatusAsync(cts.Token);
+            MarkEngineReachable();
+        }
+        catch (RpcException)
+        {
+            MarkEngineUnreachable();
+        }
+        catch (HttpRequestException)
+        {
+            MarkEngineUnreachable();
+        }
+        catch (IOException)
+        {
+            MarkEngineUnreachable();
+        }
+        catch (OperationCanceledException)
+        {
+            MarkEngineUnreachable();
+        }
+        catch (ObjectDisposedException)
+        {
+            // Engine being torn down; leave state unchanged.
+        }
+        finally
+        {
+            _engineHealthProbeInFlight = false;
         }
     }
 }

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -202,6 +202,20 @@
                  Margin="0,0,12,0" />
       </Panel>
 
+    <Border DockPanel.Dock="Top"
+            x:Name="EngineUnreachableBanner"
+            AutomationProperties.AutomationId="EngineUnreachableBanner"
+            Background="#B00020"
+            Padding="12,6"
+            Focusable="False"
+            IsHitTestVisible="False"
+            IsVisible="{Binding IsEngineUnreachable}">
+      <TextBlock Text="{Binding EngineUnreachableMessage}"
+                 Foreground="White"
+                 FontWeight="SemiBold"
+                 TextWrapping="Wrap" />
+    </Border>
+
     <Panel>
       <Grid RowDefinitions="Auto,Auto,*,Auto"
             IsEnabled="{Binding !IsWizardOpen}">

--- a/src/rust/qsoripper-tui/src/app.rs
+++ b/src/rust/qsoripper-tui/src/app.rs
@@ -15,6 +15,20 @@ pub(crate) enum RigStatus {
     Disabled,
 }
 
+/// Reachability status of the `QsoRipper` engine over gRPC.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum EngineStatus {
+    /// No probe result yet — typically only seen briefly at startup.
+    Unknown,
+    /// The engine responded successfully to the most recent health probe.
+    Connected,
+    /// The engine could not be reached; the message describes the failure.
+    Unreachable {
+        /// Human-readable failure description (tonic Status message or transport error).
+        message: String,
+    },
+}
+
 /// Display-ready rig control snapshot for the TUI.
 pub(crate) struct RigInfo {
     /// Formatted frequency string (e.g., `"14.225 MHz"`).
@@ -194,6 +208,8 @@ pub(crate) struct App {
     pub(crate) qso_timer_active: bool,
     /// When the callsign field was last modified; drives the debounce that starts the timer.
     pub(crate) callsign_last_typed_at: Option<Instant>,
+    /// Reachability of the gRPC engine — updated by a periodic background probe.
+    pub(crate) engine_status: EngineStatus,
 }
 
 impl App {
@@ -221,6 +237,7 @@ impl App {
             qso_started_at: Instant::now(),
             qso_timer_active: false,
             callsign_last_typed_at: None,
+            engine_status: EngineStatus::Unknown,
         }
     }
 
@@ -640,5 +657,60 @@ mod tests {
         app.rig_control_enabled = false;
         app.toggle_rig_control();
         assert!(app.rig_control_enabled);
+    }
+
+    #[test]
+    fn new_app_has_unknown_engine_status() {
+        let app = App::new("http://localhost:50051".to_string());
+        assert_eq!(app.engine_status, EngineStatus::Unknown);
+    }
+
+    #[test]
+    fn engine_status_can_be_updated() {
+        let mut app = App::new("http://localhost:50051".to_string());
+        app.engine_status = EngineStatus::Connected;
+        assert_eq!(app.engine_status, EngineStatus::Connected);
+        app.engine_status = EngineStatus::Unreachable {
+            message: "transport error".to_string(),
+        };
+        assert_eq!(
+            app.engine_status,
+            EngineStatus::Unreachable {
+                message: "transport error".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn engine_status_unreachable_distinguishes_messages() {
+        let a = EngineStatus::Unreachable {
+            message: "timeout".to_string(),
+        };
+        let b = EngineStatus::Unreachable {
+            message: "connection refused".to_string(),
+        };
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn engine_status_unreachable_equal_for_same_message() {
+        let a = EngineStatus::Unreachable {
+            message: "timeout".to_string(),
+        };
+        let b = EngineStatus::Unreachable {
+            message: "timeout".to_string(),
+        };
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn engine_status_variants_are_distinct() {
+        assert_ne!(EngineStatus::Unknown, EngineStatus::Connected);
+        assert_ne!(
+            EngineStatus::Connected,
+            EngineStatus::Unreachable {
+                message: "x".to_string()
+            }
+        );
     }
 }

--- a/src/rust/qsoripper-tui/src/events.rs
+++ b/src/rust/qsoripper-tui/src/events.rs
@@ -6,11 +6,17 @@ use tokio::sync::{mpsc, watch};
 use tokio::time;
 use tonic::transport::Channel;
 
-use crate::app::{CallsignInfo, RecentQso, RigInfo, SpaceWeatherInfo};
+use qsoripper_core::proto::qsoripper::services::{
+    logbook_service_client::LogbookServiceClient, GetSyncStatusRequest,
+};
+
+use crate::app::{CallsignInfo, EngineStatus, RecentQso, RigInfo, SpaceWeatherInfo};
 use crate::grpc;
 
 const SPACE_WEATHER_REFRESH_INTERVAL: Duration = Duration::from_secs(60 * 60);
 const RIG_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const ENGINE_HEALTH_INTERVAL: Duration = Duration::from_secs(5);
+const ENGINE_HEALTH_TIMEOUT: Duration = Duration::from_millis(1500);
 
 /// Events produced by background tasks and forwarded to the main event loop.
 pub(crate) enum AppEvent {
@@ -49,6 +55,8 @@ pub(crate) enum AppEvent {
         /// Operator name from the lookup cache.
         name: String,
     },
+    /// Periodic engine reachability snapshot from the health probe task.
+    EngineHealth(EngineStatus),
 }
 
 /// Spawn a blocking OS thread that reads crossterm key events and forwards them to `tx`.
@@ -177,4 +185,46 @@ pub(crate) fn spawn_rig_poll_task(
             }
         }
     });
+}
+
+/// Probe the engine's `get_sync_status` RPC once and classify the outcome.
+///
+/// Used both by the startup probe and by the periodic health task. A short
+/// per-call timeout is applied so the TUI never stalls waiting on a dead engine.
+pub(crate) async fn probe_engine_health(channel: Channel) -> EngineStatus {
+    let mut client = LogbookServiceClient::new(channel);
+    let mut request = tonic::Request::new(GetSyncStatusRequest {});
+    request.set_timeout(ENGINE_HEALTH_TIMEOUT);
+    match client.get_sync_status(request).await {
+        Ok(_) => EngineStatus::Connected,
+        Err(status) => EngineStatus::Unreachable {
+            message: status.message().to_string(),
+        },
+    }
+}
+
+/// Spawn a background task that probes engine reachability every
+/// [`ENGINE_HEALTH_INTERVAL`]. Sends [`AppEvent::EngineHealth`] on every
+/// iteration so the UI can flip between Connected/Unreachable states.
+pub(crate) fn spawn_engine_health_task(
+    channel: Channel,
+    event_tx: mpsc::UnboundedSender<AppEvent>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = time::interval(ENGINE_HEALTH_INTERVAL);
+        // Skip the immediate first tick — `main` already runs a synchronous
+        // startup probe, so the first periodic update should fire one interval
+        // later instead of racing the startup probe.
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            if event_tx.is_closed() {
+                break;
+            }
+            let status = probe_engine_health(channel.clone()).await;
+            if event_tx.send(AppEvent::EngineHealth(status)).is_err() {
+                break;
+            }
+        }
+    })
 }

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -18,8 +18,8 @@ use tokio::sync::{mpsc, watch};
 
 use app::App;
 use events::{
-    spawn_clock_task, spawn_key_task, spawn_lookup_task, spawn_rig_poll_task,
-    spawn_space_weather_task, AppEvent,
+    spawn_clock_task, spawn_engine_health_task, spawn_key_task, spawn_lookup_task,
+    spawn_rig_poll_task, spawn_space_weather_task, AppEvent,
 };
 use form::{AdvancedTab, Field, LogForm, BANDS, MODES};
 
@@ -142,11 +142,16 @@ async fn run<B: ratatui::backend::Backend>(
     let mut app = App::new(endpoint);
     let channel = grpc::create_channel(&app.endpoint)?;
 
+    // One-shot startup probe so the header reflects engine reachability before
+    // the first periodic tick of the health task fires.
+    app.engine_status = events::probe_engine_health(channel.clone()).await;
+
     spawn_key_task(event_tx.clone());
     spawn_clock_task(event_tx.clone());
     spawn_lookup_task(lookup_rx, event_tx.clone(), channel.clone());
     spawn_rig_poll_task(rig_enabled_rx, event_tx.clone(), channel.clone());
     spawn_space_weather_task(event_tx.clone(), channel.clone());
+    spawn_engine_health_task(channel.clone(), event_tx.clone());
 
     // Prefetch recent QSOs on startup.
     {
@@ -293,6 +298,11 @@ fn handle_event_with_channel(
         AppEvent::QsoNameEnriched { local_id, name } => {
             if let Some(q) = app.recent_qsos.iter_mut().find(|q| q.local_id == local_id) {
                 q.name = Some(name);
+            }
+        }
+        AppEvent::EngineHealth(status) => {
+            if app.engine_status != status {
+                app.engine_status = status;
             }
         }
     }

--- a/src/rust/qsoripper-tui/src/ui/header.rs
+++ b/src/rust/qsoripper-tui/src/ui/header.rs
@@ -8,44 +8,53 @@ use ratatui::{
     Frame,
 };
 
-use crate::app::App;
+use crate::app::{App, EngineStatus};
 
 /// Render the header bar into `area`.
 pub(super) fn render(app: &App, frame: &mut Frame, area: Rect) {
     let cols = Layout::horizontal([
+        Constraint::Length(13),
         Constraint::Fill(1),
-        Constraint::Length(32),
-        Constraint::Length(36),
         Constraint::Length(28),
+        Constraint::Length(30),
+        Constraint::Length(26),
     ])
     .split(area);
 
     let title_area = cols.first().copied().unwrap_or(area);
-    let rig_area = cols.get(1).copied().unwrap_or(area);
-    let sw_area = cols.get(2).copied().unwrap_or(area);
-    let clock_area = cols.get(3).copied().unwrap_or(area);
+    let engine_area = cols.get(1).copied().unwrap_or(area);
+    let rig_area = cols.get(2).copied().unwrap_or(area);
+    let sw_area = cols.get(3).copied().unwrap_or(area);
+    let clock_area = cols.get(4).copied().unwrap_or(area);
 
-    // Title
+    // Title.
     let title_block = Block::default()
         .borders(Borders::TOP | Borders::LEFT | Borders::BOTTOM)
         .border_style(Style::default().fg(Color::Cyan));
-    let title_text = Line::from(vec![
-        Span::styled(
-            " QsoRipper ",
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(
-            "— ham radio QSO logger",
-            Style::default().fg(Color::DarkGray),
-        ),
-    ]);
+    let title_text = Line::from(vec![Span::styled(
+        " QsoRipper ",
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )]);
     frame.render_widget(
         Paragraph::new(title_text)
             .block(title_block)
             .alignment(Alignment::Left),
         title_area,
+    );
+
+    // Engine reachability — sits next to the rig status so a downed server is
+    // impossible to miss.
+    let engine_block = Block::default()
+        .borders(Borders::TOP | Borders::BOTTOM)
+        .border_style(Style::default().fg(Color::Cyan));
+    let engine_line = Line::from(engine_status_spans(app));
+    frame.render_widget(
+        Paragraph::new(engine_line)
+            .block(engine_block)
+            .alignment(Alignment::Left),
+        engine_area,
     );
 
     // Rig control
@@ -205,4 +214,115 @@ fn rig_status_line(app: &App) -> Line<'static> {
         Span::raw(" "),
         Span::styled(mode.to_string(), Style::default().fg(Color::Cyan)),
     ])
+}
+
+/// Build the engine reachability spans rendered next to the title.
+///
+/// Returns spans (rather than a full `Line`) so the caller can append them to
+/// the existing title content without owning a separate header column.
+fn engine_status_spans(app: &App) -> Vec<Span<'static>> {
+    match &app.engine_status {
+        EngineStatus::Connected => vec![
+            Span::styled(
+                "●",
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" "),
+            Span::styled("engine", Style::default().fg(Color::Green)),
+        ],
+        EngineStatus::Unreachable { .. } => vec![
+            Span::styled(
+                "✖",
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" "),
+            Span::styled(
+                format!("engine unreachable @ {}", app.endpoint),
+                Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+            ),
+        ],
+        EngineStatus::Unknown => vec![
+            Span::styled("○", Style::default().fg(Color::DarkGray)),
+            Span::raw(" "),
+            Span::styled("engine ...", Style::default().fg(Color::DarkGray)),
+        ],
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use ratatui::{backend::TestBackend, layout::Rect, style::Color, Terminal};
+
+    use super::{engine_status_spans, render};
+    use crate::app::{App, EngineStatus};
+
+    fn make_app() -> App {
+        App::new("http://127.0.0.1:50051".to_string())
+    }
+
+    fn header_text(app: &App) -> String {
+        let backend = TestBackend::new(160, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| render(app, f, Rect::new(0, 0, 160, 3)))
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let mut out = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                out.push_str(buffer[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn engine_unreachable_renders_red_message_with_endpoint() {
+        let mut app = make_app();
+        app.engine_status = EngineStatus::Unreachable {
+            message: "transport error".to_string(),
+        };
+        let text = header_text(&app);
+        assert!(
+            text.contains("engine unreachable @ http://127.0.0.1:50051"),
+            "expected unreachable banner with endpoint, got:\n{text}"
+        );
+        assert!(text.contains('✖'), "expected red ✖ glyph, got:\n{text}");
+
+        let spans = engine_status_spans(&app);
+        assert!(spans.iter().any(|s| s.style.fg == Some(Color::Red)));
+    }
+
+    #[test]
+    fn engine_connected_renders_green_indicator() {
+        let mut app = make_app();
+        app.engine_status = EngineStatus::Connected;
+        let text = header_text(&app);
+        assert!(text.contains('●'), "expected green ● glyph, got:\n{text}");
+        assert!(
+            text.contains("engine"),
+            "expected 'engine' label, got:\n{text}"
+        );
+
+        let spans = engine_status_spans(&app);
+        assert!(spans.iter().any(|s| s.style.fg == Some(Color::Green)));
+    }
+
+    #[test]
+    fn engine_unknown_renders_dim_indicator() {
+        let app = make_app();
+        let text = header_text(&app);
+        assert!(text.contains('○'), "expected dim ○ glyph, got:\n{text}");
+        assert!(
+            text.contains("engine ..."),
+            "expected 'engine ...' placeholder, got:\n{text}"
+        );
+
+        let spans = engine_status_spans(&app);
+        assert!(spans.iter().any(|s| s.style.fg == Some(Color::DarkGray)));
+    }
 }


### PR DESCRIPTION
Adds a clear, consistent server-down indicator to all four UI tools so operators immediately see when the qsoripper gRPC engine is not running.

Avalonia GUI gets a persistent red top banner driven by a 1.5s-deadline GetSyncStatus probe on a 5s DispatcherTimer (paused while the wizard is open). The banner is bound to new IsEngineUnreachable / EngineUnreachableMessage observable state on MainWindowViewModel, which flips on every existing RpcException catch path and clears on success.

CLI gets a new EngineReachability helper (ProbeAsync, FormatUnreachableMessage, SuggestedCommand) so the top-level Program.cs catch and any future preflight surface the same wording, including endpoint, profile name, and a per-profile suggested start command.

DebugHost gets an EngineConnectivityWatcher BackgroundService that probes every 5s and exposes IsEngineUnreachable, LastError, and a StateChanged event. A global EngineUnreachableBanner is mounted at the top of MainLayout so every page surfaces the banner with a Retry probe button.

Rust TUI gets an EngineStatus enum on App, a one-shot startup probe, a periodic spawn_engine_health_task that ticks every 5s and emits AppEvent::EngineHealth, and a dedicated engine column in the header showing green dot for connected, red X with endpoint for unreachable, and gray for unknown.

Tests: 5 new EngineReachability tests, 5 new EngineConnectivityWatcher tests, 2 new MainWindowViewModel reachability tests, 8 new Rust TUI tests. Full .NET solution test run is 772/772 green; full Rust workspace cargo test, cargo fmt --check, and cargo clippy --all-targets -D warnings are all green.

Fixes #327