### PR TITLE
CW Scope: record-and-label flow on the Labeling tab

### DIFF
--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
@@ -136,6 +136,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
             {
                 OnPropertyChanged(nameof(StartStopLabel));
                 OnPropertyChanged(nameof(CurrentToneHzDisplay));
+                OnPropertyChanged(nameof(CanToggleLabelingRecord));
             }
         }
     }
@@ -729,6 +730,52 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
     private string? _harvestFilePath;
     public string? HarvestFilePath { get => _harvestFilePath; set => Set(ref _harvestFilePath, value); }
 
+    // Labeling-tab record button state.
+    private string _trainingSetSubset = "training-set-a";
+    public string TrainingSetSubset
+    {
+        get => _trainingSetSubset;
+        set
+        {
+            // Strip path separators so the user can't accidentally escape data/cw-samples.
+            var sanitized = string.IsNullOrWhiteSpace(value)
+                ? "training-set-a"
+                : new string(value.Where(c => c != '/' && c != '\\' && c != ':' && c != '*' && c != '?' && c != '"' && c != '<' && c != '>' && c != '|').ToArray()).Trim();
+            if (sanitized.Length == 0) sanitized = "training-set-a";
+            if (Set(ref _trainingSetSubset, sanitized))
+            {
+                OnPropertyChanged(nameof(CanToggleLabelingRecord));
+            }
+        }
+    }
+
+    private bool _isLabelingRecording;
+    public bool IsLabelingRecording
+    {
+        get => _isLabelingRecording;
+        private set
+        {
+            if (Set(ref _isLabelingRecording, value))
+            {
+                OnPropertyChanged(nameof(LabelingRecordButtonLabel));
+                OnPropertyChanged(nameof(CanToggleLabelingRecord));
+            }
+        }
+    }
+
+    private string _labelingRecordStatus = "Idle. Press RECORD to capture from the live audio device.";
+    public string LabelingRecordStatus { get => _labelingRecordStatus; private set => Set(ref _labelingRecordStatus, value); }
+
+    public string LabelingRecordButtonLabel => IsLabelingRecording ? "■ STOP" : "● RECORD";
+
+    public bool CanToggleLabelingRecord =>
+        // While recording: always allow stop.
+        IsLabelingRecording
+        // Otherwise: idle, with a non-empty subset, and the live decoder NOT already running.
+        || (!IsRunning && !IsAdvancedBusy && !string.IsNullOrWhiteSpace(_trainingSetSubset));
+
+    private string? _labelingRecordPath;
+
     private string _harvestNeedlesText = string.Empty;
     public string HarvestNeedlesText { get => _harvestNeedlesText; set => Set(ref _harvestNeedlesText, value); }
 
@@ -952,6 +999,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
                 OnPropertyChanged(nameof(CanUseSuggestedSpan));
                 OnPropertyChanged(nameof(CanRunLabelScore));
                 OnPropertyChanged(nameof(CanRunLabelSweep));
+                OnPropertyChanged(nameof(CanToggleLabelingRecord));
             }
         }
     }
@@ -1848,6 +1896,142 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         }
     }
 
+    public async Task ToggleLabelingRecordAsync()
+    {
+        if (IsLabelingRecording)
+        {
+            await StopLabelingRecordAsync().ConfigureAwait(true);
+            return;
+        }
+
+        if (IsRunning)
+        {
+            LabelingRecordStatus = "Stop the live decoder on the LIVE tab before recording a labeling clip.";
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(_trainingSetSubset))
+        {
+            LabelingRecordStatus = "Set a training-set subdirectory first.";
+            return;
+        }
+
+        string targetPath;
+        try
+        {
+            var targetDir = LocateTrainingSetDirectory(_trainingSetSubset);
+            Directory.CreateDirectory(targetDir);
+            targetPath = Path.Combine(targetDir, $"clip-{DateTime.Now:yyyyMMdd-HHmmss}.wav");
+        }
+        catch (Exception ex)
+        {
+            LabelingRecordStatus = $"Cannot prepare training-set directory: {ex.Message}";
+            return;
+        }
+
+        ResetDecoderSurface();
+        _liveTranscriptForReplay = null;
+        _liveTranscriptBuilder.Clear();
+        _labelingRecordPath = targetPath;
+        StatusText = "Recording labeling clip…";
+        SourceLabel = string.IsNullOrWhiteSpace(SelectedDevice)
+            ? $"LABELING · {Path.GetFileName(targetPath)}"
+            : $"LABELING · {SelectedDevice} · {Path.GetFileName(targetPath)}";
+        LabelingRecordStatus = $"Recording → {Path.Combine(_trainingSetSubset, Path.GetFileName(targetPath))}";
+
+        try
+        {
+            _process.StartLive(SelectedDevice, CurrentConfig(), CurrentBaselineConfig(), IsBaselineDecoderMode, targetPath, UseLoopback);
+            IsRunning = true;
+            IsLabelingRecording = true;
+        }
+        catch (Exception ex)
+        {
+            _labelingRecordPath = null;
+            LabelingRecordStatus = $"Failed to start capture: {ex.Message}";
+            IsRunning = false;
+            IsLabelingRecording = false;
+        }
+        await Task.CompletedTask;
+    }
+
+    private async Task StopLabelingRecordAsync()
+    {
+        var path = _labelingRecordPath;
+        IsLabelingRecording = false;
+        try
+        {
+            _liveTranscriptForReplay = _liveTranscriptBuilder.ToString();
+            _process.Stop();
+            StopPlayback();
+            IsRunning = false;
+        }
+        catch (Exception ex)
+        {
+            LabelingRecordStatus = $"Stop failed: {ex.Message}";
+            return;
+        }
+
+        if (string.IsNullOrEmpty(path))
+        {
+            LabelingRecordStatus = "Recording stopped (no file path captured).";
+            return;
+        }
+
+        // Wait for the WAV writer (Rust child Drop) to flush.
+        LabelingRecordStatus = $"Flushing {Path.GetFileName(path)}…";
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            await Task.Delay(150).ConfigureAwait(true);
+            if (File.Exists(path) && new FileInfo(path).Length > 1024) break;
+        }
+
+        if (!File.Exists(path))
+        {
+            LabelingRecordStatus = $"Recording finished but {Path.GetFileName(path)} was not written.";
+            _labelingRecordPath = null;
+            return;
+        }
+
+        LastRecordingPath = path;
+        OnPropertyChanged(nameof(HasLastRecording));
+
+        LabelingRecordStatus = $"Saved {Path.GetFileName(path)} — harvesting…";
+        try
+        {
+            SetHarvestFile(path);
+            await HarvestCandidatesAsync().ConfigureAwait(true);
+            LabelingRecordStatus = HarvestCandidates.Count == 0
+                ? $"Saved {Path.GetFileName(path)}. No candidate windows yet — adjust harvest filters and re-run."
+                : $"Saved {Path.GetFileName(path)} and harvested {HarvestCandidates.Count} candidate(s). Ready to label.";
+        }
+        catch (Exception ex)
+        {
+            LabelingRecordStatus = $"Saved {Path.GetFileName(path)} but harvest failed: {ex.Message}";
+        }
+        finally
+        {
+            _labelingRecordPath = null;
+        }
+    }
+
+    private static string LocateTrainingSetDirectory(string subset)
+    {
+        var safeSubset = string.IsNullOrWhiteSpace(subset) ? "training-set-a" : subset.Trim();
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (int i = 0; dir is not null && i < 8; i++, dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "data", "cw-samples")))
+            {
+                return Path.Combine(dir.FullName, "data", "cw-samples", safeSubset);
+            }
+            if (Directory.Exists(Path.Combine(dir.FullName, "experiments", "cw-decoder")))
+            {
+                return Path.Combine(dir.FullName, "data", "cw-samples", safeSubset);
+            }
+        }
+        return Path.Combine(AppContext.BaseDirectory, "cw-samples", safeSubset);
+    }
+
     public void SaveSelectedLabel()
     {
         if (SelectedCandidate is null || string.IsNullOrWhiteSpace(HarvestFilePath) || string.IsNullOrWhiteSpace(CorrectCopy))
@@ -1888,7 +2072,17 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
             File.WriteAllLines(labelPath, lines);
             _candidateDrafts[CandidateKey(SelectedCandidate)] = CandidateDraftState.FromLabel(label);
             SaveCurrentHarvestSession();
-            AdvancedStatusText = $"Saved verified copy to {Path.GetFileName(labelPath)}.";
+            // Also write a sidecar truth.txt next to the WAV so bench scripts (e.g. bench-30wpm.ps1) can pick it up.
+            var truthPath = Path.ChangeExtension(HarvestFilePath, ".truth.txt");
+            try
+            {
+                File.WriteAllText(truthPath, label.CorrectCopy);
+            }
+            catch
+            {
+                // Non-fatal — labels.jsonl is the source of truth; truth.txt is a convenience for bench tooling.
+            }
+            AdvancedStatusText = $"Saved verified copy to {Path.GetFileName(labelPath)} (+ {Path.GetFileName(truthPath)}).";
             OnPropertyChanged(nameof(CanRunLabelScore));
             OnPropertyChanged(nameof(CanRunLabelSweep));
             OnPropertyChanged(nameof(LabelEvaluationTargetLabel));

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml
@@ -519,8 +519,28 @@
       </TabItem>
       <TabItem Header="LABELING">
         <Border Classes="panel">
-          <Grid RowDefinitions="Auto,Auto,Auto,*,Auto" RowSpacing="10">
+          <Grid RowDefinitions="Auto,Auto,Auto,Auto,*,Auto" RowSpacing="10">
             <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
+              <StackPanel Spacing="2">
+                <TextBlock Text="TRAINING SET (under data/cw-samples/…)" Classes="label" />
+                <TextBox Text="{Binding TrainingSetSubset, Mode=TwoWay}"
+                          Background="#0C1A28" Foreground="{StaticResource TextHi}"
+                          IsEnabled="{Binding !IsLabelingRecording}"
+                          ToolTip.Tip="Subdirectory under data/cw-samples where new clips are saved." />
+              </StackPanel>
+              <Button Grid.Column="1" Classes="primary"
+                      Content="{Binding LabelingRecordButtonLabel}"
+                      Click="OnToggleLabelingRecordClick"
+                      Margin="0,16,0,0"
+                      IsEnabled="{Binding CanToggleLabelingRecord}"
+                      ToolTip.Tip="Capture from the live audio device into a fresh WAV under the chosen training set, then auto-harvest it for labeling." />
+              <TextBlock Grid.Column="2" Text="{Binding LabelingRecordStatus}"
+                         VerticalAlignment="Center" Margin="0,16,0,0"
+                         Classes="label" Foreground="{StaticResource TextDim}"
+                         MaxWidth="280" TextWrapping="Wrap" />
+            </Grid>
+
+            <Grid Grid.Row="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
               <StackPanel Spacing="2">
                 <TextBlock Text="AUDIO FILE" Classes="label" />
                 <TextBox Text="{Binding HarvestFilePath}" IsReadOnly="True"
@@ -531,7 +551,7 @@
                       IsEnabled="{Binding CanHarvestCandidates}" />
             </Grid>
 
-            <Grid Grid.Row="1" ColumnDefinitions="2*,Auto,Auto,Auto,Auto" ColumnSpacing="10">
+            <Grid Grid.Row="2" ColumnDefinitions="2*,Auto,Auto,Auto,Auto" ColumnSpacing="10">
               <StackPanel Spacing="2">
                 <TextBlock Text="ANCHOR NEEDLES" Classes="label" />
                 <TextBox Text="{Binding HarvestNeedlesText}" Watermark="Optional filters, e.g. 5NN TU W1AW"
@@ -555,7 +575,7 @@
                       IsEnabled="{Binding CanPreviewCandidate}" />
             </Grid>
 
-            <Border Grid.Row="2" BorderBrush="{StaticResource GridLine}" BorderThickness="1" CornerRadius="2" Padding="8"
+            <Border Grid.Row="3" BorderBrush="{StaticResource GridLine}" BorderThickness="1" CornerRadius="2" Padding="8"
                     IsVisible="{Binding IsHarvestBusy}">
               <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                 <TextBlock Text="{Binding HarvestProgressLabel}" Classes="label" VerticalAlignment="Center" />
@@ -564,7 +584,7 @@
               </Grid>
             </Border>
 
-            <Grid Grid.Row="3" ColumnDefinitions="380,*" ColumnSpacing="12">
+            <Grid Grid.Row="4" ColumnDefinitions="380,*" ColumnSpacing="12">
               <Border BorderBrush="{StaticResource GridLine}" BorderThickness="1" CornerRadius="2" Padding="8">
                 <Grid RowDefinitions="Auto,*">
                   <Grid ColumnDefinitions="*,Auto">
@@ -678,7 +698,7 @@
               </ScrollViewer>
             </Grid>
 
-            <TextBlock Grid.Row="4" Text="{Binding AdvancedStatusText}" Classes="label" Foreground="{StaticResource TextDim}" />
+            <TextBlock Grid.Row="5" Text="{Binding AdvancedStatusText}" Classes="label" Foreground="{StaticResource TextDim}" />
           </Grid>
         </Border>
       </TabItem>

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml.cs
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml.cs
@@ -81,6 +81,12 @@ public partial class MainWindow : Window
         await Vm.HarvestCandidatesAsync();
     }
 
+    private async void OnToggleLabelingRecordClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (Vm is null) return;
+        await Vm.ToggleLabelingRecordAsync();
+    }
+
     private async void OnPlayPreviewClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         if (Vm is null) return;


### PR DESCRIPTION
Adds a RECORD/STOP button to the Labeling tab in the CW Scope so an operator can capture live audio directly into a training-set subdirectory and immediately have the new clip selected and harvested for labeling.

What changes:

- New TRAINING SET text box (defaults to training-set-a) and a RECORD/STOP button on the Labeling tab.
- Clicking RECORD reuses the existing live-decoder pipeline to write data/cw-samples/<subset>/clip-<utc>.wav while the LIVE tab still shows real-time decoding.
- Clicking STOP waits for the WAV writer to flush, points the harvest workflow at the new clip, and runs HarvestCandidatesAsync so the candidate list and decoder output are ready to label without another click.
- Recording is blocked while the LIVE tab decoder is already running, to avoid two captures fighting for the audio device.
- SaveSelectedLabel also writes a sidecar <basename>.truth.txt next to the WAV with the verified copy, so existing bench scripts (for example experiments/cw-decoder/scripts/bench-30wpm.ps1) can immediately benchmark a freshly labeled clip. The .labels.jsonl file remains the structured source of truth.

Validation:

dotnet build experiments/cw-decoder/gui/CwDecoderGui.csproj -c Release succeeds with zero warnings, and the published GUI launches and renders the new controls.