### PR TITLE
cw-decoder: rolling ditdah beam decoder for live logger

### DIFF
--- a/experiments/cw-decoder/Cargo.toml
+++ b/experiments/cw-decoder/Cargo.toml
@@ -17,7 +17,7 @@ name = "cw_decoder_poc"
 path = "src/lib.rs"
 
 [dependencies]
-ditdah = { path = "../../../ditdah" }
+ditdah = { path = "vendor/ditdah" }
 anyhow = "1"
 clap = { version = "4.5", features = ["derive"] }
 log = "0.4"

--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
@@ -136,6 +136,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
             {
                 OnPropertyChanged(nameof(StartStopLabel));
                 OnPropertyChanged(nameof(CurrentToneHzDisplay));
+                OnPropertyChanged(nameof(CanToggleLabelingRecord));
             }
         }
     }
@@ -729,6 +730,52 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
     private string? _harvestFilePath;
     public string? HarvestFilePath { get => _harvestFilePath; set => Set(ref _harvestFilePath, value); }
 
+    // Labeling-tab record button state.
+    private string _trainingSetSubset = "training-set-a";
+    public string TrainingSetSubset
+    {
+        get => _trainingSetSubset;
+        set
+        {
+            // Strip path separators so the user can't accidentally escape data/cw-samples.
+            var sanitized = string.IsNullOrWhiteSpace(value)
+                ? "training-set-a"
+                : new string(value.Where(c => c != '/' && c != '\\' && c != ':' && c != '*' && c != '?' && c != '"' && c != '<' && c != '>' && c != '|').ToArray()).Trim();
+            if (sanitized.Length == 0) sanitized = "training-set-a";
+            if (Set(ref _trainingSetSubset, sanitized))
+            {
+                OnPropertyChanged(nameof(CanToggleLabelingRecord));
+            }
+        }
+    }
+
+    private bool _isLabelingRecording;
+    public bool IsLabelingRecording
+    {
+        get => _isLabelingRecording;
+        private set
+        {
+            if (Set(ref _isLabelingRecording, value))
+            {
+                OnPropertyChanged(nameof(LabelingRecordButtonLabel));
+                OnPropertyChanged(nameof(CanToggleLabelingRecord));
+            }
+        }
+    }
+
+    private string _labelingRecordStatus = "Idle. Press RECORD to capture from the live audio device.";
+    public string LabelingRecordStatus { get => _labelingRecordStatus; private set => Set(ref _labelingRecordStatus, value); }
+
+    public string LabelingRecordButtonLabel => IsLabelingRecording ? "■ STOP" : "● RECORD";
+
+    public bool CanToggleLabelingRecord =>
+        // While recording: always allow stop.
+        IsLabelingRecording
+        // Otherwise: idle, with a non-empty subset, and the live decoder NOT already running.
+        || (!IsRunning && !IsAdvancedBusy && !string.IsNullOrWhiteSpace(_trainingSetSubset));
+
+    private string? _labelingRecordPath;
+
     private string _harvestNeedlesText = string.Empty;
     public string HarvestNeedlesText { get => _harvestNeedlesText; set => Set(ref _harvestNeedlesText, value); }
 
@@ -952,6 +999,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
                 OnPropertyChanged(nameof(CanUseSuggestedSpan));
                 OnPropertyChanged(nameof(CanRunLabelScore));
                 OnPropertyChanged(nameof(CanRunLabelSweep));
+                OnPropertyChanged(nameof(CanToggleLabelingRecord));
             }
         }
     }
@@ -1848,6 +1896,142 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         }
     }
 
+    public async Task ToggleLabelingRecordAsync()
+    {
+        if (IsLabelingRecording)
+        {
+            await StopLabelingRecordAsync().ConfigureAwait(true);
+            return;
+        }
+
+        if (IsRunning)
+        {
+            LabelingRecordStatus = "Stop the live decoder on the LIVE tab before recording a labeling clip.";
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(_trainingSetSubset))
+        {
+            LabelingRecordStatus = "Set a training-set subdirectory first.";
+            return;
+        }
+
+        string targetPath;
+        try
+        {
+            var targetDir = LocateTrainingSetDirectory(_trainingSetSubset);
+            Directory.CreateDirectory(targetDir);
+            targetPath = Path.Combine(targetDir, $"clip-{DateTime.Now:yyyyMMdd-HHmmss}.wav");
+        }
+        catch (Exception ex)
+        {
+            LabelingRecordStatus = $"Cannot prepare training-set directory: {ex.Message}";
+            return;
+        }
+
+        ResetDecoderSurface();
+        _liveTranscriptForReplay = null;
+        _liveTranscriptBuilder.Clear();
+        _labelingRecordPath = targetPath;
+        StatusText = "Recording labeling clip…";
+        SourceLabel = string.IsNullOrWhiteSpace(SelectedDevice)
+            ? $"LABELING · {Path.GetFileName(targetPath)}"
+            : $"LABELING · {SelectedDevice} · {Path.GetFileName(targetPath)}";
+        LabelingRecordStatus = $"Recording → {Path.Combine(_trainingSetSubset, Path.GetFileName(targetPath))}";
+
+        try
+        {
+            _process.StartLive(SelectedDevice, CurrentConfig(), CurrentBaselineConfig(), IsBaselineDecoderMode, targetPath, UseLoopback);
+            IsRunning = true;
+            IsLabelingRecording = true;
+        }
+        catch (Exception ex)
+        {
+            _labelingRecordPath = null;
+            LabelingRecordStatus = $"Failed to start capture: {ex.Message}";
+            IsRunning = false;
+            IsLabelingRecording = false;
+        }
+        await Task.CompletedTask;
+    }
+
+    private async Task StopLabelingRecordAsync()
+    {
+        var path = _labelingRecordPath;
+        IsLabelingRecording = false;
+        try
+        {
+            _liveTranscriptForReplay = _liveTranscriptBuilder.ToString();
+            _process.Stop();
+            StopPlayback();
+            IsRunning = false;
+        }
+        catch (Exception ex)
+        {
+            LabelingRecordStatus = $"Stop failed: {ex.Message}";
+            return;
+        }
+
+        if (string.IsNullOrEmpty(path))
+        {
+            LabelingRecordStatus = "Recording stopped (no file path captured).";
+            return;
+        }
+
+        // Wait for the WAV writer (Rust child Drop) to flush.
+        LabelingRecordStatus = $"Flushing {Path.GetFileName(path)}…";
+        for (var attempt = 0; attempt < 20; attempt++)
+        {
+            await Task.Delay(150).ConfigureAwait(true);
+            if (File.Exists(path) && new FileInfo(path).Length > 1024) break;
+        }
+
+        if (!File.Exists(path))
+        {
+            LabelingRecordStatus = $"Recording finished but {Path.GetFileName(path)} was not written.";
+            _labelingRecordPath = null;
+            return;
+        }
+
+        LastRecordingPath = path;
+        OnPropertyChanged(nameof(HasLastRecording));
+
+        LabelingRecordStatus = $"Saved {Path.GetFileName(path)} — harvesting…";
+        try
+        {
+            SetHarvestFile(path);
+            await HarvestCandidatesAsync().ConfigureAwait(true);
+            LabelingRecordStatus = HarvestCandidates.Count == 0
+                ? $"Saved {Path.GetFileName(path)}. No candidate windows yet — adjust harvest filters and re-run."
+                : $"Saved {Path.GetFileName(path)} and harvested {HarvestCandidates.Count} candidate(s). Ready to label.";
+        }
+        catch (Exception ex)
+        {
+            LabelingRecordStatus = $"Saved {Path.GetFileName(path)} but harvest failed: {ex.Message}";
+        }
+        finally
+        {
+            _labelingRecordPath = null;
+        }
+    }
+
+    private static string LocateTrainingSetDirectory(string subset)
+    {
+        var safeSubset = string.IsNullOrWhiteSpace(subset) ? "training-set-a" : subset.Trim();
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        for (int i = 0; dir is not null && i < 8; i++, dir = dir.Parent)
+        {
+            if (Directory.Exists(Path.Combine(dir.FullName, "data", "cw-samples")))
+            {
+                return Path.Combine(dir.FullName, "data", "cw-samples", safeSubset);
+            }
+            if (Directory.Exists(Path.Combine(dir.FullName, "experiments", "cw-decoder")))
+            {
+                return Path.Combine(dir.FullName, "data", "cw-samples", safeSubset);
+            }
+        }
+        return Path.Combine(AppContext.BaseDirectory, "cw-samples", safeSubset);
+    }
+
     public void SaveSelectedLabel()
     {
         if (SelectedCandidate is null || string.IsNullOrWhiteSpace(HarvestFilePath) || string.IsNullOrWhiteSpace(CorrectCopy))
@@ -1888,7 +2072,17 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
             File.WriteAllLines(labelPath, lines);
             _candidateDrafts[CandidateKey(SelectedCandidate)] = CandidateDraftState.FromLabel(label);
             SaveCurrentHarvestSession();
-            AdvancedStatusText = $"Saved verified copy to {Path.GetFileName(labelPath)}.";
+            // Also write a sidecar truth.txt next to the WAV so bench scripts (e.g. bench-30wpm.ps1) can pick it up.
+            var truthPath = Path.ChangeExtension(HarvestFilePath, ".truth.txt");
+            try
+            {
+                File.WriteAllText(truthPath, label.CorrectCopy);
+            }
+            catch
+            {
+                // Non-fatal — labels.jsonl is the source of truth; truth.txt is a convenience for bench tooling.
+            }
+            AdvancedStatusText = $"Saved verified copy to {Path.GetFileName(labelPath)} (+ {Path.GetFileName(truthPath)}).";
             OnPropertyChanged(nameof(CanRunLabelScore));
             OnPropertyChanged(nameof(CanRunLabelSweep));
             OnPropertyChanged(nameof(LabelEvaluationTargetLabel));

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml
@@ -519,8 +519,28 @@
       </TabItem>
       <TabItem Header="LABELING">
         <Border Classes="panel">
-          <Grid RowDefinitions="Auto,Auto,Auto,*,Auto" RowSpacing="10">
+          <Grid RowDefinitions="Auto,Auto,Auto,Auto,*,Auto" RowSpacing="10">
             <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
+              <StackPanel Spacing="2">
+                <TextBlock Text="TRAINING SET (under data/cw-samples/…)" Classes="label" />
+                <TextBox Text="{Binding TrainingSetSubset, Mode=TwoWay}"
+                          Background="#0C1A28" Foreground="{StaticResource TextHi}"
+                          IsEnabled="{Binding !IsLabelingRecording}"
+                          ToolTip.Tip="Subdirectory under data/cw-samples where new clips are saved." />
+              </StackPanel>
+              <Button Grid.Column="1" Classes="primary"
+                      Content="{Binding LabelingRecordButtonLabel}"
+                      Click="OnToggleLabelingRecordClick"
+                      Margin="0,16,0,0"
+                      IsEnabled="{Binding CanToggleLabelingRecord}"
+                      ToolTip.Tip="Capture from the live audio device into a fresh WAV under the chosen training set, then auto-harvest it for labeling." />
+              <TextBlock Grid.Column="2" Text="{Binding LabelingRecordStatus}"
+                         VerticalAlignment="Center" Margin="0,16,0,0"
+                         Classes="label" Foreground="{StaticResource TextDim}"
+                         MaxWidth="280" TextWrapping="Wrap" />
+            </Grid>
+
+            <Grid Grid.Row="1" ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
               <StackPanel Spacing="2">
                 <TextBlock Text="AUDIO FILE" Classes="label" />
                 <TextBox Text="{Binding HarvestFilePath}" IsReadOnly="True"
@@ -531,7 +551,7 @@
                       IsEnabled="{Binding CanHarvestCandidates}" />
             </Grid>
 
-            <Grid Grid.Row="1" ColumnDefinitions="2*,Auto,Auto,Auto,Auto" ColumnSpacing="10">
+            <Grid Grid.Row="2" ColumnDefinitions="2*,Auto,Auto,Auto,Auto" ColumnSpacing="10">
               <StackPanel Spacing="2">
                 <TextBlock Text="ANCHOR NEEDLES" Classes="label" />
                 <TextBox Text="{Binding HarvestNeedlesText}" Watermark="Optional filters, e.g. 5NN TU W1AW"
@@ -555,7 +575,7 @@
                       IsEnabled="{Binding CanPreviewCandidate}" />
             </Grid>
 
-            <Border Grid.Row="2" BorderBrush="{StaticResource GridLine}" BorderThickness="1" CornerRadius="2" Padding="8"
+            <Border Grid.Row="3" BorderBrush="{StaticResource GridLine}" BorderThickness="1" CornerRadius="2" Padding="8"
                     IsVisible="{Binding IsHarvestBusy}">
               <Grid ColumnDefinitions="Auto,*" ColumnSpacing="10">
                 <TextBlock Text="{Binding HarvestProgressLabel}" Classes="label" VerticalAlignment="Center" />
@@ -564,7 +584,7 @@
               </Grid>
             </Border>
 
-            <Grid Grid.Row="3" ColumnDefinitions="380,*" ColumnSpacing="12">
+            <Grid Grid.Row="4" ColumnDefinitions="380,*" ColumnSpacing="12">
               <Border BorderBrush="{StaticResource GridLine}" BorderThickness="1" CornerRadius="2" Padding="8">
                 <Grid RowDefinitions="Auto,*">
                   <Grid ColumnDefinitions="*,Auto">
@@ -678,7 +698,7 @@
               </ScrollViewer>
             </Grid>
 
-            <TextBlock Grid.Row="4" Text="{Binding AdvancedStatusText}" Classes="label" Foreground="{StaticResource TextDim}" />
+            <TextBlock Grid.Row="5" Text="{Binding AdvancedStatusText}" Classes="label" Foreground="{StaticResource TextDim}" />
           </Grid>
         </Border>
       </TabItem>

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml.cs
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml.cs
@@ -81,6 +81,12 @@ public partial class MainWindow : Window
         await Vm.HarvestCandidatesAsync();
     }
 
+    private async void OnToggleLabelingRecordClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (Vm is null) return;
+        await Vm.ToggleLabelingRecordAsync();
+    }
+
     private async void OnPlayPreviewClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         if (Vm is null) return;

--- a/experiments/cw-decoder/src/decoder.rs
+++ b/experiments/cw-decoder/src/decoder.rs
@@ -24,5 +24,70 @@ pub fn decode_window(
 ) -> Result<DecodeOutcome> {
     let text = decode_text(samples, sample_rate); // ditdah bails on tiny/empty buffers; treat as "no decode"
     let stats = capture.snapshot();
+    let text = focused_long_capture_decode(samples, sample_rate, capture, &text).unwrap_or(text);
     Ok(DecodeOutcome { text, stats })
+}
+
+fn focused_long_capture_decode(
+    samples: &[f32],
+    sample_rate: u32,
+    capture: &DitdahLogCapture,
+    whole_file_text: &str,
+) -> Option<String> {
+    let duration_s = samples.len() as f32 / sample_rate as f32;
+    if duration_s < 18.0 || normalized_len(whole_file_text) < 48 {
+        return None;
+    }
+
+    let win_samples = (4.0 * sample_rate as f32).round() as usize;
+    let hop_samples = (2.0 * sample_rate as f32).round() as usize;
+    if win_samples == 0 || hop_samples == 0 || samples.len() < win_samples {
+        return None;
+    }
+
+    let mut focused = Vec::new();
+    let mut start = 0usize;
+    while start + win_samples <= samples.len() {
+        let text = decode_text(&samples[start..start + win_samples], sample_rate);
+        let stats = capture.snapshot();
+        if plausible_faded_cw_window(&text, stats) {
+            focused.push(text);
+        }
+        start += hop_samples;
+    }
+
+    if focused.is_empty() {
+        return None;
+    }
+
+    let repaired = repair_common_split_morse(&focused.join(" "));
+    let focused_len = normalized_len(&repaired);
+    if focused_len == 0 || focused_len >= normalized_len(whole_file_text) {
+        return None;
+    }
+
+    Some(repaired)
+}
+
+fn plausible_faded_cw_window(text: &str, stats: DitdahStats) -> bool {
+    let len = normalized_len(text);
+    if !(2..=24).contains(&len) {
+        return false;
+    }
+
+    let Some(wpm) = stats.wpm else {
+        return false;
+    };
+    (8.0..=20.0).contains(&wpm)
+}
+
+fn normalized_len(text: &str) -> usize {
+    text.chars().filter(|ch| ch.is_ascii_alphanumeric()).count()
+}
+
+fn repair_common_split_morse(text: &str) -> String {
+    text.split_whitespace()
+        .map(|token| token.replace("GT", "Q"))
+        .collect::<Vec<_>>()
+        .join(" ")
 }

--- a/experiments/cw-decoder/src/ditdah_streaming.rs
+++ b/experiments/cw-decoder/src/ditdah_streaming.rs
@@ -5,7 +5,7 @@ use std::collections::VecDeque;
 use crate::decoder;
 
 pub fn normalize_snapshot_text(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
+    repair_common_split_morse(&text.split_whitespace().collect::<Vec<_>>().join(" "))
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -208,7 +208,10 @@ impl PrefixStabilizer {
 
     pub fn push_snapshot(&mut self, snapshot_text: &str) -> String {
         let normalized = normalize_snapshot_text(snapshot_text);
-        if normalized.is_empty() {
+        if normalized.is_empty()
+            || is_noise_dominated_snapshot(&normalized)
+            || !has_stream_anchor(&normalized, !self.committed.is_empty())
+        {
             return String::new();
         }
 
@@ -233,6 +236,112 @@ impl PrefixStabilizer {
     pub fn transcript(&self) -> &str {
         self.committed.trim()
     }
+}
+
+fn repair_common_split_morse(text: &str) -> String {
+    text.split_whitespace()
+        .map(|token| token.replace("GT", "Q"))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn is_noise_dominated_snapshot(text: &str) -> bool {
+    let mut alnum_count = 0usize;
+    let mut single_element_count = 0usize;
+    let mut unknown_count = 0usize;
+
+    for ch in text.chars() {
+        if ch == '?' {
+            unknown_count += 1;
+            continue;
+        }
+        if ch.is_ascii_alphanumeric() {
+            alnum_count += 1;
+            if morse_element_count(ch) == Some(1) {
+                single_element_count += 1;
+            }
+        }
+    }
+
+    if alnum_count == 0 {
+        return true;
+    }
+
+    if alnum_count > 64 {
+        return true;
+    }
+
+    let single_fraction = single_element_count as f32 / alnum_count as f32;
+    let unknown_fraction = unknown_count as f32 / (alnum_count + unknown_count).max(1) as f32;
+
+    alnum_count > 16 && (single_fraction > 0.45 || unknown_fraction > 0.15)
+}
+
+fn has_stream_anchor(text: &str, stream_is_active: bool) -> bool {
+    let normalized = text.to_ascii_uppercase();
+    let tokens: Vec<&str> = normalized.split_whitespace().collect();
+    if tokens.is_empty() {
+        return false;
+    }
+
+    if tokens.iter().any(|token| {
+        *token == "CQ"
+            || token.contains("CQ")
+            || *token == "DE"
+            || *token == "POTA"
+            || *token == "TEST"
+            || *token == "Q"
+            || *token == "SB"
+            || *token == "QSB"
+            || *token == "QST"
+            || *token == "73"
+    }) {
+        return true;
+    }
+
+    stream_is_active && tokens.iter().any(|token| looks_like_callsign_token(token))
+}
+
+fn looks_like_callsign_token(token: &str) -> bool {
+    let len = token.len();
+    (4..=8).contains(&len)
+        && token.chars().any(|ch| ch.is_ascii_digit())
+        && token.chars().any(|ch| ch.is_ascii_alphabetic())
+        && token.chars().all(|ch| ch.is_ascii_alphanumeric())
+}
+
+fn morse_element_count(ch: char) -> Option<usize> {
+    let n = match ch.to_ascii_uppercase() {
+        'A' => 2,
+        'B' => 4,
+        'C' => 4,
+        'D' => 3,
+        'E' => 1,
+        'F' => 4,
+        'G' => 3,
+        'H' => 4,
+        'I' => 2,
+        'J' => 4,
+        'K' => 3,
+        'L' => 4,
+        'M' => 2,
+        'N' => 2,
+        'O' => 3,
+        'P' => 4,
+        'Q' => 4,
+        'R' => 3,
+        'S' => 3,
+        'T' => 1,
+        'U' => 3,
+        'V' => 4,
+        'W' => 3,
+        'X' => 4,
+        'Y' => 4,
+        'Z' => 4,
+        '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' | '0' => 5,
+        _ => return None,
+    };
+    Some(n)
 }
 
 pub fn append_snapshot_text(transcript: &mut String, snapshot_text: &str) -> String {
@@ -460,6 +569,13 @@ mod tests {
         assert_eq!(stabilizer.transcript(), "QST QST QST");
         assert_eq!(stabilizer.finalize_latest(), " DE");
         assert_eq!(stabilizer.transcript(), "QST QST QST DE");
+    }
+
+    #[test]
+    fn prefix_stabilizer_accepts_73_as_stream_anchor() {
+        let mut stabilizer = PrefixStabilizer::new(1);
+        assert_eq!(stabilizer.push_snapshot("73"), "73");
+        assert_eq!(stabilizer.transcript(), "73");
     }
 
     #[test]

--- a/experiments/cw-decoder/src/ditdah_streaming.rs
+++ b/experiments/cw-decoder/src/ditdah_streaming.rs
@@ -218,11 +218,25 @@ impl PrefixStabilizer {
     }
 
     pub fn push_snapshot(&mut self, snapshot_text: &str) -> String {
-        let normalized = normalize_snapshot_text(snapshot_text);
+        let mut normalized = normalize_snapshot_text(snapshot_text);
         if normalized.is_empty()
             || is_noise_dominated_snapshot(&normalized)
-            || !has_stream_anchor(&normalized, !self.committed.is_empty() || self.manual_anchor)
         {
+            return String::new();
+        }
+
+        let stream_is_active = !self.committed.is_empty() || self.manual_anchor;
+        if !stream_is_active {
+            let Some(anchored) = anchored_snapshot_text(&normalized) else {
+                return String::new();
+            };
+            normalized = anchored;
+        } else if self.manual_anchor && self.committed.is_empty() {
+            let Some(anchored) = manual_anchor_snapshot_text(&normalized) else {
+                return String::new();
+            };
+            normalized = anchored;
+        } else if !has_stream_anchor(&normalized, true) {
             return String::new();
         }
 
@@ -313,12 +327,70 @@ fn has_stream_anchor(text: &str, stream_is_active: bool) -> bool {
     stream_is_active && tokens.iter().any(|token| looks_like_callsign_token(token))
 }
 
+fn anchored_snapshot_text(text: &str) -> Option<String> {
+    let tokens: Vec<&str> = text.split_whitespace().collect();
+    let idx = tokens.iter().position(|token| is_stream_anchor_token(token))?;
+    Some(tokens[idx..].join(" "))
+}
+
+fn manual_anchor_snapshot_text(text: &str) -> Option<String> {
+    let tokens: Vec<&str> = text.split_whitespace().collect();
+    let idx = tokens.iter().position(|token| {
+        is_stream_anchor_token(token) || looks_like_strong_callsign_token(token)
+    })?;
+    Some(tokens[idx..].join(" "))
+}
+
+fn is_stream_anchor_token(token: &str) -> bool {
+    let token = token.to_ascii_uppercase();
+    token == "CQ"
+        || token.contains("CQ")
+        || token == "DE"
+        || token == "POTA"
+        || token == "TEST"
+        || token == "Q"
+        || token == "SB"
+        || token == "QSB"
+        || token == "QST"
+        || token == "73"
+}
+
 fn looks_like_callsign_token(token: &str) -> bool {
+    looks_like_strong_callsign_token(token)
+}
+
+fn looks_like_strong_callsign_token(token: &str) -> bool {
     let len = token.len();
-    (4..=8).contains(&len)
-        && token.chars().any(|ch| ch.is_ascii_digit())
-        && token.chars().any(|ch| ch.is_ascii_alphabetic())
-        && token.chars().all(|ch| ch.is_ascii_alphanumeric())
+    if !(4..=6).contains(&len) || !token.chars().all(|ch| ch.is_ascii_alphanumeric()) {
+        return false;
+    }
+
+    let chars: Vec<char> = token.chars().map(|ch| ch.to_ascii_uppercase()).collect();
+    let digit_positions: Vec<usize> = chars
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, ch)| ch.is_ascii_digit().then_some(idx))
+        .collect();
+    if digit_positions.len() != 1 {
+        return false;
+    }
+
+    let digit_idx = digit_positions[0];
+    if !(1..=2).contains(&digit_idx) {
+        return false;
+    }
+
+    let prefix = &chars[..digit_idx];
+    let suffix = &chars[digit_idx + 1..];
+    if suffix.is_empty()
+        || suffix.len() > 3
+        || !prefix.iter().all(|ch| ch.is_ascii_alphabetic())
+        || !suffix.iter().all(|ch| ch.is_ascii_alphabetic())
+    {
+        return false;
+    }
+
+    prefix.len() == 2 || matches!(prefix[0], 'A' | 'K' | 'N' | 'W')
 }
 
 fn morse_element_count(ch: char) -> Option<usize> {
@@ -598,6 +670,26 @@ mod tests {
 
         assert_eq!(stabilizer.push_snapshot("KK6QZM"), "KK6QZM");
         assert_eq!(stabilizer.transcript(), "KK6QZM");
+    }
+
+    #[test]
+    fn prefix_stabilizer_manual_anchor_rejects_e_t_heavy_gibberish() {
+        let mut stabilizer = PrefixStabilizer::new(1);
+        stabilizer.force_stream_anchor();
+
+        assert_eq!(
+            stabilizer.push_snapshot("T R T S E4CTT TN BTE5A I NT EOTG8U EEDN"),
+            ""
+        );
+        assert_eq!(stabilizer.transcript(), "");
+    }
+
+    #[test]
+    fn prefix_stabilizer_crops_noise_before_automatic_anchor() {
+        let mut stabilizer = PrefixStabilizer::new(1);
+
+        assert_eq!(stabilizer.push_snapshot("T E I CQ CQ DE K5KV"), "CQ CQ DE K5KV");
+        assert_eq!(stabilizer.transcript(), "CQ CQ DE K5KV");
     }
 
     #[test]

--- a/experiments/cw-decoder/src/ditdah_streaming.rs
+++ b/experiments/cw-decoder/src/ditdah_streaming.rs
@@ -219,9 +219,7 @@ impl PrefixStabilizer {
 
     pub fn push_snapshot(&mut self, snapshot_text: &str) -> String {
         let mut normalized = normalize_snapshot_text(snapshot_text);
-        if normalized.is_empty()
-            || is_noise_dominated_snapshot(&normalized)
-        {
+        if normalized.is_empty() || is_noise_dominated_snapshot(&normalized) {
             return String::new();
         }
 
@@ -315,8 +313,6 @@ fn has_stream_anchor(text: &str, stream_is_active: bool) -> bool {
             || *token == "DE"
             || *token == "POTA"
             || *token == "TEST"
-            || *token == "Q"
-            || *token == "SB"
             || *token == "QSB"
             || *token == "QST"
             || *token == "73"
@@ -329,7 +325,9 @@ fn has_stream_anchor(text: &str, stream_is_active: bool) -> bool {
 
 fn anchored_snapshot_text(text: &str) -> Option<String> {
     let tokens: Vec<&str> = text.split_whitespace().collect();
-    let idx = tokens.iter().position(|token| is_stream_anchor_token(token))?;
+    let idx = tokens
+        .iter()
+        .position(|token| is_stream_anchor_token(token))?;
     Some(tokens[idx..].join(" "))
 }
 
@@ -348,8 +346,6 @@ fn is_stream_anchor_token(token: &str) -> bool {
         || token == "DE"
         || token == "POTA"
         || token == "TEST"
-        || token == "Q"
-        || token == "SB"
         || token == "QSB"
         || token == "QST"
         || token == "73"
@@ -662,6 +658,23 @@ mod tests {
     }
 
     #[test]
+    fn prefix_stabilizer_rejects_weak_q_code_fragments_as_anchors() {
+        let mut stabilizer = PrefixStabilizer::new(1);
+
+        assert_eq!(stabilizer.push_snapshot("Q OEIIT OI EEE"), "");
+        assert_eq!(stabilizer.push_snapshot("SB IZ"), "");
+        assert_eq!(stabilizer.transcript(), "");
+    }
+
+    #[test]
+    fn prefix_stabilizer_accepts_complete_q_code_anchors() {
+        let mut stabilizer = PrefixStabilizer::new(1);
+
+        assert_eq!(stabilizer.push_snapshot("QSB"), "QSB");
+        assert_eq!(stabilizer.transcript(), "QSB");
+    }
+
+    #[test]
     fn prefix_stabilizer_manual_anchor_accepts_callsign_like_mid_qso_text() {
         let mut stabilizer = PrefixStabilizer::new(1);
         assert_eq!(stabilizer.push_snapshot("KK6QZM"), "");
@@ -688,7 +701,10 @@ mod tests {
     fn prefix_stabilizer_crops_noise_before_automatic_anchor() {
         let mut stabilizer = PrefixStabilizer::new(1);
 
-        assert_eq!(stabilizer.push_snapshot("T E I CQ CQ DE K5KV"), "CQ CQ DE K5KV");
+        assert_eq!(
+            stabilizer.push_snapshot("T E I CQ CQ DE K5KV"),
+            "CQ CQ DE K5KV"
+        );
         assert_eq!(stabilizer.transcript(), "CQ CQ DE K5KV");
     }
 

--- a/experiments/cw-decoder/src/ditdah_streaming.rs
+++ b/experiments/cw-decoder/src/ditdah_streaming.rs
@@ -177,6 +177,10 @@ impl CausalBaselineStreamer {
         self.buffer.iter().copied().collect()
     }
 
+    pub fn force_stream_anchor(&mut self) {
+        self.stabilizer.force_stream_anchor();
+    }
+
     fn decode_snapshot(&mut self) -> CausalBaselineSnapshot {
         let snapshot: Vec<f32> = self.buffer.iter().copied().collect();
         let text = decoder::decode_text(&snapshot, self.sample_rate);
@@ -194,6 +198,7 @@ pub struct PrefixStabilizer {
     recent_snapshots: VecDeque<String>,
     committed: String,
     latest_snapshot: String,
+    manual_anchor: bool,
 }
 
 impl PrefixStabilizer {
@@ -203,14 +208,20 @@ impl PrefixStabilizer {
             recent_snapshots: VecDeque::new(),
             committed: String::new(),
             latest_snapshot: String::new(),
+            manual_anchor: false,
         }
+    }
+
+    pub fn force_stream_anchor(&mut self) {
+        self.manual_anchor = true;
+        self.recent_snapshots.clear();
     }
 
     pub fn push_snapshot(&mut self, snapshot_text: &str) -> String {
         let normalized = normalize_snapshot_text(snapshot_text);
         if normalized.is_empty()
             || is_noise_dominated_snapshot(&normalized)
-            || !has_stream_anchor(&normalized, !self.committed.is_empty())
+            || !has_stream_anchor(&normalized, !self.committed.is_empty() || self.manual_anchor)
         {
             return String::new();
         }
@@ -576,6 +587,17 @@ mod tests {
         let mut stabilizer = PrefixStabilizer::new(1);
         assert_eq!(stabilizer.push_snapshot("73"), "73");
         assert_eq!(stabilizer.transcript(), "73");
+    }
+
+    #[test]
+    fn prefix_stabilizer_manual_anchor_accepts_callsign_like_mid_qso_text() {
+        let mut stabilizer = PrefixStabilizer::new(1);
+        assert_eq!(stabilizer.push_snapshot("KK6QZM"), "");
+
+        stabilizer.force_stream_anchor();
+
+        assert_eq!(stabilizer.push_snapshot("KK6QZM"), "KK6QZM");
+        assert_eq!(stabilizer.transcript(), "KK6QZM");
     }
 
     #[test]

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -145,6 +145,25 @@ enum Cmd {
         /// threshold under dense in-band noise (#320).
         #[arg(long, default_value_t = 0.0)]
         hysteresis_fraction: f32,
+        /// Pre-amplify input samples by this many dB before feeding the
+        /// decoder. Useful for real-radio audio that comes in well below
+        /// 0 dBFS (e.g. USB Audio Codec at default Windows mic level).
+        /// 0 = no gain. 20 dB = 10x amplitude.
+        #[arg(long, default_value_t = 0.0)]
+        input_gain_db: f32,
+        /// Automatically normalise input samples to a target peak of
+        /// `--auto-gain-target` (default 0.5). Overrides `--input-gain-db`
+        /// when set. Computes the gain from the peak of the current input
+        /// (whole-file for file mode, sliding window for live), so weak
+        /// real-radio signals get amplified up to where the decoder's
+        /// thresholds were tuned.
+        #[arg(long)]
+        auto_input_gain: bool,
+        /// Target peak amplitude (0..1) for `--auto-input-gain`. Default
+        /// 0.5 leaves headroom while pushing weak signals into the
+        /// decoder's calibrated range.
+        #[arg(long, default_value_t = 0.5)]
+        auto_gain_target: f32,
         /// Read NDJSON config-update lines from stdin while streaming.
         /// Each line: {"type":"config","min_snr_db":...,"pitch_min_snr_db":...,"threshold_scale":...}
         #[arg(long)]
@@ -178,6 +197,17 @@ enum Cmd {
         /// Emit newline-delimited JSON events for the GUI bridge.
         #[arg(long)]
         json: bool,
+        /// Pre-amplify input samples by this many dB before feeding the
+        /// decoder. See `stream-file --input-gain-db`.
+        #[arg(long, default_value_t = 0.0)]
+        input_gain_db: f32,
+        /// Auto-normalise input samples to a target RMS level (with soft
+        /// clip). See `stream-file --auto-input-gain`.
+        #[arg(long)]
+        auto_input_gain: bool,
+        /// Target RMS amplitude (0..1) for `--auto-input-gain`.
+        #[arg(long, default_value_t = 0.3)]
+        auto_gain_target: f32,
     },
 
     /// Stream live audio through the causal ditdah baseline.
@@ -523,6 +553,43 @@ enum Cmd {
         #[arg(long, default_value_t = false)]
         json: bool,
     },
+
+    /// Generate a synthetic CW WAV with rough-fist jitter (variable
+    /// element/gap durations) and a `.truth.txt` sidecar containing the
+    /// reference text. Stress-tests adaptive dit/dah classifiers.
+    GenRoughFist {
+        /// Output WAV path. A `<basename>.truth.txt` sidecar is also written.
+        #[arg(long)]
+        output: PathBuf,
+        /// Reference text to encode (uppercased; non-Morse chars are skipped).
+        #[arg(long)]
+        text: String,
+        /// Nominal speed in WPM.
+        #[arg(long, default_value_t = 20.0)]
+        wpm: f32,
+        /// Carrier pitch in Hz.
+        #[arg(long, default_value_t = 700.0)]
+        pitch_hz: f32,
+        /// Sample rate in Hz.
+        #[arg(long, default_value_t = 12000)]
+        sample_rate: u32,
+        /// Per-element timing jitter as a fraction (e.g., 0.20 = ±20%).
+        /// Applied multiplicatively to dit, dah, and gap durations.
+        #[arg(long, default_value_t = 0.20)]
+        jitter: f32,
+        /// Dah/dit ratio (textbook is 3.0; sloppy fists often run 2.3..2.7).
+        #[arg(long, default_value_t = 3.0)]
+        dah_ratio: f32,
+        /// Multiplicative bias on dit length (e.g., 1.1 = "heavy dits").
+        #[arg(long, default_value_t = 1.0)]
+        dit_weight: f32,
+        /// Additive white-noise amplitude (0..1). 0 = clean.
+        #[arg(long, default_value_t = 0.0)]
+        noise: f32,
+        /// Random seed (for reproducible jitter).
+        #[arg(long, default_value_t = 1)]
+        seed: u64,
+    },
 }
 
 fn main() -> Result<()> {
@@ -601,6 +668,9 @@ fn main() -> Result<()> {
             min_pulse_dot_fraction,
             min_gap_dot_fraction,
             hysteresis_fraction,
+            input_gain_db,
+            auto_input_gain,
+            auto_gain_target,
             stdin_control,
         } => {
             let cfg = streaming::DecoderConfig {
@@ -620,7 +690,18 @@ fn main() -> Result<()> {
 
                 cfar_keying: false,
             };
-            run_stream_file(&path, chunk_ms, realtime, quiet, json, cfg, stdin_control)
+            run_stream_file(
+                &path,
+                chunk_ms,
+                realtime,
+                quiet,
+                json,
+                cfg,
+                stdin_control,
+                input_gain_db,
+                auto_input_gain,
+                auto_gain_target,
+            )
         }
         Cmd::StreamFileDitdah {
             path,
@@ -632,6 +713,9 @@ fn main() -> Result<()> {
             realtime,
             quiet,
             json,
+            input_gain_db,
+            auto_input_gain,
+            auto_gain_target,
         } => run_stream_file_ditdah(
             &path,
             chunk_ms,
@@ -642,6 +726,9 @@ fn main() -> Result<()> {
             realtime,
             quiet,
             json,
+            input_gain_db,
+            auto_input_gain,
+            auto_gain_target,
             &log_capture,
         ),
         Cmd::StreamLiveDitdah {
@@ -850,6 +937,29 @@ fn main() -> Result<()> {
             min_pulse_dot_fraction,
             cfar_keying,
             json,
+        ),
+        Cmd::GenRoughFist {
+            output,
+            text,
+            wpm,
+            pitch_hz,
+            sample_rate,
+            jitter,
+            dah_ratio,
+            dit_weight,
+            noise,
+            seed,
+        } => run_gen_rough_fist(
+            &output,
+            &text,
+            wpm,
+            pitch_hz,
+            sample_rate,
+            jitter,
+            dah_ratio,
+            dit_weight,
+            noise,
+            seed,
         ),
     }
 }
@@ -1724,6 +1834,52 @@ fn emit_decoder_events(
     }
 }
 
+/// Pre-amplify input samples in-place. Real-radio captures (USB Audio
+/// Codec mic input) routinely come in 20-30 dB below the synthetic test
+/// corpus the decoder was tuned against, so the keying threshold and
+/// SNR gate spend the whole clip on noise. Boosting brings the input
+/// back into the calibrated range. Returns the dB applied (None if
+/// no-op).
+fn apply_input_gain(
+    samples: &mut [f32],
+    input_gain_db: f32,
+    auto_input_gain: bool,
+    auto_gain_target: f32,
+) -> Option<f32> {
+    if auto_input_gain {
+        // Drive a high-percentile sample to the target ceiling, then
+        // tanh-clip. RMS-targeted gain under-amplified weak signals
+        // because the noise floor swallows the budget; peak-targeted
+        // saturation matches what manual +25..+45 dB pre-amp does for
+        // real-radio captures (and that hits ~70% LCS on labelled
+        // clips that pure RMS scaling caps at ~20%).
+        let mut abs: Vec<f32> = samples.iter().map(|s| s.abs()).collect();
+        if abs.is_empty() {
+            return None;
+        }
+        // 99th percentile via partial sort.
+        let idx = ((abs.len() as f32) * 0.99) as usize;
+        let idx = idx.min(abs.len() - 1);
+        abs.select_nth_unstable_by(idx, |a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let p99 = abs[idx].max(1e-6);
+        // Allow target up to 4.0 so the tanh deliberately saturates.
+        let target = auto_gain_target.max(0.05).min(4.0);
+        let scale = target / p99;
+        for s in samples.iter_mut() {
+            *s = (*s * scale).tanh();
+        }
+        Some(20.0 * scale.log10())
+    } else if input_gain_db.abs() > f32::EPSILON {
+        let scale = 10.0_f32.powf(input_gain_db / 20.0);
+        for s in samples.iter_mut() {
+            *s = (*s * scale).tanh();
+        }
+        Some(input_gain_db)
+    } else {
+        None
+    }
+}
+
 fn run_stream_file(
     path: &std::path::Path,
     chunk_ms: u32,
@@ -1732,9 +1888,18 @@ fn run_stream_file(
     json: bool,
     cfg: streaming::DecoderConfig,
     stdin_control: bool,
+    input_gain_db: f32,
+    auto_input_gain: bool,
+    auto_gain_target: f32,
 ) -> Result<()> {
     use std::time::Instant;
-    let audio = audio::decode_file(path).context("decoding audio file")?;
+    let mut audio = audio::decode_file(path).context("decoding audio file")?;
+    let applied_gain_db = apply_input_gain(
+        &mut audio.samples,
+        input_gain_db,
+        auto_input_gain,
+        auto_gain_target,
+    );
     let dur = audio.samples.len() as f32 / audio.sample_rate as f32;
     let mut emitter = if json {
         Some(json::JsonEmitter::new())
@@ -1755,6 +1920,7 @@ fn run_stream_file(
                     "pitch_min_snr_db": cfg.pitch_min_snr_db,
                     "threshold_scale": cfg.threshold_scale,
                     "auto_threshold": cfg.auto_threshold,
+                    "input_gain_db": applied_gain_db,
                 }),
             }),
         );
@@ -1766,6 +1932,9 @@ fn run_stream_file(
             dur,
             audio.samples.len()
         );
+        if let Some(g) = applied_gain_db {
+            println!("Input gain applied: {:+.1} dB", g);
+        }
     }
 
     let mut decoder = streaming::StreamingDecoder::new(audio.sample_rate)?;
@@ -1967,11 +2136,20 @@ fn run_stream_file_ditdah(
     realtime: bool,
     quiet: bool,
     json: bool,
+    input_gain_db: f32,
+    auto_input_gain: bool,
+    auto_gain_target: f32,
     log_capture: &log_capture::DitdahLogCapture,
 ) -> Result<()> {
     use std::time::Instant;
 
-    let audio = audio::decode_file(path).context("decoding audio file")?;
+    let mut audio = audio::decode_file(path).context("decoding audio file")?;
+    let _applied_gain_db = apply_input_gain(
+        &mut audio.samples,
+        input_gain_db,
+        auto_input_gain,
+        auto_gain_target,
+    );
     let dur = audio.samples.len() as f32 / audio.sample_rate as f32;
     let chunk_samples = (((audio.sample_rate as u64) * chunk_ms as u64) / 1000) as usize;
     let chunk_samples = chunk_samples.max(64);
@@ -2832,4 +3010,166 @@ fn spawn_stdin_config_channel(
         }
     });
     rx
+}
+
+fn morse_for_char(c: char) -> Option<&'static str> {
+    Some(match c.to_ascii_uppercase() {
+        'A' => ".-", 'B' => "-...", 'C' => "-.-.", 'D' => "-..", 'E' => ".",
+        'F' => "..-.", 'G' => "--.", 'H' => "....", 'I' => "..", 'J' => ".---",
+        'K' => "-.-", 'L' => ".-..", 'M' => "--", 'N' => "-.", 'O' => "---",
+        'P' => ".--.", 'Q' => "--.-", 'R' => ".-.", 'S' => "...", 'T' => "-",
+        'U' => "..-", 'V' => "...-", 'W' => ".--", 'X' => "-..-", 'Y' => "-.--",
+        'Z' => "--..",
+        '0' => "-----", '1' => ".----", '2' => "..---", '3' => "...--",
+        '4' => "....-", '5' => ".....", '6' => "-....", '7' => "--...",
+        '8' => "---..", '9' => "----.",
+        '.' => ".-.-.-", ',' => "--..--", '?' => "..--..", '/' => "-..-.",
+        '=' => "-...-", '+' => ".-.-.", '-' => "-....-",
+        _ => return None,
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_gen_rough_fist(
+    output: &std::path::Path,
+    text: &str,
+    wpm: f32,
+    pitch_hz: f32,
+    sample_rate: u32,
+    jitter: f32,
+    dah_ratio: f32,
+    dit_weight: f32,
+    noise: f32,
+    seed: u64,
+) -> Result<()> {
+    use std::f32::consts::TAU;
+    // Cheap deterministic LCG so we don't add a `rand` dep.
+    let mut rng_state = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+    let mut rand_unit = || -> f32 {
+        rng_state = rng_state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let r = ((rng_state >> 33) as u32) as f32 / u32::MAX as f32;
+        // Map [0,1) -> [-1,1)
+        2.0 * r - 1.0
+    };
+    let jitter_mul = |base: f32, rng: &mut dyn FnMut() -> f32| -> f32 {
+        let factor = (1.0 + jitter * rng()).max(0.1);
+        base * factor
+    };
+
+    let dot_secs = 1.2 / wpm;
+    let ramp_n = ((sample_rate as f32) * 0.005) as usize;
+    let mut samples: Vec<f32> = Vec::new();
+    let mut t: usize = 0;
+
+    // Leading silence so the decoder has time to lock pitch.
+    let lead_n = (sample_rate as f32 * 0.5) as usize;
+    samples.resize(lead_n, 0.0);
+
+    let mut canonical_text = String::new();
+
+    let words: Vec<&str> = text.split_whitespace().collect();
+    for (wi, w) in words.iter().enumerate() {
+        let mut word_chars = String::new();
+        let mut word_emitted = false;
+        for c in w.chars() {
+            let code = match morse_for_char(c) {
+                Some(s) => s,
+                None => continue,
+            };
+            if word_emitted {
+                // Inter-character gap: 3 dot units (jittered).
+                let gap_secs = jitter_mul(dot_secs * 3.0, &mut rand_unit);
+                let n = (gap_secs * sample_rate as f32) as usize;
+                samples.resize(samples.len() + n, 0.0);
+            }
+            word_emitted = true;
+            word_chars.push(c.to_ascii_uppercase());
+
+            let mut first_elem = true;
+            for el in code.chars() {
+                if !first_elem {
+                    let gap_secs = jitter_mul(dot_secs, &mut rand_unit);
+                    let n = (gap_secs * sample_rate as f32) as usize;
+                    samples.resize(samples.len() + n, 0.0);
+                }
+                first_elem = false;
+                let base = if el == '.' { dot_secs * dit_weight } else { dot_secs * dah_ratio };
+                let on_secs = jitter_mul(base, &mut rand_unit);
+                let n = (on_secs * sample_rate as f32) as usize;
+                for k in 0..n {
+                    let env = {
+                        let rise = if k < ramp_n {
+                            0.5 * (1.0 - ((std::f32::consts::PI * k as f32) / ramp_n as f32).cos())
+                        } else { 1.0 };
+                        let fall = if k + ramp_n > n {
+                            let kk = (n - k) as f32;
+                            0.5 * (1.0 - ((std::f32::consts::PI * kk) / ramp_n as f32).cos())
+                        } else { 1.0 };
+                        rise.min(fall)
+                    };
+                    let s = (TAU * pitch_hz * (t as f32) / sample_rate as f32).sin() * 0.6 * env;
+                    samples.push(s);
+                    t += 1;
+                }
+            }
+        }
+        if !word_chars.is_empty() {
+            if wi > 0 { canonical_text.push(' '); }
+            canonical_text.push_str(&word_chars);
+        }
+        if wi + 1 < words.len() && word_emitted {
+            // Inter-word gap: 7 dot units (jittered).
+            let gap_secs = jitter_mul(dot_secs * 7.0, &mut rand_unit);
+            let n = (gap_secs * sample_rate as f32) as usize;
+            samples.resize(samples.len() + n, 0.0);
+        }
+    }
+
+    // Trailing silence.
+    let tail_n = (sample_rate as f32 * 0.5) as usize;
+    samples.resize(samples.len() + tail_n, 0.0);
+
+    if noise > 0.0 {
+        for s in samples.iter_mut() {
+            *s = (*s + noise * rand_unit()).clamp(-1.0, 1.0);
+        }
+    }
+
+    if let Some(parent) = output.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(output, spec)
+        .with_context(|| format!("creating WAV {}", output.display()))?;
+    for s in &samples {
+        let v = (s * i16::MAX as f32) as i16;
+        writer.write_sample(v).context("writing sample")?;
+    }
+    writer.finalize().context("finalising WAV")?;
+
+    let truth_path = output.with_extension("truth.txt");
+    std::fs::write(&truth_path, canonical_text.as_bytes())
+        .with_context(|| format!("writing truth {}", truth_path.display()))?;
+
+    let dur_s = samples.len() as f32 / sample_rate as f32;
+    println!(
+        "Wrote {} ({:.2}s, {} WPM, jitter±{:.0}%, dah/dit={:.2}, dit_weight={:.2}, noise={:.2})",
+        output.display(),
+        dur_s,
+        wpm,
+        jitter * 100.0,
+        dah_ratio,
+        dit_weight,
+        noise,
+    );
+    println!("Truth: {}", truth_path.display());
+    println!("Text:  {}", canonical_text);
+    Ok(())
 }

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -236,6 +236,10 @@ enum Cmd {
         /// device's native sample rate). Useful for post-stop offline analysis.
         #[arg(long)]
         record: Option<PathBuf>,
+        /// Capture from a system output device using WASAPI loopback instead
+        /// of from an input device.
+        #[arg(long)]
+        loopback: bool,
         /// Emit newline-delimited JSON events for the GUI bridge.
         #[arg(long)]
         json: bool,
@@ -740,6 +744,7 @@ fn main() -> Result<()> {
             decode_every_ms,
             confirmations,
             record,
+            loopback,
             json,
         } => run_stream_live_ditdah(
             device.as_deref(),
@@ -750,6 +755,7 @@ fn main() -> Result<()> {
             decode_every_ms,
             confirmations,
             record.as_deref(),
+            loopback,
             json,
             &log_capture,
         ),
@@ -1860,7 +1866,9 @@ fn apply_input_gain(
         // 99th percentile via partial sort.
         let idx = ((abs.len() as f32) * 0.99) as usize;
         let idx = idx.min(abs.len() - 1);
-        abs.select_nth_unstable_by(idx, |a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        abs.select_nth_unstable_by(idx, |a, b| {
+            a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+        });
         let p99 = abs[idx].max(1e-6);
         // Allow target up to 4.0 so the tanh deliberately saturates.
         let target = auto_gain_target.max(0.05).min(4.0);
@@ -2311,6 +2319,7 @@ fn run_stream_live_ditdah(
     decode_every_ms: u32,
     required_confirmations: usize,
     record_path: Option<&std::path::Path>,
+    loopback: bool,
     json: bool,
     log_capture: &log_capture::DitdahLogCapture,
 ) -> Result<()> {
@@ -2318,7 +2327,11 @@ fn run_stream_live_ditdah(
     use std::sync::Arc;
     use std::time::{Duration, Instant};
 
-    let capture = audio::open_input_with_recording(device, 1.0, record_path)?;
+    let capture = if loopback {
+        audio::open_loopback_with_recording(device, 1.0, record_path)?
+    } else {
+        audio::open_input_with_recording(device, 1.0, record_path)?
+    };
     let baseline_cfg = ditdah_streaming::CausalBaselineConfig {
         window_seconds,
         min_window_seconds: min_window_seconds.clamp(0.1, window_seconds.max(0.5)),
@@ -2361,10 +2374,11 @@ fn run_stream_live_ditdah(
             stop.store(true, Ordering::Relaxed);
         });
     }
-    // Watch stdin for EOF or any byte — the GUI signals a graceful
-    // shutdown by writing "stop\n" and then closing our stdin. Either a
-    // successful read or EOF triggers the shutdown path so Drop runs on
-    // LiveCapture and the WAV writer flushes the data chunk + RIFF header.
+    // Watch stdin for EOF or a stop line. The GUI also sends control
+    // messages such as reset_lock; those must not terminate the rolling
+    // ditdah backend (it has no persistent pitch lock to reset anyway).
+    // EOF still triggers shutdown so Drop runs on LiveCapture and the WAV
+    // writer flushes the data chunk + RIFF header.
     // Without this, Kill leaves a header-only WAV that Replay can't read.
     //
     // NOTE: on Windows, std::io::stdin() with an anonymous pipe can fail
@@ -2373,10 +2387,15 @@ fn run_stream_live_ditdah(
     {
         let stop = Arc::clone(&stop);
         std::thread::spawn(move || {
-            use std::io::Read;
-            let mut buf = [0u8; 256];
-            let mut stdin = std::io::stdin();
-            let _ = stdin.read(&mut buf);
+            use std::io::BufRead;
+            let stdin = std::io::stdin();
+            for line in stdin.lock().lines() {
+                match line {
+                    Ok(line) if line.trim().eq_ignore_ascii_case("stop") => break,
+                    Ok(_) => continue,
+                    Err(_) => break,
+                }
+            }
             stop.store(true, Ordering::Relaxed);
         });
     }
@@ -3014,17 +3033,49 @@ fn spawn_stdin_config_channel(
 
 fn morse_for_char(c: char) -> Option<&'static str> {
     Some(match c.to_ascii_uppercase() {
-        'A' => ".-", 'B' => "-...", 'C' => "-.-.", 'D' => "-..", 'E' => ".",
-        'F' => "..-.", 'G' => "--.", 'H' => "....", 'I' => "..", 'J' => ".---",
-        'K' => "-.-", 'L' => ".-..", 'M' => "--", 'N' => "-.", 'O' => "---",
-        'P' => ".--.", 'Q' => "--.-", 'R' => ".-.", 'S' => "...", 'T' => "-",
-        'U' => "..-", 'V' => "...-", 'W' => ".--", 'X' => "-..-", 'Y' => "-.--",
+        'A' => ".-",
+        'B' => "-...",
+        'C' => "-.-.",
+        'D' => "-..",
+        'E' => ".",
+        'F' => "..-.",
+        'G' => "--.",
+        'H' => "....",
+        'I' => "..",
+        'J' => ".---",
+        'K' => "-.-",
+        'L' => ".-..",
+        'M' => "--",
+        'N' => "-.",
+        'O' => "---",
+        'P' => ".--.",
+        'Q' => "--.-",
+        'R' => ".-.",
+        'S' => "...",
+        'T' => "-",
+        'U' => "..-",
+        'V' => "...-",
+        'W' => ".--",
+        'X' => "-..-",
+        'Y' => "-.--",
         'Z' => "--..",
-        '0' => "-----", '1' => ".----", '2' => "..---", '3' => "...--",
-        '4' => "....-", '5' => ".....", '6' => "-....", '7' => "--...",
-        '8' => "---..", '9' => "----.",
-        '.' => ".-.-.-", ',' => "--..--", '?' => "..--..", '/' => "-..-.",
-        '=' => "-...-", '+' => ".-.-.", '-' => "-....-",
+        '0' => "-----",
+        '1' => ".----",
+        '2' => "..---",
+        '3' => "...--",
+        '4' => "....-",
+        '5' => ".....",
+        '6' => "-....",
+        '7' => "--...",
+        '8' => "---..",
+        '9' => "----.",
+        '.' => ".-.-.-",
+        ',' => "--..--",
+        '?' => "..--..",
+        '/' => "-..-.",
+        '=' => "-...-",
+        '+' => ".-.-.",
+        '-' => "-....-",
         _ => return None,
     })
 }
@@ -3044,7 +3095,9 @@ fn run_gen_rough_fist(
 ) -> Result<()> {
     use std::f32::consts::TAU;
     // Cheap deterministic LCG so we don't add a `rand` dep.
-    let mut rng_state = seed.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+    let mut rng_state = seed
+        .wrapping_mul(6364136223846793005)
+        .wrapping_add(1442695040888963407);
     let mut rand_unit = || -> f32 {
         rng_state = rng_state
             .wrapping_mul(6364136223846793005)
@@ -3095,18 +3148,26 @@ fn run_gen_rough_fist(
                     samples.resize(samples.len() + n, 0.0);
                 }
                 first_elem = false;
-                let base = if el == '.' { dot_secs * dit_weight } else { dot_secs * dah_ratio };
+                let base = if el == '.' {
+                    dot_secs * dit_weight
+                } else {
+                    dot_secs * dah_ratio
+                };
                 let on_secs = jitter_mul(base, &mut rand_unit);
                 let n = (on_secs * sample_rate as f32) as usize;
                 for k in 0..n {
                     let env = {
                         let rise = if k < ramp_n {
                             0.5 * (1.0 - ((std::f32::consts::PI * k as f32) / ramp_n as f32).cos())
-                        } else { 1.0 };
+                        } else {
+                            1.0
+                        };
                         let fall = if k + ramp_n > n {
                             let kk = (n - k) as f32;
                             0.5 * (1.0 - ((std::f32::consts::PI * kk) / ramp_n as f32).cos())
-                        } else { 1.0 };
+                        } else {
+                            1.0
+                        };
                         rise.min(fall)
                     };
                     let s = (TAU * pitch_hz * (t as f32) / sample_rate as f32).sin() * 0.6 * env;
@@ -3116,7 +3177,9 @@ fn run_gen_rough_fist(
             }
         }
         if !word_chars.is_empty() {
-            if wi > 0 { canonical_text.push(' '); }
+            if wi > 0 {
+                canonical_text.push(' ');
+            }
             canonical_text.push_str(&word_chars);
         }
         if wi + 1 < words.len() && word_emitted {

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -2368,6 +2368,7 @@ fn run_stream_live_ditdah(
     }
 
     let stop = Arc::new(AtomicBool::new(false));
+    let manual_anchor = Arc::new(AtomicBool::new(false));
     {
         let stop = Arc::clone(&stop);
         ctrlc_setup(move || {
@@ -2386,12 +2387,16 @@ fn run_stream_live_ditdah(
     // is the robust signal. We accept either path.
     {
         let stop = Arc::clone(&stop);
+        let manual_anchor = Arc::clone(&manual_anchor);
         std::thread::spawn(move || {
             use std::io::BufRead;
             let stdin = std::io::stdin();
             for line in stdin.lock().lines() {
                 match line {
                     Ok(line) if line.trim().eq_ignore_ascii_case("stop") => break,
+                    Ok(line) if is_manual_anchor_command(line.trim()) => {
+                        manual_anchor.store(true, Ordering::Relaxed);
+                    }
                     Ok(_) => continue,
                     Err(_) => break,
                 }
@@ -2431,6 +2436,19 @@ fn run_stream_live_ditdah(
         }
         if seconds > 0.0 && started.elapsed().as_secs_f32() >= seconds {
             break;
+        }
+
+        if manual_anchor.swap(false, Ordering::Relaxed) {
+            streamer.force_stream_anchor();
+            if let Some(em) = emitter.as_mut() {
+                em.emit(
+                    started.elapsed().as_secs_f32(),
+                    serde_json::json!({
+                        "type": "status",
+                        "message": "Manual anchor armed",
+                    }),
+                );
+            }
         }
 
         let chunk = {
@@ -2567,6 +2585,21 @@ fn run_stream_live_ditdah(
     println!("Final transcript:");
     println!("{}", transcript.trim());
     Ok(())
+}
+
+fn is_manual_anchor_command(line: &str) -> bool {
+    if line.eq_ignore_ascii_case("anchor") || line.eq_ignore_ascii_case("manual_anchor") {
+        return true;
+    }
+
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+        return false;
+    };
+
+    matches!(
+        v.get("type").and_then(|t| t.as_str()),
+        Some("manual_anchor") | Some("anchor")
+    )
 }
 
 fn handle_baseline_snapshot(

--- a/experiments/cw-decoder/src/streaming.rs
+++ b/experiments/cw-decoder/src/streaming.rs
@@ -148,6 +148,12 @@ const QUALITY_SILENCE_RMS: f32 = 0.01;
 const RELOCK_SECONDS: f32 = 3.0;
 const POWER_HISTORY_SECONDS: f32 = 4.0;
 const DIT_HISTORY: usize = 32;
+/// Static fallback boundary: an ON run longer than this many learned
+/// dot-lengths is classified as a dah. Used only when we have a
+/// `dot_len` estimate but no `dah_len` (early bootstrap). Once the
+/// k-means clusterer locks both centers we switch to the
+/// learned midpoint `(dot_len + dah_len) / 2.0`, which adapts to
+/// sloppy keying where dahs are not the textbook 3:1 ratio.
 const DIT_DAH_BOUNDARY: f32 = 2.0;
 const LETTER_SPACE_BOUNDARY: f32 = 2.0;
 const WORD_SPACE_BOUNDARY: f32 = 5.0;
@@ -1631,7 +1637,22 @@ impl Decoder {
         // Feed the rhythm gate first so it always sees every interval.
         self.rhythm.push(ivl, dot);
         if ivl.is_on {
-            if len_norm < DIT_DAH_BOUNDARY {
+            // Adaptive dit/dah boundary: once the k-means clusterer has
+            // locked BOTH cluster centers, classify against the midpoint
+            // of the learned `(dot_len, dah_len)` pair. Hand-sent CW
+            // commonly has dah/dit ratios down to ~2.3:1 (not the
+            // textbook 3:1), and the static `2.0 * dot_len` boundary
+            // mis-reads those dahs as dits. The learned midpoint also
+            // shifts with the operator's QRQ/QRS drift over time.
+            //
+            // While the dah cluster is unlocked (early bootstrap) we
+            // fall back to the static `DIT_DAH_BOUNDARY` so we don't
+            // need a full pair of clusters before emitting anything.
+            let boundary = match self.dah_len {
+                Some(dah) if dah > dot * 1.5 => 0.5 * (1.0 + dah / dot),
+                _ => DIT_DAH_BOUNDARY,
+            };
+            if len_norm < boundary {
                 self.current_letter.push('.');
             } else {
                 self.current_letter.push('-');

--- a/experiments/cw-decoder/vendor/ditdah/Cargo.toml
+++ b/experiments/cw-decoder/vendor/ditdah/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "ditdah"
+version = "0.2.0"
+edition = "2024"
+license = "MIT"
+description = "High-performance Morse code decoder with 100% test suite accuracy"
+repository = "https://github.com/yuvadm/ditdah"
+keywords = ["morse", "audio", "signal-processing", "decoder"]
+categories = ["multimedia::audio", "science"]
+
+[lib]
+name = "ditdah"
+path = "src/lib.rs"
+
+[[bin]]
+name = "ditdah"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1.0.98"
+clap = { version = "4.5.40", features = ["derive"] }
+env_logger = "0.11.8"
+hound = "3.5.1"
+log = "0.4.27"
+rubato = "0.16.2"
+rustfft = "6.4.0"

--- a/experiments/cw-decoder/vendor/ditdah/LICENSE
+++ b/experiments/cw-decoder/vendor/ditdah/LICENSE
@@ -1,0 +1,26 @@
+MIT License
+
+Copyright (c) 2025 ditdah contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+This project includes concepts and approaches inspired by ggmorse
+(https://github.com/ggerganov/ggmorse) which is also licensed under the MIT License.

--- a/experiments/cw-decoder/vendor/ditdah/README.md
+++ b/experiments/cw-decoder/vendor/ditdah/README.md
@@ -1,0 +1,177 @@
+# ditdah - Morse Code Decoder
+
+[![CI](https://github.com/yuvadm/ditdah/workflows/CI/badge.svg)](https://github.com/yuvadm/ditdah/actions)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+A high-performance Rust implementation of a Morse code decoder that can process WAV audio files and decode them into text with **100% accuracy** on the comprehensive test suite.
+
+## Features
+
+- **High Accuracy**: Achieves 100% pass rate on comprehensive test suite
+- **Clean Library API**: High-level functions for easy integration (`decode_wav_file`, `decode_samples`)
+- **Full-Featured CLI**: Decode files, generate test audio, verbose output, timing information
+- **Audio Processing**: Supports WAV files with various sample rates (12kHz, 44.1kHz) and formats
+- **Signal Processing**: Uses FFT-based pitch detection, Goertzel filtering, and adaptive threshold detection
+- **Self-Calibrating**: Automatically determines timing, WPM, and optimal thresholds
+- **Robust Decoding**: Handles uniform dot/dash sequences and complex multi-letter words
+- **Comprehensive Testing**: Built-in test suite with Morse code generator for validation
+
+## Performance
+
+✅ **All tests passing with 100% accuracy:**
+- Basic signals (SOS, HELLO WORLD)
+- Full alphabet (A-Z)
+- Numbers (0-9)
+- Different frequencies (300Hz - 1000Hz)
+- Variable speeds (10-30 WPM)
+- Different sample rates (12kHz, 44.1kHz)
+- Complex content (CQ DE W1AW)
+
+## Installation
+
+```bash
+git clone https://github.com/yuvadm/ditdah
+cd ditdah
+cargo build --release
+```
+
+## Usage
+
+### Command Line Interface
+
+**Decode a WAV file:**
+```bash
+cargo run -- input.wav
+```
+
+**With verbose output and timing:**
+```bash
+cargo run -- input.wav --verbose --time
+```
+
+**Generate test Morse code WAV files:**
+```bash
+cargo run -- --generate "SOS" --verbose
+cargo run -- --generate "HELLO WORLD" --output test.wav --frequency 800 --wpm 25
+```
+
+**With debug logging:**
+```bash
+RUST_LOG=info cargo run -- input.wav
+```
+
+### Library Usage
+
+**High-level API (recommended):**
+```rust
+use ditdah::{decode_wav_file, decode_samples, MorseGenerator};
+
+// Decode a WAV file directly
+let decoded_text = decode_wav_file("morse.wav")?;
+println!("Decoded: {}", decoded_text);
+
+// Decode audio samples directly
+let samples: Vec<f32> = /* your audio data */;
+let decoded_text = decode_samples(&samples, 12000)?;
+println!("Decoded: {}", decoded_text);
+
+// Generate Morse code WAV files
+let generator = MorseGenerator::new(12000, 600.0, 20.0);
+generator.generate_wav_file("SOS", "output.wav")?;
+```
+
+## Testing
+
+### Run All Tests
+
+```bash
+cargo test
+```
+
+### Baseline Tests (Quick Verification)
+
+```bash
+# Basic test
+cargo test baseline_decoder_test -- --nocapture
+
+# With debug output
+RUST_LOG=info cargo test baseline_decoder_test -- --nocapture
+```
+
+### Comprehensive Test Suite
+
+```bash
+cargo test run_comprehensive_test_suite -- --nocapture
+```
+
+The test suite automatically:
+- Generates test WAV files with known Morse content
+- Decodes them using the library
+- Measures accuracy and reports results
+- Cleans up temporary files automatically
+
+## Algorithm
+
+The decoder uses a sophisticated multi-stage approach:
+
+1. **Audio Preprocessing**: Resampling, bandpass filtering (200Hz-1200Hz)
+2. **Pitch Detection**: STFT-based frequency analysis
+3. **Signal Extraction**: Goertzel filtering tuned to detected frequency
+4. **Self-Calibration**: Intelligent timing analysis for dots vs dashes
+5. **Letter Boundary Detection**: Proper gap analysis for multi-letter words
+6. **Character Assembly**: Morse pattern to text conversion
+
+### Key Innovations
+
+- **Self-calibrating timing**: Handles both uniform sequences (EEEE, TTTT) and mixed patterns
+- **Adaptive gap detection**: Distinguishes element gaps, letter gaps, and word gaps
+- **Robust parameter estimation**: Works across different speeds and frequencies
+
+## Library API
+
+The library provides a clean, high-level API:
+
+```rust
+pub fn decode_wav_file<P: AsRef<std::path::Path>>(path: P) -> Result<String>
+pub fn decode_samples(samples: &[f32], sample_rate: u32) -> Result<String>
+pub use generator::MorseGenerator;
+```
+
+**All signal processing complexity is handled internally** - the library automatically:
+- Detects audio format and converts to the required sample rate
+- Performs frequency analysis and filtering
+- Calibrates timing parameters
+- Decodes Morse patterns to text
+
+## Project Structure
+
+```
+ditdah/
+├── src/
+│   ├── main.rs          # CLI application
+│   ├── lib.rs           # Public library API
+│   ├── decoder.rs       # Internal Morse decoder implementation
+│   └── generator.rs     # Public Morse code generator
+├── tests/
+│   └── integration_tests.rs  # Comprehensive test suite
+├── .github/workflows/   # CI pipeline
+├── Cargo.toml           # Rust 2024 edition project configuration
+├── LICENSE              # MIT License
+└── README.md           # This file
+```
+
+## Attribution
+
+This implementation is based on the excellent work from [ggmorse](https://github.com/ggerganov/ggmorse) by Georgi Gerganov, which provided inspiration for the signal processing pipeline. The Rust implementation includes significant enhancements for robustness and accuracy.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## Contributing
+
+1. Run the test suite to verify functionality: `cargo test`
+2. All tests should pass with 100% accuracy
+3. Add tests for new features or edge cases
+4. Ensure code is properly formatted: `cargo fmt`
+5. Run clippy for additional checks: `cargo clippy`

--- a/experiments/cw-decoder/vendor/ditdah/src/decoder.rs
+++ b/experiments/cw-decoder/vendor/ditdah/src/decoder.rs
@@ -430,7 +430,7 @@ impl MorseDecoder {
         power_signal: &[f32],
         wpm: f32,
         threshold: f32,
-        _power_signal_rate: f32,
+        power_signal_rate: f32,
     ) -> String {
         // First pass: collect all element lengths for self-calibration
         let (on_intervals, off_intervals) = get_raw_intervals(power_signal, threshold);
@@ -454,7 +454,7 @@ impl MorseDecoder {
             None
         };
 
-        let actual_dot_len = if length_ratio > 1.8 {
+        let raw_dot_len = if length_ratio > 1.8 {
             // Mixed signal: 2-means cluster the on-intervals to find the
             // dit cluster centroid. Robust against rough fists where the
             // dah/dit ratio drops below the textbook 3:1, which used to
@@ -482,23 +482,38 @@ impl MorseDecoder {
                 median_len
             }
         };
+        let theoretical_dot_len = ((1200.0 / wpm / 1000.0) * power_signal_rate).max(1.0);
+        let actual_dot_len = if length_ratio > 1.8 && raw_dot_len < theoretical_dot_len * 0.65 {
+            // A very low ON centroid usually means the tone envelope is being
+            // sliced into half-dits by threshold chatter, not that the sender
+            // suddenly doubled speed.  The WPM search has already selected a
+            // timing hypothesis from both ON and OFF intervals, so use it as a
+            // lower-bound prior for self-calibration.  Without this, long
+            // well-toned QSOs can normalize true element gaps to ~2 dots and
+            // the beam happily emits E/T-heavy fragments.
+            (raw_dot_len * theoretical_dot_len).sqrt()
+        } else {
+            raw_dot_len
+        };
 
         // Log calibration for debugging
         log::debug!(
-            "Self-calibration: WPM={:.1} (ignored), actual_dot_len={:.1} samples",
+            "Self-calibration: WPM={:.1}, raw_dot_len={:.1}, actual_dot_len={:.1}, theoretical_dot_len={:.1} samples",
             wpm,
-            actual_dot_len
+            raw_dot_len,
+            actual_dot_len,
+            theoretical_dot_len
         );
         log::debug!("Element lengths: {:?}", on_intervals);
 
         let dit_dah_boundary_norm = if length_ratio > 1.8 {
             if let Some((low, high)) = on_centroids {
-                if low > 0.0 && high > low * 1.5 {
+                if low > 0.0 && high > actual_dot_len * 1.3 {
                     // Midpoint between dit and dah centroids in normalized
                     // (dot-length) units. This adapts to rough fists where
                     // the textbook 2.0× boundary misses dahs that fall
                     // closer to 1.7..2.5 of the dit length.
-                    0.5 * (1.0 + high / low)
+                    0.5 * (1.0 + high / actual_dot_len)
                 } else {
                     DIT_DAH_BOUNDARY
                 }
@@ -529,7 +544,7 @@ impl MorseDecoder {
                     gap_centroids_norm = (c1, c2, c3);
                     // c1 = element gap, c2 = letter gap, c3 = word gap
                     let letter_b = if c2 > c1 * 1.3 {
-                        (0.5 * (c1 + c2)).clamp(1.4, 3.4)
+                        (0.5 * (c1 + c2)).clamp(1.8, 3.4)
                     } else {
                         // Bad split (clusters too close); fall back.
                         (2.0 * c1).clamp(1.7, 2.6)
@@ -567,6 +582,14 @@ impl MorseDecoder {
                 (LETTER_SPACE_BOUNDARY, WORD_SPACE_BOUNDARY)
             }
         };
+        log::debug!(
+            "Gap centroids/boundaries (dot units): c1={:.2}, c2={:.2}, c3={:.2}, letter_b={:.2}, word_b={:.2}",
+            gap_centroids_norm.0,
+            gap_centroids_norm.1,
+            gap_centroids_norm.2,
+            letter_space_norm,
+            word_space_norm
+        );
 
         let mut result = String::new();
         let mut current_letter = String::new();
@@ -583,7 +606,13 @@ impl MorseDecoder {
         );
 
         let dah_len_norm = on_centroids
-            .map(|(low, high)| if low > 0.0 { high / low } else { 3.0 })
+            .map(|(_low, high)| {
+                if actual_dot_len > 0.0 {
+                    high / actual_dot_len
+                } else {
+                    3.0
+                }
+            })
             .unwrap_or(3.0)
             .clamp(1.8, 4.5);
         let beam_result = decode_with_morse_beam(
@@ -592,6 +621,8 @@ impl MorseDecoder {
             actual_dot_len,
             dah_len_norm,
             gap_centroids_norm,
+            letter_space_norm,
+            word_space_norm,
             debounce_samples,
         );
         if !beam_result.is_empty() {
@@ -777,6 +808,8 @@ fn decode_with_morse_beam(
     dot_len: f32,
     dah_len_norm: f32,
     gap_centroids_norm: (f32, f32, f32),
+    letter_space_norm: f32,
+    word_space_norm: f32,
     debounce_samples: usize,
 ) -> String {
     if power_signal.is_empty() || dot_len <= 0.0 {
@@ -804,7 +837,14 @@ fn decode_with_morse_beam(
             }
         } else {
             for state in &beams {
-                extend_gap(&mut next, state, len_norm, gap_centroids_norm);
+                extend_gap(
+                    &mut next,
+                    state,
+                    len_norm,
+                    gap_centroids_norm,
+                    letter_space_norm,
+                    word_space_norm,
+                );
             }
         }
         beams = prune_beam(next);
@@ -860,6 +900,8 @@ fn extend_gap(
     state: &MorseBeamState,
     len_norm: f32,
     gap_centroids_norm: (f32, f32, f32),
+    letter_space_norm: f32,
+    word_space_norm: f32,
 ) {
     let (element_gap, letter_gap, word_gap) = gap_centroids_norm;
 
@@ -880,7 +922,9 @@ fn extend_gap(
         });
     }
 
-    if let Some(ch) = morse_alnum_to_char(&state.pattern) {
+    if len_norm >= letter_space_norm
+        && let Some(ch) = morse_alnum_to_char(&state.pattern)
+    {
         let mut text = state.text.clone();
         push_char(&mut text, ch);
         next.push(MorseBeamState {
@@ -889,12 +933,14 @@ fn extend_gap(
             score: state.score + morse_len_cost(len_norm, letter_gap),
         });
 
-        push_space(&mut text);
-        next.push(MorseBeamState {
-            text,
-            pattern: String::new(),
-            score: state.score + morse_len_cost(len_norm, word_gap),
-        });
+        if len_norm >= word_space_norm {
+            push_space(&mut text);
+            next.push(MorseBeamState {
+                text,
+                pattern: String::new(),
+                score: state.score + morse_len_cost(len_norm, word_gap),
+            });
+        }
     }
 }
 
@@ -975,9 +1021,22 @@ fn ordered_intervals(
     threshold: f32,
     debounce_samples: usize,
 ) -> Vec<(bool, usize)> {
-    let mut intervals = Vec::new();
+    fn push_interval(intervals: &mut Vec<(bool, usize)>, is_on: bool, len: usize) {
+        if len == 0 {
+            return;
+        }
+        if let Some((last_is_on, last_len)) = intervals.last_mut() {
+            if *last_is_on == is_on {
+                *last_len += len;
+                return;
+            }
+        }
+        intervals.push((is_on, len));
+    }
+
+    let mut raw_intervals = Vec::new();
     if power_signal.is_empty() {
-        return intervals;
+        return raw_intervals;
     }
 
     let mut current_len = 0usize;
@@ -986,15 +1045,42 @@ fn ordered_intervals(
         if (p > threshold) == is_on {
             current_len += 1;
         } else {
-            if current_len > debounce_samples {
-                intervals.push((is_on, current_len));
-            }
+            raw_intervals.push((is_on, current_len));
             is_on = !is_on;
             current_len = 1;
         }
     }
-    if current_len > debounce_samples {
-        intervals.push((is_on, current_len));
+    raw_intervals.push((is_on, current_len));
+
+    if debounce_samples == 0 {
+        return raw_intervals;
+    }
+
+    let mut intervals = Vec::with_capacity(raw_intervals.len());
+    for (idx, (run_is_on, run_len)) in raw_intervals.iter().copied().enumerate() {
+        if run_len > debounce_samples {
+            push_interval(&mut intervals, run_is_on, run_len);
+            continue;
+        }
+
+        if let Some((last_is_on, last_len)) = intervals.last_mut() {
+            // Treat sub-dwell opposite-polarity runs as threshold chatter:
+            // bridge tiny OFF holes inside key-downs and absorb tiny ON
+            // spikes inside key-up gaps, but only when a following accepted
+            // run confirms the previous state.  Trailing sub-dwell runs are
+            // dropped instead of inflating the final symbol/gap.
+            if raw_intervals
+                .iter()
+                .skip(idx + 1)
+                .find(|(_, len)| *len > debounce_samples)
+                .is_some_and(|(next_is_on, _)| next_is_on == last_is_on)
+            {
+                *last_len += run_len;
+            }
+        }
+        // If the capture starts with a tiny glitch, there is no previous
+        // accepted state. Drop it rather than emitting a standalone E/T-sized
+        // run.
     }
     intervals
 }
@@ -1086,6 +1172,52 @@ fn is_morse_alnum_prefix(s: &str) -> bool {
     MORSE_ALNUM_TABLE
         .iter()
         .any(|&(morse, _)| morse.starts_with(s))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn push_power_run(signal: &mut Vec<f32>, is_on: bool, len: usize) {
+        signal.extend(std::iter::repeat(if is_on { 1.0 } else { 0.0 }).take(len));
+    }
+
+    #[test]
+    fn ordered_intervals_bridges_sub_dwell_gaps() {
+        let mut signal = Vec::new();
+        push_power_run(&mut signal, true, 6);
+        push_power_run(&mut signal, false, 2);
+        push_power_run(&mut signal, true, 7);
+        push_power_run(&mut signal, false, 8);
+
+        let intervals = ordered_intervals(&signal, 0.5, 3);
+
+        assert_eq!(intervals, vec![(true, 15), (false, 8)]);
+    }
+
+    #[test]
+    fn ordered_intervals_absorbs_sub_dwell_on_blips() {
+        let mut signal = Vec::new();
+        push_power_run(&mut signal, false, 7);
+        push_power_run(&mut signal, true, 2);
+        push_power_run(&mut signal, false, 6);
+        push_power_run(&mut signal, true, 5);
+
+        let intervals = ordered_intervals(&signal, 0.5, 3);
+
+        assert_eq!(intervals, vec![(false, 15), (true, 5)]);
+    }
+
+    #[test]
+    fn ordered_intervals_drops_trailing_sub_dwell_runs() {
+        let mut signal = Vec::new();
+        push_power_run(&mut signal, true, 6);
+        push_power_run(&mut signal, false, 2);
+
+        let intervals = ordered_intervals(&signal, 0.5, 3);
+
+        assert_eq!(intervals, vec![(true, 6)]);
+    }
 }
 
 const MORSE_ALNUM_TABLE: &[(&str, char)] = &[

--- a/experiments/cw-decoder/vendor/ditdah/src/decoder.rs
+++ b/experiments/cw-decoder/vendor/ditdah/src/decoder.rs
@@ -1,0 +1,1185 @@
+use anyhow::{Result, bail};
+use rubato::{
+    Resampler, SincFixedIn, SincInterpolationParameters, SincInterpolationType, WindowFunction,
+};
+use rustfft::{FftPlanner, num_complex::Complex};
+use std::collections::VecDeque;
+use std::io::Write;
+// --- DSP Constants ---
+const FREQ_MIN_HZ: f32 = 200.0;
+const FREQ_MAX_HZ: f32 = 1200.0;
+const RESAMPLER_CHUNK_SIZE: usize = 1024;
+
+// --- Decoding Constants ---
+const DIT_DAH_BOUNDARY: f32 = 2.0;
+const LETTER_SPACE_BOUNDARY: f32 = 2.0; // Gaps > 2x dot length end the current letter
+const WORD_SPACE_BOUNDARY: f32 = 5.0; // Gaps > 5x dot length add word space
+const MORSE_BEAM_WIDTH: usize = 96;
+
+// --- BiquadFilter (Unchanged) ---
+#[derive(Debug, Clone, Copy)]
+pub enum FilterType {
+    HighPass,
+    LowPass,
+}
+pub struct BiquadFilter {
+    a0: f32,
+    a1: f32,
+    a2: f32,
+    b1: f32,
+    b2: f32,
+    x1: f32,
+    x2: f32,
+    y1: f32,
+    y2: f32,
+}
+impl BiquadFilter {
+    pub fn new(filter_type: FilterType, cutoff_hz: f32, sample_rate: u32) -> Self {
+        let mut filter = Self {
+            a0: 1.0,
+            a1: 0.0,
+            a2: 0.0,
+            b1: 0.0,
+            b2: 0.0,
+            x1: 0.0,
+            x2: 0.0,
+            y1: 0.0,
+            y2: 0.0,
+        };
+        let c = (std::f32::consts::PI * cutoff_hz / sample_rate as f32).tan();
+        let sqrt2 = 2.0f32.sqrt();
+        match filter_type {
+            FilterType::LowPass => {
+                let d = 1.0 / (1.0 + sqrt2 * c + c * c);
+                filter.a0 = c * c * d;
+                filter.a1 = 2.0 * filter.a0;
+                filter.a2 = filter.a0;
+                filter.b1 = 2.0 * (c * c - 1.0) * d;
+                filter.b2 = (1.0 - sqrt2 * c + c * c) * d;
+            }
+            FilterType::HighPass => {
+                let d = 1.0 / (1.0 + sqrt2 * c + c * c);
+                filter.a0 = d;
+                filter.a1 = -2.0 * d;
+                filter.a2 = d;
+                filter.b1 = 2.0 * (c * c - 1.0) * d;
+                filter.b2 = (1.0 - sqrt2 * c + c * c) * d;
+            }
+        }
+        filter
+    }
+    pub fn process(&mut self, input: &mut [f32]) {
+        for sample in input.iter_mut() {
+            let x0 = *sample;
+            let y0 = self.a0 * x0 + self.a1 * self.x1 + self.a2 * self.x2
+                - self.b1 * self.y1
+                - self.b2 * self.y2;
+            self.x2 = self.x1;
+            self.x1 = x0;
+            self.y2 = self.y1;
+            self.y1 = y0;
+            *sample = y0;
+        }
+    }
+}
+
+// --- Goertzel Filter (Unchanged) ---
+struct Goertzel {
+    coeff: f32,
+    window: Vec<f32>,
+}
+impl Goertzel {
+    fn new(target_freq: f32, sample_rate: u32, window_size: usize) -> Self {
+        let k = 0.5 + (window_size as f32 * target_freq) / sample_rate as f32;
+        let omega = (2.0 * std::f32::consts::PI * k) / window_size as f32;
+        let coeff = 2.0 * omega.cos();
+        let window = (0..window_size)
+            .map(|i| {
+                0.54 - 0.46 * (2.0 * std::f32::consts::PI * i as f32 / window_size as f32).cos()
+            })
+            .collect();
+        Self { coeff, window }
+    }
+    fn run(&self, samples: &[f32]) -> f32 {
+        let mut q1 = 0.0;
+        let mut q2 = 0.0;
+        for (i, &sample) in samples.iter().enumerate() {
+            let q0 = self.coeff * q1 - q2 + sample * self.window[i];
+            q2 = q1;
+            q1 = q0;
+        }
+        q1 * q1 + q2 * q2 - self.coeff * q1 * q2
+    }
+    fn process_decimated(&self, samples: &[f32], step_size: usize) -> Vec<f32> {
+        if samples.len() < self.window.len() {
+            return Vec::new();
+        }
+        samples
+            .windows(self.window.len())
+            .step_by(step_size)
+            .map(|chunk| self.run(chunk))
+            .collect()
+    }
+}
+pub struct MorseDecoder {
+    resampler: Option<SincFixedIn<f32>>,
+    filter_hp: BiquadFilter,
+    filter_lp: BiquadFilter,
+    input_buffer: Vec<f32>, // Buffer for raw audio before resampling
+    audio_buffer: Vec<f32>, // Buffer for resampled, filtered audio
+    target_sample_rate: u32,
+}
+
+impl MorseDecoder {
+    pub fn new(source_sample_rate: u32, target_sample_rate: u32) -> Result<Self> {
+        let resampler = if source_sample_rate != target_sample_rate {
+            Some(SincFixedIn::new(
+                target_sample_rate as f64 / source_sample_rate as f64,
+                2.0,
+                SincInterpolationParameters {
+                    sinc_len: 256,
+                    f_cutoff: 0.95,
+                    interpolation: SincInterpolationType::Linear,
+                    oversampling_factor: 256,
+                    window: WindowFunction::BlackmanHarris,
+                },
+                RESAMPLER_CHUNK_SIZE,
+                1,
+            )?)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            resampler,
+            filter_hp: BiquadFilter::new(FilterType::HighPass, FREQ_MIN_HZ, target_sample_rate),
+            filter_lp: BiquadFilter::new(FilterType::LowPass, FREQ_MAX_HZ, target_sample_rate),
+            input_buffer: Vec::new(),
+            audio_buffer: Vec::new(),
+            target_sample_rate,
+        })
+    }
+
+    /// Processes a chunk of audio. Buffers input to meet the resampler's requirements.
+    pub fn process(&mut self, chunk: &[f32]) -> Result<()> {
+        if let Some(resampler) = &mut self.resampler {
+            // Add new audio to our input buffer
+            self.input_buffer.extend_from_slice(chunk);
+
+            // Process full chunks from the buffer
+            while self.input_buffer.len() >= RESAMPLER_CHUNK_SIZE {
+                let waves_in = &[&self.input_buffer[..RESAMPLER_CHUNK_SIZE]];
+                let mut resampled = resampler.process(waves_in, None)?;
+                self.input_buffer.drain(..RESAMPLER_CHUNK_SIZE);
+
+                let mut processed_chunk = resampled.remove(0);
+                self.filter_hp.process(&mut processed_chunk);
+                self.filter_lp.process(&mut processed_chunk);
+                self.audio_buffer.extend(processed_chunk);
+            }
+        } else {
+            // No resampling, just filter and add to the main buffer
+            let mut processed_chunk = chunk.to_vec();
+            self.filter_hp.process(&mut processed_chunk);
+            self.filter_lp.process(&mut processed_chunk);
+            self.audio_buffer.extend(processed_chunk);
+        }
+        Ok(())
+    }
+
+    /// Finalizes decoding. Processes any remaining buffered audio and decodes the full signal.
+    pub fn finalize(&mut self) -> Result<String> {
+        // --- Flush remaining audio from the input buffer ---
+        if let Some(resampler) = &mut self.resampler {
+            if !self.input_buffer.is_empty() {
+                // Pad the remaining buffer to the required chunk size if needed
+                while self.input_buffer.len() < RESAMPLER_CHUNK_SIZE {
+                    self.input_buffer.push(0.0);
+                }
+                let waves_in = &[self.input_buffer.as_slice()];
+                let mut resampled = resampler.process(waves_in, None)?;
+                self.input_buffer.clear();
+
+                let mut processed_chunk = resampled.remove(0);
+                self.filter_hp.process(&mut processed_chunk);
+                self.filter_lp.process(&mut processed_chunk);
+                self.audio_buffer.extend(processed_chunk);
+            }
+        }
+
+        if self.audio_buffer.is_empty() {
+            bail!("Audio buffer is empty, cannot process.");
+        }
+
+        // --- The rest of the decoding pipeline is unchanged ---
+        let pitch = self.detect_pitch_stft()?;
+        log::info!("Estimated pitch: {:.2} Hz", pitch);
+
+        let goertzel_window_size = (self.target_sample_rate as f32 * 0.025) as usize;
+        let step_size = (goertzel_window_size / 4).max(1);
+        let goertzel_filter = Goertzel::new(pitch, self.target_sample_rate, goertzel_window_size);
+        let raw_power = goertzel_filter.process_decimated(&self.audio_buffer, step_size);
+        let power_signal_rate = self.target_sample_rate as f32 / step_size as f32;
+
+        let smooth_window = (power_signal_rate * 0.02).round() as usize;
+        let smoothed_power = moving_average(&raw_power, smooth_window.max(1));
+        if smoothed_power.is_empty() {
+            bail!("No power signal after processing");
+        }
+
+        let (best_wpm, best_threshold) =
+            self.find_best_params(&smoothed_power, power_signal_rate)?;
+        log::info!(
+            "Best fit: WPM = {:.1}, Threshold = {:.4e}",
+            best_wpm,
+            best_threshold
+        );
+
+        if log::log_enabled!(log::Level::Trace) {
+            trace_signal(&smoothed_power, best_threshold, best_wpm)?;
+            log::trace!("Wrote signal trace to signal_trace.txt");
+        }
+
+        let text =
+            self.decode_with_params(&smoothed_power, best_wpm, best_threshold, power_signal_rate);
+        Ok(text)
+    }
+
+    // --- The complex analysis functions below are unchanged ---
+    fn detect_pitch_stft(&self) -> Result<f32> {
+        let fft_size = 4096;
+        let step_size = fft_size / 4;
+        let mut planner = FftPlanner::new();
+        let fft = planner.plan_fft_forward(fft_size);
+        let window: Vec<f32> = (0..fft_size)
+            .map(|i| 0.54 - 0.46 * (2.0 * std::f32::consts::PI * i as f32 / fft_size as f32).cos())
+            .collect();
+        let mut spectrum_sum = vec![0.0; fft_size / 2];
+        let mut count = 0;
+        for chunk in self.audio_buffer.windows(fft_size).step_by(step_size) {
+            let mut buffer: Vec<Complex<f32>> = chunk
+                .iter()
+                .zip(window.iter())
+                .map(|(s, w)| Complex::new(s * w, 0.0))
+                .collect();
+            fft.process(&mut buffer);
+            for (i, v) in buffer.iter().take(fft_size / 2).enumerate() {
+                spectrum_sum[i] += v.norm_sqr();
+            }
+            count += 1;
+        }
+        if count == 0 {
+            bail!("Not enough audio data for pitch detection");
+        }
+        let df = self.target_sample_rate as f32 / fft_size as f32;
+        let (max_idx, max_power) =
+            spectrum_sum
+                .iter()
+                .enumerate()
+                .fold((0, 0.0), |(max_i, max_p), (i, &p)| {
+                    let freq = i as f32 * df;
+                    if (FREQ_MIN_HZ..=FREQ_MAX_HZ).contains(&freq) && p > max_p {
+                        (i, p)
+                    } else {
+                        (max_i, max_p)
+                    }
+                });
+        if max_power == 0.0 {
+            bail!("Could not find a dominant frequency in the specified range.");
+        }
+        Ok(max_idx as f32 * df)
+    }
+
+    fn find_best_params(&self, power_signal: &[f32], power_signal_rate: f32) -> Result<(f32, f32)> {
+        if power_signal.is_empty() {
+            bail!("Power signal is empty");
+        }
+        let mut sorted_power: Vec<f32> =
+            power_signal.iter().cloned().filter(|&p| p > 0.0).collect();
+        if sorted_power.len() < 10 {
+            bail!("Not enough signal to determine parameters");
+        }
+        sorted_power.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+        let p25 = sorted_power[(sorted_power.len() as f32 * 0.25) as usize];
+        let p75 = sorted_power[(sorted_power.len() as f32 * 0.75) as usize];
+        let iqr = p75 - p25;
+        let threshold_candidates = [
+            p25 + iqr * 0.01,
+            p25 + iqr * 0.02,
+            p25 + iqr * 0.05,
+            p25 + iqr * 0.10,
+            p25 + iqr * 0.25,
+            p25 + iqr * 0.50,
+            p25 + iqr * 0.75,
+        ];
+        let mut best_cost = f32::MAX;
+        let mut best_wpm = 20.0;
+        let mut best_threshold = threshold_candidates[1];
+        for &threshold in &threshold_candidates {
+            for wpm_int in 5..=50 {
+                let wpm = wpm_int as f32;
+                let timing_cost =
+                    self.calculate_cost(power_signal, wpm, threshold, power_signal_rate);
+                if !timing_cost.is_finite() {
+                    continue;
+                }
+                let decoded =
+                    self.decode_with_params(power_signal, wpm, threshold, power_signal_rate);
+                let cost = timing_cost + 0.35 * decode_quality_cost(&decoded);
+                if cost < best_cost {
+                    best_cost = cost;
+                    best_wpm = wpm;
+                    best_threshold = threshold;
+                }
+            }
+        }
+        Ok((best_wpm, best_threshold))
+    }
+
+    fn calculate_cost(
+        &self,
+        power_signal: &[f32],
+        wpm: f32,
+        threshold: f32,
+        power_signal_rate: f32,
+    ) -> f32 {
+        let (on_intervals, off_intervals) = get_raw_intervals(power_signal, threshold);
+        if on_intervals.len() < 3 || off_intervals.len() < 3 {
+            return f32::MAX;
+        }
+        let dot_len_samples = (1200.0 / wpm / 1000.0) * power_signal_rate;
+        if dot_len_samples < 1.0 {
+            return f32::MAX;
+        }
+        let on_norm: Vec<f32> = on_intervals
+            .iter()
+            .map(|&s| s as f32 / dot_len_samples)
+            .collect();
+        let off_norm: Vec<f32> = off_intervals
+            .iter()
+            .map(|&s| s as f32 / dot_len_samples)
+            .collect();
+        let mut short_elements: Vec<f32> = on_norm
+            .iter()
+            .chain(off_norm.iter())
+            .cloned()
+            .filter(|&l| l < 2.0)
+            .collect();
+        if short_elements.is_empty() {
+            return f32::MAX;
+        }
+        short_elements.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap());
+        let median_dot_len = short_elements[short_elements.len() / 2];
+        if median_dot_len < 0.25 {
+            return f32::MAX;
+        }
+        // Reject degenerate WPM hypotheses where every on-interval falls
+        // into a single cluster (all dits or all dahs). Without this
+        // guard a wildly-wrong WPM that maps every element to "1 dot"
+        // wins because each per-element cost is small. Real Morse for
+        // anything beyond a single character has both dits and dahs;
+        // require at least one short and one long ON element relative
+        // to the median dot length, with the long cluster mean roughly
+        // 2..5 dot lengths (dah ratios in the wild fall in 2.3..3.5).
+        let on_short_n = on_norm.iter().filter(|&&l| l < 2.0).count();
+        let on_long_n = on_norm.iter().filter(|&&l| l >= 2.0).count();
+        if on_short_n == 0 || on_long_n == 0 {
+            return f32::MAX;
+        }
+        let on_long_mean: f32 =
+            on_norm.iter().filter(|&&l| l >= 2.0).copied().sum::<f32>() / on_long_n as f32;
+        let dah_ratio = on_long_mean / median_dot_len;
+        if !(2.0..=5.0).contains(&dah_ratio) {
+            return f32::MAX;
+        }
+        // Penalize WPM hypotheses where median_dot_len drifts far from 1.0.
+        // Without this, two different WPM candidates produce near-identical
+        // residual costs (the residual is shape-invariant under WPM
+        // rescaling once it's normalized by median_dot_len), so the picker
+        // would happily settle on a WPM 30..50% off the true value, which
+        // shifts both the dit/dah and letter/word boundaries enough to
+        // shred multi-element letters under high jitter. The correct WPM
+        // makes median_dot_len ≈ 1.0; deviation in either direction is bad.
+        // Use log-space distance so the penalty is symmetric for halving vs
+        // doubling.
+        let wpm_drift = median_dot_len.ln().powi(2);
+        let cost_on: f32 = on_norm
+            .iter()
+            .map(|&len| {
+                (len / median_dot_len - 1.0)
+                    .powi(2)
+                    .min((len / median_dot_len - 3.0).powi(2))
+            })
+            .sum();
+        let cost_off: f32 = off_norm
+            .iter()
+            .map(|&len| {
+                (len / median_dot_len - 1.0)
+                    .powi(2)
+                    .min((len / median_dot_len - 3.0).powi(2))
+                    .min((len / median_dot_len - 7.0).powi(2))
+            })
+            .sum();
+        (cost_on / on_intervals.len() as f32)
+            + (cost_off / off_intervals.len() as f32)
+            + 0.25 * wpm_drift
+    }
+
+    fn decode_with_params(
+        &self,
+        power_signal: &[f32],
+        wpm: f32,
+        threshold: f32,
+        _power_signal_rate: f32,
+    ) -> String {
+        // First pass: collect all element lengths for self-calibration
+        let (on_intervals, off_intervals) = get_raw_intervals(power_signal, threshold);
+
+        if on_intervals.is_empty() {
+            return String::new();
+        }
+
+        // Self-calibrate: detect if we have mixed dots/dashes or all same type
+        let mut sorted_lengths = on_intervals.clone();
+        sorted_lengths.sort_unstable();
+
+        let min_len = sorted_lengths[0] as f32;
+        let max_len = sorted_lengths[sorted_lengths.len() - 1] as f32;
+        let length_ratio = max_len / min_len;
+
+        let lengths_for_high: Vec<f32> = sorted_lengths.iter().map(|&x| x as f32).collect();
+        let on_centroids = if length_ratio > 1.8 {
+            kmeans_two_centroids(&lengths_for_high)
+        } else {
+            None
+        };
+
+        let actual_dot_len = if length_ratio > 1.8 {
+            // Mixed signal: 2-means cluster the on-intervals to find the
+            // dit cluster centroid. Robust against rough fists where the
+            // dah/dit ratio drops below the textbook 3:1, which used to
+            // collapse the old "median of shortest half" heuristic into
+            // a number small enough that every real dit looked like a dah.
+            on_centroids
+                .map(|(low, _high)| low)
+                .unwrap_or_else(|| sorted_lengths[sorted_lengths.len() / 4] as f32)
+        } else {
+            // All similar lengths: Use a simple heuristic based on absolute length
+            // This is more robust than relying on potentially inaccurate WPM estimates
+            let median_len = sorted_lengths[sorted_lengths.len() / 2] as f32;
+
+            // Based on actual observed values:
+            // - EEEE (dots): median ~10 power signal samples
+            // - TTTT (dashes): median ~29 power signal samples
+            // Use a breakpoint between these ranges
+            let breakpoint = 18.0;
+
+            if median_len > breakpoint {
+                // Likely all dashes - use theoretical dot length
+                median_len / 3.0
+            } else {
+                // Likely all dots
+                median_len
+            }
+        };
+
+        // Log calibration for debugging
+        log::debug!(
+            "Self-calibration: WPM={:.1} (ignored), actual_dot_len={:.1} samples",
+            wpm,
+            actual_dot_len
+        );
+        log::debug!("Element lengths: {:?}", on_intervals);
+
+        let dit_dah_boundary_norm = if length_ratio > 1.8 {
+            if let Some((low, high)) = on_centroids {
+                if low > 0.0 && high > low * 1.5 {
+                    // Midpoint between dit and dah centroids in normalized
+                    // (dot-length) units. This adapts to rough fists where
+                    // the textbook 2.0× boundary misses dahs that fall
+                    // closer to 1.7..2.5 of the dit length.
+                    0.5 * (1.0 + high / low)
+                } else {
+                    DIT_DAH_BOUNDARY
+                }
+            } else {
+                DIT_DAH_BOUNDARY
+            }
+        } else {
+            DIT_DAH_BOUNDARY
+        };
+
+        // Adaptive letter-space and word-space boundaries via 3-means
+        // cluster on the off-interval distribution (element / letter / word
+        // gaps). Boundaries are placed at the midpoints of adjacent
+        // centroids. With heavy timing jitter the canonical (1, 3, 7) dot
+        // gaps drift enough that fixed thresholds shred letters; a 3-cluster
+        // model adapts to the actual fist while a 2-cluster fallback covers
+        // short clips with no word gaps at all.
+        let mut gap_centroids_norm = (1.0_f32, 3.0_f32, 7.0_f32);
+        let (letter_space_norm, word_space_norm) = {
+            let off_norm: Vec<f32> = off_intervals
+                .iter()
+                .map(|&s| s as f32 / actual_dot_len)
+                // Drop the trailing silence and other gross outliers.
+                .filter(|&l| l < 12.0)
+                .collect();
+            if off_norm.len() >= 6 {
+                if let Some((c1, c2, c3)) = kmeans_three_centroids(&off_norm) {
+                    gap_centroids_norm = (c1, c2, c3);
+                    // c1 = element gap, c2 = letter gap, c3 = word gap
+                    let letter_b = if c2 > c1 * 1.3 {
+                        (0.5 * (c1 + c2)).clamp(1.4, 3.4)
+                    } else {
+                        // Bad split (clusters too close); fall back.
+                        (2.0 * c1).clamp(1.7, 2.6)
+                    };
+                    let word_b = if c3 > c2 * 1.3 {
+                        (0.5 * (c2 + c3)).clamp(letter_b + 0.5, 8.0)
+                    } else {
+                        WORD_SPACE_BOUNDARY
+                    };
+                    (letter_b, word_b)
+                } else if let Some((low, _high)) = kmeans_two_centroids(&off_norm) {
+                    gap_centroids_norm = (low, (low * 3.0).max(3.0), 7.0);
+                    let letter_b = if low > 0.0 {
+                        (2.0 * low).clamp(1.7, 2.6)
+                    } else {
+                        LETTER_SPACE_BOUNDARY
+                    };
+                    (letter_b, WORD_SPACE_BOUNDARY)
+                } else {
+                    (LETTER_SPACE_BOUNDARY, WORD_SPACE_BOUNDARY)
+                }
+            } else if off_norm.len() >= 3 {
+                if let Some((low, _high)) = kmeans_two_centroids(&off_norm) {
+                    gap_centroids_norm = (low, (low * 3.0).max(3.0), 7.0);
+                    let letter_b = if low > 0.0 {
+                        (2.0 * low).clamp(1.7, 2.6)
+                    } else {
+                        LETTER_SPACE_BOUNDARY
+                    };
+                    (letter_b, WORD_SPACE_BOUNDARY)
+                } else {
+                    (LETTER_SPACE_BOUNDARY, WORD_SPACE_BOUNDARY)
+                }
+            } else {
+                (LETTER_SPACE_BOUNDARY, WORD_SPACE_BOUNDARY)
+            }
+        };
+
+        let mut result = String::new();
+        let mut current_letter = String::new();
+        if power_signal.is_empty() {
+            return result;
+        }
+        let mut current_len = 0;
+        let mut is_on = power_signal[0] > threshold;
+        let debounce_samples = (actual_dot_len * 0.3).round() as usize;
+        log::debug!("Debounce threshold: {} samples", debounce_samples);
+        log::debug!(
+            "Dit/dah boundary (in dot units): {:.2}",
+            dit_dah_boundary_norm
+        );
+
+        let dah_len_norm = on_centroids
+            .map(|(low, high)| if low > 0.0 { high / low } else { 3.0 })
+            .unwrap_or(3.0)
+            .clamp(1.8, 4.5);
+        let beam_result = decode_with_morse_beam(
+            power_signal,
+            threshold,
+            actual_dot_len,
+            dah_len_norm,
+            gap_centroids_norm,
+            debounce_samples,
+        );
+        if !beam_result.is_empty() {
+            return beam_result;
+        }
+
+        for &p in power_signal.iter().chain(std::iter::once(&0.0)) {
+            if (p > threshold) == is_on {
+                current_len += 1;
+            } else {
+                if current_len > debounce_samples {
+                    let len_norm = current_len as f32 / actual_dot_len;
+                    if is_on {
+                        if len_norm < dit_dah_boundary_norm {
+                            current_letter.push('.');
+                        } else {
+                            current_letter.push('-');
+                        }
+                    } else {
+                        // Handle gaps (off periods)
+                        if len_norm > letter_space_norm {
+                            // Gap is long enough to end the current letter
+                            if !current_letter.is_empty() {
+                                if let Some(c) = morse_to_char(&current_letter) {
+                                    result.push(c);
+                                } else {
+                                    result.push('?');
+                                }
+                                current_letter.clear();
+                            }
+                            // If gap is also long enough for word boundary, add space
+                            if len_norm > word_space_norm && !result.ends_with(' ') {
+                                result.push(' ');
+                            }
+                        }
+                        // If gap is shorter than LETTER_SPACE_BOUNDARY, it's just an element gap - ignore
+                    }
+                }
+                is_on = !is_on;
+                current_len = 1;
+            }
+        }
+
+        // Process any remaining letter at the end
+        if !current_letter.is_empty() {
+            if let Some(c) = morse_to_char(&current_letter) {
+                result.push(c);
+            } else {
+                result.push('?');
+            }
+        }
+
+        result.trim().to_string()
+    }
+}
+
+// --- Helper Functions ---
+
+/// 1-D k-means with k=2 on positive lengths. Returns `(low_centroid,
+/// high_centroid)` if the input contains at least two distinct non-empty
+/// clusters after convergence, otherwise `None`.
+fn kmeans_two_centroids(values: &[f32]) -> Option<(f32, f32)> {
+    if values.len() < 2 {
+        return None;
+    }
+    let min = values.iter().cloned().fold(f32::INFINITY, f32::min);
+    let max = values.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+    if (max - min).abs() < f32::EPSILON {
+        return None;
+    }
+    // Seed centroids at 25th and 75th percentile (sorted assumed by caller
+    // in our usage; sort defensively otherwise).
+    let mut sorted: Vec<f32> = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mut c_low = sorted[sorted.len() / 4];
+    let mut c_high = sorted[(3 * sorted.len()) / 4];
+    if (c_high - c_low).abs() < f32::EPSILON {
+        c_low = min;
+        c_high = max;
+    }
+    for _ in 0..32 {
+        let mut sum_low = 0.0;
+        let mut n_low = 0usize;
+        let mut sum_high = 0.0;
+        let mut n_high = 0usize;
+        for &v in values {
+            if (v - c_low).abs() <= (v - c_high).abs() {
+                sum_low += v;
+                n_low += 1;
+            } else {
+                sum_high += v;
+                n_high += 1;
+            }
+        }
+        if n_low == 0 || n_high == 0 {
+            return None;
+        }
+        let new_low = sum_low / n_low as f32;
+        let new_high = sum_high / n_high as f32;
+        if (new_low - c_low).abs() < 1e-3 && (new_high - c_high).abs() < 1e-3 {
+            c_low = new_low;
+            c_high = new_high;
+            break;
+        }
+        c_low = new_low;
+        c_high = new_high;
+    }
+    if c_low > c_high {
+        std::mem::swap(&mut c_low, &mut c_high);
+    }
+    Some((c_low, c_high))
+}
+
+/// 1-D k-means with k=3 on positive lengths. Returns
+/// `(c1, c2, c3)` sorted ascending if the input partitions into three
+/// non-empty clusters, otherwise `None`. Used to split off-interval
+/// distributions into element/letter/word gap buckets.
+fn kmeans_three_centroids(values: &[f32]) -> Option<(f32, f32, f32)> {
+    if values.len() < 3 {
+        return None;
+    }
+    let mut sorted: Vec<f32> = values.to_vec();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let mut c1 = sorted[sorted.len() / 6];
+    let mut c2 = sorted[sorted.len() / 2];
+    let mut c3 = sorted[(5 * sorted.len()) / 6];
+    if (c2 - c1).abs() < f32::EPSILON || (c3 - c2).abs() < f32::EPSILON {
+        c1 = sorted[0];
+        c2 = sorted[sorted.len() / 2];
+        c3 = sorted[sorted.len() - 1];
+    }
+    if (c3 - c1).abs() < f32::EPSILON {
+        return None;
+    }
+    for _ in 0..32 {
+        let (mut s1, mut n1) = (0.0f32, 0usize);
+        let (mut s2, mut n2) = (0.0f32, 0usize);
+        let (mut s3, mut n3) = (0.0f32, 0usize);
+        for &v in values {
+            let d1 = (v - c1).abs();
+            let d2 = (v - c2).abs();
+            let d3 = (v - c3).abs();
+            if d1 <= d2 && d1 <= d3 {
+                s1 += v;
+                n1 += 1;
+            } else if d2 <= d3 {
+                s2 += v;
+                n2 += 1;
+            } else {
+                s3 += v;
+                n3 += 1;
+            }
+        }
+        if n1 == 0 || n2 == 0 || n3 == 0 {
+            return None;
+        }
+        let nc1 = s1 / n1 as f32;
+        let nc2 = s2 / n2 as f32;
+        let nc3 = s3 / n3 as f32;
+        let conv = (nc1 - c1).abs() < 1e-3 && (nc2 - c2).abs() < 1e-3 && (nc3 - c3).abs() < 1e-3;
+        c1 = nc1;
+        c2 = nc2;
+        c3 = nc3;
+        if conv {
+            break;
+        }
+    }
+    let mut sorted_c = [c1, c2, c3];
+    sorted_c.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    Some((sorted_c[0], sorted_c[1], sorted_c[2]))
+}
+
+#[derive(Clone)]
+struct MorseBeamState {
+    text: String,
+    pattern: String,
+    score: f32,
+}
+
+fn decode_with_morse_beam(
+    power_signal: &[f32],
+    threshold: f32,
+    dot_len: f32,
+    dah_len_norm: f32,
+    gap_centroids_norm: (f32, f32, f32),
+    debounce_samples: usize,
+) -> String {
+    if power_signal.is_empty() || dot_len <= 0.0 {
+        return String::new();
+    }
+
+    let intervals = ordered_intervals(power_signal, threshold, debounce_samples.max(1));
+    if intervals.iter().filter(|(is_on, _)| *is_on).count() < 2 {
+        return String::new();
+    }
+
+    let mut beams = vec![MorseBeamState {
+        text: String::new(),
+        pattern: String::new(),
+        score: 0.0,
+    }];
+
+    for (is_on, len) in intervals {
+        let len_norm = len as f32 / dot_len;
+        let mut next = Vec::with_capacity(beams.len() * 4);
+        if is_on {
+            for state in &beams {
+                extend_symbol(&mut next, state, '.', len_norm, 1.0);
+                extend_symbol(&mut next, state, '-', len_norm, dah_len_norm);
+            }
+        } else {
+            for state in &beams {
+                extend_gap(&mut next, state, len_norm, gap_centroids_norm);
+            }
+        }
+        beams = prune_beam(next);
+        if beams.is_empty() {
+            return String::new();
+        }
+    }
+
+    let mut finals = Vec::with_capacity(beams.len() * 2);
+    for state in beams {
+        if state.pattern.is_empty() {
+            finals.push(state);
+        } else if let Some(ch) = morse_alnum_to_char(&state.pattern) {
+            let mut emitted = state.clone();
+            push_char(&mut emitted.text, ch);
+            emitted.pattern.clear();
+            finals.push(emitted);
+        }
+    }
+
+    finals
+        .into_iter()
+        .min_by(|a, b| {
+            a.score
+                .partial_cmp(&b.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        })
+        .map(|state| state.text.trim().to_string())
+        .unwrap_or_default()
+}
+
+fn extend_symbol(
+    next: &mut Vec<MorseBeamState>,
+    state: &MorseBeamState,
+    symbol: char,
+    len_norm: f32,
+    target_norm: f32,
+) {
+    let mut pattern = state.pattern.clone();
+    pattern.push(symbol);
+    if pattern.len() > 5 || !is_morse_alnum_prefix(&pattern) {
+        return;
+    }
+    next.push(MorseBeamState {
+        text: state.text.clone(),
+        pattern,
+        score: state.score + morse_len_cost(len_norm, target_norm),
+    });
+}
+
+fn extend_gap(
+    next: &mut Vec<MorseBeamState>,
+    state: &MorseBeamState,
+    len_norm: f32,
+    gap_centroids_norm: (f32, f32, f32),
+) {
+    let (element_gap, letter_gap, word_gap) = gap_centroids_norm;
+
+    if state.pattern.is_empty() {
+        let mut carry = state.clone();
+        if !carry.text.is_empty() && len_norm > (letter_gap + word_gap) * 0.5 {
+            push_space(&mut carry.text);
+        }
+        next.push(carry);
+        return;
+    }
+
+    if state.pattern.len() < 5 && is_morse_alnum_prefix(&state.pattern) {
+        next.push(MorseBeamState {
+            text: state.text.clone(),
+            pattern: state.pattern.clone(),
+            score: state.score + morse_len_cost(len_norm, element_gap),
+        });
+    }
+
+    if let Some(ch) = morse_alnum_to_char(&state.pattern) {
+        let mut text = state.text.clone();
+        push_char(&mut text, ch);
+        next.push(MorseBeamState {
+            text: text.clone(),
+            pattern: String::new(),
+            score: state.score + morse_len_cost(len_norm, letter_gap),
+        });
+
+        push_space(&mut text);
+        next.push(MorseBeamState {
+            text,
+            pattern: String::new(),
+            score: state.score + morse_len_cost(len_norm, word_gap),
+        });
+    }
+}
+
+fn prune_beam(mut states: Vec<MorseBeamState>) -> Vec<MorseBeamState> {
+    states.sort_by(|a, b| {
+        a.score
+            .partial_cmp(&b.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    states.truncate(MORSE_BEAM_WIDTH);
+    states
+}
+
+fn morse_len_cost(observed: f32, target: f32) -> f32 {
+    let observed = observed.max(0.05);
+    let target = target.max(0.05);
+    let ratio = observed / target;
+    ratio.ln().powi(2)
+}
+
+fn push_char(text: &mut String, ch: char) {
+    text.push(ch);
+}
+
+fn push_space(text: &mut String) {
+    if !text.is_empty() && !text.ends_with(' ') {
+        text.push(' ');
+    }
+}
+
+fn decode_quality_cost(text: &str) -> f32 {
+    let mut alnum_count = 0usize;
+    let mut unknown_count = 0usize;
+    let mut single_element_count = 0usize;
+    let mut element_sum = 0usize;
+
+    for ch in text.chars() {
+        if ch == '?' {
+            unknown_count += 1;
+            continue;
+        }
+        if ch.is_ascii_alphanumeric() {
+            alnum_count += 1;
+            if let Some(morse) = morse_for_alnum(ch) {
+                let element_count = morse.len();
+                element_sum += element_count;
+                if element_count == 1 {
+                    single_element_count += 1;
+                }
+            }
+        }
+    }
+
+    if alnum_count == 0 {
+        return unknown_count as f32 * 2.0;
+    }
+
+    let avg_elements = element_sum as f32 / alnum_count as f32;
+    let single_fraction = single_element_count as f32 / alnum_count as f32;
+    let unknown_fraction = unknown_count as f32 / (alnum_count + unknown_count).max(1) as f32;
+
+    let complexity_penalty = (2.2 - avg_elements).max(0.0).powi(2) * 8.0;
+    let fragmentation_penalty = (single_fraction - 0.45).max(0.0).powi(2) * 10.0;
+    let unknown_penalty = unknown_fraction * 4.0;
+
+    complexity_penalty + fragmentation_penalty + unknown_penalty
+}
+
+fn morse_for_alnum(ch: char) -> Option<&'static str> {
+    let ch = ch.to_ascii_uppercase();
+    MORSE_ALNUM_TABLE
+        .iter()
+        .find_map(|&(morse, c)| (c == ch).then_some(morse))
+}
+
+fn ordered_intervals(
+    power_signal: &[f32],
+    threshold: f32,
+    debounce_samples: usize,
+) -> Vec<(bool, usize)> {
+    let mut intervals = Vec::new();
+    if power_signal.is_empty() {
+        return intervals;
+    }
+
+    let mut current_len = 0usize;
+    let mut is_on = power_signal[0] > threshold;
+    for &p in power_signal {
+        if (p > threshold) == is_on {
+            current_len += 1;
+        } else {
+            if current_len > debounce_samples {
+                intervals.push((is_on, current_len));
+            }
+            is_on = !is_on;
+            current_len = 1;
+        }
+    }
+    if current_len > debounce_samples {
+        intervals.push((is_on, current_len));
+    }
+    intervals
+}
+
+fn get_raw_intervals(power_signal: &[f32], threshold: f32) -> (Vec<usize>, Vec<usize>) {
+    let mut on = Vec::new();
+    let mut off = Vec::new();
+    if power_signal.is_empty() {
+        return (on, off);
+    }
+
+    let mut current_len = 0;
+    let mut is_on = power_signal[0] > threshold;
+    for &p in power_signal {
+        if (p > threshold) == is_on {
+            current_len += 1;
+        } else {
+            if is_on {
+                on.push(current_len);
+            } else {
+                off.push(current_len);
+            }
+            is_on = !is_on;
+            current_len = 1;
+        }
+    }
+    if is_on {
+        on.push(current_len);
+    } else {
+        off.push(current_len);
+    }
+    (on, off)
+}
+
+fn moving_average(data: &[f32], window_size: usize) -> Vec<f32> {
+    if window_size <= 1 {
+        return data.to_vec();
+    }
+    let mut smoothed = Vec::with_capacity(data.len());
+    let mut sum = 0.0;
+    let mut window = VecDeque::with_capacity(window_size);
+    for &x in data {
+        if window.len() == window_size {
+            sum -= window.pop_front().unwrap();
+        }
+        sum += x;
+        window.push_back(x);
+        smoothed.push(sum / window.len() as f32);
+    }
+    smoothed
+}
+
+fn trace_signal(signal: &[f32], threshold: f32, wpm: f32) -> std::io::Result<()> {
+    let mut file = std::fs::File::create("signal_trace.txt")?;
+    writeln!(file, "# WPM: {:.1}, Threshold: {:.4e}", wpm, threshold)?;
+    let max_val = signal.iter().cloned().fold(f32::MIN, f32::max);
+    if max_val <= 0.0 {
+        return Ok(());
+    }
+
+    for &val in signal {
+        let bar_len = (val / max_val * 100.0).round() as usize;
+        let thresh_pos = (threshold / max_val * 100.0).round() as usize;
+        let mut line = vec![' '; 101];
+        for item in line.iter_mut().take(bar_len.min(100)) {
+            *item = '#';
+        }
+        if thresh_pos <= 100 {
+            line[thresh_pos] = '|';
+        }
+        writeln!(file, "{}", line.into_iter().collect::<String>())?;
+    }
+    Ok(())
+}
+
+fn morse_to_char(s: &str) -> Option<char> {
+    MORSE_TABLE
+        .iter()
+        .find_map(|&(morse, ch)| (morse == s).then_some(ch))
+}
+
+fn morse_alnum_to_char(s: &str) -> Option<char> {
+    MORSE_ALNUM_TABLE
+        .iter()
+        .find_map(|&(morse, ch)| (morse == s).then_some(ch))
+}
+
+fn is_morse_alnum_prefix(s: &str) -> bool {
+    MORSE_ALNUM_TABLE
+        .iter()
+        .any(|&(morse, _)| morse.starts_with(s))
+}
+
+const MORSE_ALNUM_TABLE: &[(&str, char)] = &[
+    (".-", 'A'),
+    ("-...", 'B'),
+    ("-.-.", 'C'),
+    ("-..", 'D'),
+    (".", 'E'),
+    ("..-.", 'F'),
+    ("--.", 'G'),
+    ("....", 'H'),
+    ("..", 'I'),
+    (".---", 'J'),
+    ("-.-", 'K'),
+    (".-..", 'L'),
+    ("--", 'M'),
+    ("-.", 'N'),
+    ("---", 'O'),
+    (".--.", 'P'),
+    ("--.-", 'Q'),
+    (".-.", 'R'),
+    ("...", 'S'),
+    ("-", 'T'),
+    ("..-", 'U'),
+    ("...-", 'V'),
+    (".--", 'W'),
+    ("-..-", 'X'),
+    ("-.--", 'Y'),
+    ("--..", 'Z'),
+    (".----", '1'),
+    ("..---", '2'),
+    ("...--", '3'),
+    ("....-", '4'),
+    (".....", '5'),
+    ("-....", '6'),
+    ("--...", '7'),
+    ("---..", '8'),
+    ("----.", '9'),
+    ("-----", '0'),
+];
+
+const MORSE_TABLE: &[(&str, char)] = &[
+    (".-", 'A'),
+    ("-...", 'B'),
+    ("-.-.", 'C'),
+    ("-..", 'D'),
+    (".", 'E'),
+    ("..-.", 'F'),
+    ("--.", 'G'),
+    ("....", 'H'),
+    ("..", 'I'),
+    (".---", 'J'),
+    ("-.-", 'K'),
+    (".-..", 'L'),
+    ("--", 'M'),
+    ("-.", 'N'),
+    ("---", 'O'),
+    (".--.", 'P'),
+    ("--.-", 'Q'),
+    (".-.", 'R'),
+    ("...", 'S'),
+    ("-", 'T'),
+    ("..-", 'U'),
+    ("...-", 'V'),
+    (".--", 'W'),
+    ("-..-", 'X'),
+    ("-.--", 'Y'),
+    ("--..", 'Z'),
+    (".----", '1'),
+    ("..---", '2'),
+    ("...--", '3'),
+    ("....-", '4'),
+    (".....", '5'),
+    ("-....", '6'),
+    ("--...", '7'),
+    ("---..", '8'),
+    ("----.", '9'),
+    ("-----", '0'),
+    (".-.-.-", '.'),
+    ("--..--", ','),
+    ("..--..", '?'),
+    (".----.", '\''),
+    ("-.-.--", '!'),
+    ("-..-.", '/'),
+    ("-.--.", '('),
+    ("-.--.-", ')'),
+    (".-...", '&'),
+    ("---...", ':'),
+    ("-.-.-.", ';'),
+    ("-...-", '='),
+    (".-.-.", '+'),
+    ("-....-", '-'),
+    ("..--.-", '_'),
+    (".-..-.", '"'),
+    ("...-..-", '$'),
+    (".--.-.", '@'),
+];

--- a/experiments/cw-decoder/vendor/ditdah/src/generator.rs
+++ b/experiments/cw-decoder/vendor/ditdah/src/generator.rs
@@ -1,0 +1,194 @@
+// src/generator.rs
+// Morse code WAV file generator for testing
+
+use anyhow::Result;
+use hound::{SampleFormat, WavSpec, WavWriter};
+use std::collections::HashMap;
+use std::f32::consts::PI;
+use std::path::Path;
+
+pub struct MorseGenerator {
+    sample_rate: u32,
+    frequency: f32,
+    _wpm: f32, // Stored for reference but not directly used in generation
+    dot_duration: f32,
+    dash_duration: f32,
+    element_gap: f32,
+    letter_gap: f32,
+    word_gap: f32,
+}
+
+impl MorseGenerator {
+    pub fn new(sample_rate: u32, frequency: f32, wpm: f32) -> Self {
+        let dot_duration = 1.2 / wpm; // seconds per dot
+        let dash_duration = 3.0 * dot_duration;
+        let element_gap = dot_duration; // gap between dots/dashes
+        let letter_gap = 3.0 * dot_duration; // gap between letters
+        let word_gap = 7.0 * dot_duration; // gap between words
+
+        Self {
+            sample_rate,
+            frequency,
+            _wpm: wpm,
+            dot_duration,
+            dash_duration,
+            element_gap,
+            letter_gap,
+            word_gap,
+        }
+    }
+
+    pub fn generate_wav_file<P: AsRef<Path>>(&self, text: &str, path: P) -> Result<()> {
+        let spec = WavSpec {
+            channels: 1,
+            sample_rate: self.sample_rate,
+            bits_per_sample: 16,
+            sample_format: SampleFormat::Int,
+        };
+
+        let mut writer = WavWriter::create(path, spec)?;
+        let morse_code = self.text_to_morse(text);
+
+        for &code in morse_code.iter() {
+            match code {
+                MorseElement::Dot => self.write_tone(&mut writer, self.dot_duration)?,
+                MorseElement::Dash => self.write_tone(&mut writer, self.dash_duration)?,
+                MorseElement::ElementGap => self.write_silence(&mut writer, self.element_gap)?,
+                MorseElement::LetterGap => self.write_silence(&mut writer, self.letter_gap)?,
+                MorseElement::WordGap => self.write_silence(&mut writer, self.word_gap)?,
+            }
+        }
+
+        writer.finalize()?;
+        Ok(())
+    }
+
+    fn write_tone<W: std::io::Write + std::io::Seek>(
+        &self,
+        writer: &mut WavWriter<W>,
+        duration: f32,
+    ) -> Result<()> {
+        let samples = (duration * self.sample_rate as f32) as usize;
+        for i in 0..samples {
+            let t = i as f32 / self.sample_rate as f32;
+            let sample = (2.0 * PI * self.frequency * t).sin();
+            let amplitude = 0.5; // 50% amplitude to avoid clipping
+            writer.write_sample((sample * amplitude * i16::MAX as f32) as i16)?;
+        }
+        Ok(())
+    }
+
+    fn write_silence<W: std::io::Write + std::io::Seek>(
+        &self,
+        writer: &mut WavWriter<W>,
+        duration: f32,
+    ) -> Result<()> {
+        let samples = (duration * self.sample_rate as f32) as usize;
+        for _ in 0..samples {
+            writer.write_sample(0i16)?;
+        }
+        Ok(())
+    }
+
+    fn text_to_morse(&self, text: &str) -> Vec<MorseElement> {
+        let morse_map = get_morse_map();
+        let mut result = Vec::new();
+        let words: Vec<&str> = text.split_whitespace().collect();
+
+        for (word_idx, word) in words.iter().enumerate() {
+            for (char_idx, ch) in word.chars().enumerate() {
+                if let Some(morse_str) = morse_map.get(&ch.to_ascii_uppercase()) {
+                    for (elem_idx, morse_char) in morse_str.chars().enumerate() {
+                        match morse_char {
+                            '.' => result.push(MorseElement::Dot),
+                            '-' => result.push(MorseElement::Dash),
+                            _ => {}
+                        }
+                        // Add element gap between dots/dashes (except after last element)
+                        if elem_idx < morse_str.len() - 1 {
+                            result.push(MorseElement::ElementGap);
+                        }
+                    }
+                }
+                // Add letter gap between letters (except after last letter)
+                if char_idx < word.len() - 1 {
+                    result.push(MorseElement::LetterGap);
+                }
+            }
+            // Add word gap between words (except after last word)
+            if word_idx < words.len() - 1 {
+                result.push(MorseElement::WordGap);
+            }
+        }
+
+        result
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum MorseElement {
+    Dot,
+    Dash,
+    ElementGap,
+    LetterGap,
+    WordGap,
+}
+
+fn get_morse_map() -> HashMap<char, &'static str> {
+    [
+        ('A', ".-"),
+        ('B', "-..."),
+        ('C', "-.-."),
+        ('D', "-.."),
+        ('E', "."),
+        ('F', "..-."),
+        ('G', "--."),
+        ('H', "...."),
+        ('I', ".."),
+        ('J', ".---"),
+        ('K', "-.-"),
+        ('L', ".-.."),
+        ('M', "--"),
+        ('N', "-."),
+        ('O', "---"),
+        ('P', ".--."),
+        ('Q', "--.-"),
+        ('R', ".-."),
+        ('S', "..."),
+        ('T', "-"),
+        ('U', "..-"),
+        ('V', "...-"),
+        ('W', ".--"),
+        ('X', "-..-"),
+        ('Y', "-.--"),
+        ('Z', "--.."),
+        ('1', ".----"),
+        ('2', "..---"),
+        ('3', "...--"),
+        ('4', "....-"),
+        ('5', "....."),
+        ('6', "-...."),
+        ('7', "--..."),
+        ('8', "---.."),
+        ('9', "----."),
+        ('0', "-----"),
+    ]
+    .iter()
+    .cloned()
+    .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_morse_generation() {
+        let generator = MorseGenerator::new(12000, 600.0, 20.0);
+        let result = generator.generate_wav_file("SOS", "test_sos.wav");
+        assert!(result.is_ok());
+
+        // Clean up test file
+        std::fs::remove_file("test_sos.wav").ok();
+    }
+}

--- a/experiments/cw-decoder/vendor/ditdah/src/lib.rs
+++ b/experiments/cw-decoder/vendor/ditdah/src/lib.rs
@@ -1,0 +1,87 @@
+// src/lib.rs
+// Library interface for ditdah
+
+mod decoder;
+pub mod generator;
+
+use decoder::MorseDecoder;
+pub use generator::MorseGenerator;
+
+use anyhow::Result;
+
+/// High-level convenience function to decode a WAV file directly
+///
+/// # Example
+/// ```no_run
+/// use ditdah::decode_wav_file;
+///
+/// let decoded_text = decode_wav_file("morse.wav").unwrap();
+/// println!("Decoded: {}", decoded_text);
+/// ```
+pub fn decode_wav_file<P: AsRef<std::path::Path>>(path: P) -> Result<String> {
+    use hound::{SampleFormat, WavReader};
+
+    let mut reader = WavReader::open(path)?;
+    let spec = reader.spec();
+
+    // Check supported formats
+    if spec.sample_format != SampleFormat::Int && spec.sample_format != SampleFormat::Float {
+        anyhow::bail!(
+            "Unsupported sample format: {:?}. Only 16-bit Int and 32-bit Float are supported.",
+            spec.sample_format
+        );
+    }
+
+    // Create decoder with automatic sample rate conversion
+    let mut decoder = MorseDecoder::new(spec.sample_rate, 12000)?;
+
+    // Read all samples
+    let samples_f32: Vec<f32> = if spec.sample_format == SampleFormat::Int {
+        reader
+            .samples::<i16>()
+            .map(|s| s.unwrap() as f32 / 32768.0)
+            .collect()
+    } else {
+        reader.samples::<f32>().map(|s| s.unwrap()).collect()
+    };
+
+    // Convert to mono if necessary
+    let mono_samples: Vec<f32> = if spec.channels > 1 {
+        samples_f32
+            .chunks_exact(spec.channels as usize)
+            .map(|chunk| chunk.iter().sum::<f32>() / spec.channels as f32)
+            .collect()
+    } else {
+        samples_f32
+    };
+
+    // Process in chunks for better memory efficiency
+    const CHUNK_SIZE: usize = 4096;
+    for chunk in mono_samples.chunks(CHUNK_SIZE) {
+        decoder.process(chunk)?;
+    }
+
+    decoder.finalize()
+}
+
+/// High-level convenience function to decode audio samples directly
+///
+/// # Example
+/// ```no_run
+/// use ditdah::decode_samples;
+///
+/// // For real audio data with sufficient length for processing
+/// let samples = vec![0.0; 48000]; // 4 seconds of audio at 12kHz
+/// let decoded_text = decode_samples(&samples, 12000).unwrap();
+/// println!("Decoded: {}", decoded_text);
+/// ```
+pub fn decode_samples(samples: &[f32], sample_rate: u32) -> Result<String> {
+    let mut decoder = MorseDecoder::new(sample_rate, 12000)?;
+
+    const CHUNK_SIZE: usize = 4096;
+    for chunk in samples.chunks(CHUNK_SIZE) {
+        decoder.process(chunk)?;
+    }
+
+    decoder.finalize()
+}

--- a/experiments/cw-decoder/vendor/ditdah/src/main.rs
+++ b/experiments/cw-decoder/vendor/ditdah/src/main.rs
@@ -1,0 +1,225 @@
+use anyhow::{Result, bail};
+use clap::Parser;
+use std::path::PathBuf;
+use std::time::Instant;
+
+mod generator;
+
+#[derive(Parser)]
+#[command(
+    name = "ditdah",
+    version,
+    about = "High-performance Morse code decoder",
+    long_about = "A high-performance Rust implementation of a Morse code decoder that can process WAV audio files and decode them into text with 100% accuracy on the comprehensive test suite."
+)]
+struct Cli {
+    /// Path to the input WAV file
+    #[arg(value_name = "FILE", help = "WAV file containing Morse code audio")]
+    wav_file: Option<PathBuf>,
+
+    /// Show detailed processing information
+    #[arg(short, long, help = "Enable verbose output")]
+    verbose: bool,
+
+    /// Show timing information
+    #[arg(short, long, help = "Show processing time")]
+    time: bool,
+
+    /// Generate a test WAV file instead of decoding
+    #[arg(
+        long,
+        value_name = "TEXT",
+        help = "Generate test WAV file with given text"
+    )]
+    generate: Option<String>,
+
+    /// Output file for generation (default: output.wav)
+    #[arg(
+        short,
+        long,
+        value_name = "FILE",
+        help = "Output file for generated WAV"
+    )]
+    output: Option<PathBuf>,
+
+    /// Frequency for generated audio (default: 600 Hz)
+    #[arg(
+        long,
+        value_name = "HZ",
+        default_value = "600",
+        help = "Frequency in Hz for generated audio"
+    )]
+    frequency: f32,
+
+    /// Words per minute for generated audio (default: 20 WPM)
+    #[arg(
+        long,
+        value_name = "WPM",
+        default_value = "20",
+        help = "Words per minute for generated audio"
+    )]
+    wpm: f32,
+}
+
+fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    // Set up logging - user can control with RUST_LOG environment variable
+    env_logger::try_init().ok();
+
+    // Handle generation mode
+    if let Some(text) = &cli.generate {
+        return generate_wav_file(&cli, text);
+    }
+
+    // Validate we have an input file for decoding
+    let wav_file = cli.wav_file.as_ref().ok_or_else(|| {
+        anyhow::anyhow!("No input file specified. Use --help for usage information.")
+    })?;
+
+    // Validate input file exists
+    if !wav_file.exists() {
+        bail!("File not found: {}", wav_file.display());
+    }
+
+    let start_time = Instant::now();
+
+    if cli.verbose {
+        println!("Processing: {}", wav_file.display());
+    }
+
+    // Use the new high-level API
+    let decoded_text = ditdah::decode_wav_file(wav_file).map_err(|e| {
+        // Provide user-friendly error messages
+        match e.to_string().as_str() {
+            s if s.contains("No such file") => {
+                anyhow::anyhow!("File not found: {}", wav_file.display())
+            }
+            s if s.contains("Unsupported sample format") => {
+                anyhow::anyhow!("Unsupported audio format. Please use 16-bit or 32-bit WAV files.")
+            }
+            s if s.contains("Could not find a dominant frequency") => anyhow::anyhow!(
+                "No Morse code signal detected. Check that the file contains clear Morse audio."
+            ),
+            _ => e,
+        }
+    })?;
+
+    let duration = start_time.elapsed();
+
+    // Output results
+    if decoded_text.is_empty() {
+        println!("No Morse code detected");
+        if !cli.verbose {
+            println!("Try using --verbose flag for detailed processing information");
+        }
+    } else {
+        println!("Decoded: {}", decoded_text);
+
+        if cli.time {
+            println!("Processing time: {:.2?}", duration);
+        }
+
+        if cli.verbose {
+            println!("Length: {} characters", decoded_text.len());
+            if decoded_text.len() > 50 {
+                println!("Text: {}...", &decoded_text[..50]);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn generate_wav_file(cli: &Cli, text: &str) -> Result<()> {
+    use generator::MorseGenerator;
+
+    let output_path = cli
+        .output
+        .clone()
+        .unwrap_or_else(|| PathBuf::from("output.wav"));
+
+    if cli.verbose {
+        println!(
+            "Generating: '{}' at {} Hz, {} WPM",
+            text, cli.frequency, cli.wpm
+        );
+        println!("Output: {}", output_path.display());
+    }
+
+    let generator = MorseGenerator::new(12000, cli.frequency, cli.wpm);
+    generator.generate_wav_file(text, &output_path)?;
+
+    println!("Generated: {}", output_path.display());
+
+    if cli.verbose {
+        println!(
+            "Settings: {} Hz, {} WPM, 12kHz sample rate",
+            cli.frequency, cli.wpm
+        );
+
+        // Show what the Morse pattern looks like
+        let morse_pattern = text_to_morse_pattern(text);
+        if !morse_pattern.is_empty() {
+            println!("Morse: {}", morse_pattern);
+        }
+    }
+
+    Ok(())
+}
+
+fn text_to_morse_pattern(text: &str) -> String {
+    let morse_map = [
+        ('A', ".-"),
+        ('B', "-..."),
+        ('C', "-.-."),
+        ('D', "-.."),
+        ('E', "."),
+        ('F', "..-."),
+        ('G', "--."),
+        ('H', "...."),
+        ('I', ".."),
+        ('J', ".---"),
+        ('K', "-.-"),
+        ('L', ".-.."),
+        ('M', "--"),
+        ('N', "-."),
+        ('O', "---"),
+        ('P', ".--."),
+        ('Q', "--.-"),
+        ('R', ".-."),
+        ('S', "..."),
+        ('T', "-"),
+        ('U', "..-"),
+        ('V', "...-"),
+        ('W', ".--"),
+        ('X', "-..-"),
+        ('Y', "-.--"),
+        ('Z', "--.."),
+        ('1', ".----"),
+        ('2', "..---"),
+        ('3', "...--"),
+        ('4', "....-"),
+        ('5', "....."),
+        ('6', "-...."),
+        ('7', "--..."),
+        ('8', "---.."),
+        ('9', "----."),
+        ('0', "-----"),
+    ]
+    .into_iter()
+    .collect::<std::collections::HashMap<_, _>>();
+
+    text.to_uppercase()
+        .chars()
+        .filter_map(|c| {
+            if c == ' ' {
+                Some("  ".to_string())
+            } else {
+                morse_map.get(&c).map(|&morse| format!("{} ", morse))
+            }
+        })
+        .collect::<String>()
+        .trim()
+        .to_string()
+}

--- a/experiments/cw-decoder/vendor/ditdah/tests/integration_tests.rs
+++ b/experiments/cw-decoder/vendor/ditdah/tests/integration_tests.rs
@@ -1,0 +1,332 @@
+// tests/integration_tests.rs
+// Comprehensive integration tests for the Morse decoder
+
+use anyhow::Result;
+use ditdah::{MorseGenerator, decode_wav_file};
+use std::{fs, io::Write};
+
+#[derive(Debug)]
+struct TestCase {
+    name: &'static str,
+    text: &'static str,
+    frequency: f32,
+    wpm: f32,
+    sample_rate: u32,
+    expected_accuracy: f32, // Minimum accuracy threshold (0.0 to 1.0)
+}
+
+const TEST_CASES: &[TestCase] = &[
+    // Basic tests
+    TestCase {
+        name: "simple_sos",
+        text: "SOS",
+        frequency: 600.0,
+        wpm: 20.0,
+        sample_rate: 12000,
+        expected_accuracy: 0.8,
+    },
+    TestCase {
+        name: "hello_world",
+        text: "HELLO WORLD",
+        frequency: 600.0,
+        wpm: 20.0,
+        sample_rate: 12000,
+        expected_accuracy: 0.7,
+    },
+    TestCase {
+        name: "alphabet",
+        text: "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+        frequency: 600.0,
+        wpm: 15.0,
+        sample_rate: 12000,
+        expected_accuracy: 0.6,
+    },
+    // Different frequencies
+    TestCase {
+        name: "low_freq",
+        text: "TEST",
+        frequency: 300.0,
+        wpm: 20.0,
+        sample_rate: 12000,
+        expected_accuracy: 0.7,
+    },
+    TestCase {
+        name: "high_freq",
+        text: "TEST",
+        frequency: 1000.0,
+        wpm: 20.0,
+        sample_rate: 12000,
+        expected_accuracy: 0.7,
+    },
+    // Different WPM speeds
+    TestCase {
+        name: "slow_wpm",
+        text: "SLOW",
+        frequency: 600.0,
+        wpm: 10.0,
+        sample_rate: 12000,
+        expected_accuracy: 0.8,
+    },
+    TestCase {
+        name: "fast_wpm",
+        text: "FAST",
+        frequency: 600.0,
+        wpm: 30.0,
+        sample_rate: 12000,
+        expected_accuracy: 0.6,
+    },
+    // Numbers
+    TestCase {
+        name: "numbers",
+        text: "12345",
+        frequency: 600.0,
+        wpm: 20.0,
+        sample_rate: 12000,
+        expected_accuracy: 0.7,
+    },
+    // Mixed content
+    TestCase {
+        name: "mixed",
+        text: "CQ DE W1AW",
+        frequency: 600.0,
+        wpm: 20.0,
+        sample_rate: 12000,
+        expected_accuracy: 0.6,
+    },
+    // Different sample rates
+    TestCase {
+        name: "different_sample_rate",
+        text: "RATE",
+        frequency: 600.0,
+        wpm: 20.0,
+        sample_rate: 44100,
+        expected_accuracy: 0.7,
+    },
+];
+
+#[test]
+fn run_comprehensive_test_suite() -> Result<()> {
+    println!("Running comprehensive Morse decoder test suite...");
+
+    // Create test directory
+    fs::create_dir_all("test_outputs")?;
+
+    let mut results = Vec::new();
+    let mut total_tests = 0;
+    let mut passed_tests = 0;
+
+    // Create a detailed report file
+    let mut report_file = fs::File::create("test_outputs/test_report.txt")?;
+    writeln!(report_file, "Morse Decoder Test Report")?;
+    writeln!(report_file, "=========================")?;
+    writeln!(report_file)?;
+
+    for test_case in TEST_CASES {
+        total_tests += 1;
+        println!("Running test: {}", test_case.name);
+
+        let result = run_single_test(test_case);
+        let passed = result.is_ok();
+        if passed {
+            passed_tests += 1;
+        }
+
+        // Log detailed results
+        match &result {
+            Ok(test_result) => {
+                println!(
+                    "  ✓ PASSED - Accuracy: {:.1}%",
+                    test_result.accuracy * 100.0
+                );
+                writeln!(
+                    report_file,
+                    "TEST: {} - PASSED\n  Expected: '{}'\n  Decoded: '{}'\n  Accuracy: {:.1}%\n  WPM: {}, Freq: {}Hz, SR: {}Hz\n",
+                    test_case.name,
+                    test_case.text,
+                    test_result.decoded_text,
+                    test_result.accuracy * 100.0,
+                    test_case.wpm,
+                    test_case.frequency,
+                    test_case.sample_rate
+                )?;
+            }
+            Err(e) => {
+                println!("  ✗ FAILED - {}", e);
+                writeln!(
+                    report_file,
+                    "TEST: {} - FAILED\n  Expected: '{}'\n  Error: {}\n  WPM: {}, Freq: {}Hz, SR: {}Hz\n",
+                    test_case.name,
+                    test_case.text,
+                    e,
+                    test_case.wpm,
+                    test_case.frequency,
+                    test_case.sample_rate
+                )?;
+            }
+        }
+
+        results.push((test_case, result));
+    }
+
+    // Summary
+    let pass_rate = (passed_tests as f32 / total_tests as f32) * 100.0;
+    println!("\nTest Summary:");
+    println!("  Total tests: {}", total_tests);
+    println!("  Passed: {}", passed_tests);
+    println!("  Failed: {}", total_tests - passed_tests);
+    println!("  Pass rate: {:.1}%", pass_rate);
+
+    writeln!(report_file, "\nSUMMARY:")?;
+    writeln!(report_file, "  Total tests: {}", total_tests)?;
+    writeln!(report_file, "  Passed: {}", passed_tests)?;
+    writeln!(report_file, "  Failed: {}", total_tests - passed_tests)?;
+    writeln!(report_file, "  Pass rate: {:.1}%", pass_rate)?;
+
+    // Analyze failure patterns
+    let failed_tests: Vec<_> = results.iter().filter(|(_, r)| r.is_err()).collect();
+    if !failed_tests.is_empty() {
+        writeln!(report_file, "\nFAILURE ANALYSIS:")?;
+        for (test_case, error) in failed_tests {
+            writeln!(
+                report_file,
+                "  {} - {}",
+                test_case.name,
+                error.as_ref().unwrap_err()
+            )?;
+        }
+    }
+
+    // Clean up test directory
+    std::fs::remove_dir_all("test_outputs").ok();
+
+    // If overall pass rate is too low, fail the test
+    if pass_rate < 50.0 {
+        panic!("Test suite failed with pass rate of {:.1}%.", pass_rate);
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct TestResult {
+    decoded_text: String,
+    accuracy: f32,
+}
+
+fn run_single_test(test_case: &TestCase) -> Result<TestResult> {
+    // Generate the test WAV file in a temporary location
+    let generator = MorseGenerator::new(test_case.sample_rate, test_case.frequency, test_case.wpm);
+    let wav_path = format!("test_outputs/{}.wav", test_case.name);
+    generator.generate_wav_file(test_case.text, &wav_path)?;
+
+    // Decode the WAV file
+    let decoded_text = decode_test_wav_file(&wav_path)?;
+
+    // Calculate accuracy
+    let accuracy = calculate_accuracy(test_case.text, &decoded_text);
+
+    let result = TestResult {
+        decoded_text,
+        accuracy,
+    };
+
+    // Clean up the temporary WAV file
+    std::fs::remove_file(&wav_path).ok();
+
+    // Check if accuracy meets threshold
+    if accuracy >= test_case.expected_accuracy {
+        Ok(result)
+    } else {
+        Err(anyhow::anyhow!(
+            "Accuracy {:.1}% below threshold {:.1}%",
+            accuracy * 100.0,
+            test_case.expected_accuracy * 100.0
+        ))
+    }
+}
+
+fn decode_test_wav_file(path: &str) -> Result<String> {
+    decode_wav_file(path)
+}
+
+fn calculate_accuracy(expected: &str, actual: &str) -> f32 {
+    if expected.is_empty() {
+        return if actual.is_empty() { 1.0 } else { 0.0 };
+    }
+
+    let expected_clean = expected.to_uppercase().replace(" ", "");
+    let actual_clean = actual.to_uppercase().replace(" ", "").replace("?", "");
+
+    if expected_clean.is_empty() {
+        return if actual_clean.is_empty() { 1.0 } else { 0.0 };
+    }
+
+    // Simple character-by-character comparison
+    let expected_chars: Vec<char> = expected_clean.chars().collect();
+    let actual_chars: Vec<char> = actual_clean.chars().collect();
+
+    let max_len = expected_chars.len().max(actual_chars.len());
+    let mut matches = 0;
+
+    for i in 0..max_len {
+        let expected_char = expected_chars.get(i);
+        let actual_char = actual_chars.get(i);
+
+        if expected_char == actual_char {
+            matches += 1;
+        }
+    }
+
+    matches as f32 / max_len as f32
+}
+
+#[test]
+fn test_accuracy_calculation() {
+    assert_eq!(calculate_accuracy("SOS", "SOS"), 1.0);
+    assert_eq!(calculate_accuracy("SOS", "SO"), 2.0 / 3.0);
+    assert_eq!(calculate_accuracy("SOS", "XOS"), 2.0 / 3.0);
+    assert_eq!(calculate_accuracy("HELLO", "WORLD"), 1.0 / 5.0); // Only L matches
+    assert_eq!(calculate_accuracy("", ""), 1.0);
+    assert_eq!(calculate_accuracy("A", ""), 0.0);
+}
+
+#[test]
+fn baseline_decoder_test() -> Result<()> {
+    // Clean baseline test to establish current decoder status
+    println!("=== DECODER BASELINE TEST ===");
+
+    // Note: Set RUST_LOG=info environment variable to see decoder output during testing
+    env_logger::try_init().ok();
+
+    let generator = MorseGenerator::new(12000, 600.0, 20.0);
+
+    let test_cases = [
+        ("EEEE", "4 dots"),
+        ("TTTT", "4 dashes"),
+        ("ETET", "dot-dash-dot-dash"),
+    ];
+
+    for (i, (test_text, description)) in test_cases.iter().enumerate() {
+        println!("\n--- Test {}: {} ({}) ---", i + 1, test_text, description);
+
+        let temp_file = format!("baseline_test_{}.wav", i);
+        generator.generate_wav_file(test_text, &temp_file)?;
+        let decoded = decode_test_wav_file(&temp_file)?;
+        println!(
+            "Expected: {} | Decoded: {} | Success: {}",
+            test_text,
+            decoded,
+            decoded == *test_text
+        );
+
+        // Clean up immediately
+        std::fs::remove_file(&temp_file).ok();
+    }
+
+    // Summary
+    println!("\n=== BASELINE SUMMARY ===");
+    println!("This establishes our current decoder capabilities");
+    println!("Focus on getting these 3 simple patterns working first");
+
+    Ok(())
+}

--- a/src/dotnet/QsoRipper.Gui.Tests/CwDecoderProcessSampleSourceTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/CwDecoderProcessSampleSourceTests.cs
@@ -1,0 +1,34 @@
+using QsoRipper.Gui.Services;
+
+namespace QsoRipper.Gui.Tests;
+
+public sealed class CwDecoderProcessSampleSourceTests
+{
+    [Theory]
+    [InlineData("{\"type\":\"char\",\"ch\":\"C\"}")]
+    [InlineData("{\"type\":\"word\"}")]
+    [InlineData("{\"type\":\"wpm\",\"wpm\":20.0}")]
+    public void RollingBackendDecodedEventsPromoteToLocked(string line)
+    {
+        Assert.True(CwDecoderProcessSampleSource.TryParseRollingBackendState(line, out var state));
+        Assert.Equal(CwLockState.Locked, state);
+    }
+
+    [Theory]
+    [InlineData("{\"type\":\"power\",\"signal\":true}")]
+    [InlineData("{\"type\":\"stats\",\"wpm\":20.0}")]
+    [InlineData("{\"type\":\"pitch\",\"hz\":700.0}")]
+    public void RollingBackendMeterEventsDoNotDemoteLockState(string line)
+    {
+        Assert.False(CwDecoderProcessSampleSource.TryParseRollingBackendState(line, out _));
+    }
+
+    [Fact]
+    public void RollingBackendReadyInitializesHuntingState()
+    {
+        Assert.True(CwDecoderProcessSampleSource.TryParseRollingBackendState(
+            "{\"type\":\"ready\",\"source\":\"stream-live-ditdah\"}",
+            out var state));
+        Assert.Equal(CwLockState.Hunting, state);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui.Tests/CwDecoderProcessSampleSourceTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/CwDecoderProcessSampleSourceTests.cs
@@ -7,7 +7,6 @@ public sealed class CwDecoderProcessSampleSourceTests
     [Theory]
     [InlineData("{\"type\":\"char\",\"ch\":\"C\"}")]
     [InlineData("{\"type\":\"word\"}")]
-    [InlineData("{\"type\":\"wpm\",\"wpm\":20.0}")]
     public void RollingBackendDecodedEventsPromoteToLocked(string line)
     {
         Assert.True(CwDecoderProcessSampleSource.TryParseRollingBackendState(line, out var state));
@@ -18,6 +17,7 @@ public sealed class CwDecoderProcessSampleSourceTests
     [InlineData("{\"type\":\"power\",\"signal\":true}")]
     [InlineData("{\"type\":\"stats\",\"wpm\":20.0}")]
     [InlineData("{\"type\":\"pitch\",\"hz\":700.0}")]
+    [InlineData("{\"type\":\"wpm\",\"wpm\":20.0}")]
     public void RollingBackendMeterEventsDoNotDemoteLockState(string line)
     {
         Assert.False(CwDecoderProcessSampleSource.TryParseRollingBackendState(line, out _));

--- a/src/dotnet/QsoRipper.Gui.Tests/CwQsoTranscriptAggregatorTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/CwQsoTranscriptAggregatorTests.cs
@@ -19,6 +19,7 @@ public sealed class CwQsoTranscriptAggregatorTests
 
         public void Emit(string line) => RawLineReceived?.Invoke(this, line);
         public void Start(string? deviceOverride) { }
+        public void MarkAnchorHeard() { }
         public void Stop() { }
         public void Dispose() { }
     }

--- a/src/dotnet/QsoRipper.Gui.Tests/CwQsoWpmAggregatorTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/CwQsoWpmAggregatorTests.cs
@@ -27,6 +27,7 @@ public sealed class CwQsoWpmAggregatorTests
         }
 
         public void Start(string? deviceOverride) => StatusChanged?.Invoke(this, EventArgs.Empty);
+        public void MarkAnchorHeard() { }
         public void Stop() => StatusChanged?.Invoke(this, EventArgs.Empty);
         public void Dispose() { }
     }

--- a/src/dotnet/QsoRipper.Gui.Tests/CwStatsPaneViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/CwStatsPaneViewModelTests.cs
@@ -17,6 +17,7 @@ public class CwStatsPaneViewModelTests
         public bool IsRunning => true;
         public CwWpmSample? LatestSample { get; private set; }
         public CwLockState CurrentLockState { get; set; } = CwLockState.Unknown;
+        public int AnchorHeardCount { get; private set; }
 
         public event EventHandler<CwWpmSample>? SampleReceived;
         public event EventHandler? StatusChanged;
@@ -38,6 +39,7 @@ public class CwStatsPaneViewModelTests
         }
 
         public void Start(string? deviceOverride) => StatusChanged?.Invoke(this, EventArgs.Empty);
+        public void MarkAnchorHeard() => AnchorHeardCount++;
         public void Stop() => StatusChanged?.Invoke(this, EventArgs.Empty);
         public void Dispose() { }
     }
@@ -145,6 +147,30 @@ public class CwStatsPaneViewModelTests
         Assert.True(vm.IsLocked);
         Assert.Equal("● LIVE", vm.LockBadgeText);
         Assert.Equal("LOCKED", vm.ConfidenceText);
+    });
+
+    [Fact]
+    public void MarkAnchorHeardCommandSendsManualAnchorAndUpdatesStatus() => OnDispatcher(() =>
+    {
+        using var src = new InMemorySource { CurrentLockState = CwLockState.Hunting };
+        using var vm = new CwStatsPaneViewModel(src);
+
+        vm.MarkAnchorHeardCommand.Execute(null);
+
+        Assert.Equal(1, src.AnchorHeardCount);
+        Assert.Equal("Manual anchor armed", vm.StatusText);
+    });
+
+    [Fact]
+    public void StatusEventUpdatesStatusText() => OnDispatcher(() =>
+    {
+        using var src = new InMemorySource { CurrentLockState = CwLockState.Hunting };
+        using var vm = new CwStatsPaneViewModel(src);
+
+        src.EmitRaw("{\"type\":\"status\",\"message\":\"Manual anchor armed\"}");
+        Pump();
+
+        Assert.Equal("Manual anchor armed", vm.StatusText);
     });
 
     [Fact]

--- a/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
@@ -58,6 +58,7 @@ public sealed class QsoLoggerEnrichmentTests
             SampleReceived?.Invoke(this, s);
         }
         public void Start(string? deviceOverride) => StatusChanged?.Invoke(this, EventArgs.Empty);
+        public void MarkAnchorHeard() { }
         public void Stop() => StatusChanged?.Invoke(this, EventArgs.Empty);
         public void Dispose() { }
     }

--- a/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
@@ -10,7 +10,7 @@ namespace QsoRipper.Gui.Services;
 
 /// <summary>
 /// Spawns the experimental <c>cw-decoder</c> Rust binary in
-/// <c>stream-live --json</c> mode and surfaces parsed <c>wpm</c>
+/// <c>stream-live-ditdah --json</c> mode and surfaces parsed <c>wpm</c>
 /// NDJSON events as <see cref="CwWpmSample"/>s.
 ///
 /// Round 1 deliberately reuses the experiment binary rather than the
@@ -114,8 +114,16 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
             CreateNoWindow = true,
             WorkingDirectory = Path.GetDirectoryName(exe)!,
         };
-        psi.ArgumentList.Add("stream-live");
+        psi.ArgumentList.Add("stream-live-ditdah");
         psi.ArgumentList.Add("--json");
+        psi.ArgumentList.Add("--window");
+        psi.ArgumentList.Add("6");
+        psi.ArgumentList.Add("--min-window");
+        psi.ArgumentList.Add("4");
+        psi.ArgumentList.Add("--decode-every-ms");
+        psi.ArgumentList.Add("1000");
+        psi.ArgumentList.Add("--confirmations");
+        psi.ArgumentList.Add("1");
         if (loopback)
         {
             // WASAPI loopback: capture from a system OUTPUT device so audio

--- a/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
@@ -451,7 +451,7 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
 
             state = typeProp.GetString() switch
             {
-                "char" or "word" or "wpm" => CwLockState.Locked,
+                "char" or "word" => CwLockState.Locked,
                 "ready" => CwLockState.Hunting,
                 "status" => CwLockState.Probation,
                 _ => CwLockState.Unknown,

--- a/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
@@ -437,7 +437,7 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
         }
     }
 
-    private static bool TryParseRollingBackendState(string ndjsonLine, out CwLockState state)
+    internal static bool TryParseRollingBackendState(string ndjsonLine, out CwLockState state)
     {
         state = CwLockState.Unknown;
         try
@@ -452,7 +452,7 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
             state = typeProp.GetString() switch
             {
                 "char" or "word" or "wpm" => CwLockState.Locked,
-                "ready" or "power" or "stats" or "pitch" => CwLockState.Hunting,
+                "ready" => CwLockState.Hunting,
                 "status" => CwLockState.Probation,
                 _ => CwLockState.Unknown,
             };

--- a/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
@@ -249,6 +249,23 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
     /// </summary>
     public void ResetLock()
     {
+        WriteControlLine("{\"type\":\"reset_lock\"}");
+    }
+
+    /// <summary>
+    /// Send a manual-anchor hint to the running decoder so the rolling
+    /// ditdah backend can start accepting plausible mid-QSO text even when
+    /// the operator tuned in after automatic anchors such as CQ/DE/73.
+    /// No-op if the decoder is not running.
+    /// </summary>
+    public void MarkAnchorHeard()
+    {
+        WriteControlLine("{\"type\":\"manual_anchor\"}");
+        SetLockState(CwLockState.Probation);
+    }
+
+    private void WriteControlLine(string line)
+    {
         Process? proc;
         lock (_stateLock)
         {
@@ -260,7 +277,7 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
         }
         try
         {
-            proc.StandardInput.WriteLine("{\"type\":\"reset_lock\"}");
+            proc.StandardInput.WriteLine(line);
             proc.StandardInput.Flush();
         }
         catch (IOException) { /* best effort */ }
@@ -288,16 +305,7 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
 
                 if (TryParseConfidenceEvent(line, out var newState))
                 {
-                    bool changed;
-                    lock (_stateLock)
-                    {
-                        changed = _lockState != newState;
-                        _lockState = newState;
-                    }
-                    if (changed)
-                    {
-                        LockStateChanged?.Invoke(this, newState);
-                    }
+                    SetLockState(newState);
                 }
                 else if (TryParsePitchLostEvent(line))
                 {
@@ -305,16 +313,11 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
                     // signal; the next confidence event will follow but
                     // we surface the lock loss immediately so the GUI
                     // doesn't keep showing a stale WPM for the gap.
-                    bool changed;
-                    lock (_stateLock)
-                    {
-                        changed = _lockState != CwLockState.Hunting;
-                        _lockState = CwLockState.Hunting;
-                    }
-                    if (changed)
-                    {
-                        LockStateChanged?.Invoke(this, CwLockState.Hunting);
-                    }
+                    SetLockState(CwLockState.Hunting);
+                }
+                else if (TryParseRollingBackendState(line, out var rollingState))
+                {
+                    SetLockState(rollingState);
                 }
 
                 if (TryParseWpmEvent(line, out var wpm))
@@ -335,6 +338,20 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
         catch (IOException)
         {
             // Stdout pipe closed during shutdown.
+        }
+    }
+
+    private void SetLockState(CwLockState newState)
+    {
+        bool changed;
+        lock (_stateLock)
+        {
+            changed = _lockState != newState;
+            _lockState = newState;
+        }
+        if (changed)
+        {
+            LockStateChanged?.Invoke(this, newState);
         }
     }
 
@@ -413,6 +430,34 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
             return doc.RootElement.TryGetProperty("type", out var typeProp)
                 && typeProp.ValueKind == JsonValueKind.String
                 && string.Equals(typeProp.GetString(), "pitch_lost", StringComparison.Ordinal);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryParseRollingBackendState(string ndjsonLine, out CwLockState state)
+    {
+        state = CwLockState.Unknown;
+        try
+        {
+            using var doc = JsonDocument.Parse(ndjsonLine);
+            if (!doc.RootElement.TryGetProperty("type", out var typeProp)
+                || typeProp.ValueKind != JsonValueKind.String)
+            {
+                return false;
+            }
+
+            state = typeProp.GetString() switch
+            {
+                "char" or "word" or "wpm" => CwLockState.Locked,
+                "ready" or "power" or "stats" or "pitch" => CwLockState.Hunting,
+                "status" => CwLockState.Probation,
+                _ => CwLockState.Unknown,
+            };
+
+            return state != CwLockState.Unknown;
         }
         catch (JsonException)
         {

--- a/src/dotnet/QsoRipper.Gui/Services/ICwWpmSampleSource.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/ICwWpmSampleSource.cs
@@ -52,6 +52,12 @@ internal interface ICwWpmSampleSource : IDisposable
     /// (null/empty = system default capture device).</summary>
     void Start(string? deviceOverride);
 
+    /// <summary>
+    /// Tell the decoder the operator has heard a CW anchor manually, allowing
+    /// rolling-stream decode to become active when tuning in mid-QSO.
+    /// </summary>
+    void MarkAnchorHeard();
+
     /// <summary>Stop the source. Safe to call when not running.</summary>
     void Stop();
 }

--- a/src/dotnet/QsoRipper.Gui/ViewModels/CwStatsPaneViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/CwStatsPaneViewModel.cs
@@ -104,6 +104,24 @@ internal sealed partial class CwStatsPaneViewModel : ObservableObject, IDisposab
     [RelayCommand]
     private void Close() => CloseRequested?.Invoke(this, EventArgs.Empty);
 
+    [RelayCommand]
+    public void MarkAnchorHeard()
+    {
+        if (_source is null)
+        {
+            StatusText = "Radio monitor is OFF";
+            return;
+        }
+        if (!_source.IsRunning)
+        {
+            StatusText = "Decoder is not running";
+            return;
+        }
+
+        _source.MarkAnchorHeard();
+        StatusText = "Manual anchor armed";
+    }
+
     /// <summary>
     /// Reset the live displays to a quiescent state. Called by
     /// <c>MainWindowViewModel</c> when a QSO episode boundary fires
@@ -244,6 +262,9 @@ internal sealed partial class CwStatsPaneViewModel : ObservableObject, IDisposab
                     break;
                 case "ready":
                     StatusText = "Decoder ready";
+                    break;
+                case "status":
+                    StatusText = TryGetString(doc.RootElement, "message") ?? StatusText;
                     break;
                 default:
                     break;

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -1323,6 +1323,32 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     }
 
     [RelayCommand]
+    private void MarkCwAnchorHeard()
+    {
+        if (_cwSampleSource is null)
+        {
+            CwDecoderStatusText = "WPM: disabled (Settings → Radio Monitor)";
+            return;
+        }
+        if (!_cwSampleSource.IsRunning)
+        {
+            CwDecoderStatusText = "WPM: decoder not running";
+            CwStatsPane?.MarkAnchorHeard();
+            return;
+        }
+
+        if (CwStatsPane is { } pane)
+        {
+            pane.MarkAnchorHeard();
+        }
+        else
+        {
+            _cwSampleSource.MarkAnchorHeard();
+        }
+        CwDecoderStatusText = "WPM: manual anchor armed";
+    }
+
+    [RelayCommand]
     private void ToggleCwStatsPane()
     {
         if (IsCwStatsPaneOpen)

--- a/src/dotnet/QsoRipper.Gui/Views/CwStatsPaneView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/CwStatsPaneView.axaml
@@ -65,6 +65,11 @@
       <Setter Property="Background" Value="#cc3333" />
       <Setter Property="TextElement.Foreground" Value="White" />
     </Style>
+    <Style Selector="Button.actionBtn">
+      <Setter Property="Padding" Value="8,3" />
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="HorizontalAlignment" Value="Left" />
+    </Style>
   </UserControl.Styles>
 
   <!-- Outer border has a fixed width AND fixed height so the pane
@@ -73,11 +78,11 @@
   <Border Background="#202028"
           BorderBrush="#0096D6"
           BorderThickness="1"
-          CornerRadius="4"
-          Padding="14,10,14,12"
-          Width="360"
-          Height="320"
-          automation:AutomationProperties.AutomationId="CwStatsPane">
+           CornerRadius="4"
+           Padding="14,10,14,12"
+           Width="360"
+           Height="340"
+           automation:AutomationProperties.AutomationId="CwStatsPane">
     <DockPanel LastChildFill="True">
 
       <!-- Header row: title + lock badge on left, close button pinned
@@ -150,11 +155,26 @@
           <TextBlock Grid.Row="3" Grid.Column="0" Classes="label" Text="Garbled" />
           <TextBlock Grid.Row="3" Grid.Column="1" Classes="value" Foreground="#cc8866"
                      Text="{Binding LastGarbledText}" />
-        </Grid>
+         </Grid>
 
-        <Border Height="1" Background="#333355" />
+         <Border Height="1" Background="#333355" />
 
-        <TextBlock Classes="label" Text="Decoded" />
+         <DockPanel>
+           <Button DockPanel.Dock="Left"
+                   Classes="actionBtn"
+                   Content="Anchor heard"
+                   Command="{Binding MarkAnchorHeardCommand}"
+                   IsEnabled="{Binding IsLive}"
+                   ToolTip.Tip="Manually start mid-QSO decoding (Ctrl+Shift+A)"
+                   automation:AutomationProperties.AutomationId="CwStatsAnchorHeard" />
+           <TextBlock Margin="8,0,0,0"
+                      VerticalAlignment="Center"
+                      FontSize="10.5"
+                      Foreground="#777788"
+                      Text="Ctrl+Shift+A" />
+         </DockPanel>
+
+         <TextBlock Classes="label" Text="Decoded" />
         <Border Background="#101018"
                 BorderBrush="#333355"
                 BorderThickness="1"

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -27,6 +27,7 @@
     <KeyBinding Gesture="Alt+Enter" Command="{Binding ToggleInspectorCommand}" />
     <KeyBinding Gesture="F8" Command="{Binding OpenCallsignCardCommand}" />
     <KeyBinding Gesture="F9" Command="{Binding ToggleCwStatsPaneCommand}" />
+    <KeyBinding Gesture="Ctrl+Shift+A" Command="{Binding MarkCwAnchorHeardCommand}" />
     <KeyBinding Gesture="F6" Command="{Binding SyncNowCommand}" />
     <KeyBinding Gesture="Ctrl+Enter" Command="{Binding Logger.LogQsoCommand}" />
     <KeyBinding Gesture="F10" Command="{Binding Logger.LogQsoCommand}" />


### PR DESCRIPTION
This PR advances the experimental CW decoder toward live logger use and packages the current branch state for review.

It adds the CW Scope recording flow for building labeled training samples, vendors the ditdah decoder under experiments/cw-decoder, adds rough-fist stress generation, adds a rolling ditdah stream path, and routes the GUI CW subprocess through that rolling backend. The rolling path now has Morse-prefix beam decoding, adaptive timing/gap handling, snapshot quality filtering, stronger live-copy gates, and manual F9 anchoring via the Anchor heard action / Ctrl+Shift+A for tuning in mid-QSO.

The F9 pane no longer treats routine meter events or WPM-only updates as confident LIVE copy. It waits for committed char/word output, ignores weak Q/SB fragments as anchors, and rejects the E/T-heavy false-call bursts seen in the saved strong-QSO diagnostic capture. The logger wiring is also present on this branch: live CW samples feed WPM and transcript aggregators, CW QSOs auto-fill cw_decode_rx_wpm and cw_decode_transcript, the full QSO card can view/edit those fields, and Rust/.NET ADIF round-trip APP_QSORIPPER_RX_WPM plus APP_QSORIPPER_CW_TRANSCRIPT.

Local validation completed during the branch work: focused CW decoder tests and release build passed, focused GUI logger/transcript/card tests passed, .NET ADIF codec tests passed, Rust transcript ADIF tests passed, buf lint passed, and the full .NET solution build passed after clearing a stale local engine file lock. The PR checks are currently green for .NET Quality, Rust Quality, and Win32 Quality.

One important limitation remains: strong off-air QSO copy is safer but still not clean enough to call solved. The decoder-quality follow-up is tracked in issue #345; this PR keeps that remaining work separate from the live logger wiring and safety gates.