### PR TITLE
cw-decoder: widen auto-pitch sweep to cover 1200 Hz sidetones

### DIFF
--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -53,7 +53,7 @@ impl Default for RegionStreamConfig {
             frame_len_s: 0.025,
             frame_step_s: 0.010,
             pitch_lo_hz: 400.0,
-            pitch_hi_hz: 900.0,
+            pitch_hi_hz: 1200.0,
             pitch_step_hz: 25.0,
             threshold_factor: 0.30,
             merge_gap_s: 3.0,
@@ -299,6 +299,24 @@ mod tests {
         assert!(
             (pitch - 600.0).abs() <= cfg.pitch_step_hz,
             "expected ~600, got {pitch}"
+        );
+    }
+
+    #[test]
+    fn estimate_pitch_finds_high_sidetone() {
+        // Real-world live captures (e.g. live-20260427-111419.wav) use
+        // sidetones up to ~1100 Hz. Default pitch sweep must cover that
+        // range; otherwise the detector locks onto whatever has highest
+        // power inside the [pitch_lo, pitch_hi] window (typically a
+        // low-frequency noise hump) and the rest of the decoder
+        // produces ghost-character garbage.
+        let sr = 12_000u32;
+        let buf = synth_tone(1100.0, 2.0, sr, 0.5);
+        let cfg = RegionStreamConfig::default();
+        let pitch = estimate_dominant_pitch(&buf, sr, &cfg);
+        assert!(
+            (pitch - 1100.0).abs() <= cfg.pitch_step_hz,
+            "expected ~1100 Hz, got {pitch} (default pitch_hi_hz must cover common operator sidetones)"
         );
     }
 


### PR DESCRIPTION
You spotted a clip that the visualizer was flagging as LOW SNR even though the waveform clearly contained decodable morse: data/cw-samples/training-set-a/live-20260427-111419.wav. This PR fixes the root cause.

Diagnosis. Probing the file with the auto-pitch detector reported pitch=400 Hz with SNR=23 dB and produced ghost-character garbage on every 5-second window. Sweeping pitch by hand showed SNR climbing monotonically from 25 dB at 400 Hz up to 70 dB at 1100 Hz, where the decoder produced clean recognizable text including USA, DX, CQ, and CG. The actual CW sidetone in the clip is around 1100-1120 Hz, well above the old default sweep ceiling of pitch_hi_hz=900. With the real tone outside the search window, the auto-pitch detector locked onto whatever bin had the highest power inside [400, 900] (typically a low-frequency noise hump at the bottom of the band), and the rest of the decoder dutifully produced garbage that the SNR / dynamic-range gates from PR #351 then correctly suppressed. The visible symptom in the GUI is a persistent red LOW SNR badge on a clip that obviously contains signal.

Fix. Widen the default RegionStreamConfig.pitch_hi_hz from 900 to 1200 Hz so the auto-pitch sweep covers the full range of common operator sidetones (400-1200 Hz). pitch_lo_hz and pitch_step_hz are unchanged. Sweep cost grows by 12 extra Goertzel passes per pitch estimation call; not measurable in practice because pitch estimation runs once per buffer, not per frame.

Per-clip impact on the training-set-a labels (env strategy, default config):
- clip-20260427-124427: CER 1.00 (empty) -> 0.40 (decoded partial)
- live-20260427-111419: CER 1.00 (empty) -> 0.69 (decoded partial — the user's failing clip now produces real text)
- cw_30wpm_abbrev (clean): unchanged at 0.05
- cw_30wpm_abbrev (extreme QRN): unchanged at 0.05

env28 weighted CER on training-set-a improved from 0.09 to 0.08.

Tests. Added estimate_pitch_finds_high_sidetone in src/region_stream.rs which synthesizes a 1100 Hz tone and asserts the default sweep recovers it within one pitch_step_hz (25 Hz). All 75 release-mode lib tests pass. Pre-existing estimate_pitch_picks_dominant_frequency at 600 Hz still passes.

Independent of and complementary to PR #351 (SNR + dynamic-range gate). The two PRs touch different files and address different failure modes; either order is fine.
