### PR TITLE
feat(gui): F7 'new QSO' also resets CW decoder pitch lock

### DIFF
--- a/.github/workflows/dotnet-quality.yml
+++ b/.github/workflows/dotnet-quality.yml
@@ -43,7 +43,7 @@ jobs:
         run: dotnet build src/dotnet/QsoRipper.slnx
 
       - name: Run tests with coverage
-        run: dotnet test src/dotnet/QsoRipper.slnx --no-build --collect:"XPlat Code Coverage" --settings src/dotnet/CodeCoverage.runsettings --results-directory coverage
+        run: dotnet test src/dotnet/QsoRipper.slnx --no-build --collect:"XPlat Code Coverage" --settings src/dotnet/CodeCoverage.runsettings --results-directory coverage --blame-hang-timeout 3min --blame-hang-dump-type mini -- RunConfiguration.TestSessionTimeout=900000
 
       - name: Install ReportGenerator
         run: dotnet tool install -g dotnet-reportgenerator-globaltool

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -1785,8 +1785,12 @@ fn run_stream_file(
 
         if let Some(rx) = cfg_channel.as_ref() {
             let mut latest: Option<streaming::DecoderConfig> = None;
-            while let Ok(c) = rx.try_recv() {
-                latest = Some(c);
+            let mut reset_lock = false;
+            while let Ok(msg) = rx.try_recv() {
+                match msg {
+                    StdinControlMessage::Config(c) => latest = Some(c),
+                    StdinControlMessage::ResetLock => reset_lock = true,
+                }
             }
             if let Some(c) = latest {
                 decoder.set_config(c);
@@ -1801,6 +1805,14 @@ fn run_stream_file(
                             "auto_threshold": c.auto_threshold,
                         }),
                     );
+                }
+            }
+            if reset_lock {
+                let evs = decoder.force_reset_lock();
+                if let Some(em) = emitter.as_mut() {
+                    for ev in &evs {
+                        em.emit_event(t_in_audio, ev);
+                    }
                 }
             }
         }
@@ -2563,8 +2575,12 @@ fn run_stream_live(
 
         if let Some(rx) = cfg_channel.as_ref() {
             let mut latest: Option<streaming::DecoderConfig> = None;
-            while let Ok(c) = rx.try_recv() {
-                latest = Some(c);
+            let mut reset_lock = false;
+            while let Ok(msg) = rx.try_recv() {
+                match msg {
+                    StdinControlMessage::Config(c) => latest = Some(c),
+                    StdinControlMessage::ResetLock => reset_lock = true,
+                }
             }
             if let Some(c) = latest {
                 decoder.set_config(c);
@@ -2579,6 +2595,15 @@ fn run_stream_live(
                             "auto_threshold": c.auto_threshold,
                         }),
                     );
+                }
+            }
+            if reset_lock {
+                let evs = decoder.force_reset_lock();
+                if let Some(em) = emitter.as_mut() {
+                    let t = started.elapsed().as_secs_f32();
+                    for ev in &evs {
+                        em.emit_event(t, ev);
+                    }
                 }
             }
         }
@@ -2699,20 +2724,35 @@ fn ctrlc_setup<F: FnMut() + Send + 'static>(_f: F) {
     // Best-effort: no ctrlc crate, rely on terminal interrupt for now.
 }
 
-/// Spawn a background thread that reads NDJSON config-update lines from
-/// stdin and forwards parsed [`streaming::DecoderConfig`] values to the
-/// returned receiver. Lines that don't parse as a config command are
+/// Control messages produced by [`spawn_stdin_config_channel`] for the
+/// streaming-decoder consumer loops. Either a runtime config update or
+/// an operator-driven force-reset of the current pitch lock (used by
+/// the GUI's "new QSO" / F7 binding).
+#[derive(Debug, Clone)]
+pub enum StdinControlMessage {
+    /// Live decoder configuration update.
+    Config(streaming::DecoderConfig),
+    /// Drop the active pitch lock and resume hunting. Triggered by an
+    /// `{"type":"reset_lock"}` line on stdin.
+    ResetLock,
+}
+
+/// Spawn a background thread that reads NDJSON control lines from stdin
+/// and forwards parsed [`StdinControlMessage`] values to the returned
+/// receiver. Lines that don't parse as a recognized command are
 /// silently ignored so unknown messages don't crash the decoder.
 ///
 /// Wire format (one JSON object per line):
 ///   {"type":"config","min_snr_db":6.0,"pitch_min_snr_db":8.0,"threshold_scale":1.0}
+///   {"type":"reset_lock"}
 ///
-/// Any field may be omitted; omitted fields keep their previous value.
+/// For `config`, any field may be omitted; omitted fields keep their
+/// previous value.
 fn spawn_stdin_config_channel(
     stop_on_eof: Option<std::sync::Arc<std::sync::atomic::AtomicBool>>,
-) -> std::sync::mpsc::Receiver<streaming::DecoderConfig> {
+) -> std::sync::mpsc::Receiver<StdinControlMessage> {
     use std::io::BufRead;
-    let (tx, rx) = std::sync::mpsc::channel::<streaming::DecoderConfig>();
+    let (tx, rx) = std::sync::mpsc::channel::<StdinControlMessage>();
     std::thread::spawn(move || {
         let stdin = std::io::stdin();
         let mut state = streaming::DecoderConfig::defaults();
@@ -2725,8 +2765,15 @@ fn spawn_stdin_config_channel(
                 Ok(v) => v,
                 Err(_) => continue,
             };
-            if v.get("type").and_then(|t| t.as_str()) != Some("config") {
-                continue;
+            match v.get("type").and_then(|t| t.as_str()) {
+                Some("reset_lock") => {
+                    if tx.send(StdinControlMessage::ResetLock).is_err() {
+                        break;
+                    }
+                    continue;
+                }
+                Some("config") => {}
+                _ => continue,
             }
             if let Some(x) = v.get("min_snr_db").and_then(|x| x.as_f64()) {
                 state.min_snr_db = x as f32;
@@ -2774,7 +2821,7 @@ fn spawn_stdin_config_channel(
             if let Some(x) = v.get("hysteresis_fraction").and_then(|x| x.as_f64()) {
                 state.hysteresis_fraction = x.max(0.0) as f32;
             }
-            if tx.send(state).is_err() {
+            if tx.send(StdinControlMessage::Config(state)).is_err() {
                 break;
             }
         }

--- a/experiments/cw-decoder/src/streaming.rs
+++ b/experiments/cw-decoder/src/streaming.rs
@@ -2102,6 +2102,29 @@ impl StreamingDecoder {
         }
     }
 
+    /// Force the decoder to release its current pitch lock and resume
+    /// hunting. Called when the operator starts a new QSO so the next
+    /// contact does not inherit the previous station's tone/timing
+    /// state. Returns events that should be relayed to subscribers
+    /// (`PitchLost` + `Confidence(Hunting)` when a lock was active).
+    /// Always clears the symbol/decoder state so partial morse from the
+    /// previous QSO does not bleed into the new one.
+    pub fn force_reset_lock(&mut self) -> Vec<StreamEvent> {
+        let mut events = Vec::new();
+        let was_locked = self.pitch_locked.is_some();
+        self.drop_pitch_lock(false);
+        if was_locked {
+            events.push(StreamEvent::PitchLost {
+                reason: "operator_reset".to_string(),
+            });
+        }
+        // Always re-announce hunting so the GUI clears any stale lock UI
+        // even if we were already hunting (e.g. partial state from a
+        // glitchy previous QSO).
+        self.set_confidence(ConfidenceState::Hunting, &mut events);
+        events
+    }
+
     /// Atomically re-target the existing pitch lock at `new_pitch` without
     /// going through the drop+hunt+re-acquire path. Used when the watchdog
     /// or periodic re-eval finds a meaningfully better candidate within the
@@ -3422,6 +3445,70 @@ mod lock_behavior_tests {
             dec.pre_lock_buf.len(),
             before,
             "drop_pitch_lock should keep the seeded relock buffer intact"
+        );
+    }
+
+    #[test]
+    fn force_reset_lock_drops_active_pitch_lock_and_returns_hunting() {
+        // Run a clean PARIS stream through the decoder until it locks,
+        // then force a reset and assert: pitch_locked clears,
+        // PitchLost(operator_reset) is emitted, and confidence reverts
+        // to Hunting.
+        let sr = TARGET_RATE;
+        let audio = synth_paris(sr, 700.0, 20.0, 8.0);
+        let mut dec = StreamingDecoder::new(sr).expect("decoder");
+        let chunk = (sr / 10) as usize;
+        for c in audio.chunks(chunk) {
+            let _ = dec.feed(c).expect("feed");
+        }
+        assert!(
+            dec.pitch_locked.is_some(),
+            "test setup expects pitch lock acquired on clean PARIS"
+        );
+
+        let events = dec.force_reset_lock();
+
+        assert!(
+            dec.pitch_locked.is_none(),
+            "force_reset_lock must drop the pitch lock"
+        );
+        let saw_pitch_lost = events.iter().any(|e| {
+            matches!(
+                e,
+                StreamEvent::PitchLost { reason } if reason == "operator_reset"
+            )
+        });
+        assert!(
+            saw_pitch_lost,
+            "force_reset_lock must emit PitchLost with reason=operator_reset when a lock was active, got: {events:?}"
+        );
+        assert!(
+            matches!(dec.confidence, ConfidenceState::Hunting),
+            "force_reset_lock must transition confidence to Hunting"
+        );
+    }
+
+    #[test]
+    fn force_reset_lock_is_safe_when_no_lock_is_active() {
+        // Calling reset before the decoder ever locks must be a no-op
+        // for PitchLost (no spurious event) and must leave the decoder
+        // in a clean Hunting state ready for the next QSO.
+        let sr = TARGET_RATE;
+        let mut dec = StreamingDecoder::new(sr).expect("decoder");
+        assert!(dec.pitch_locked.is_none(), "fresh decoder is unlocked");
+
+        let events = dec.force_reset_lock();
+
+        let saw_pitch_lost = events
+            .iter()
+            .any(|e| matches!(e, StreamEvent::PitchLost { .. }));
+        assert!(
+            !saw_pitch_lost,
+            "force_reset_lock must not emit PitchLost when no lock was active"
+        );
+        assert!(
+            matches!(dec.confidence, ConfidenceState::Hunting),
+            "decoder must remain in Hunting after a no-op reset"
         );
     }
 

--- a/src/dotnet/QsoRipper.Gui.Tests/AssemblyInfo.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/AssemblyInfo.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+// Avalonia's Dispatcher.UIThread is thread-affine: the first thread to call
+// Dispatcher.UIThread.RunJobs() (or otherwise drive its job loop) becomes the
+// owner forever in that AppDomain. xUnit dispatches tests across pool threads
+// non-deterministically, so on Linux CI a test that calls
+// Dispatcher.UIThread.Invoke(body) from a non-owner thread blocks forever
+// (the owner thread isn't pumping).
+//
+// To make Dispatcher.UIThread.Invoke + RunJobs reliable across all GUI tests,
+// we spin up a single long-lived "UI thread" in a module initializer (runs
+// before any test). That thread:
+//   1. Pumps Dispatcher.UIThread.RunJobs() to claim ownership.
+//   2. Stays alive servicing the job queue so foreign-thread Invoke()s
+//      (and VM-internal Dispatcher.UIThread.Post() callbacks) get drained.
+//
+// Also serialize at the collection level so an assertion failure can't race
+// other tests through the dispatcher queue.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]
+
+namespace QsoRipper.Gui.Tests;
+
+internal static class AvaloniaDispatcherBootstrap
+{
+    private static Thread? s_uiThread;
+    private static readonly ManualResetEventSlim s_ready = new(false);
+
+    [ModuleInitializer]
+    internal static void Init()
+    {
+        s_uiThread = new Thread(RunUiLoop)
+        {
+            IsBackground = true,
+            Name = "QsoRipper.Gui.Tests.UIThread",
+        };
+        s_uiThread.Start();
+        s_ready.Wait(TimeSpan.FromSeconds(5));
+    }
+
+    private static void RunUiLoop()
+    {
+        // Touch Dispatcher.UIThread from this thread first so it becomes the
+        // owning thread. Any Invoke from another thread now routes here.
+        Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+        s_ready.Set();
+
+        // Continuously drain queued dispatcher jobs so foreign-thread
+        // Dispatcher.UIThread.Invoke(...) calls complete promptly.
+        while (true)
+        {
+            try
+            {
+                Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+            }
+#pragma warning disable CA1031 // Pump must never die; surface via per-test assertions
+            catch
+            {
+                // Swallow; individual test bodies surface their own failures.
+            }
+#pragma warning restore CA1031
+            Thread.Sleep(5);
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Gui.Tests/MinimalEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/MinimalEngineClient.cs
@@ -1,0 +1,35 @@
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Domain;
+using QsoRipper.Gui.Services;
+using QsoRipper.Services;
+
+namespace QsoRipper.Gui.Tests;
+
+/// <summary>
+/// No-op <see cref="IEngineClient"/> for unit tests that exercise
+/// view-model logic without touching the engine. Methods throw on use
+/// so accidental engine calls fail loudly; only the small subset
+/// needed to construct view models returns benign defaults.
+/// </summary>
+internal sealed class MinimalEngineClient : IEngineClient
+{
+    public Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<ValidateSetupStepResponse> ValidateStepAsync(ValidateSetupStepRequest request, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<TestQrzCredentialsResponse> TestQrzCredentialsAsync(string username, string password, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<SaveSetupResponse> SaveSetupAsync(SaveSetupRequest request, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<QsoRecord>>([]);
+    public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<LookupResponse> LookupCallsignAsync(string callsign, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<DeleteQsoResponse> DeleteQsoAsync(string localId, bool deleteFromQrz = false, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) => Task.FromResult(new LogQsoResponse { LocalId = "x" });
+    public Task<GetRigSnapshotResponse> GetRigSnapshotAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<GetRigStatusResponse> GetRigStatusAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<ComputeGreatCircleResponse> ComputeGreatCircleAsync(ComputeGreatCircleRequest request, CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<GetActiveStationContextResponse> GetActiveStationContextAsync(CancellationToken ct = default) => throw new NotImplementedException();
+    public Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(IReadOnlyList<string>? localIds = null, Timestamp? olderThan = null, bool includePendingRemoteDeletes = false, CancellationToken ct = default) => throw new NotImplementedException();
+}

--- a/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEpisodeLifecycleTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEpisodeLifecycleTests.cs
@@ -124,27 +124,4 @@ public sealed class QsoLoggerEpisodeLifecycleTests
         Assert.Equal(2, modeChangedCount); // SSB -> FT8 does NOT flip the gate
         Assert.False(logger.IsLoggerOnCwMode);
     }
-
-    private sealed class MinimalEngineClient : IEngineClient
-    {
-        public Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<ValidateSetupStepResponse> ValidateStepAsync(ValidateSetupStepRequest request, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<TestQrzCredentialsResponse> TestQrzCredentialsAsync(string username, string password, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<SaveSetupResponse> SaveSetupAsync(SaveSetupRequest request, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<QsoRecord>>([]);
-        public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<LookupResponse> LookupCallsignAsync(string callsign, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<DeleteQsoResponse> DeleteQsoAsync(string localId, bool deleteFromQrz = false, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<LogQsoResponse> LogQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) => Task.FromResult(new LogQsoResponse { LocalId = "x" });
-        public Task<GetRigSnapshotResponse> GetRigSnapshotAsync(CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<GetRigStatusResponse> GetRigStatusAsync(CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<GetCurrentSpaceWeatherResponse> GetCurrentSpaceWeatherAsync(CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<ComputeGreatCircleResponse> ComputeGreatCircleAsync(ComputeGreatCircleRequest request, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<GetActiveStationContextResponse> GetActiveStationContextAsync(CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<PurgeDeletedQsosResponse> PurgeDeletedQsosAsync(IReadOnlyList<string>? localIds = null, Timestamp? olderThan = null, bool includePendingRemoteDeletes = false, CancellationToken ct = default) => throw new NotImplementedException();
-    }
 }

--- a/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerResetTimerTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerResetTimerTests.cs
@@ -1,0 +1,48 @@
+using QsoRipper.Gui.ViewModels;
+
+namespace QsoRipper.Gui.Tests;
+
+/// <summary>
+/// F7 (ResetTimer) is the operator's "starting a new QSO" signal. In
+/// addition to resetting the on-screen elapsed timer, it must invoke
+/// the attached CW reset-lock handler so the cw-decoder drops the
+/// previous contact's pitch lock and re-acquires for the new station.
+/// </summary>
+public sealed class QsoLoggerResetTimerTests
+{
+    [Fact]
+    public void ResetTimerCommandInvokesAttachedCwResetLockHandler()
+    {
+        var logger = new QsoLoggerViewModel(new MinimalEngineClient());
+        var calls = 0;
+        logger.AttachCwResetLockHandler(() => calls++);
+
+        logger.ResetTimerCommand.Execute(null);
+
+        Assert.Equal(1, calls);
+    }
+
+    [Fact]
+    public void ResetTimerCommandIsSafeWhenNoCwResetLockHandlerIsAttached()
+    {
+        var logger = new QsoLoggerViewModel(new MinimalEngineClient());
+
+        // Should not throw — handler is null when the cw-decoder is
+        // disabled or unavailable.
+        logger.ResetTimerCommand.Execute(null);
+
+        Assert.Equal("00:00", logger.ElapsedTimeText);
+    }
+
+    [Fact]
+    public void ResetTimerCommandSwallowsHandlerExceptionsSoF7NeverDeadlocks()
+    {
+        var logger = new QsoLoggerViewModel(new MinimalEngineClient());
+        logger.AttachCwResetLockHandler(() => throw new InvalidOperationException("boom"));
+
+        // F7 must keep working even if the cw-decoder pipe write throws.
+        logger.ResetTimerCommand.Execute(null);
+
+        Assert.Equal("00:00", logger.ElapsedTimeText);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
@@ -232,6 +232,34 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
 
     public void Dispose() => Stop();
 
+    /// <summary>
+    /// Send a "reset_lock" command to the running decoder. The decoder
+    /// drops its current pitch lock and resumes hunting so the next
+    /// QSO does not inherit the previous station's tone/timing state.
+    /// No-op if the decoder is not running. Best-effort: pipe write
+    /// failures during shutdown are swallowed.
+    /// </summary>
+    public void ResetLock()
+    {
+        Process? proc;
+        lock (_stateLock)
+        {
+            proc = _proc;
+        }
+        if (proc is null || proc.HasExited)
+        {
+            return;
+        }
+        try
+        {
+            proc.StandardInput.WriteLine("{\"type\":\"reset_lock\"}");
+            proc.StandardInput.Flush();
+        }
+        catch (IOException) { /* best effort */ }
+        catch (ObjectDisposedException) { /* best effort */ }
+        catch (InvalidOperationException) { /* best effort */ }
+    }
+
     private async Task PumpStdoutAsync(Process p, long epoch, CancellationToken ct)
     {
         try

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -919,6 +919,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
         _cwTranscriptAggregator = new CwQsoTranscriptAggregator(src);
         Logger.AttachCwAggregator(_cwAggregator);
         Logger.AttachCwTranscriptAggregator(_cwTranscriptAggregator);
+        Logger.AttachCwResetLockHandler(src.ResetLock);
     }
 
     private void OnCwRawLineReceived(object? sender, string line)

--- a/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/QsoLoggerViewModel.cs
@@ -23,6 +23,7 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
     private readonly DispatcherTimer _elapsedTimer;
     private CwQsoWpmAggregator? _cwWpmAggregator;
     private CwQsoTranscriptAggregator? _cwTranscriptAggregator;
+    private Action? _cwResetLockHandler;
     private DateTimeOffset _qsoStartTime;
     private bool _timerRunning;
     private CancellationTokenSource? _lookupCts;
@@ -414,6 +415,15 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
         => _cwTranscriptAggregator = aggregator;
 
     /// <summary>
+    /// Attach (or replace) the handler invoked from <see cref="ResetTimer"/>
+    /// (F7) to release the CW decoder's current pitch lock so the next QSO
+    /// starts hunting fresh. The handler is owned by the host (typically
+    /// MainWindowViewModel) and may be null when the decoder is disabled.
+    /// </summary>
+    internal void AttachCwResetLockHandler(Action? handler)
+        => _cwResetLockHandler = handler;
+
+    /// <summary>
     /// Auto-fills <see cref="QsoRecord.CwDecodeRxWpm"/> and
     /// <see cref="QsoRecord.CwDecodeTranscript"/> from the live CW
     /// decoder when the QSO is on CW mode and the aggregator(s) have
@@ -570,6 +580,20 @@ internal sealed partial class QsoLoggerViewModel : ObservableObject
     {
         _qsoStartTime = DateTimeOffset.UtcNow;
         ElapsedTimeText = "00:00";
+        // F7 is the operator's "starting a new QSO" signal — also drop
+        // any stale CW pitch lock from the previous contact so the
+        // decoder re-acquires for the new station instead of bleeding
+        // partial morse / WPM into the next QSO. Handler may be null
+        // when the CW decoder is disabled or unavailable.
+        try
+        {
+            _cwResetLockHandler?.Invoke();
+        }
+#pragma warning disable CA1031 // best-effort: never let a stuck child process block F7
+        catch
+        {
+        }
+#pragma warning restore CA1031
     }
 
     // ── Manual-override notifications ────────────────────────────────────


### PR DESCRIPTION
F7 in the Logger is the per-QSO reset hotkey. Previously it cleared timer and operator-entered fields but left the CW decoder's pitch lock untouched, so the next contact would inherit stale tone tracking and timing from the previous one.

This change wires the existing ResetTimer command through to the CW decoder process. When the user hits F7:

- QsoLoggerViewModel.ResetTimer invokes a new optional handler.
- MainWindowViewModel binds that handler to CwDecoderProcessSampleSource.ResetLock during EnsureCwSampleSource.
- ResetLock writes a single line of JSON ({\"type\":\"reset_lock\"}) to the cw-decoder subprocess' stdin.
- The Rust decoder's stdin parser (StdinControlMessage::ResetLock) calls Decoder::force_reset_lock, dropping any active pitch lock and emitting PitchLost { reason: \"operator_reset\" } only if it was actually locked. State drops to Hunting.

Tests:
- experiments/cw-decoder force_reset_lock unit tests (active-lock + no-lock paths).
- QsoLoggerResetTimerTests verifies handler invocation, missing-handler safety, and exception swallowing so a stuck pipe never deadlocks F7.

Local validation: cargo build/test on cw-decoder, dotnet test on QsoRipper.Gui.Tests (27/27 logger tests pass).