### PR TITLE
cw-decoder: rolling session transcript in V3 visualizer

### DIFF
--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Visualizer.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Visualizer.cs
@@ -258,7 +258,12 @@ public sealed partial class MainWindowViewModel
                     VizStatus = $"ready @ {ev.Rate ?? 0} Hz";
                     break;
                 case "transcript":
-                    if (ev.Text is not null) VizTranscript = ev.Text;
+                    // Prefer the durable session transcript that the Rust
+                    // streamer accumulates via suffix-prefix overlap.
+                    // Fall back to ev.Text (the rolling-window snapshot)
+                    // for backwards compatibility with older binaries.
+                    if (ev.Transcript is not null) VizTranscript = ev.Transcript;
+                    else if (ev.Text is not null) VizTranscript = ev.Text;
                     if (ev.Wpm.HasValue) VizCurrentWpm = ev.Wpm.Value;
                     break;
                 case "viz":

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml
@@ -1218,12 +1218,15 @@
             <Border Grid.Row="3" Background="{StaticResource BgDeep}" CornerRadius="4"
                     BorderBrush="{StaticResource EdgeGlow}" BorderThickness="1"
                     Padding="10,8" Margin="0,8,0,0">
-              <ScrollViewer HorizontalScrollBarVisibility="Auto"
-                            VerticalScrollBarVisibility="Auto"
-                            MaxHeight="120">
+              <ScrollViewer Name="VizTranscriptScroll"
+                             HorizontalScrollBarVisibility="Disabled"
+                             VerticalScrollBarVisibility="Auto"
+                             MinHeight="120"
+                             MaxHeight="240">
                 <TextBlock Text="{Binding VizTranscript}"
                            FontFamily="Consolas"
-                           FontSize="14"
+                           FontSize="16"
+                           LineHeight="22"
                            TextWrapping="Wrap"
                            Foreground="{StaticResource TextHi}" />
               </ScrollViewer>

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml.cs
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml.cs
@@ -1,16 +1,50 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Platform.Storage;
+using Avalonia.Threading;
 using CwDecoderGui.ViewModels;
+using System.ComponentModel;
 using System.Linq;
 
 namespace CwDecoderGui.Views;
 
 public partial class MainWindow : Window
 {
-    public MainWindow() => InitializeComponent();
+    public MainWindow()
+    {
+        InitializeComponent();
+        DataContextChanged += (_, _) => HookVmForTranscriptScroll();
+    }
 
     private void InitializeComponent() => AvaloniaXamlLoader.Load(this);
+
+    private MainWindowViewModel? _hookedVm;
+
+    private void HookVmForTranscriptScroll()
+    {
+        if (_hookedVm is not null)
+        {
+            _hookedVm.PropertyChanged -= OnVmPropertyChanged;
+            _hookedVm = null;
+        }
+        if (DataContext is MainWindowViewModel vm)
+        {
+            _hookedVm = vm;
+            vm.PropertyChanged += OnVmPropertyChanged;
+        }
+    }
+
+    private void OnVmPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(MainWindowViewModel.VizTranscript)) return;
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (this.FindControl<ScrollViewer>("VizTranscriptScroll") is { } sv)
+            {
+                sv.ScrollToEnd();
+            }
+        }, DispatcherPriority.Background);
+    }
 
     private MainWindowViewModel? Vm => DataContext as MainWindowViewModel;
 

--- a/experiments/cw-decoder/src/envelope_decoder.rs
+++ b/experiments/cw-decoder/src/envelope_decoder.rs
@@ -27,6 +27,8 @@ const FRAME_STEP_S: f32 = 0.005; // 5 ms hop.
 const HYST_HIGH: f32 = 0.55; // Fraction of (signal - noise) to enter key-on.
 const HYST_LOW: f32 = 0.35; // Fraction of (signal - noise) to leave key-on.
 const MIN_ELEMENT_S: f32 = 0.012; // Reject sub-12ms blips as noise (~50 WPM dot).
+const MAX_AUTO_WPM: f32 = 45.0;
+const MIN_AUTO_DOT_S: f32 = 1.2 / MAX_AUTO_WPM;
 /// Default SNR floor (dB) below which the decode is suppressed and the
 /// pipeline returns empty text. 20*log10(2.0) ≈ 6 dB; CW signals worth
 /// decoding sit comfortably above this. Tuned to filter out the
@@ -235,6 +237,10 @@ pub fn decode_envelope(samples: &[f32], sample_rate: u32, cfg: &EnvelopeConfig) 
         estimate_dot_kmeans(&ons).max(MIN_ELEMENT_S)
     };
 
+    if suppress_implausible_auto_wpm(cfg, dot_s) {
+        return String::new();
+    }
+
     // 5) Decode events into morse + gap tokens, then to text.
     decode_events(&ons, &offs, dot_s)
 }
@@ -342,9 +348,18 @@ pub fn decode_envelope_with_stats(
     } else {
         estimate_dot_kmeans(&ons).max(MIN_ELEMENT_S)
     };
+    let wpm = if dot_s > 0.0 { 1.2 / dot_s } else { 0.0 };
+
+    if suppress_implausible_auto_wpm(cfg, dot_s) {
+        return EnvelopeDecode {
+            text: String::new(),
+            dot_seconds: dot_s,
+            wpm,
+            elements: 0,
+        };
+    }
 
     let text = decode_events(&ons, &offs, dot_s);
-    let wpm = if dot_s > 0.0 { 1.2 / dot_s } else { 0.0 };
     EnvelopeDecode {
         text,
         dot_seconds: dot_s,
@@ -514,7 +529,11 @@ impl LiveEnvelopeStreamer {
             pinned_hz: None,
             min_snr_db: DEFAULT_MIN_SNR_DB,
             min_dyn_range_ratio: DEFAULT_MIN_DYN_RANGE_RATIO,
-            preprocess: PreprocessConfig::default(),
+            // The compander is useful for offline bake-offs, but live V3
+            // currently over-amplifies receiver noise into short-pulse
+            // chatter. Keep the live visualizer conservative until the
+            // preprocessing stage has a stronger live quality gate.
+            preprocess: PreprocessConfig::disabled(),
             // Live decode: only the most recent 3s drive the gate, hysteresis,
             // and decode. Insulates the gate from QSO turn-taking — when a
             // strong station finishes and a weaker one starts, the strong
@@ -641,7 +660,7 @@ impl LiveEnvelopeStreamer {
             && self.locked_wpm.is_none()
             && elements >= self.lock_after_elements
             && wpm > 5.0
-            && wpm < 60.0
+            && wpm <= MAX_AUTO_WPM
         {
             self.locked_wpm = Some(wpm);
         }
@@ -831,8 +850,12 @@ pub fn decode_envelope_with_viz(
     };
     let (centroid_dot, centroid_dah) = kmeans_centroids(&on_durations);
 
-    let text = decode_events(&on_durations, &off_durations, dot_s);
     let wpm = if dot_s > 0.0 { 1.2 / dot_s } else { 0.0 };
+    let text = if suppress_implausible_auto_wpm(cfg, dot_s) {
+        String::new()
+    } else {
+        decode_events(&on_durations, &off_durations, dot_s)
+    };
 
     let elem_split = 2.0 * dot_s;
     let char_gap = 2.0 * dot_s;
@@ -1041,6 +1064,10 @@ fn kmeans_centroids(durations: &[f32]) -> (f32, f32) {
 fn dot_seconds_from_wpm(wpm: f32) -> f32 {
     // PARIS standard: 1 word = 50 dot units => dot = 1.2 / wpm seconds.
     (1.2_f32 / wpm.max(1.0)).max(MIN_ELEMENT_S)
+}
+
+fn suppress_implausible_auto_wpm(cfg: &EnvelopeConfig, dot_s: f32) -> bool {
+    cfg.pin_wpm.is_none() && dot_s.is_finite() && dot_s > 0.0 && dot_s < MIN_AUTO_DOT_S
 }
 
 /// Returns `(on_durations_s, off_durations_s)` aligned so that
@@ -1779,6 +1806,34 @@ mod tests {
             final_snap.transcript
         );
         assert_eq!(final_snap.viz.and_then(|viz| viz.locked_wpm), Some(20.0));
+    }
+
+    #[test]
+    fn auto_wpm_gate_suppresses_implausibly_fast_chatter() {
+        let rate = 8000u32;
+        let s = synth_morse(rate, 0.020, 700.0, "..."); // 60 WPM "S"
+
+        let (text, viz) = decode_envelope_with_viz(&s, rate, &EnvelopeConfig::default());
+
+        assert_eq!(
+            text, "",
+            "un-pinned auto decode should suppress implausibly fast chatter"
+        );
+        assert!(
+            viz.wpm > MAX_AUTO_WPM,
+            "test fixture should measure as too fast, got {} WPM",
+            viz.wpm
+        );
+
+        let pinned = decode_envelope(
+            &s,
+            rate,
+            &EnvelopeConfig {
+                pin_wpm: Some(60.0),
+                ..Default::default()
+            },
+        );
+        assert_eq!(pinned, "S", "explicit high-speed pin should still decode");
     }
 
     #[test]

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -3739,7 +3739,7 @@ fn run_stream_live_v3(
     let mut last_drain_at: u64 = 0;
     let mut last_decode_at = Instant::now();
     let decode_period = Duration::from_millis(decode_every_ms);
-    let mut last_transcript: Option<String> = None;
+    let mut session_transcript = String::new();
 
     loop {
         if stop.load(Ordering::Relaxed) {
@@ -3756,7 +3756,7 @@ fn run_stream_live_v3(
                     streamer = new_streamer();
                     multi_streamer = new_multi();
                     last_drain_at = capture.buffer.lock().written;
-                    last_transcript = None;
+                    session_transcript.clear();
                     if let Some(em) = emitter.as_mut() {
                         em.emit(
                             started.elapsed().as_secs_f32(),
@@ -3797,7 +3797,9 @@ fn run_stream_live_v3(
         // Force a viz-producing decode now.
         let snap = streamer.flush_with_viz();
         let t = started.elapsed().as_secs_f32();
-        last_transcript = Some(snap.transcript.clone());
+        let appended_session =
+            ditdah_streaming::append_snapshot_text(&mut session_transcript, &snap.transcript);
+        cap_session_transcript(&mut session_transcript, MAX_V3_SESSION_TRANSCRIPT_CHARS);
 
         if let Some(em) = emitter.as_mut() {
             em.emit(
@@ -3805,7 +3807,8 @@ fn run_stream_live_v3(
                 serde_json::json!({
                     "type": "transcript",
                     "text": snap.transcript,
-                    "appended": snap.appended,
+                    "appended": appended_session,
+                    "transcript": session_transcript.as_str(),
                     "wpm": snap.wpm,
                 }),
             );
@@ -3882,7 +3885,10 @@ fn run_stream_live_v3(
                 }
             }
         } else {
-            println!("[t={:>6.2}s wpm={:>5.1}] {}", t, snap.wpm, snap.transcript);
+            println!(
+                "[t={:>6.2}s wpm={:>5.1}] {}",
+                t, snap.wpm, session_transcript
+            );
             if let Some(m) = multi_streamer.as_mut() {
                 let snaps = m.flush();
                 for s in snaps {
@@ -3904,14 +3910,14 @@ fn run_stream_live_v3(
             started.elapsed().as_secs_f32(),
             serde_json::json!({
                 "type": "end",
-                "transcript": last_transcript.unwrap_or_default(),
+                "transcript": session_transcript,
                 "recording": recording_saved.or(recording_path),
             }),
         );
     } else {
         println!();
         println!("Final transcript (v3):");
-        println!("{}", last_transcript.unwrap_or_default());
+        println!("{session_transcript}");
     }
     Ok(())
 }
@@ -3985,7 +3991,7 @@ fn run_stream_live_v3_file(
     let chunk_period = Duration::from_millis(50);
     let chunk_samples = ((sr as u64 * 50) / 1000) as usize;
     let mut cursor = 0usize;
-    let mut last_transcript: Option<String> = None;
+    let mut session_transcript = String::new();
 
     while cursor < total_samples {
         if seconds > 0.0 && started.elapsed().as_secs_f32() >= seconds {
@@ -4008,7 +4014,9 @@ fn run_stream_live_v3_file(
 
         let snap = streamer.flush_with_viz();
         let t = started.elapsed().as_secs_f32();
-        last_transcript = Some(snap.transcript.clone());
+        let appended_session =
+            ditdah_streaming::append_snapshot_text(&mut session_transcript, &snap.transcript);
+        cap_session_transcript(&mut session_transcript, MAX_V3_SESSION_TRANSCRIPT_CHARS);
 
         if let Some(em) = emitter.as_mut() {
             em.emit(
@@ -4016,7 +4024,8 @@ fn run_stream_live_v3_file(
                 serde_json::json!({
                     "type": "transcript",
                     "text": snap.transcript,
-                    "appended": snap.appended,
+                    "appended": appended_session,
+                    "transcript": session_transcript.as_str(),
                     "wpm": snap.wpm,
                 }),
             );
@@ -4091,7 +4100,10 @@ fn run_stream_live_v3_file(
                 }
             }
         } else {
-            println!("[t={:>6.2}s wpm={:>5.1}] {}", t, snap.wpm, snap.transcript);
+            println!(
+                "[t={:>6.2}s wpm={:>5.1}] {}",
+                t, snap.wpm, session_transcript
+            );
             if let Some(m) = multi_streamer.as_mut() {
                 let snaps = m.flush();
                 for s in snaps {
@@ -4109,14 +4121,101 @@ fn run_stream_live_v3_file(
             started.elapsed().as_secs_f32(),
             serde_json::json!({
                 "type": "end",
-                "transcript": last_transcript.unwrap_or_default(),
+                "transcript": session_transcript,
                 "recording": serde_json::Value::Null,
             }),
         );
     } else {
         println!();
         println!("Final transcript (v3 file):");
-        println!("{}", last_transcript.unwrap_or_default());
+        println!("{session_transcript}");
     }
     Ok(())
+}
+
+/// Soft cap on the V3 visualizer session transcript. Keeps the rolling
+/// log bounded for live runs that go on for hours while still preserving
+/// enough context to read recent QSOs. We trim from the front on
+/// whitespace boundaries so we don't tear words in half.
+const MAX_V3_SESSION_TRANSCRIPT_CHARS: usize = 12_000;
+
+fn cap_session_transcript(transcript: &mut String, max_chars: usize) {
+    if transcript.chars().count() <= max_chars {
+        return;
+    }
+    let target_keep = max_chars * 4 / 5;
+    let total_chars = transcript.chars().count();
+    let drop_chars = total_chars - target_keep;
+    let drop_byte_idx = transcript
+        .char_indices()
+        .nth(drop_chars)
+        .map(|(idx, _)| idx)
+        .unwrap_or(0);
+    let trimmed = &transcript[drop_byte_idx..];
+    let cut = trimmed
+        .find(' ')
+        .map(|p| drop_byte_idx + p + 1)
+        .unwrap_or(drop_byte_idx);
+    transcript.replace_range(0..cut, "");
+}
+
+#[cfg(test)]
+mod v3_session_transcript_tests {
+    use super::cap_session_transcript;
+    use cw_decoder_poc::ditdah_streaming::append_snapshot_text;
+
+    #[test]
+    fn rolling_snapshots_grow_session_via_token_overlap() {
+        let mut session = String::new();
+        append_snapshot_text(&mut session, "CQ CQ DE W7LXN W7LXN");
+        append_snapshot_text(&mut session, "DE W7LXN W7LXN K");
+        append_snapshot_text(&mut session, "W7LXN K KC7AVA DE W7LXN");
+        assert!(session.contains("CQ CQ DE W7LXN W7LXN"));
+        assert!(session.contains("KC7AVA"));
+        assert!(session.ends_with("DE W7LXN"));
+    }
+
+    #[test]
+    fn rolling_snapshots_dont_double_repeat_callsigns() {
+        let mut session = String::new();
+        append_snapshot_text(&mut session, "CQ CQ CQ DE W7LXN W7LXN K");
+        append_snapshot_text(&mut session, "DE W7LXN W7LXN K");
+        append_snapshot_text(&mut session, "W7LXN K");
+        let count = session.matches("W7LXN").count();
+        assert_eq!(count, 2, "session={session:?}");
+    }
+
+    #[test]
+    fn unrelated_garbage_snapshot_is_appended_not_filtered() {
+        // We deliberately do NOT gate on anchors. Garbage rolling-window
+        // snapshots still flow through; the operator can see what the
+        // decoder is producing in noise. The cap eventually evicts old
+        // garbage as fresh copy arrives.
+        let mut session = String::new();
+        append_snapshot_text(&mut session, "CQ CQ DE K5KV");
+        let appended = append_snapshot_text(&mut session, "E2VI J VR T E");
+        assert!(!appended.is_empty());
+        assert!(session.contains("CQ CQ DE K5KV"));
+        assert!(session.contains("E2VI"));
+    }
+
+    #[test]
+    fn cap_session_transcript_keeps_recent_tail_on_word_boundary() {
+        let mut session = "AAA BBB CCC DDD EEE FFF GGG HHH III JJJ".to_string();
+        cap_session_transcript(&mut session, 16);
+        assert!(session.len() <= 16);
+        assert!(!session.starts_with(' '));
+        assert!(session.contains("JJJ"));
+        // Make sure we did not truncate mid-token.
+        assert!(session
+            .split_whitespace()
+            .all(|t| t.chars().all(|c| c.is_ascii_uppercase())));
+    }
+
+    #[test]
+    fn cap_session_transcript_noop_when_under_limit() {
+        let mut session = "CQ CQ DE W7LXN".to_string();
+        cap_session_transcript(&mut session, 100);
+        assert_eq!(session, "CQ CQ DE W7LXN");
+    }
 }


### PR DESCRIPTION
The CW Scope Visualizer transcript was scrolling fresh copy off-screen because each rolling window snapshot replaced the prior one. This commit makes the V3 emitter maintain a Rust-side session transcript that grows monotonically across snapshots, so copy persists.

The session transcript is appended via ditdah_streaming::append_snapshot_text (token-level suffix-prefix overlap with dedup), which is the same primitive used elsewhere in the rolling decoder. We deliberately do not gate on anchors and do not filter "noisy" snapshots: the operator sees what the decoder is producing, and the 12000 char cap with whitespace-boundary trimming evicts old copy as fresh copy lands.

The new transcript field rides alongside the existing rolling text and appended fields, so JSON consumers that want the small "current decode" view still have it. The C# visualizer prefers ev.Transcript and falls back to ev.Text. The transcript panel is resized (MinHeight 120, MaxHeight 240, FontSize 16) and auto-scrolls to end when VizTranscript updates.

Validation:
- cargo test --release --bin cw-decoder -- v3_session_transcript: 5/5 pass
- cargo test --release --lib (cw-decoder): 97/97 pass (skipping the pre-existing missing W1AW fixture)
- cargo build --release (cw-decoder): green
- dotnet build experiments/cw-decoder/gui/CwDecoderGui.csproj -c Release: green
- cargo fmt --check: green
- Replayed viz-20260428-222800-508.wav (9.19 MB, ~3 minutes): session transcript grew to 479 chars; recognizable English fragments persisted on screen during silent gaps instead of vanishing.