### PR TITLE
Always-visible azimuthal map section + freshest engine binary

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -82,6 +82,14 @@ $Win32FfiGateSource = Join-Path $Win32SourceDir 'src' 'backend_ffi_gate.c'
 $Win32ResourcesDir = Join-Path $Win32SourceDir 'resources'
 $Win32ResourceScript = Join-Path $Win32ResourcesDir 'app.rc'
 $Win32PublishDir = Join-Path $PSScriptRoot 'artifacts' 'publish' | Join-Path -ChildPath 'qsoripper-win32' | Join-Path -ChildPath $Configuration
+$ServerPublishDir = Join-Path $PSScriptRoot 'artifacts' 'publish' | Join-Path -ChildPath 'qsoripper-server' | Join-Path -ChildPath $Configuration
+$DotnetEnginePublishDir = Join-Path $PSScriptRoot 'artifacts' 'publish' | Join-Path -ChildPath 'qsoripper-engine-dotnet' | Join-Path -ChildPath $Configuration
+$DotnetDebugHostPublishDir = Join-Path $PSScriptRoot 'artifacts' 'publish' | Join-Path -ChildPath 'qsoripper-debughost' | Join-Path -ChildPath $Configuration
+$CwScopeGuiPublishDir = Join-Path $PSScriptRoot 'artifacts' 'publish' | Join-Path -ChildPath 'cw-decoder-gui' | Join-Path -ChildPath $Configuration
+$DotnetEngineProject = Join-Path $PSScriptRoot 'src' 'dotnet' 'QsoRipper.Engine.DotNet' 'QsoRipper.Engine.DotNet.csproj'
+$DotnetDebugHostProject = Join-Path $PSScriptRoot 'src' 'dotnet' 'QsoRipper.DebugHost' 'QsoRipper.DebugHost.csproj'
+$CwScopeGuiProject = Join-Path $PSScriptRoot 'experiments' 'cw-decoder' 'gui' 'CwDecoderGui.csproj'
+$ServerBinary = if ($IsWindows) { 'qsoripper-server.exe' } else { 'qsoripper-server' }
 
 function Build-Rust {
     $arguments = @('build', '--manifest-path', $RustManifest)
@@ -105,6 +113,14 @@ function Build-Rust {
         $null = New-Item -ItemType Directory -Force -Path $StressTuiPublishDir
         Copy-Item -Path $stressTuiSrc -Destination $StressTuiPublishDir -Force
         Write-Host "  -> $StressTuiPublishDir"
+    }
+
+    $serverSrc = Join-Path $PSScriptRoot 'src' 'rust' 'target' $RustTargetProfile $ServerBinary
+    if (Test-Path $serverSrc) {
+        Write-Step "Publishing qsoripper-server ($Configuration)"
+        $null = New-Item -ItemType Directory -Force -Path $ServerPublishDir
+        Copy-Item -Path $serverSrc -Destination $ServerPublishDir -Force
+        Write-Host "  -> $ServerPublishDir"
     }
 
     # Publish qsoripper-ffi DLL and import library (Windows only)
@@ -212,6 +228,38 @@ function Build-Dotnet {
         '-o',
         $DotnetGuiPublishDir
     )
+
+    Invoke-Build "Publishing QsoRipper.Engine.DotNet ($Configuration)" dotnet @(
+        'publish',
+        $DotnetEngineProject,
+        '-c',
+        $Configuration,
+        '--use-current-runtime',
+        '-o',
+        $DotnetEnginePublishDir
+    )
+
+    Invoke-Build "Publishing QsoRipper.DebugHost ($Configuration)" dotnet @(
+        'publish',
+        $DotnetDebugHostProject,
+        '-c',
+        $Configuration,
+        '--use-current-runtime',
+        '-o',
+        $DotnetDebugHostPublishDir
+    )
+
+    if (Test-Path $CwScopeGuiProject) {
+        Invoke-Build "Publishing CwDecoderGui ($Configuration)" dotnet @(
+            'publish',
+            $CwScopeGuiProject,
+            '-c',
+            $Configuration,
+            '--use-current-runtime',
+            '-o',
+            $CwScopeGuiPublishDir
+        )
+    }
 }
 
 function Build-Win32 {

--- a/runall.ps1
+++ b/runall.ps1
@@ -1,0 +1,191 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Build everything and bring up the full local QsoRipper stack from
+    artifacts/publish.
+
+.DESCRIPTION
+    1. Builds Rust + .NET + Win32 via build.ps1 (skip with -SkipBuild).
+    2. Force-restarts the Rust engine (50051) and .NET engine (50052) using
+       start-qsoripper.ps1 so the GUI's engine selector sees both.
+    3. Stops any running DebugHost / Avalonia GUI / CW Scope and relaunches
+       them from artifacts/publish so they reflect the latest build.
+    4. Opens http://localhost:5082 in the default browser for the DebugHost.
+
+    Every binary is launched from the published artifact path (no `dotnet run`
+    or `cargo run`) so what you exercise on screen is exactly what was built.
+
+.PARAMETER Configuration
+    Release (default) or Debug.
+
+.PARAMETER SkipBuild
+    Skip build.ps1 — just relaunch from existing artifacts.
+
+.PARAMETER NoEngines
+    Do not start the Rust / .NET engine servers.
+
+.PARAMETER NoDebugHost
+    Do not start the DebugHost web app.
+
+.PARAMETER NoGui
+    Do not start the main Avalonia GUI.
+
+.PARAMETER NoCwScope
+    Do not start the CW Scope GUI.
+
+.EXAMPLE
+    .\runall.ps1
+    Build and launch every component.
+
+.EXAMPLE
+    .\runall.ps1 -SkipBuild
+    Re-launch every component without rebuilding.
+
+.EXAMPLE
+    .\runall.ps1 -NoCwScope
+    Skip the CW Scope GUI but bring up the rest.
+#>
+
+param(
+    [ValidateSet('Release', 'Debug')]
+    [string]$Configuration = 'Release',
+    [switch]$SkipBuild,
+    [switch]$NoEngines,
+    [switch]$NoDebugHost,
+    [switch]$NoGui,
+    [switch]$NoCwScope
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Step([string]$Message) {
+    Write-Host "`n=== $Message ===" -ForegroundColor Cyan
+}
+
+function Stop-ProcessByName([string]$Name) {
+    $procs = Get-Process -Name $Name -ErrorAction SilentlyContinue
+    if (-not $procs) { return }
+    foreach ($p in $procs) {
+        try {
+            Write-Host "  Stopping $($p.ProcessName) (PID $($p.Id))" -ForegroundColor Yellow
+            Stop-Process -Id $p.Id -Force -ErrorAction Stop
+        } catch {
+            Write-Host "  Warning: failed to stop PID $($p.Id): $_" -ForegroundColor Yellow
+        }
+    }
+    # Give the OS a moment to release file/socket handles.
+    Start-Sleep -Milliseconds 500
+}
+
+function Start-Detached([string]$Path, [string[]]$Arguments, [string]$WorkingDirectory) {
+    if (-not (Test-Path -LiteralPath $Path)) {
+        throw "Cannot launch '$Path' — file not found. Did the build step run?"
+    }
+    $params = @{
+        FilePath         = $Path
+        WorkingDirectory = $WorkingDirectory
+        PassThru         = $true
+    }
+    if ($Arguments -and $Arguments.Count -gt 0) {
+        $params.ArgumentList = $Arguments
+    }
+    $proc = Start-Process @params
+    Write-Host "  Launched $([System.IO.Path]::GetFileName($Path)) (PID $($proc.Id))" -ForegroundColor Green
+    return $proc
+}
+
+# --- Resolve published artifact paths ----------------------------------------
+
+$publishRoot              = Join-Path $PSScriptRoot 'artifacts' 'publish'
+$serverExe                = Join-Path $publishRoot 'qsoripper-server'        | Join-Path -ChildPath $Configuration | Join-Path -ChildPath ($IsWindows ? 'qsoripper-server.exe' : 'qsoripper-server')
+$dotnetEngineDir          = Join-Path $publishRoot 'qsoripper-engine-dotnet' | Join-Path -ChildPath $Configuration
+$dotnetEngineExe          = Join-Path $dotnetEngineDir ($IsWindows ? 'QsoRipper.Engine.DotNet.exe' : 'QsoRipper.Engine.DotNet')
+$debugHostDir             = Join-Path $publishRoot 'qsoripper-debughost'     | Join-Path -ChildPath $Configuration
+$debugHostExe             = Join-Path $debugHostDir ($IsWindows ? 'QsoRipper.DebugHost.exe' : 'QsoRipper.DebugHost')
+$guiDir                   = Join-Path $publishRoot 'qsoripper-gui'           | Join-Path -ChildPath $Configuration
+$guiExe                   = Join-Path $guiDir ($IsWindows ? 'QsoRipper.Gui.exe' : 'QsoRipper.Gui')
+$cwScopeDir               = Join-Path $publishRoot 'cw-decoder-gui'          | Join-Path -ChildPath $Configuration
+$cwScopeExe               = Join-Path $cwScopeDir ($IsWindows ? 'CwDecoderGui.exe' : 'CwDecoderGui')
+
+# --- Step 1: build -----------------------------------------------------------
+
+if (-not $SkipBuild) {
+    Write-Step "Building all artifacts ($Configuration)"
+    & "$PSScriptRoot\build.ps1" -Configuration $Configuration
+    if ($LASTEXITCODE -ne 0) {
+        throw "build.ps1 exited with $LASTEXITCODE"
+    }
+} else {
+    Write-Step 'Skipping build (-SkipBuild)'
+}
+
+# --- Step 2: engines (force restart) -----------------------------------------
+
+if (-not $NoEngines) {
+    # Start the .NET engine first and the Rust engine LAST so the legacy
+    # qsoripper-engine.json (used by the GUI as the default endpoint) ends
+    # up pointing at the Rust engine, which fully loads the persisted
+    # station_profile from config.toml. The .NET engine doesn't yet hydrate
+    # station profiles from config.toml, so making it the default would
+    # silently hide the F8 azimuthal map (origin lat/lon comes back empty).
+    Write-Step 'Restarting .NET engine on 127.0.0.1:50052'
+    & "$PSScriptRoot\start-qsoripper.ps1" -Engine local-dotnet -ForceRestart -SkipBuild
+    if ($LASTEXITCODE -ne 0) { throw "start-qsoripper.ps1 (dotnet) exited with $LASTEXITCODE" }
+
+    Write-Step 'Restarting Rust engine on 127.0.0.1:50051 (default for GUI)'
+    & "$PSScriptRoot\start-qsoripper.ps1" -Engine local-rust -ForceRestart -SkipBuild
+    if ($LASTEXITCODE -ne 0) { throw "start-qsoripper.ps1 (rust) exited with $LASTEXITCODE" }
+} else {
+    Write-Step 'Skipping engine startup (-NoEngines)'
+}
+
+# --- Step 3: DebugHost (force restart, launch from artifacts) ----------------
+
+if (-not $NoDebugHost) {
+    Write-Step 'Restarting DebugHost on http://localhost:5082'
+    Stop-ProcessByName 'QsoRipper.DebugHost'
+    $null = Start-Detached -Path $debugHostExe -WorkingDirectory $debugHostDir -Arguments @('--urls', 'http://localhost:5082')
+    Start-Sleep -Seconds 2
+    try {
+        Start-Process 'http://localhost:5082'
+    } catch {
+        Write-Host "  Could not auto-open browser: $_" -ForegroundColor Yellow
+    }
+} else {
+    Write-Step 'Skipping DebugHost (-NoDebugHost)'
+}
+
+# --- Step 4: main GUI --------------------------------------------------------
+
+if (-not $NoGui) {
+    Write-Step 'Restarting QsoRipper GUI'
+    Stop-ProcessByName 'QsoRipper.Gui'
+    $null = Start-Detached -Path $guiExe -WorkingDirectory $guiDir
+} else {
+    Write-Step 'Skipping main GUI (-NoGui)'
+}
+
+# --- Step 5: CW Scope --------------------------------------------------------
+
+if (-not $NoCwScope) {
+    Write-Step 'Restarting CW Scope GUI'
+    Stop-ProcessByName 'CwDecoderGui'
+    if (Test-Path -LiteralPath $cwScopeExe) {
+        $null = Start-Detached -Path $cwScopeExe -WorkingDirectory $cwScopeDir
+    } else {
+        Write-Host "  CW Scope artifact not found at $cwScopeExe — skipping (was the build skipped?)" -ForegroundColor Yellow
+    }
+} else {
+    Write-Step 'Skipping CW Scope (-NoCwScope)'
+}
+
+Write-Step 'All requested components launched'
+Write-Host @"
+Endpoints:
+  Rust engine        http://127.0.0.1:50051
+  .NET engine        http://127.0.0.1:50052
+  DebugHost          http://localhost:5082
+
+Use .\stop-qsoripper.ps1 to stop the engines.
+GUI / DebugHost / CW Scope can be closed via their windows or Stop-Process.
+"@ -ForegroundColor Cyan

--- a/src/dotnet/QsoRipper.Gui/ViewModels/CallsignCardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/CallsignCardViewModel.cs
@@ -134,7 +134,19 @@ internal sealed partial class CallsignCardViewModel : ObservableObject
     private bool _isMapAvailable;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsMapSectionVisible))]
     private bool _isMapLoading;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsMapSectionVisible))]
+    [NotifyPropertyChangedFor(nameof(HasMapStatus))]
+    private string _mapStatusText = string.Empty;
+
+    public bool IsMapSectionVisible => IsMapAvailable || IsMapLoading || HasMapStatus;
+
+    public bool HasMapStatus => !string.IsNullOrEmpty(MapStatusText);
+
+    partial void OnIsMapAvailableChanged(bool value) => OnPropertyChanged(nameof(IsMapSectionVisible));
 
     [ObservableProperty]
     private string _mapCountryLabel = string.Empty;
@@ -305,14 +317,24 @@ internal sealed partial class CallsignCardViewModel : ObservableObject
         MapPath = null;
         MapDistanceText = string.Empty;
         MapBearingText = string.Empty;
-        MapCountryLabel = !string.IsNullOrWhiteSpace(record.DxccCountryName)
+        MapStatusText = "Loading map…";
+        var countryName = !string.IsNullOrWhiteSpace(record.DxccCountryName)
             ? record.DxccCountryName!
             : (record.Country ?? string.Empty);
+        var stateLabel = record.State?.Trim() ?? string.Empty;
+        var isUnitedStates = !string.IsNullOrEmpty(countryName) && (
+            countryName.Contains("United States", StringComparison.OrdinalIgnoreCase)
+            || countryName.Equals("USA", StringComparison.OrdinalIgnoreCase)
+            || countryName.Equals("US", StringComparison.OrdinalIgnoreCase));
+        MapCountryLabel = (isUnitedStates && stateLabel.Length > 0)
+            ? $"{stateLabel} · {countryName}"
+            : countryName;
         try
         {
             var target = BuildTargetReference(record);
             if (target is null)
             {
+                MapStatusText = "Map unavailable: target callsign has no grid or coordinates.";
                 return;
             }
 
@@ -320,6 +342,7 @@ internal sealed partial class CallsignCardViewModel : ObservableObject
             var origin = BuildOriginReference(contextResponse?.Context);
             if (origin is null)
             {
+                MapStatusText = "Map unavailable: station profile has no grid or coordinates (configure in Setup).";
                 return;
             }
 
@@ -333,6 +356,7 @@ internal sealed partial class CallsignCardViewModel : ObservableObject
             var path = response?.Path;
             if (path is null || path.Origin is null || path.Target is null || path.Samples.Count < 2)
             {
+                MapStatusText = "Map unavailable: engine returned no great-circle path.";
                 return;
             }
 
@@ -344,20 +368,30 @@ internal sealed partial class CallsignCardViewModel : ObservableObject
             var scaleKm = ChooseMapScaleKm(path.DistanceKm);
             MapScaleKm = scaleKm;
             MapScaleText = $"scale ~{FormatScaleKm(scaleKm)}";
+            MapStatusText = string.Empty;
             IsMapAvailable = true;
         }
-        catch (Grpc.Core.RpcException)
+        catch (Grpc.Core.RpcException ex)
         {
-            // Engine unreachable / great-circle service unavailable — hide the map silently.
+            MapStatusText = $"Map unavailable: engine RPC failed ({ex.Status.StatusCode}).";
+            System.Diagnostics.Trace.WriteLine($"[CallsignCard] ComputeGreatCircle RPC failed: {ex}");
         }
-        catch (InvalidOperationException)
+        catch (InvalidOperationException ex)
         {
-            // Engine client mis-configured — hide the map silently.
+            MapStatusText = "Map unavailable: engine client misconfigured.";
+            System.Diagnostics.Trace.WriteLine($"[CallsignCard] LoadMapAsync InvalidOperationException: {ex}");
         }
         catch (NotImplementedException)
         {
-            // Test or stub engine client without map support — hide the map.
+            MapStatusText = "Map unavailable: engine does not implement great-circle service.";
         }
+#pragma warning disable CA1031 // Diagnostic catch-all so the section reports failures instead of silently hiding.
+        catch (Exception ex)
+        {
+            MapStatusText = $"Map unavailable: {ex.GetType().Name}: {ex.Message}";
+            System.Diagnostics.Trace.WriteLine($"[CallsignCard] LoadMapAsync unexpected exception: {ex}");
+        }
+#pragma warning restore CA1031
         finally
         {
             IsMapLoading = false;

--- a/src/dotnet/QsoRipper.Gui/Views/CallsignCardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/CallsignCardView.axaml
@@ -229,8 +229,8 @@
           </Grid>
 
           <!-- Azimuthal Map Section -->
-          <Border Classes="sectionDivider" IsVisible="{Binding IsMapAvailable}" />
-          <Grid ColumnDefinitions="*,Auto" IsVisible="{Binding IsMapAvailable}">
+          <Border Classes="sectionDivider" IsVisible="{Binding IsMapSectionVisible}" />
+          <Grid ColumnDefinitions="*,Auto" IsVisible="{Binding IsMapSectionVisible}">
             <TextBlock Grid.Column="0" Classes="sectionHeader" Text="AZIMUTHAL MAP" />
             <Button Grid.Column="1"
                     Padding="6,2"
@@ -242,8 +242,16 @@
                     FontSize="11"
                     Content="⤢ Pop out"
                     Command="{Binding ExpandMapCommand}"
+                    IsVisible="{Binding IsMapAvailable}"
                     ToolTip.Tip="Open larger map (Ctrl+M)" />
           </Grid>
+          <TextBlock HorizontalAlignment="Center"
+                     FontSize="11"
+                     Foreground="#7088a8"
+                     TextWrapping="Wrap"
+                     Margin="0,2,0,4"
+                     Text="{Binding MapStatusText}"
+                     IsVisible="{Binding HasMapStatus}" />
           <StackPanel Spacing="6" IsVisible="{Binding IsMapAvailable}">
             <Border HorizontalAlignment="Center"
                     Background="#101c30"

--- a/start-qsoripper.ps1
+++ b/start-qsoripper.ps1
@@ -488,7 +488,23 @@ function Get-EngineProfiles {
         $dotnetDebugDllPath
     }
     $binaryName = if ($IsWindows) { 'qsoripper-server.exe' } else { 'qsoripper-server' }
-    $rustBinaryPath = Join-Path $PSScriptRoot 'src' | Join-Path -ChildPath 'rust' | Join-Path -ChildPath 'target' | Join-Path -ChildPath 'debug' | Join-Path -ChildPath $binaryName
+    $rustReleaseArtifactPath = Join-Path $PSScriptRoot 'artifacts' | Join-Path -ChildPath 'publish' | Join-Path -ChildPath 'qsoripper-server' | Join-Path -ChildPath 'Release' | Join-Path -ChildPath $binaryName
+    $rustReleaseTargetPath = Join-Path $PSScriptRoot 'src' | Join-Path -ChildPath 'rust' | Join-Path -ChildPath 'target' | Join-Path -ChildPath 'release' | Join-Path -ChildPath $binaryName
+    $rustDebugTargetPath = Join-Path $PSScriptRoot 'src' | Join-Path -ChildPath 'rust' | Join-Path -ChildPath 'target' | Join-Path -ChildPath 'debug' | Join-Path -ChildPath $binaryName
+    # Pick the freshest available binary so -SkipBuild after PR merges doesn't
+    # silently re-launch a stale debug build (which then 404s on new RPCs).
+    $rustCandidates = @($rustReleaseArtifactPath, $rustReleaseTargetPath, $rustDebugTargetPath) | Where-Object { Test-Path -LiteralPath $_ }
+    $rustBinaryPath = if ($rustCandidates.Count -gt 0) {
+        ($rustCandidates | Sort-Object { (Get-Item -LiteralPath $_).LastWriteTimeUtc } -Descending | Select-Object -First 1)
+    } else {
+        $rustDebugTargetPath
+    }
+
+    $dotnetReleasePublishedDllPath = Join-Path $PSScriptRoot 'artifacts' | Join-Path -ChildPath 'publish' | Join-Path -ChildPath 'qsoripper-engine-dotnet' | Join-Path -ChildPath 'Release' | Join-Path -ChildPath 'QsoRipper.Engine.DotNet.dll'
+    $dotnetCandidates = @($dotnetReleasePublishedDllPath, $dotnetReleaseDllPath, $dotnetDebugDllPath) | Where-Object { Test-Path -LiteralPath $_ }
+    if ($dotnetCandidates.Count -gt 0) {
+        $dotnetDllPath = ($dotnetCandidates | Sort-Object { (Get-Item -LiteralPath $_).LastWriteTimeUtc } -Descending | Select-Object -First 1)
+    }
 
     return @(
         [pscustomobject]@{


### PR DESCRIPTION
Fixes two coupled bugs uncovered after PR #336 merged.

The F8 callsign card's azimuthal map section was gated entirely on IsMapAvailable and the LoadMapAsync catch list only handled three exception types, so a failed great-circle call produced no visible feedback at all - the section simply did not render. start-qsoripper.ps1 hardcoded the target/debug Rust binary, so runall -SkipBuild after a PR merge silently re-launched the pre-merge debug build. The GUI then got Unimplemented from GreatCircleService and the user saw nothing.

CallsignCardViewModel: new MapStatusText / IsMapSectionVisible / HasMapStatus. LoadMapAsync sets a status string for every failure mode and adds a diagnostic Exception catch-all so the unobserved-task handler can no longer hide failures.

CallsignCardView.axaml: gate the section on IsMapSectionVisible so the header appears during loading and on errors. Status TextBlock bound to MapStatusText.

start-qsoripper.ps1: prefer the freshest of artifacts/publish/.../Release, target/release, or target/debug for both Rust and .NET.

build.ps1: also publish qsoripper-server, QsoRipper.Engine.DotNet, QsoRipper.DebugHost, and CwDecoderGui.

runall.ps1 (new): build then force-restart both engines and launch DebugHost / GUI / CW Scope from the published artifacts. Starts .NET first and Rust last so the legacy qsoripper-engine.json default points at the Rust engine, which fully hydrates station_profile from config.toml.

Smoke test: with this change, the F8 card now always shows a status, and after rebuilding the Rust engine the map renders end-to-end against the live engine.