### PR TITLE
fix(sqlite): migrate pre-soft-delete databases without no-such-column crash

### DIFF
--- a/src/dotnet/QsoRipper.Engine.Storage.Sqlite.Tests/SqliteStorageTests.cs
+++ b/src/dotnet/QsoRipper.Engine.Storage.Sqlite.Tests/SqliteStorageTests.cs
@@ -909,5 +909,96 @@ public sealed class SqliteStorageTests : IDisposable
             }
         }
     }
+    [Fact]
+    public async Task Build_migrates_pre_soft_delete_database_without_throwing()
+    {
+        // Regression: a database created before PR #289 (soft-delete schema)
+        // does not have the deleted_at_ms / pending_remote_delete columns and
+        // does not have idx_qsos_deleted_at_ms. Opening it with the current
+        // SqliteStorage must run the ALTER TABLE migrations and the new
+        // index creation in the right order — historically the bootstrap
+        // SQL tried to CREATE INDEX on deleted_at_ms before the column
+        // ALTER ran, blowing up with "no such column: deleted_at_ms".
+        var dbPath = Path.Combine(Path.GetTempPath(), $"qsoripper-presoftdelete-{Guid.NewGuid():N}.db");
+        try
+        {
+            // Hand-construct the pre-soft-delete schema (the exact CREATE
+            // TABLE shipped before PR #289) plus a row that uses the old
+            // column set, so we also confirm the migration preserves data.
+            using (var bootstrap = new SqliteConnection($"Data Source={dbPath}"))
+            {
+                bootstrap.Open();
+                using var cmd = bootstrap.CreateCommand();
+                cmd.CommandText =
+                    """
+                    CREATE TABLE qsos (
+                        local_id TEXT PRIMARY KEY NOT NULL,
+                        qrz_logid TEXT,
+                        qrz_bookid TEXT,
+                        station_callsign TEXT NOT NULL,
+                        worked_callsign TEXT NOT NULL,
+                        utc_timestamp_ms INTEGER,
+                        band INTEGER NOT NULL,
+                        mode INTEGER NOT NULL,
+                        contest_id TEXT,
+                        created_at_ms INTEGER,
+                        updated_at_ms INTEGER,
+                        sync_status INTEGER NOT NULL,
+                        record BLOB NOT NULL
+                    );
+                    CREATE INDEX idx_qsos_station_callsign ON qsos (station_callsign);
+                    CREATE INDEX idx_qsos_worked_callsign ON qsos (worked_callsign);
+                    CREATE INDEX idx_qsos_utc_timestamp_ms ON qsos (utc_timestamp_ms);
+                    CREATE INDEX idx_qsos_band ON qsos (band);
+                    CREATE INDEX idx_qsos_mode ON qsos (mode);
+                    CREATE INDEX idx_qsos_contest_id ON qsos (contest_id);
+                    CREATE INDEX idx_qsos_sync_status ON qsos (sync_status);
+                    """;
+                cmd.ExecuteNonQuery();
+            }
+            SqliteConnection.ClearAllPools();
+
+            // Opening with the current SqliteStorage must succeed and the
+            // new soft-delete columns + index must be present afterwards.
+            using (var storage = new SqliteStorageBuilder().Path(dbPath).Build())
+            {
+                var qso = MakeQso("postmig", "W1AW", Band._20M, Mode.Cw, "2026-01-15T12:00:00Z");
+                await storage.Logbook.InsertQsoAsync(qso);
+
+                var loaded = await storage.Logbook.GetQsoAsync("postmig");
+                Assert.NotNull(loaded);
+                Assert.Null(loaded!.DeletedAt);
+
+                await storage.Logbook.SoftDeleteQsoAsync("postmig", DateTimeOffset.UtcNow, pendingRemoteDelete: false);
+                var afterDelete = await storage.Logbook.GetQsoAsync("postmig");
+                Assert.NotNull(afterDelete);
+                Assert.NotNull(afterDelete!.DeletedAt);
+            }
+
+            using (var verify = new SqliteConnection($"Data Source={dbPath}"))
+            {
+                verify.Open();
+                using var cmd = verify.CreateCommand();
+                cmd.CommandText =
+                    "SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_qsos_deleted_at_ms'";
+                var name = cmd.ExecuteScalar() as string;
+                Assert.Equal("idx_qsos_deleted_at_ms", name);
+            }
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+            {
+                try
+                {
+                    File.Delete(dbPath);
+                }
+                catch (IOException)
+                {
+                }
+            }
+        }
+    }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Engine.Storage.Sqlite/SqliteStorage.cs
+++ b/src/dotnet/QsoRipper.Engine.Storage.Sqlite/SqliteStorage.cs
@@ -40,7 +40,15 @@ public sealed class SqliteStorage : IEngineStorage, ILogbookStore, ILookupSnapsh
         CREATE INDEX IF NOT EXISTS idx_qsos_mode ON qsos (mode);
         CREATE INDEX IF NOT EXISTS idx_qsos_contest_id ON qsos (contest_id);
         CREATE INDEX IF NOT EXISTS idx_qsos_sync_status ON qsos (sync_status);
-        CREATE INDEX IF NOT EXISTS idx_qsos_deleted_at_ms ON qsos (deleted_at_ms);
+        -- NOTE: idx_qsos_deleted_at_ms is intentionally NOT created here.
+        -- On a fresh database the qsos table above already has the column,
+        -- but on a database that predates the soft-delete schema (PR #289)
+        -- the CREATE TABLE IF NOT EXISTS above is a no-op and the column
+        -- doesn't exist yet. Creating the index here would fail with
+        -- "no such column: deleted_at_ms" before ApplySoftDeleteMigration
+        -- gets a chance to ALTER TABLE the column in. The index is created
+        -- in ApplySoftDeleteMigration() instead, after the column is
+        -- guaranteed to exist.
 
         CREATE TABLE IF NOT EXISTS sync_metadata (
             id INTEGER PRIMARY KEY CHECK (id = 1),


### PR DESCRIPTION
The .NET engine crashes on startup against any database created before PR #289 (the soft-delete schema):

  SqliteException: no such column: deleted_at_ms
    at SqliteStorage.RunMigrations() line 533
    at SqliteStorageBuilder.Build() line 66

Root cause: the bootstrap MigrationSql block creates the deleted_at_ms index unconditionally, right after the CREATE TABLE IF NOT EXISTS qsos. On a fresh DB this works because the table-create includes the column. On an upgraded DB, the table already exists, the CREATE TABLE IF NOT EXISTS no-ops, and the CREATE INDEX runs before ApplySoftDeleteMigration() gets to ALTER the new columns in — aborting the entire migration before any of the ALTER TABLE / CREATE INDEX calls in ApplySoftDeleteMigration() execute.

Fix: drop the deleted_at_ms index from the bootstrap SQL block. ApplySoftDeleteMigration() already creates the index after ensuring the column exists, so removing the bootstrap copy is safe in both fresh-DB and legacy-DB cases and fixes the upgrade crash.

Adds a regression test that hand-constructs the pre-soft-delete schema in a temp file, opens it with the current SqliteStorage, asserts the open succeeds, soft-deletes a row, and verifies idx_qsos_deleted_at_ms exists afterward. The test reproduces the user's exact SqliteException on baseline and passes with the fix. All 57 SqliteStorageTests pass.