### PR TITLE
cw-decoder: pass region/env/live-env strategy tokens through to v2 sweep

### DIFF
--- a/experiments/cw-decoder/gui/Models/StrategyOption.cs
+++ b/experiments/cw-decoder/gui/Models/StrategyOption.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace CwDecoderGui.Models;
+
+/// <summary>
+/// One row in the TUNING tab strategy picker. Backs a checkbox plus tooltip;
+/// the resolved set of checked tokens (plus operator-supplied custom tokens)
+/// is forwarded to the Rust eval binary by RunStrategySweepAsync.
+/// </summary>
+public sealed class StrategyOption : INotifyPropertyChanged
+{
+    public StrategyOption(string token, string label, bool defaultChecked, string tooltip)
+    {
+        Token = token;
+        Label = label;
+        DefaultChecked = defaultChecked;
+        Tooltip = tooltip;
+        _isChecked = defaultChecked;
+    }
+
+    /// <summary>Token forwarded verbatim to the eval binary (e.g. "auto", "28", "region28").</summary>
+    public string Token { get; }
+
+    /// <summary>Display label shown next to the checkbox.</summary>
+    public string Label { get; }
+
+    /// <summary>Tooltip explaining what this strategy does.</summary>
+    public string Tooltip { get; }
+
+    /// <summary>Documented default checked state, used by RESET TO DEFAULTS.</summary>
+    public bool DefaultChecked { get; }
+
+    private bool _isChecked;
+    public bool IsChecked
+    {
+        get => _isChecked;
+        set
+        {
+            if (_isChecked == value) return;
+            _isChecked = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name!));
+}

--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
@@ -54,6 +54,8 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         _selectedLabelCorpusFolder = defaultFolder;
         ReloadAvailableLabelFiles();
 
+        HookStrategyOptionEvents();
+
         _process.EventReceived += OnEvent;
         _process.StderrLine += line => Dispatcher.UIThread.Post(() => StatusText = line);
         _process.Exited += code => Dispatcher.UIThread.Post(() =>
@@ -2504,15 +2506,122 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
     }
 
     private string _strategySweepWpms = "auto,28,region28,env,env28,live-env";
-    /// <summary>Comma-separated list of strategy tokens to sweep alongside auto.
-    /// Editable by the operator. "auto" is always included.
-    /// Includes "live-env" by default so the VISUALIZER tab's decoder
-    /// (LiveEnvelopeStreamer / stream-live-v3) is scored apples-to-apples
-    /// alongside the offline strategies.</summary>
+    /// <summary>Comma-separated list of strategy tokens. Retained for
+    /// backwards compatibility (some tests/bindings still reference it),
+    /// but no longer the source of truth for the TUNING tab — the picker
+    /// (<see cref="StrategyOptions"/> + <see cref="StrategySweepCustomTokens"/>)
+    /// is what <see cref="RunStrategySweepAsync"/> forwards to the eval binary.</summary>
     public string StrategySweepWpms
     {
         get => _strategySweepWpms;
         set => Set(ref _strategySweepWpms, value);
+    }
+
+    /// <summary>Predefined strategy checkboxes shown in the TUNING tab picker.
+    /// Tokens are forwarded verbatim to the Rust eval binary's
+    /// parse_strategy_list (auto, region, region&lt;N&gt;, env, env&lt;N&gt;,
+    /// live-env, bare numbers).</summary>
+    public ObservableCollection<StrategyOption> StrategyOptions { get; } = new()
+    {
+        new StrategyOption("auto",     "auto",     true,  "Whole-buffer ditdah, auto-detect WPM (DECODE tab default)"),
+        new StrategyOption("22",       "22 wpm",   false, "Whole-buffer ditdah, pinned to 22 wpm"),
+        new StrategyOption("25",       "25 wpm",   false, "Whole-buffer ditdah, pinned to 25 wpm"),
+        new StrategyOption("28",       "28 wpm",   true,  "Whole-buffer ditdah, pinned to 28 wpm"),
+        new StrategyOption("30",       "30 wpm",   false, "Whole-buffer ditdah, pinned to 30 wpm"),
+        new StrategyOption("region",   "region",   false, "Region-stream pipeline, auto-detect WPM"),
+        new StrategyOption("region28", "region28", true,  "Region-stream pipeline, pinned to 28 wpm"),
+        new StrategyOption("env",      "env",      true,  "Offline envelope decoder, auto-detect WPM"),
+        new StrategyOption("env28",    "env28",    true,  "Offline envelope decoder, pinned to 28 wpm"),
+        new StrategyOption("live-env", "live-env", true,  "Live envelope streamer (VISUALIZER tab decoder), auto-detect WPM"),
+    };
+
+    private string _strategySweepCustomTokens = string.Empty;
+    /// <summary>One-off comma-separated tokens (e.g. "region30,env25") appended
+    /// to the picker selection before forwarding to the eval binary.</summary>
+    public string StrategySweepCustomTokens
+    {
+        get => _strategySweepCustomTokens;
+        set
+        {
+            if (Set(ref _strategySweepCustomTokens, value))
+            {
+                OnPropertyChanged(nameof(StrategyPickerSummary));
+            }
+        }
+    }
+
+    /// <summary>Live label for the picker button — e.g. "STRATEGIES (5)" or
+    /// "STRATEGIES (5+2 custom)" when custom tokens are present.</summary>
+    public string StrategyPickerSummary
+    {
+        get
+        {
+            int checkedCount = 0;
+            foreach (var opt in StrategyOptions)
+            {
+                if (opt.IsChecked) checkedCount++;
+            }
+            int customCount = 0;
+            foreach (var tok in (_strategySweepCustomTokens ?? string.Empty).Split(','))
+            {
+                if (!string.IsNullOrWhiteSpace(tok)) customCount++;
+            }
+            return customCount > 0
+                ? $"STRATEGIES ({checkedCount}+{customCount} custom)"
+                : $"STRATEGIES ({checkedCount})";
+        }
+    }
+
+    /// <summary>Resolve the ordered, deduped (case-insensitive) token list to send
+    /// to the eval binary: always "auto" first, then checked picker tokens in
+    /// declaration order, then comma-split custom tokens.</summary>
+    private List<string> BuildStrategyTokens()
+    {
+        var tokens = new List<string> { "auto" };
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "auto" };
+        foreach (var opt in StrategyOptions)
+        {
+            if (!opt.IsChecked) continue;
+            var t = opt.Token?.Trim();
+            if (string.IsNullOrEmpty(t)) continue;
+            if (!seen.Add(t)) continue;
+            tokens.Add(t);
+        }
+        foreach (var raw in (_strategySweepCustomTokens ?? string.Empty).Split(','))
+        {
+            var t = raw.Trim();
+            if (string.IsNullOrEmpty(t)) continue;
+            if (!seen.Add(t)) continue;
+            tokens.Add(t);
+        }
+        return tokens;
+    }
+
+    /// <summary>Restore the strategy picker to its documented defaults and
+    /// clear the custom-tokens textbox. Wired to the RESET TO DEFAULTS button.</summary>
+    public void ResetStrategyDefaults()
+    {
+        foreach (var opt in StrategyOptions)
+        {
+            opt.IsChecked = opt.DefaultChecked;
+        }
+        StrategySweepCustomTokens = string.Empty;
+    }
+
+    private void HookStrategyOptionEvents()
+    {
+        foreach (var opt in StrategyOptions)
+        {
+            opt.PropertyChanged += OnStrategyOptionPropertyChanged;
+        }
+    }
+
+    private void OnStrategyOptionPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(StrategyOption.IsChecked))
+        {
+            OnPropertyChanged(nameof(StrategyPickerSummary));
+        }
     }
 
     private StrategySweepResult? _strategySweepResult;
@@ -2573,23 +2682,13 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
             return;
         }
 
-        // Always include "auto" plus operator-supplied tokens. The Rust eval
-        // binary's parse_strategy_list accepts: auto, region, region<N>,
-        // region:<N>, env, envelope, env<N>, envelope<N>, env:<N>,
-        // envelope:<N>, live-env, liveenv, and bare numbers (ExactPin).
-        // Forward any non-empty, case-insensitively-deduped token; let the
-        // Rust parser decide what's valid. (The previous implementation only
-        // accepted "auto" and bare numbers, silently dropping region*/env*
-        // tokens advertised by the tooltip and watermark.)
-        var strategies = new List<string> { "auto" };
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "auto" };
-        foreach (var tok in (StrategySweepWpms ?? string.Empty).Split(','))
-        {
-            var t = tok.Trim();
-            if (string.IsNullOrEmpty(t)) continue;
-            if (!seen.Add(t)) continue;
-            strategies.Add(t);
-        }
+        // The picker (StrategyOptions + StrategySweepCustomTokens) is the
+        // source of truth. The Rust eval binary's parse_strategy_list accepts:
+        // auto, region, region<N>, region:<N>, env, envelope, env<N>,
+        // envelope<N>, env:<N>, envelope:<N>, live-env, liveenv, and bare
+        // numbers (ExactPin). BuildStrategyTokens always includes "auto"
+        // first and dedupes case-insensitively across picker + custom tokens.
+        var strategies = BuildStrategyTokens();
 
         CancelAndDisposeEvaluation();
         var cts = new CancellationTokenSource();

--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
@@ -2570,16 +2570,22 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
             return;
         }
 
-        // Always include "auto" plus operator-supplied pin values.
+        // Always include "auto" plus operator-supplied tokens. The Rust eval
+        // binary's parse_strategy_list accepts: auto, region, region<N>,
+        // region:<N>, env, envelope, env<N>, envelope<N>, env:<N>,
+        // envelope:<N>, live-env, liveenv, and bare numbers (ExactPin).
+        // Forward any non-empty, case-insensitively-deduped token; let the
+        // Rust parser decide what's valid. (The previous implementation only
+        // accepted "auto" and bare numbers, silently dropping region*/env*
+        // tokens advertised by the tooltip and watermark.)
         var strategies = new List<string> { "auto" };
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "auto" };
         foreach (var tok in (StrategySweepWpms ?? string.Empty).Split(','))
         {
             var t = tok.Trim();
-            if (string.IsNullOrEmpty(t) || t.Equals("auto", StringComparison.OrdinalIgnoreCase)) continue;
-            if (double.TryParse(t, NumberStyles.Float, CultureInfo.InvariantCulture, out var v) && v > 0)
-            {
-                strategies.Add(v.ToString("0.##", CultureInfo.InvariantCulture));
-            }
+            if (string.IsNullOrEmpty(t)) continue;
+            if (!seen.Add(t)) continue;
+            strategies.Add(t);
         }
 
         CancelAndDisposeEvaluation();

--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
@@ -2503,9 +2503,12 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         }
     }
 
-    private string _strategySweepWpms = "auto,28,region28,env,env28";
-    /// <summary>Comma-separated list of pin-WPM values to sweep alongside auto.
-    /// Editable by the operator. "auto" is always included.</summary>
+    private string _strategySweepWpms = "auto,28,region28,env,env28,live-env";
+    /// <summary>Comma-separated list of strategy tokens to sweep alongside auto.
+    /// Editable by the operator. "auto" is always included.
+    /// Includes "live-env" by default so the VISUALIZER tab's decoder
+    /// (LiveEnvelopeStreamer / stream-live-v3) is scored apples-to-apples
+    /// alongside the offline strategies.</summary>
     public string StrategySweepWpms
     {
         get => _strategySweepWpms;
@@ -2604,7 +2607,13 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
                 strategies,
                 cts.Token).ConfigureAwait(true);
             StrategySweepResult = result;
-            LabelEvaluationStatusText = $"Strategy sweep done — {result.Labels} labels × {result.Strategies.Length} strategies.";
+            var autoApply = TryAutoApplyBestPinToVisualizer(result);
+            var status = $"Strategy sweep done — {result.Labels} labels × {result.Strategies.Length} strategies.";
+            if (autoApply is not null)
+            {
+                status += $" Auto-applied to visualizer: PIN WPM={autoApply.Value.Wpm:0.##} (best {autoApply.Value.Strategy} CER {autoApply.Value.WeightedCer:0.000}).";
+            }
+            LabelEvaluationStatusText = status;
         }
         catch (OperationCanceledException) { }
         catch (Exception ex)
@@ -2621,6 +2630,50 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
             IsEvaluationBusy = false;
             IsAdvancedBusy = false;
         }
+    }
+
+    /// <summary>
+    /// After a strategy sweep, find the best <c>pinNN</c> strategy by weighted CER
+    /// and apply that NN to the visualizer's PIN WPM control. This automates the
+    /// "explore the best decode path" loop: run sweep on a labeled clip, then
+    /// drop the same clip into the visualizer with the WPM the sweep proved
+    /// works best for it.
+    ///
+    /// Only triggers when the best pinNN strategy meaningfully beats the auto
+    /// row (delta CER &gt;= 0.02) so that pristine clips where auto already wins
+    /// don't pin away the auto-detect path. Returns the applied details, or
+    /// null if no auto-apply happened.
+    /// </summary>
+    private (string Strategy, double Wpm, double WeightedCer)? TryAutoApplyBestPinToVisualizer(StrategySweepResult result)
+    {
+        if (result.Summary is null || result.Summary.Length == 0) return null;
+
+        var auto = Array.Find(result.Summary, s => string.Equals(s.Strategy, "auto", StringComparison.OrdinalIgnoreCase));
+        var autoCer = auto?.WeightedCer ?? double.PositiveInfinity;
+
+        (string Strategy, double Wpm, double WeightedCer)? best = null;
+        foreach (var row in result.Summary)
+        {
+            if (string.IsNullOrEmpty(row.Strategy)) continue;
+            // Match pinNN tokens like "pin28", "pin22.5". Skip region/env/live-env -
+            // those are different decoder pipelines, not WPM hints for the visualizer.
+            if (!row.Strategy.StartsWith("pin", StringComparison.OrdinalIgnoreCase)) continue;
+            var numPart = row.Strategy.Substring(3);
+            if (!double.TryParse(numPart, NumberStyles.Float, CultureInfo.InvariantCulture, out var wpm) || wpm <= 0)
+                continue;
+            if (best is null || row.WeightedCer < best.Value.WeightedCer)
+            {
+                best = (row.Strategy, wpm, row.WeightedCer);
+            }
+        }
+
+        if (best is null) return null;
+        // Only auto-apply when the pin meaningfully helps. Avoids pinning away
+        // a working auto-detect on clean clips.
+        if (autoCer - best.Value.WeightedCer < 0.02) return null;
+
+        VizPinWpm = best.Value.Wpm;
+        return best;
     }
 
     public string BuildStrategySweepMarkdown()

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml
@@ -723,16 +723,36 @@
               <CheckBox Grid.Column="1" Content="ALL LABELS" IsChecked="{Binding EvaluateAllLabels, Mode=TwoWay}" VerticalAlignment="Center" />
               <CheckBox Grid.Column="2" Content="WIDE SWEEP" IsChecked="{Binding UseWideSweep, Mode=TwoWay}" VerticalAlignment="Center" />
               <CheckBox Grid.Column="3" Content="USE CHECKED LABELS" IsChecked="{Binding UseSelectedLabelFiles, Mode=TwoWay}" VerticalAlignment="Center" />
-              <StackPanel Grid.Column="4" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center"
-                          ToolTip.Tip="Comma-separated strategy tokens. auto / N (e.g. 28) = ditdah exact-window. region / regionN = region-stream pipeline + ditdah. env / envN = alternate envelope decoder. Example: auto,28,region28,env,env28">
-                <TextBlock Text="STRAT WPMS" Classes="label" VerticalAlignment="Center" />
-                <TextBox Width="240" Text="{Binding StrategySweepWpms, Mode=TwoWay}"
-                         Background="{StaticResource BgPanel}" Foreground="{StaticResource TextHi}"
-                         Watermark="auto,28,region28,env28" />
-              </StackPanel>
+              <Button Grid.Column="4" Content="{Binding StrategyPickerSummary}" FontSize="11" Padding="14,4"
+                      VerticalAlignment="Center"
+                      ToolTip.Tip="Pick which strategies the eval binary scores. auto/N = ditdah whole-buffer. region/regionN = region-stream pipeline + ditdah. env/envN = offline envelope decoder. live-env = VISUALIZER tab streamer. Use CUSTOM TOKENS for one-offs (e.g. region30,env25).">
+                <Button.Flyout>
+                  <Flyout Placement="Bottom">
+                    <StackPanel Orientation="Vertical" Spacing="6" MinWidth="240">
+                      <TextBlock Text="STRATEGIES" Classes="label" />
+                      <ItemsControl ItemsSource="{Binding StrategyOptions}">
+                        <ItemsControl.ItemTemplate>
+                          <DataTemplate>
+                            <CheckBox Content="{Binding Label}"
+                                      IsChecked="{Binding IsChecked, Mode=TwoWay}"
+                                      ToolTip.Tip="{Binding Tooltip}" />
+                          </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                      </ItemsControl>
+                      <TextBlock Text="CUSTOM TOKENS" Classes="label" Margin="0,4,0,0" />
+                      <TextBox Text="{Binding StrategySweepCustomTokens, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                               Background="{StaticResource BgPanel}" Foreground="{StaticResource TextHi}"
+                               Watermark="region30,env25,live-env"
+                               ToolTip.Tip="Comma-separated extra tokens forwarded verbatim to the eval binary." />
+                      <Button Content="RESET TO DEFAULTS" Click="OnResetStrategyDefaultsClick"
+                              FontSize="11" Padding="10,4" HorizontalAlignment="Stretch" />
+                    </StackPanel>
+                  </Flyout>
+                </Button.Flyout>
+              </Button>
               <Button Grid.Column="5" Classes="primary" Content="SCORE LABELS (v2 — recommended)" Click="OnRunStrategySweepClick"
                       IsEnabled="{Binding CanRunLabelScore}" FontSize="11" Padding="14,4"
-                      ToolTip.Tip="Recommended decoder-quality test. Runs the bounded v2 decoder (the same one the live DECODE tab uses by default) across the selected labels using the STRAT WPMS tokens. auto/N = ditdah whole-buffer. region/regionN = region-stream pipeline + ditdah. env/envN = alternate envelope decoder. Outputs a per-clip × strategy CER table." />
+                      ToolTip.Tip="Recommended decoder-quality test. Runs the bounded v2 decoder (the same one the live DECODE tab uses by default) across the selected labels using the STRATEGIES picker tokens. auto/N = ditdah whole-buffer. region/regionN = region-stream pipeline + ditdah. env/envN = alternate envelope decoder. live-env = VISUALIZER tab streamer. Outputs a per-clip × strategy CER table." />
               <CheckBox Grid.Column="6" Content="FULL STREAM" IsChecked="{Binding UseFullStreamScorer, Mode=TwoWay}" VerticalAlignment="Center"
                         ToolTip.Tip="v1 legacy SCORE LABELS scoring mode. Off = exact-window (decode just the labeled slice; measures decoder quality). On = full-stream (run the streaming decoder over the whole file and align to the label window; measures live acquisition + lock behavior — much harsher, often CER 0.8+ on the same clip). Does not affect the v2 SCORE LABELS button above." />
               <Button Grid.Column="7" Content="SCORE LABELS (v1 legacy)" Click="OnRunLabelScoreClick"

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml.cs
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml.cs
@@ -187,6 +187,9 @@ public partial class MainWindow : Window
         await Vm.RunStrategySweepAsync();
     }
 
+    private void OnResetStrategyDefaultsClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => Vm?.ResetStrategyDefaults();
+
     private async void OnCopyStrategySweepMarkdownClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
     {
         if (Vm is null) return;


### PR DESCRIPTION
The TUNING tab STRAT WPMS box advertises tokens like region28, env, env28 in its tooltip and watermark, but the C# wrapper at MainWindowViewModel.RunStrategySweepAsync was silently dropping them: the parser only accepted "auto" and bare numbers (which it then re-formatted as ExactPin).

Real bug report: user typed `auto,28,region28,env,env28`, ran the sweep, got back a markdown table with only `auto` and `pin28` columns:

```
| clip | len | auto | pin28 |
| live-...labels#1 | 92 | 0.42 | 0.38 |
```

The Rust eval binary already accepts every advertised token (auto, region, region<N>, region:<N>, env, envelope, env<N>, envelope<N>, env:<N>, envelope:<N>, live-env, liveenv, bare numbers). The C# wrapper was the chokepoint.

Changes (4 commits):

1. **Strategy token passthrough.** Stop second-guessing the Rust parser. Forward every non-empty, case-insensitively-deduped token and let Rust validate. "auto" is still always prepended.

2. **Default STRAT WPMS now includes `live-env`** so every v2 sweep also scores the visualizer''s actual decoder (LiveEnvelopeStreamer / stream-live-v3) apples-to-apples alongside the offline strategies. Previously you had to know to type it in.

3. **Auto-apply best pinNN to VISUALIZER PIN WPM.** After a sweep completes, `TryAutoApplyBestPinToVisualizer` finds the best `pinNN` strategy by weighted CER and (if it meaningfully beats `auto`, delta CER >= 0.02) sets `VizPinWpm` to that NN and reports it in the status line: "Auto-applied to visualizer: PIN WPM=28 (best pin28 CER 0.380)". Drop the same clip into VISUALIZER and you start with the WPM the sweep just proved best. Region/env/live-env strategies are intentionally skipped because they swap the decoder pipeline rather than tune the visualizer''s existing one.

4. **Replace STRAT WPMS textbox with checkbox picker + custom tokens.** The free-form comma-delimited textbox is now a `STRATEGIES (N)` button whose flyout shows one checkbox per known strategy (auto, 22/25/28/30 wpm, region, region28, env, env28, live-env), each with its own tooltip explaining what that strategy does. A small CUSTOM TOKENS textbox under the checkboxes lets operators add one-offs (e.g. `region30,env25`) and the button label updates live to "STRATEGIES (5+2 custom)". A RESET TO DEFAULTS button restores the documented checked set. The eval CLI invocation is unchanged - the picker just feeds `BuildStrategyTokens()` which produces the same ordered/deduped token list that used to come from splitting the textbox. The legacy `StrategySweepWpms` property is retained for backwards compatibility but is no longer the source of truth.

Together these turn the "explore the best decode path" loop into one click: run SCORE LABELS (v2), look at the per-strategy CER table, drop the same clip into VISUALIZER and play it - PIN WPM is already set if the sweep found a better one. And operators no longer have to memorize the strategy token vocabulary.

Verified:
- `target/release/eval.exe --strategies "auto,28,region28,env,env28"` returns all 5 strategies
- `dotnet build -c Release` on `experiments/cw-decoder/gui` - 0 warnings, 0 errors
- GUI smoke-tested via UI Automation: TUNING tab → STRATEGIES button opens flyout, toggling checkboxes updates the live count (6 → 7 → 6)