### PR TITLE
cw-decoder: promote v2 STRATEGY SWEEP to primary 'SCORE LABELS (v2)' button on TUNING tab

### DIFF
--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml
@@ -721,32 +721,32 @@
             <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto" ColumnSpacing="10">
               <TextBlock Text="LABEL EVAL / SWEEP" Classes="label" VerticalAlignment="Center" />
               <CheckBox Grid.Column="1" Content="ALL LABELS" IsChecked="{Binding EvaluateAllLabels, Mode=TwoWay}" VerticalAlignment="Center" />
-              <CheckBox Grid.Column="2" Content="FULL STREAM" IsChecked="{Binding UseFullStreamScorer, Mode=TwoWay}" VerticalAlignment="Center"
-                        ToolTip.Tip="SCORE LABELS scoring mode. Off = exact-window (decode just the labeled slice; measures decoder quality). On = full-stream (run the streaming decoder over the whole file and align to the label window; measures live acquisition + lock behavior — much harsher, often CER 0.8+ on the same clip)." />
-              <CheckBox Grid.Column="3" Content="WIDE SWEEP" IsChecked="{Binding UseWideSweep, Mode=TwoWay}" VerticalAlignment="Center" />
-              <CheckBox Grid.Column="4" Content="USE CHECKED LABELS" IsChecked="{Binding UseSelectedLabelFiles, Mode=TwoWay}" VerticalAlignment="Center" />
-              <Button Grid.Column="5" Classes="primary" Content="SCORE LABELS (v1 legacy)" Click="OnRunLabelScoreClick"
-                      IsEnabled="{Binding CanRunLabelScore}" FontSize="11" Padding="14,4"
-                      ToolTip.Tip="LEGACY label-eval harness that runs the v1 streaming decoder (window/decode_every/confirmations). The live decoder on the DECODE tab does NOT use this path — it uses Whole-buffer ditdah (v2) by default. Use STRATEGY SWEEP for honest decoder-quality numbers; this button is kept only for historical comparison." />
-              <Button Grid.Column="6" Classes="primary" Content="SWEEP BASELINE (v1 legacy)" Click="OnRunLabelSweepClick"
-                      IsEnabled="{Binding CanRunLabelSweep}" FontSize="11" Padding="14,4"
-                      ToolTip.Tip="LEGACY: tunes v1 streaming parameters. The live decoder doesn't use these. Kept for historical comparison." />
-              <StackPanel Grid.Column="7" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center"
+              <CheckBox Grid.Column="2" Content="WIDE SWEEP" IsChecked="{Binding UseWideSweep, Mode=TwoWay}" VerticalAlignment="Center" />
+              <CheckBox Grid.Column="3" Content="USE CHECKED LABELS" IsChecked="{Binding UseSelectedLabelFiles, Mode=TwoWay}" VerticalAlignment="Center" />
+              <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center"
                           ToolTip.Tip="Comma-separated strategy tokens. auto / N (e.g. 28) = ditdah exact-window. region / regionN = region-stream pipeline + ditdah. env / envN = alternate envelope decoder. Example: auto,28,region28,env,env28">
                 <TextBlock Text="STRAT WPMS" Classes="label" VerticalAlignment="Center" />
                 <TextBox Width="240" Text="{Binding StrategySweepWpms, Mode=TwoWay}"
                          Background="{StaticResource BgPanel}" Foreground="{StaticResource TextHi}"
                          Watermark="auto,28,region28,env28" />
               </StackPanel>
-              <Button Grid.Column="8" Classes="primary" Content="STRATEGY SWEEP" Click="OnRunStrategySweepClick"
+              <Button Grid.Column="5" Classes="primary" Content="SCORE LABELS (v2 — recommended)" Click="OnRunStrategySweepClick"
                       IsEnabled="{Binding CanRunLabelScore}" FontSize="11" Padding="14,4"
-                      ToolTip.Tip="Recommended decoder-quality test. Runs the bounded v2 decoder across the selected labels. auto/N = ditdah whole-buffer (the live default). region/regionN = region-stream pipeline + ditdah. env/envN = alternate envelope decoder. Outputs a per-clip × strategy CER table." />
+                      ToolTip.Tip="Recommended decoder-quality test. Runs the bounded v2 decoder (the same one the live DECODE tab uses by default) across the selected labels using the STRAT WPMS tokens. auto/N = ditdah whole-buffer. region/regionN = region-stream pipeline + ditdah. env/envN = alternate envelope decoder. Outputs a per-clip × strategy CER table." />
+              <CheckBox Grid.Column="6" Content="FULL STREAM" IsChecked="{Binding UseFullStreamScorer, Mode=TwoWay}" VerticalAlignment="Center"
+                        ToolTip.Tip="v1 legacy SCORE LABELS scoring mode. Off = exact-window (decode just the labeled slice; measures decoder quality). On = full-stream (run the streaming decoder over the whole file and align to the label window; measures live acquisition + lock behavior — much harsher, often CER 0.8+ on the same clip). Does not affect the v2 SCORE LABELS button above." />
+              <Button Grid.Column="7" Content="SCORE LABELS (v1 legacy)" Click="OnRunLabelScoreClick"
+                      IsEnabled="{Binding CanRunLabelScore}" FontSize="11" Padding="14,4"
+                      ToolTip.Tip="LEGACY label-eval harness that runs the v1 streaming decoder (window/decode_every/confirmations). The live decoder on the DECODE tab does NOT use this path — it uses Whole-buffer ditdah (v2) by default. Use the v2 SCORE LABELS button above for honest decoder-quality numbers; this button is kept only for historical comparison." />
+              <Button Grid.Column="8" Content="SWEEP BASELINE (v1 legacy)" Click="OnRunLabelSweepClick"
+                      IsEnabled="{Binding CanRunLabelSweep}" FontSize="11" Padding="14,4"
+                      ToolTip.Tip="LEGACY: tunes v1 streaming parameters. The live decoder doesn't use these. Kept for historical comparison." />
             </Grid>
 
             <Border Grid.Row="1" BorderBrush="{StaticResource AccentCyan}" BorderThickness="1" CornerRadius="2" Padding="8"
                     IsVisible="{Binding ShowSelectedLabelPicker}">
               <Grid RowDefinitions="Auto,Auto,Auto,*" RowSpacing="6">
-                <TextBlock Text="LABEL FILES — check the .labels.jsonl files to include in SCORE LABELS / SWEEP BASELINE / STRATEGY SWEEP"
+                <TextBlock Text="LABEL FILES — check the .labels.jsonl files to include in SCORE LABELS (v2) and the v1 legacy harnesses"
                            Classes="label" Foreground="{StaticResource AccentCyan}" TextWrapping="Wrap" />
                 <Grid Grid.Row="1" ColumnDefinitions="Auto,Auto,Auto,Auto,*" ColumnSpacing="8">
                   <TextBlock Text="FOLDER" Classes="label" VerticalAlignment="Center" />
@@ -935,7 +935,7 @@
                 <Border BorderBrush="{StaticResource GridLine}" BorderThickness="1" CornerRadius="2" Padding="8"
                         IsVisible="{Binding HasStrategySweepResult}">
                   <StackPanel Spacing="8">
-                    <TextBlock Text="STRATEGY SWEEP — bounded v2 decoder (the same one the live DECODE tab uses by default). auto/N = whole-buffer ditdah. region/regionN = region-stream pipeline. env/envN = alternate envelope decoder."
+                    <TextBlock Text="SCORE LABELS (v2) — bounded v2 decoder (the same one the live DECODE tab uses by default). auto/N = whole-buffer ditdah. region/regionN = region-stream pipeline. env/envN = alternate envelope decoder."
                                Foreground="{StaticResource AccentAmber}" FontSize="11" TextWrapping="Wrap" />
                     <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
                       <TextBlock Text="{Binding StrategySweepSummaryText}" Foreground="{StaticResource AccentCyan}" TextWrapping="Wrap" />
@@ -979,7 +979,7 @@
                 <Expander Header="RAW RESULT JSON — SCORE LABELS (v1 legacy harness)"
                           IsVisible="{Binding LabelEvaluationOutputText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
                   <StackPanel Spacing="6">
-                    <TextBlock Text="LEGACY: this is from the v1 streaming label-eval harness, not the live decoder. The live decoder defaults to Whole-buffer ditdah (v2) which gets near-zero CER on these same clips — see STRATEGY SWEEP above."
+                    <TextBlock Text="LEGACY: this is from the v1 streaming label-eval harness, not the live decoder. The live decoder defaults to Whole-buffer ditdah (v2) which gets near-zero CER on these same clips — see SCORE LABELS (v2) above."
                                Foreground="{StaticResource AccentAmber}" FontSize="11" TextWrapping="Wrap" />
                     <TextBox Text="{Binding LabelEvaluationOutputText}"
                            IsReadOnly="True"


### PR DESCRIPTION
The TUNING tab had two prominent buttons explicitly labeled "v1 legacy" and a third button called STRATEGY SWEEP that was actually the recommended v2 scoring action. Operators repeatedly miss it because the name does not read as "scoring" and it sits at the far right of a 9-column row, behind a 240px text field and the two legacy buttons.

Real bug report from a user looking at the tab: "I do not see how to score with v2 - the 2 scoring buttons both say v1." A screenshot confirmed they had run a v2 strategy sweep but did not realize STRATEGY SWEEP was the v2 button.

Changes (UI-only, single AXAML file):

- Rename STRATEGY SWEEP to "SCORE LABELS (v2 - recommended)" so the v2 path advertises itself as a scoring button
- Reorder the row so the v2 button sits immediately after STRAT WPMS (col 5), with the v1 legacy buttons demoted to the right (cols 7-8)
- Move FULL STREAM checkbox next to the legacy buttons (col 6) since it only affects the v1 SCORE LABELS path; tooltip clarifies it does not affect the v2 button
- Clarify the v1 button tooltip and update all surrounding labels/headers/status text that referenced STRATEGY SWEEP by name (LABEL FILES picker header, STRATEGY SWEEP results section header, raw-result expander hint)

No behavior change. Same wired Click handler (OnRunStrategySweepClick), same enable binding (CanRunLabelScore), same STRAT WPMS tokens box. View-model is untouched.

Build: dotnet build -c Release on experiments/cw-decoder/gui - 0 warnings, 0 errors.