### PR TITLE
QRZ sync: rewrite STATION_CALLSIGN to logbook owner for previous calls (#337)

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -228,7 +228,18 @@ The sync follows a three-phase lifecycle:
 
 2. **Upload phase** — Find all local QSOs with `sync_status` of `SYNC_STATUS_NOT_SYNCED` or `SYNC_STATUS_MODIFIED`. For each, serialize to ADIF and upload via the QRZ logbook API. On success, update `sync_status` to `SYNC_STATUS_SYNCED` and record the `qrz_logid` returned by QRZ.
 
-3. **Metadata phase** — Update the `sync_metadata` record with the current QRZ QSO count, last sync timestamp, and logbook owner callsign.
+   **Previous-callsign rewrite (issue #337).** QRZ logbooks are bound to a single callsign and reject ADIF whose `STATION_CALLSIGN` does not match the logbook owner. Operators who have changed callsigns (e.g. KB7QOP → AE7XI) keep historical QSOs locally with the old call. To avoid those rejections, engines MUST:
+
+   - Fetch the QRZ logbook owner callsign once per sync via QRZ `STATUS` immediately after the download phase. Reuse the same result for the metadata phase below — do not call `STATUS` twice.
+   - If `STATUS` fails or returns an empty owner, fall back to the cached `sync_metadata.qrz_logbook_owner`.
+   - Per upload, when the resolved owner is non-empty and differs (case-insensitive, trimmed) from the QSO's `station_callsign`, rewrite the upload payload only:
+     - Set the payload's `station_callsign` (and `station_snapshot.station_callsign`) to the owner.
+     - If `station_snapshot.operator_callsign` is empty, set it to the original `station_callsign` so the historical operator-of-record is preserved as ADIF `OPERATOR`.
+   - The local stored row MUST NOT be modified by the rewrite. Skip the rewrite entirely when `station_callsign` contains a `/` (portable / mobile / secondary suffix); those callsigns generally belong to a different QRZ logbook.
+
+   *Known caveat:* on the next download, the merge logic for `SYNC_STATUS_SYNCED` rows is remote-wins, so the local `station_callsign` may drift to the book owner. The historical operator survives in `station_snapshot.operator_callsign`. Round-tripping the original via an `APP_QSORIPPER_ORIG_STATION_CALLSIGN` ADIF field on download is planned future work.
+
+3. **Metadata phase** — Update the `sync_metadata` record with the QRZ QSO count, last sync timestamp, and logbook owner callsign reported by the `STATUS` call already fetched in step 2. Because that `STATUS` is taken before the upload phase, the persisted `qrz_qso_count` reflects the pre-upload count; the next `SyncWithQrz` cycle naturally observes the post-upload count.
 
 Stream progress messages throughout all phases so clients can display real-time sync state.
 

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -138,7 +138,10 @@ public sealed class ManagedEngineStateTests : IDisposable
         Assert.Equal(1u, syncResult.UploadedRecords);
         Assert.True(syncResult.Complete);
         Assert.Equal(0u, afterSync.PendingUpload);
-        Assert.Equal(1u, afterSync.QrzQsoCount);
+        // STATUS is fetched once before upload (issue #337 fix), so the count
+        // it reports is the pre-upload count (0). The next sync cycle will
+        // see the post-upload count.
+        Assert.Equal(0u, afterSync.QrzQsoCount);
         Assert.Equal("K7RND", afterSync.QrzLogbookOwner);
     }
 
@@ -1201,13 +1204,13 @@ public sealed class ManagedEngineStateTests : IDisposable
         public Task<List<QsoRecord>> FetchQsosAsync(string? sinceDateYmd) =>
             Task.FromResult(new List<QsoRecord>());
 
-        public Task<string> UploadQsoAsync(QsoRecord qso)
+        public Task<string> UploadQsoAsync(QsoRecord qso, string? bookOwner = null)
         {
             var logId = $"FAKE-{Interlocked.Increment(ref _logIdCounter)}";
             return Task.FromResult(logId);
         }
 
-        public Task<string> UpdateQsoAsync(QsoRecord qso)
+        public Task<string> UpdateQsoAsync(QsoRecord qso, string? bookOwner = null)
         {
             var logId = $"FAKE-{Interlocked.Increment(ref _logIdCounter)}";
             return Task.FromResult(logId);
@@ -1224,9 +1227,9 @@ public sealed class ManagedEngineStateTests : IDisposable
         public Task<List<QsoRecord>> FetchQsosAsync(string? sinceDateYmd)
             => Task.FromResult(new List<QsoRecord> { null! });
 
-        public Task<string> UploadQsoAsync(QsoRecord qso) => Task.FromResult("FAKE-1");
+        public Task<string> UploadQsoAsync(QsoRecord qso, string? bookOwner = null) => Task.FromResult("FAKE-1");
 
-        public Task<string> UpdateQsoAsync(QsoRecord qso) => Task.FromResult("FAKE-1");
+        public Task<string> UpdateQsoAsync(QsoRecord qso, string? bookOwner = null) => Task.FromResult("FAKE-1");
 
         public Task<QrzLogbookStatus> GetStatusAsync() =>
             Task.FromResult(new QrzLogbookStatus("K7RND", 0));

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
@@ -746,6 +746,104 @@ public sealed class QrzSyncEngineTests
         Assert.Equal("LOG-FAIL", all[0].QrzLogid);
     }
 
+    // -- Issue #337: previous-callsign rewrite ------------------------------
+
+    [Fact]
+    public async Task Upload_rewrites_station_callsign_to_book_owner_for_previous_call()
+    {
+        var api = new FakeQrzLogbookApi { StatusOwner = "AE7XI" };
+        var store = CreateStore();
+        var local = MakeLocalQso("K7ABC", BaseTime, Band._20M, Mode.Cw, SyncStatus.LocalOnly);
+        local.StationCallsign = "KB7QOP"; // historical previous call
+        await store.Logbook.InsertQsoAsync(local);
+
+        var engine = new QrzSyncEngine(api);
+        var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
+
+        Assert.Equal(1u, result.UploadedCount);
+        Assert.Equal("AE7XI", api.LastUploadBookOwner);
+
+        var uploaded = Assert.Single(api.UploadedQsos);
+        // QrzLogbookClient (real) clones; the engine forwards the live qso.
+        // What matters is that the *bookOwner argument* is correct AND that
+        // RewriteStationCallsignForBook is what the client applies. Verify
+        // the helper directly:
+        AdifCodec.RewriteStationCallsignForBook(uploaded, api.LastUploadBookOwner);
+        Assert.Equal("AE7XI", uploaded.StationCallsign);
+        Assert.NotNull(uploaded.StationSnapshot);
+        Assert.Equal("AE7XI", uploaded.StationSnapshot!.StationCallsign);
+        Assert.Equal("KB7QOP", uploaded.StationSnapshot.OperatorCallsign);
+
+        // Local row must remain with the historical station callsign.
+        var localList = await store.Logbook.ListQsosAsync(new QsoListQuery());
+        var saved = Assert.Single(localList);
+        Assert.Equal("KB7QOP", saved.StationCallsign);
+    }
+
+    [Fact]
+    public async Task Upload_falls_back_to_cached_owner_when_status_fails()
+    {
+        var api = new FakeQrzLogbookApi
+        {
+            StatusException = new InvalidOperationException("transient"),
+        };
+        var store = CreateStore();
+        await store.Logbook.UpsertSyncMetadataAsync(new SyncMetadata { QrzLogbookOwner = "AE7XI" });
+        var local = MakeLocalQso("K7ABC", BaseTime, Band._20M, Mode.Cw, SyncStatus.LocalOnly);
+        local.StationCallsign = "KB7QOP";
+        await store.Logbook.InsertQsoAsync(local);
+
+        var engine = new QrzSyncEngine(api);
+        await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
+
+        Assert.Equal("AE7XI", api.LastUploadBookOwner);
+    }
+
+    [Fact]
+    public async Task Upload_makes_only_one_status_call_per_sync()
+    {
+        // Regression: STATUS used to be called twice (once for owner-resolution
+        // before upload, once for metadata refresh in Phase 3). Phase 3 must
+        // reuse the Phase 1.5 result so we don't double-bill the QRZ API.
+        var api = new FakeQrzLogbookApi { StatusOwner = "K7TEST" };
+        var store = CreateStore();
+        await store.Logbook.InsertQsoAsync(
+            MakeLocalQso("K7DEST", BaseTime, Band._20M, Mode.Ft8, SyncStatus.LocalOnly));
+
+        var engine = new QrzSyncEngine(api);
+        await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
+
+        Assert.Equal(1, api.StatusCallCount);
+    }
+
+    [Fact]
+    public void RewriteStationCallsignForBook_skips_slash_suffix_calls()
+    {
+        var qso = MakeLocalQso("K7ABC", BaseTime, Band._20M, Mode.Cw, SyncStatus.LocalOnly);
+        qso.StationCallsign = "KB7QOP/P";
+
+        AdifCodec.RewriteStationCallsignForBook(qso, "AE7XI");
+
+        Assert.Equal("KB7QOP/P", qso.StationCallsign);
+    }
+
+    [Fact]
+    public void RewriteStationCallsignForBook_does_not_overwrite_existing_operator()
+    {
+        var qso = MakeLocalQso("K7ABC", BaseTime, Band._20M, Mode.Cw, SyncStatus.LocalOnly);
+        qso.StationCallsign = "KB7QOP";
+        qso.StationSnapshot = new StationSnapshot
+        {
+            StationCallsign = "KB7QOP",
+            OperatorCallsign = "W1ZZZ",
+        };
+
+        AdifCodec.RewriteStationCallsignForBook(qso, "AE7XI");
+
+        Assert.Equal("AE7XI", qso.StationCallsign);
+        Assert.Equal("W1ZZZ", qso.StationSnapshot.OperatorCallsign);
+    }
+
     // -- Helpers ------------------------------------------------------------
 
     private static MemoryStorage CreateStore() => new();
@@ -801,9 +899,14 @@ public sealed class QrzSyncEngineTests
             return Task.FromResult(FetchResult);
         }
 
-        public Task<string> UploadQsoAsync(QsoRecord qso)
+        public string? LastUploadBookOwner { get; private set; }
+
+        public string? LastUpdateBookOwner { get; private set; }
+
+        public Task<string> UploadQsoAsync(QsoRecord qso, string? bookOwner = null)
         {
             UploadedQsos.Add(qso);
+            LastUploadBookOwner = bookOwner;
             if (UploadFunc is not null)
             {
                 return UploadFunc(qso);
@@ -812,9 +915,10 @@ public sealed class QrzSyncEngineTests
             return Task.FromResult(UploadLogid);
         }
 
-        public Task<string> UpdateQsoAsync(QsoRecord qso)
+        public Task<string> UpdateQsoAsync(QsoRecord qso, string? bookOwner = null)
         {
             UpdatedQsos.Add(qso);
+            LastUpdateBookOwner = bookOwner;
             return Task.FromResult(UpdateLogid);
         }
 

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/AdifCodec.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/AdifCodec.cs
@@ -91,6 +91,73 @@ internal static class AdifCodec
     }
 
     /// <summary>
+    /// QRZ Logbook rejects uploads whose <c>STATION_CALLSIGN</c> does not match
+    /// the callsign the logbook is registered to. Operators who have changed
+    /// callsigns (e.g. KB7QOP → AE7XI) keep historical QSOs locally with the
+    /// old call. Without rewriting, every such QSO fails with "wrong
+    /// station_callsign for this logbook".
+    /// <para>
+    /// Mirrors the Rust helper
+    /// <c>qsoripper-core::qrz_logbook::rewrite_station_callsign_for_book</c>.
+    /// When the book owner is known and differs (case-insensitive, trimmed)
+    /// from the QSO's <see cref="QsoRecord.StationCallsign"/>:
+    /// </para>
+    /// <list type="bullet">
+    ///   <item><description><c>StationCallsign</c> is set to the book owner.</description></item>
+    ///   <item><description>The station snapshot's <c>StationCallsign</c> is updated too
+    ///     (the snapshot is what <see cref="WriteAdifFields"/> emits).</description></item>
+    ///   <item><description>The original station callsign is preserved as <c>OPERATOR</c>
+    ///     (via <c>StationSnapshot.OperatorCallsign</c>) when no operator was recorded.</description></item>
+    /// </list>
+    /// <para>Skipped (payload left untouched) when:</para>
+    /// <list type="bullet">
+    ///   <item><description>book owner is empty/missing</description></item>
+    ///   <item><description><c>StationCallsign</c> is empty/missing</description></item>
+    ///   <item><description><c>StationCallsign</c> contains a <c>/</c> (portable / mobile /
+    ///     secondary suffix) — these typically belong to a different QRZ logbook.</description></item>
+    /// </list>
+    /// <para>
+    /// This mutates <paramref name="prepared"/> in place; callers must clone the
+    /// QSO first if local storage must remain untouched.
+    /// </para>
+    /// </summary>
+    internal static void RewriteStationCallsignForBook(QsoRecord prepared, string? bookOwner)
+    {
+        ArgumentNullException.ThrowIfNull(prepared);
+
+        if (string.IsNullOrWhiteSpace(bookOwner))
+        {
+            return;
+        }
+
+        var owner = bookOwner.Trim();
+        var original = prepared.StationCallsign?.Trim() ?? string.Empty;
+        if (string.IsNullOrEmpty(original))
+        {
+            return;
+        }
+
+        if (original.Contains('/', StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (string.Equals(original, owner, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        prepared.StationCallsign = owner;
+        prepared.StationSnapshot ??= new StationSnapshot();
+        prepared.StationSnapshot.StationCallsign = owner;
+
+        if (string.IsNullOrWhiteSpace(prepared.StationSnapshot.OperatorCallsign))
+        {
+            prepared.StationSnapshot.OperatorCallsign = original;
+        }
+    }
+
+    /// <summary>
     /// Serialize multiple QSOs with an optional ADIF header.
     /// </summary>
     internal static byte[] SerializeAdif(IEnumerable<QsoRecord> qsos, bool includeHeader)

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/IQrzLogbookApi.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/IQrzLogbookApi.cs
@@ -17,7 +17,15 @@ public interface IQrzLogbookApi
     /// Upload a single QSO to QRZ via the INSERT action.
     /// Returns the QRZ-assigned LOGID on success.
     /// </summary>
-    Task<string> UploadQsoAsync(QsoRecord qso);
+    /// <param name="qso">The QSO record to upload.</param>
+    /// <param name="bookOwner">
+    /// Optional QRZ logbook owner callsign (from a fresh STATUS call, falling back to
+    /// cached <c>SyncMetadata.QrzLogbookOwner</c>). When provided and different from
+    /// <c>qso.StationCallsign</c>, the upload payload's <c>STATION_CALLSIGN</c> is
+    /// rewritten to the owner so QRZ accepts QSOs logged under a previous callsign.
+    /// The local QSO is never modified.
+    /// </param>
+    Task<string> UploadQsoAsync(QsoRecord qso, string? bookOwner = null);
 
     /// <summary>
     /// Update an existing QSO on QRZ via the REPLACE action.
@@ -25,7 +33,13 @@ public interface IQrzLogbookApi
     /// that identifies the remote record to overwrite.
     /// Returns the QRZ LOGID on success.
     /// </summary>
-    Task<string> UpdateQsoAsync(QsoRecord qso);
+    /// <param name="qso">The QSO record to update.</param>
+    /// <param name="bookOwner">
+    /// Optional QRZ logbook owner callsign — same semantics as
+    /// <see cref="UploadQsoAsync"/>: rewrites the upload payload's
+    /// <c>STATION_CALLSIGN</c> when the QSO was logged under a previous callsign.
+    /// </param>
+    Task<string> UpdateQsoAsync(QsoRecord qso, string? bookOwner = null);
 
     /// <summary>
     /// Calls the QRZ Logbook <c>STATUS</c> action and returns the authoritative

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
@@ -97,11 +97,13 @@ public sealed class QrzLogbookClient : IQrzLogbookApi, IDisposable
     }
 
     /// <inheritdoc />
-    public async Task<string> UploadQsoAsync(QsoRecord qso)
+    public async Task<string> UploadQsoAsync(QsoRecord qso, string? bookOwner = null)
     {
         ArgumentNullException.ThrowIfNull(qso);
 
-        var adifRecord = AdifCodec.SerializeSingleQso(qso);
+        var prepared = qso.Clone();
+        AdifCodec.RewriteStationCallsignForBook(prepared, bookOwner);
+        var adifRecord = AdifCodec.SerializeSingleQso(prepared);
 
         var formFields = new List<KeyValuePair<string, string>>(3)
         {
@@ -123,7 +125,7 @@ public sealed class QrzLogbookClient : IQrzLogbookApi, IDisposable
     }
 
     /// <inheritdoc />
-    public async Task<string> UpdateQsoAsync(QsoRecord qso)
+    public async Task<string> UpdateQsoAsync(QsoRecord qso, string? bookOwner = null)
     {
         ArgumentNullException.ThrowIfNull(qso);
 
@@ -132,7 +134,9 @@ public sealed class QrzLogbookClient : IQrzLogbookApi, IDisposable
             throw new QrzLogbookException("REPLACE requires a QRZ LOGID but the QSO has none.");
         }
 
-        var adifRecord = AdifCodec.SerializeSingleQso(qso);
+        var prepared = qso.Clone();
+        AdifCodec.RewriteStationCallsignForBook(prepared, bookOwner);
+        var adifRecord = AdifCodec.SerializeSingleQso(prepared);
 
         // Per docs/integrations/qrz-logbook-api.md the documented way to
         // update an existing QSO is ACTION=INSERT with

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
@@ -227,6 +227,37 @@ public sealed class QrzSyncEngine
         }
 
         // ---------------------------------------------------------------
+        // Phase 1.5 — Resolve the QRZ logbook owner callsign
+        // ---------------------------------------------------------------
+        // Fetch STATUS once, before upload, so we can rewrite the
+        // STATION_CALLSIGN of QSOs logged under a previous callsign
+        // (issue #337). The same result is reused in Phase 3 for metadata
+        // refresh, avoiding a second STATUS round-trip per sync.
+
+        QrzLogbookStatus? statusResult = null;
+        Exception? statusException = null;
+        try
+        {
+            statusResult = await _client.GetStatusAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            statusException = ex;
+        }
+
+        string? bookOwner = null;
+        if (statusResult is { } sr && !string.IsNullOrWhiteSpace(sr.Owner))
+        {
+            bookOwner = sr.Owner.Trim();
+        }
+        else if (!string.IsNullOrWhiteSpace(metadata.QrzLogbookOwner))
+        {
+            // STATUS failed or returned no owner — fall back to the cached
+            // owner so QSOs can still upload after a transient API hiccup.
+            bookOwner = metadata.QrzLogbookOwner;
+        }
+
+        // ---------------------------------------------------------------
         // Phase 2 — Upload pending local QSOs
         // ---------------------------------------------------------------
 
@@ -249,8 +280,8 @@ public sealed class QrzSyncEngine
             try
             {
                 var logid = qso.SyncStatus == SyncStatus.Modified && !string.IsNullOrWhiteSpace(qso.QrzLogid)
-                    ? await _client.UpdateQsoAsync(qso).ConfigureAwait(false)
-                    : await _client.UploadQsoAsync(qso).ConfigureAwait(false);
+                    ? await _client.UpdateQsoAsync(qso, bookOwner).ConfigureAwait(false)
+                    : await _client.UploadQsoAsync(qso, bookOwner).ConfigureAwait(false);
                 var synced = qso.Clone();
                 synced.QrzLogid = logid;
                 synced.SyncStatus = SyncStatus.Synced;
@@ -324,23 +355,24 @@ public sealed class QrzSyncEngine
         // ---------------------------------------------------------------
         // Phase 3 — Refresh metadata from authoritative QRZ STATUS
         // ---------------------------------------------------------------
-        // Mirrors src/rust/qsoripper-server/src/sync.rs::refresh_metadata:
-        // prefer the remote STATUS result; on failure fall back to estimating
-        // from local counts so metadata stays at least approximately correct.
+        // Reuses the STATUS call made in Phase 1.5 (so each sync makes one
+        // STATUS round-trip, not two). Mirrors
+        // src/rust/qsoripper-server/src/sync.rs::execute_sync: prefer remote
+        // STATUS; on failure fall back to estimating from local counts so
+        // metadata stays at least approximately correct.
 
         uint? remoteCount = null;
         string? remoteOwner = null;
-        try
+        if (statusResult is { } status)
         {
-            var status = await _client.GetStatusAsync().ConfigureAwait(false);
             remoteCount = status.QsoCount;
             remoteOwner = string.IsNullOrWhiteSpace(status.Owner)
                 ? metadata.QrzLogbookOwner
                 : status.Owner;
         }
-        catch (Exception ex)
+        else
         {
-            errors.Add($"STATUS refresh failed: {ex.Message}");
+            errors.Add($"STATUS refresh failed: {statusException?.Message ?? "unknown"}");
             remoteOwner = metadata.QrzLogbookOwner;
         }
 

--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -332,10 +332,74 @@ fn is_syncable_qso(qso: &QsoRecord) -> bool {
     !qso.worked_callsign.trim().is_empty() && qso.utc_timestamp.is_some()
 }
 
-fn qso_to_qrz_adif(qso: &QsoRecord) -> String {
+fn qso_to_qrz_adif(qso: &QsoRecord, book_owner: Option<&str>) -> String {
     let mut prepared = qso.clone();
     prepared.tx_power = normalize_qrz_power(prepared.tx_power.as_deref());
+    rewrite_station_callsign_for_book(&mut prepared, book_owner);
     AdifMapper::qso_to_adi(&prepared)
+}
+
+/// QRZ Logbook rejects uploads whose `STATION_CALLSIGN` does not match the
+/// callsign the logbook is registered to. Operators who have changed callsigns
+/// (e.g. KB7QOP → AE7XI) keep historical QSOs locally with the old call as the
+/// `station_callsign`. Without rewriting, every such QSO fails with
+/// "wrong `station_callsign` for this logbook".
+///
+/// When the book owner is known and differs (case-insensitive, trimmed) from
+/// the QSO's `station_callsign`, this rewrites the upload payload so QRZ
+/// accepts it:
+///
+/// * `station_callsign` is set to the book owner.
+/// * If the QSO has a station snapshot, its `station_callsign` is updated too
+///   (the snapshot is what `AdifMapper::qso_to_adi` actually emits as
+///   `STATION_CALLSIGN` when present).
+/// * The original station callsign is preserved as the ADIF `OPERATOR`
+///   (mapped from `station_snapshot.operator_callsign`) when no operator was
+///   recorded, so the historical operator-of-record survives on QRZ.
+///
+/// Skipped (the original payload is left untouched, QRZ may still reject):
+///
+/// * Empty/missing book owner.
+/// * Empty/missing `station_callsign`.
+/// * `station_callsign` containing a `/` (portable / mobile / secondary suffix
+///   such as `KB7QOP/P`). These typically belong to a different QRZ logbook
+///   and should not be silently rewritten.
+///
+/// The local QSO is **not** modified; only the in-memory upload payload is
+/// rewritten via the cloned `prepared` value in [`qso_to_qrz_adif`].
+fn rewrite_station_callsign_for_book(prepared: &mut QsoRecord, book_owner: Option<&str>) {
+    let Some(owner) = book_owner.map(str::trim).filter(|s| !s.is_empty()) else {
+        return;
+    };
+
+    let original = prepared.station_callsign.trim().to_owned();
+    if original.is_empty() {
+        return;
+    }
+    if original.contains('/') {
+        return;
+    }
+    if original.eq_ignore_ascii_case(owner) {
+        return;
+    }
+
+    owner.clone_into(&mut prepared.station_callsign);
+
+    let snapshot = prepared
+        .station_snapshot
+        .get_or_insert_with(crate::proto::qsoripper::domain::StationSnapshot::default);
+    // The snapshot is what the ADIF mapper actually emits as
+    // STATION_CALLSIGN when present, so it must be rewritten too.
+    owner.clone_into(&mut snapshot.station_callsign);
+
+    // Preserve the historical operator-of-record on QRZ.
+    if snapshot
+        .operator_callsign
+        .as_deref()
+        .is_none_or(|op| op.trim().is_empty())
+    {
+        snapshot.operator_callsign = Some(original);
+    }
 }
 
 fn normalize_qrz_power(value: Option<&str>) -> Option<String> {
@@ -542,8 +606,12 @@ impl QrzLogbookClient {
     ///
     /// Returns an error on network failure, authentication failure, or if
     /// the QRZ API rejects the record.
-    pub async fn upload_qso(&self, qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError> {
-        let adif_record = qso_to_qrz_adif(qso);
+    pub async fn upload_qso(
+        &self,
+        qso: &QsoRecord,
+        book_owner: Option<&str>,
+    ) -> Result<QrzUploadResult, QrzLogbookError> {
+        let adif_record = qso_to_qrz_adif(qso, book_owner);
 
         let body = self
             .post_form(&[("ACTION", "INSERT"), ("ADIF", &adif_record)])
@@ -578,13 +646,14 @@ impl QrzLogbookClient {
         &self,
         logid: &str,
         qso: &QsoRecord,
+        book_owner: Option<&str>,
     ) -> Result<QrzUploadResult, QrzLogbookError> {
         if logid.is_empty() {
             return Err(QrzLogbookError::ParseError(
                 "replace_qso called with empty logid".to_string(),
             ));
         }
-        let adif_record = AdifMapper::qso_to_adi(qso);
+        let adif_record = qso_to_qrz_adif(qso, book_owner);
         let option = format!("REPLACE,LOGID:{logid}");
 
         let body = self
@@ -910,7 +979,7 @@ mod tests {
             worked_callsign: "W1AW".to_string(),
             ..Default::default()
         };
-        let adif = qso_to_qrz_adif(&qso);
+        let adif = qso_to_qrz_adif(&qso, None);
         assert!(adif.contains("<CALL:4>W1AW"));
         assert!(adif.contains("<eor>"));
     }
@@ -923,7 +992,7 @@ mod tests {
             ..Default::default()
         };
 
-        let adif = qso_to_qrz_adif(&qso);
+        let adif = qso_to_qrz_adif(&qso, None);
 
         assert!(adif.contains("<TX_PWR:3>100"));
     }
@@ -936,9 +1005,108 @@ mod tests {
             ..Default::default()
         };
 
-        let adif = qso_to_qrz_adif(&qso);
+        let adif = qso_to_qrz_adif(&qso, None);
 
         assert!(!adif.contains("TX_PWR"));
+    }
+
+    #[test]
+    fn upload_rewrites_station_callsign_to_book_owner_when_previous_call() {
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            station_callsign: "KB7QOP".to_string(),
+            ..Default::default()
+        };
+
+        let adif = qso_to_qrz_adif(&qso, Some("AE7XI"));
+
+        assert!(
+            adif.contains("<STATION_CALLSIGN:5>AE7XI"),
+            "STATION_CALLSIGN should be rewritten to book owner; got: {adif}"
+        );
+        assert!(
+            adif.contains("<OPERATOR:6>KB7QOP"),
+            "Original station callsign should be preserved as OPERATOR; got: {adif}"
+        );
+    }
+
+    #[test]
+    fn upload_does_not_rewrite_when_station_callsign_matches_book_owner() {
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            station_callsign: "AE7XI".to_string(),
+            ..Default::default()
+        };
+
+        let adif = qso_to_qrz_adif(&qso, Some("ae7xi"));
+
+        assert!(adif.contains("<STATION_CALLSIGN:5>AE7XI"));
+        assert!(
+            !adif.contains("OPERATOR"),
+            "OPERATOR should not be backfilled when calls already match; got: {adif}"
+        );
+    }
+
+    #[test]
+    fn upload_does_not_rewrite_portable_or_secondary_suffix_calls() {
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            station_callsign: "KB7QOP/P".to_string(),
+            ..Default::default()
+        };
+
+        let adif = qso_to_qrz_adif(&qso, Some("AE7XI"));
+
+        assert!(
+            adif.contains("KB7QOP/P"),
+            "Slash-suffixed calls must be left alone (different QRZ logbook); got: {adif}"
+        );
+        assert!(
+            !adif.contains("AE7XI"),
+            "Should not silently rewrite slash-suffixed calls to book owner; got: {adif}"
+        );
+    }
+
+    #[test]
+    fn upload_does_not_rewrite_when_book_owner_unknown() {
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            station_callsign: "KB7QOP".to_string(),
+            ..Default::default()
+        };
+
+        let adif_none = qso_to_qrz_adif(&qso, None);
+        let adif_blank = qso_to_qrz_adif(&qso, Some("   "));
+
+        assert!(adif_none.contains("KB7QOP"));
+        assert!(adif_blank.contains("KB7QOP"));
+    }
+
+    #[test]
+    fn upload_does_not_overwrite_existing_operator() {
+        use crate::proto::qsoripper::domain::StationSnapshot;
+        let qso = QsoRecord {
+            worked_callsign: "W1AW".to_string(),
+            station_callsign: "KB7QOP".to_string(),
+            station_snapshot: Some(StationSnapshot {
+                station_callsign: "KB7QOP".to_string(),
+                operator_callsign: Some("N7XYZ".to_string()),
+                ..StationSnapshot::default()
+            }),
+            ..Default::default()
+        };
+
+        let adif = qso_to_qrz_adif(&qso, Some("AE7XI"));
+
+        assert!(adif.contains("<STATION_CALLSIGN:5>AE7XI"));
+        assert!(
+            adif.contains("<OPERATOR:5>N7XYZ"),
+            "Existing OPERATOR must be preserved; got: {adif}"
+        );
+        assert!(
+            !adif.contains("KB7QOP"),
+            "Original station callsign should not appear when an operator was already set; got: {adif}"
+        );
     }
 
     #[tokio::test]
@@ -1390,7 +1558,7 @@ mod tests {
             worked_callsign: "W1AW".to_string(),
             ..Default::default()
         };
-        let result = client.upload_qso(&qso).await.expect("upload");
+        let result = client.upload_qso(&qso, None).await.expect("upload");
 
         assert_eq!(result.logid, "999888");
 
@@ -1409,7 +1577,7 @@ mod tests {
             worked_callsign: "W1AW".to_string(),
             ..Default::default()
         };
-        let err = client.upload_qso(&qso).await.unwrap_err();
+        let err = client.upload_qso(&qso, None).await.unwrap_err();
 
         assert!(
             matches!(err, QrzLogbookError::ParseError(_)),
@@ -1424,7 +1592,7 @@ mod tests {
         let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
 
         let qso = QsoRecord::default();
-        let err = client.upload_qso(&qso).await.unwrap_err();
+        let err = client.upload_qso(&qso, None).await.unwrap_err();
 
         match err {
             QrzLogbookError::ApiError(reason) => assert_eq!(reason, "duplicate QSO"),
@@ -1445,7 +1613,7 @@ mod tests {
             ..Default::default()
         };
         let result = client
-            .replace_qso("555444333", &qso)
+            .replace_qso("555444333", &qso, None)
             .await
             .expect("replace");
 
@@ -1475,7 +1643,10 @@ mod tests {
         let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
 
         let qso = QsoRecord::default();
-        let result = client.replace_qso("777", &qso).await.expect("replace");
+        let result = client
+            .replace_qso("777", &qso, None)
+            .await
+            .expect("replace");
         assert_eq!(result.logid, "777");
     }
 
@@ -1484,7 +1655,7 @@ mod tests {
         let client =
             QrzLogbookClient::new(test_config("http://127.0.0.1:1".to_string())).expect("client");
         let err = client
-            .replace_qso("", &QsoRecord::default())
+            .replace_qso("", &QsoRecord::default(), None)
             .await
             .unwrap_err();
         assert!(matches!(err, QrzLogbookError::ParseError(_)));

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -359,7 +359,21 @@ impl DeveloperLogbookService {
             Err(err) => return (false, Some(err)),
         };
 
-        match sync::sync_single_qso(&client, engine.logbook_store(), stored).await {
+        let cached_metadata = engine
+            .logbook_store()
+            .get_sync_metadata()
+            .await
+            .unwrap_or_default();
+        let book_owner = sync::resolve_book_owner_for_upload(&client, &cached_metadata).await;
+
+        match sync::sync_single_qso(
+            &client,
+            engine.logbook_store(),
+            stored,
+            book_owner.as_deref(),
+        )
+        .await
+        {
             Ok(synced) => {
                 *stored = synced;
                 (true, None)

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -57,13 +57,27 @@ pub(crate) trait QrzLogbookApi: Send + Sync {
     async fn fetch_qsos(&self, since: Option<&str>) -> Result<Vec<QsoRecord>, QrzLogbookError>;
 
     /// Upload a single QSO and return its QRZ-assigned log ID.
-    async fn upload_qso(&self, qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError>;
+    ///
+    /// `book_owner` is the callsign the QRZ logbook is registered to (from a
+    /// fresh `STATUS` call, falling back to cached `SyncMetadata`). When
+    /// supplied, the upload payload's `STATION_CALLSIGN` is rewritten to the
+    /// book owner if it differs (for operators with previous callsigns), so
+    /// QRZ accepts the record. See
+    /// [`crate::qrz_logbook::rewrite_station_callsign_for_book`].
+    async fn upload_qso(
+        &self,
+        qso: &QsoRecord,
+        book_owner: Option<&str>,
+    ) -> Result<QrzUploadResult, QrzLogbookError>;
 
     /// Replace an existing QSO on the remote logbook (preserves logid).
+    ///
+    /// `book_owner` has the same semantics as in [`Self::upload_qso`].
     async fn replace_qso(
         &self,
         logid: &str,
         qso: &QsoRecord,
+        book_owner: Option<&str>,
     ) -> Result<QrzUploadResult, QrzLogbookError>;
 
     /// Query the remote logbook for the current owner callsign and QSO count.
@@ -80,16 +94,21 @@ impl QrzLogbookApi for QrzLogbookClient {
         QrzLogbookClient::fetch_qsos(self, since).await
     }
 
-    async fn upload_qso(&self, qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError> {
-        QrzLogbookClient::upload_qso(self, qso).await
+    async fn upload_qso(
+        &self,
+        qso: &QsoRecord,
+        book_owner: Option<&str>,
+    ) -> Result<QrzUploadResult, QrzLogbookError> {
+        QrzLogbookClient::upload_qso(self, qso, book_owner).await
     }
 
     async fn replace_qso(
         &self,
         logid: &str,
         qso: &QsoRecord,
+        book_owner: Option<&str>,
     ) -> Result<QrzUploadResult, QrzLogbookError> {
-        QrzLogbookClient::replace_qso(self, logid, qso).await
+        QrzLogbookClient::replace_qso(self, logid, qso, book_owner).await
     }
 
     async fn fetch_status(&self) -> Result<QrzLogbookStatus, QrzLogbookError> {
@@ -159,11 +178,32 @@ pub(crate) async fn execute_sync(
         return;
     };
 
-    upload_phase(client, store, progress_tx, &mut counters).await;
+    let status_result = client.fetch_status().await;
+    let book_owner = match &status_result {
+        Ok(status) if !status.owner.trim().is_empty() => Some(status.owner.clone()),
+        Ok(_) => metadata.qrz_logbook_owner.clone(),
+        Err(err) => {
+            eprintln!(
+                "[sync] STATUS call failed before upload; falling back to cached owner: {err}"
+            );
+            metadata.qrz_logbook_owner.clone()
+        }
+    }
+    .map(|s| s.trim().to_owned())
+    .filter(|s| !s.is_empty());
+
+    upload_phase(
+        client,
+        store,
+        book_owner.as_deref(),
+        progress_tx,
+        &mut counters,
+    )
+    .await;
 
     push_pending_remote_deletes(client, store, progress_tx, &mut counters).await;
 
-    update_metadata(client, store, &metadata, &mut counters).await;
+    update_metadata(store, &metadata, status_result, &mut counters).await;
 
     let error_summary = if counters.errors.is_empty() {
         None
@@ -423,6 +463,7 @@ async fn insert_new_remote_qso(
 async fn upload_phase(
     client: &dyn QrzLogbookApi,
     store: &dyn LogbookStore,
+    book_owner: Option<&str>,
     progress_tx: &mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
     counters: &mut SyncCounters,
 ) {
@@ -458,7 +499,7 @@ async fn upload_phase(
     );
 
     for qso in &pending_qsos {
-        match sync_single_qso(client, store, qso).await {
+        match sync_single_qso(client, store, qso, book_owner).await {
             Ok(_) => counters.uploaded += 1,
             Err(err) => {
                 eprintln!(
@@ -476,6 +517,36 @@ async fn upload_phase(
 // ---------------------------------------------------------------------------
 // Per-operation sync helper (used by Phase 2 and by per-RPC sync_to_qrz=true)
 // ---------------------------------------------------------------------------
+
+/// Resolve the QRZ logbook owner callsign to use when rewriting upload
+/// payloads.
+///
+/// QRZ Logbook rejects `STATION_CALLSIGN` mismatches against the book owner.
+/// To avoid wrongly rewriting against a stale cached owner (e.g. after the
+/// operator switched to a different logbook API key), prefer a fresh `STATUS`
+/// call. Fall back to the cached value from `SyncMetadata` only if STATUS
+/// fails (rate limit, transient network blip).
+///
+/// Returns `None` when neither source yields a non-empty owner; callers
+/// should then upload without rewriting (and let QRZ surface the error so the
+/// user gets a clear signal that their book owner is unknown).
+pub(crate) async fn resolve_book_owner_for_upload(
+    client: &dyn QrzLogbookApi,
+    cached_metadata: &SyncMetadata,
+) -> Option<String> {
+    match client.fetch_status().await {
+        Ok(status) if !status.owner.trim().is_empty() => Some(status.owner),
+        Ok(_) => cached_metadata.qrz_logbook_owner.clone(),
+        Err(err) => {
+            eprintln!(
+                "[sync] STATUS call failed while resolving book owner; falling back to cached: {err}"
+            );
+            cached_metadata.qrz_logbook_owner.clone()
+        }
+    }
+    .map(|s| s.trim().to_owned())
+    .filter(|s| !s.is_empty())
+}
 
 /// Push a single QSO to QRZ, then mirror the QRZ-assigned logid + Synced
 /// state back into local storage. Used by both bulk sync Phase 2 and the
@@ -495,12 +566,13 @@ pub(crate) async fn sync_single_qso(
     client: &dyn QrzLogbookApi,
     store: &dyn LogbookStore,
     qso: &QsoRecord,
+    book_owner: Option<&str>,
 ) -> Result<QsoRecord, String> {
     let existing_logid = qso.qrz_logid.clone().filter(|s| !s.is_empty());
 
     let result = match existing_logid.as_deref() {
-        Some(logid) => client.replace_qso(logid, qso).await,
-        None => client.upload_qso(qso).await,
+        Some(logid) => client.replace_qso(logid, qso, book_owner).await,
+        None => client.upload_qso(qso, book_owner).await,
     };
 
     let upload = result.map_err(|err| format!("QRZ upload failed: {err}"))?;
@@ -606,17 +678,19 @@ async fn push_pending_remote_deletes(
 // ---------------------------------------------------------------------------
 
 async fn update_metadata(
-    client: &dyn QrzLogbookApi,
     store: &dyn LogbookStore,
     prev_metadata: &SyncMetadata,
+    status_result: Result<QrzLogbookStatus, QrzLogbookError>,
     counters: &mut SyncCounters,
 ) {
     let now = chrono::Utc::now();
 
-    // Prefer the authoritative remote STATUS result. If QRZ's STATUS call
-    // fails (auth blip, transient network error) we fall back to estimating
-    // from local counts so metadata at least stays approximately correct.
-    let (qrz_qso_count, qrz_logbook_owner) = match client.fetch_status().await {
+    // Prefer the authoritative remote STATUS result (already fetched once
+    // before the upload phase to avoid double-billing the QRZ API). If that
+    // STATUS call failed (auth blip, transient network error) we fall back
+    // to estimating from local counts so metadata at least stays
+    // approximately correct.
+    let (qrz_qso_count, qrz_logbook_owner) = match status_result {
         Ok(status) => {
             let owner = if status.owner.is_empty() {
                 prev_metadata.qrz_logbook_owner.clone()
@@ -962,6 +1036,7 @@ mod tests {
     struct MockQrzApi {
         fetch_result: Mutex<Option<Result<Vec<QsoRecord>, QrzLogbookError>>>,
         upload_results: Mutex<Vec<Result<QrzUploadResult, QrzLogbookError>>>,
+        upload_calls: Mutex<Vec<(QsoRecord, Option<String>)>>,
         replace_calls: Mutex<Vec<(String, String)>>, // (logid, local_id)
         replace_results: Mutex<Vec<Result<QrzUploadResult, QrzLogbookError>>>,
         status_result: Mutex<Option<Result<QrzLogbookStatus, QrzLogbookError>>>,
@@ -977,6 +1052,7 @@ mod tests {
             Self {
                 fetch_result: Mutex::new(Some(fetch)),
                 upload_results: Mutex::new(uploads),
+                upload_calls: Mutex::new(Vec::new()),
                 replace_calls: Mutex::new(Vec::new()),
                 replace_results: Mutex::new(Vec::new()),
                 status_result: Mutex::new(Some(Ok(QrzLogbookStatus {
@@ -1007,7 +1083,15 @@ mod tests {
                 .unwrap_or_else(|| Ok(Vec::new()))
         }
 
-        async fn upload_qso(&self, _qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError> {
+        async fn upload_qso(
+            &self,
+            qso: &QsoRecord,
+            book_owner: Option<&str>,
+        ) -> Result<QrzUploadResult, QrzLogbookError> {
+            self.upload_calls
+                .lock()
+                .unwrap()
+                .push((qso.clone(), book_owner.map(str::to_owned)));
             let mut results = self.upload_results.lock().unwrap();
             if results.is_empty() {
                 Err(QrzLogbookError::ApiError(
@@ -1022,6 +1106,7 @@ mod tests {
             &self,
             logid: &str,
             qso: &QsoRecord,
+            _book_owner: Option<&str>,
         ) -> Result<QrzUploadResult, QrzLogbookError> {
             self.replace_calls
                 .lock()
@@ -1074,7 +1159,11 @@ mod tests {
             Ok(vec![])
         }
 
-        async fn upload_qso(&self, _qso: &QsoRecord) -> Result<QrzUploadResult, QrzLogbookError> {
+        async fn upload_qso(
+            &self,
+            _qso: &QsoRecord,
+            _book_owner: Option<&str>,
+        ) -> Result<QrzUploadResult, QrzLogbookError> {
             Ok(QrzUploadResult {
                 logid: "ignored".into(),
             })
@@ -1084,6 +1173,7 @@ mod tests {
             &self,
             logid: &str,
             _qso: &QsoRecord,
+            _book_owner: Option<&str>,
         ) -> Result<QrzUploadResult, QrzLogbookError> {
             Ok(QrzUploadResult {
                 logid: logid.to_string(),
@@ -1266,7 +1356,7 @@ mod tests {
             })],
         );
 
-        let synced = sync_single_qso(&api, &store, &q).await.expect("ok");
+        let synced = sync_single_qso(&api, &store, &q, None).await.expect("ok");
         assert_eq!(synced.qrz_logid.as_deref(), Some("QRZ-NEW"));
         assert_eq!(synced.sync_status, SyncStatus::Synced as i32);
 
@@ -1290,7 +1380,7 @@ mod tests {
         // defaults to echoing the logid back.
         let api = MockQrzApi::new(Ok(vec![]), vec![]);
 
-        let synced = sync_single_qso(&api, &store, &q).await.expect("ok");
+        let synced = sync_single_qso(&api, &store, &q, None).await.expect("ok");
         assert_eq!(synced.qrz_logid.as_deref(), Some("QRZ-EXISTING"));
         assert_eq!(synced.sync_status, SyncStatus::Synced as i32);
 
@@ -1316,7 +1406,7 @@ mod tests {
             vec![Err(QrzLogbookError::ApiError("boom".into()))],
         );
 
-        let err = sync_single_qso(&api, &store, &q)
+        let err = sync_single_qso(&api, &store, &q, None)
             .await
             .expect_err("should return error");
         assert!(err.contains("QRZ upload failed"), "actual error: {err}");
@@ -1326,6 +1416,90 @@ mod tests {
         let saved = store.get_qso(&q.local_id).await.unwrap().unwrap();
         assert_eq!(saved.sync_status, SyncStatus::LocalOnly as i32);
         assert!(saved.qrz_logid.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_sync_passes_book_owner_from_status_to_upload_payload() {
+        // Regression for issue #337: QSOs whose station_callsign is the
+        // operator's previous call (e.g. KB7QOP) must be uploaded with the
+        // current logbook owner callsign so QRZ accepts them.
+        let store = MemoryStorage::new();
+        let mut q = make_qso("KB7QOP", "K7ABC", Band::Band20m, Mode::Cw, 1_700_000_000);
+        q.qrz_logid = None;
+        q.sync_status = SyncStatus::LocalOnly as i32;
+        store.insert_qso(&q).await.unwrap();
+
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![Ok(QrzUploadResult {
+                logid: "QRZ-NEW".into(),
+            })],
+        )
+        .with_status(Ok(QrzLogbookStatus {
+            owner: "AE7XI".into(),
+            qso_count: 0,
+        }));
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.uploaded_records, 1, "upload must succeed");
+        assert!(final_msg.error.is_none(), "error: {:?}", final_msg.error);
+
+        let upload_calls = api.upload_calls.lock().unwrap().clone();
+        assert_eq!(upload_calls.len(), 1, "exactly one INSERT expected");
+        assert_eq!(
+            upload_calls[0].1.as_deref(),
+            Some("AE7XI"),
+            "fresh STATUS owner must reach upload_qso as book_owner"
+        );
+        // Local storage retains the historical station_callsign — only the
+        // upload payload is rewritten.
+        let saved = store.get_qso(&q.local_id).await.unwrap().unwrap();
+        assert_eq!(saved.station_callsign, "KB7QOP");
+        assert_eq!(saved.sync_status, SyncStatus::Synced as i32);
+    }
+
+    #[tokio::test]
+    async fn execute_sync_falls_back_to_cached_owner_when_status_fails() {
+        let store = MemoryStorage::new();
+        store
+            .upsert_sync_metadata(&SyncMetadata {
+                qrz_qso_count: 0,
+                last_sync: None,
+                qrz_logbook_owner: Some("AE7XI".into()),
+            })
+            .await
+            .unwrap();
+        let mut q = make_qso("KB7QOP", "K7ABC", Band::Band20m, Mode::Cw, 1_700_000_000);
+        q.qrz_logid = None;
+        q.sync_status = SyncStatus::LocalOnly as i32;
+        store.insert_qso(&q).await.unwrap();
+
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![Ok(QrzUploadResult {
+                logid: "QRZ-NEW".into(),
+            })],
+        )
+        .with_status(Err(QrzLogbookError::ApiError("transient".into())));
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+
+        let _final_msg = collect_final(rx).await;
+
+        let upload_calls = api.upload_calls.lock().unwrap().clone();
+        assert_eq!(upload_calls.len(), 1);
+        assert_eq!(
+            upload_calls[0].1.as_deref(),
+            Some("AE7XI"),
+            "cached owner must be used when STATUS fails"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes the QRZ logbook sync rejection for QSOs logged under a previous callsign (issue #337). When an operator changes callsigns (for example KB7QOP -> AE7XI), historical QSOs locally have the old call as station_callsign. QRZ logbooks are bound to a single owner callsign and reject ADIF whose STATION_CALLSIGN does not match, so every previous-call QSO fails to sync.

This change rewrites the upload payload only - local storage is never modified. At sync time the engine fetches a fresh QRZ STATUS call once, derives the logbook owner (with cached sync_metadata.qrz_logbook_owner as a fallback when STATUS fails), and for each upload payload whose station_callsign differs from the owner sets station_callsign and station_snapshot.station_callsign to the owner. The historical original is preserved as station_snapshot.operator_callsign so it lands in QRZ as ADIF OPERATOR. Slash-suffixed calls (KB7QOP/P) are skipped because they belong to a different logbook.

The single STATUS call is reused for the Phase 3 metadata refresh, avoiding double-billing the QRZ API per sync. Implemented in both engines (Rust qsoripper-core qrz_logbook + qsoripper-server sync; .NET QrzLogbookClient + QrzSyncEngine + AdifCodec.RewriteStationCallsignForBook). Engine specification updated to document the rewrite contract and the known download-side caveat (next download merges remote-wins for Synced rows, so local station_callsign may drift; APP_QSORIPPER_ORIG_STATION_CALLSIGN round-trip is planned future work).

Tests: 2 new sync.rs integration tests (fresh-status owner reaches upload_qso, cached-owner fallback when STATUS fails), 5 new qrz_logbook unit tests for the helper, and 5 new .NET tests covering the rewrite, single-STATUS dedup, slash-suffix skip, and operator-no-overwrite. All Rust tests (qsoripper-core and qsoripper-server) and the QRZ + ManagedEngine .NET test suites pass; cargo clippy --all-targets -D warnings clean.

Closes #337