### PR TITLE
cw-decoder: fix V3 auto-lock so session transcript actually grows

### DIFF
--- a/experiments/cw-decoder/src/envelope_decoder.rs
+++ b/experiments/cw-decoder/src/envelope_decoder.rs
@@ -31,6 +31,11 @@ const MIN_ELEMENT_S: f32 = 0.012; // Reject sub-12ms blips as noise (~50 WPM dot
                                   // noise-locked rather than real CW; blank the transcript instead of
                                   // emitting dit-spam. Pinned WPM bypasses this gate.
 const MAX_AUTO_WPM: f32 = 45.0;
+/// Maximum cycle-to-cycle WPM delta (WPM) for the auto-lock to fire.
+/// Empirically clean/weak/qrn fixtures sit at p50 ~0.55 WPM and p90
+/// ~2.95 WPM; chaos sits at p90 ~7.7 WPM. ±2 WPM admits stable signals
+/// while rejecting noise-induced bounces.
+const LOCK_WPM_TOLERANCE: f32 = 2.0;
 
 /// Default SNR floor (dB) below which the decode is suppressed and the
 /// pipeline returns empty text. 20*log10(2.0) ≈ 6 dB; CW signals worth
@@ -462,6 +467,11 @@ pub struct LiveEnvelopeStreamer {
     locked_wpm: Option<f32>,
     pinned_wpm: Option<f32>,
     lock_after_elements: usize,
+    /// WPM observed on the prior decode cycle. The auto-lock requires
+    /// the current cycle's WPM to be within `LOCK_WPM_TOLERANCE` of this
+    /// value so noise-induced WPM bounces (e.g., chaos QRM) cannot
+    /// promote a single noisy cycle to a sticky lock.
+    prev_decode_wpm: Option<f32>,
     last_text: String,
     last_wpm: f32,
     pinned_hz: Option<f32>,
@@ -545,7 +555,15 @@ impl LiveEnvelopeStreamer {
             since_last_decode: 0,
             locked_wpm: None,
             pinned_wpm: None,
-            lock_after_elements: 30,
+            // Lowered from 30 because the 3-second rolling analysis
+            // window structurally caps `on_durations` at ~20 at 30 WPM,
+            // making a 30-element threshold unreachable on healthy
+            // signals. Empirical sweep across clean/weak/qrn fixtures
+            // showed >95% of cycles satisfy >=10. False locks on chaos
+            // are gated by the WPM-consistency check below combined
+            // with the existing `wpm <= MAX_AUTO_WPM` filter.
+            lock_after_elements: 10,
+            prev_decode_wpm: None,
             last_text: String::new(),
             last_wpm: 0.0,
             pinned_hz: None,
@@ -679,8 +697,16 @@ impl LiveEnvelopeStreamer {
             && elements >= self.lock_after_elements
             && wpm > 5.0
             && wpm <= MAX_AUTO_WPM
+            && self
+                .prev_decode_wpm
+                .is_some_and(|prev| (wpm - prev).abs() <= LOCK_WPM_TOLERANCE)
         {
             self.locked_wpm = Some(wpm);
+        }
+        if wpm > 5.0 && wpm <= MAX_AUTO_WPM {
+            self.prev_decode_wpm = Some(wpm);
+        } else {
+            self.prev_decode_wpm = None;
         }
 
         let appended = if text.starts_with(&self.last_text) {
@@ -1816,6 +1842,63 @@ mod tests {
             final_snap.transcript
         );
         assert_eq!(final_snap.viz.and_then(|viz| viz.locked_wpm), Some(20.0));
+    }
+
+    #[test]
+    fn live_streamer_auto_locks_after_consistent_wpm_window() {
+        let rate = 8000u32;
+        let dot = 0.060_f32;
+        // 30 dits provides plenty of on-durations and a stable WPM
+        // across multiple decode cycles; the lock should fire once
+        // the rolling analysis window observes >= 10 elements with
+        // a WPM consistent (within +/- LOCK_WPM_TOLERANCE) across
+        // two consecutive decode cycles.
+        let s = synth_morse(rate, dot, 700.0, &". ".repeat(30));
+        let mut streamer = LiveEnvelopeStreamer::new(rate);
+        let chunk = (rate as usize) / 20; // 50 ms
+        let mut i = 0;
+        while i < s.len() {
+            let end = (i + chunk).min(s.len());
+            streamer.feed(&s[i..end]);
+            i = end;
+        }
+        let final_snap = streamer.flush_with_viz();
+        let locked = final_snap
+            .viz
+            .as_ref()
+            .and_then(|viz| viz.locked_wpm)
+            .expect("lock should fire on a long stable PARIS-like dit train");
+        assert!(
+            (15.0..=30.0).contains(&locked),
+            "locked_wpm out of expected range: {locked}"
+        );
+    }
+
+    #[test]
+    fn live_streamer_does_not_auto_lock_above_max_auto_wpm() {
+        let rate = 8000u32;
+        // Synthesize an extremely fast tone train (well above
+        // MAX_AUTO_WPM == 45). Even though many elements appear,
+        // the auto-lock must not promote a noisy/runaway WPM.
+        let dot = 0.015_f32; // ~80 wpm-ish
+        let s = synth_morse(rate, dot, 700.0, &". ".repeat(40));
+        let mut streamer = LiveEnvelopeStreamer::new(rate);
+        let chunk = (rate as usize) / 20;
+        let mut i = 0;
+        while i < s.len() {
+            let end = (i + chunk).min(s.len());
+            streamer.feed(&s[i..end]);
+            i = end;
+        }
+        let final_snap = streamer.flush_with_viz();
+        assert!(
+            final_snap
+                .viz
+                .as_ref()
+                .and_then(|viz| viz.locked_wpm)
+                .is_none(),
+            "lock unexpectedly fired above MAX_AUTO_WPM"
+        );
     }
 
     #[test]

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -3740,6 +3740,7 @@ fn run_stream_live_v3(
     let mut last_decode_at = Instant::now();
     let decode_period = Duration::from_millis(decode_every_ms);
     let mut session_transcript: String = String::new();
+    let mut diag = DiagWriter::from_env();
 
     loop {
         if stop.load(Ordering::Relaxed) {
@@ -3803,12 +3804,23 @@ fn run_stream_live_v3(
         // per-cycle `text` field still carries the raw snapshot for
         // anyone who wants to see what the decoder was emitting before
         // it locked.
-        let appended_session = if should_stitch_to_session(&snap) {
+        let stitched = should_stitch_to_session(&snap);
+        let appended_session = if stitched {
             ditdah_streaming::append_snapshot_text(&mut session_transcript, &snap.transcript)
         } else {
             String::new()
         };
         cap_session_transcript(&mut session_transcript, MAX_V3_SESSION_TRANSCRIPT_CHARS);
+        if let Some(d) = diag.as_mut() {
+            d.record(
+                t,
+                &snap,
+                stitched,
+                &appended_session,
+                &session_transcript,
+                "live",
+            );
+        }
 
         if let Some(em) = emitter.as_mut() {
             em.emit(
@@ -3998,6 +4010,7 @@ fn run_stream_live_v3_file(
     let chunk_samples = ((sr as u64 * 50) / 1000) as usize;
     let mut cursor = 0usize;
     let mut session_transcript: String = String::new();
+    let mut diag = DiagWriter::from_env();
 
     while cursor < total_samples {
         if seconds > 0.0 && started.elapsed().as_secs_f32() >= seconds {
@@ -4023,12 +4036,23 @@ fn run_stream_live_v3_file(
         // Same lock-state gate as the live capture path: only stitch
         // into the session transcript once the decoder has locked and
         // the SNR gate is not suppressing.
-        let appended_session = if should_stitch_to_session(&snap) {
+        let stitched = should_stitch_to_session(&snap);
+        let appended_session = if stitched {
             ditdah_streaming::append_snapshot_text(&mut session_transcript, &snap.transcript)
         } else {
             String::new()
         };
         cap_session_transcript(&mut session_transcript, MAX_V3_SESSION_TRANSCRIPT_CHARS);
+        if let Some(d) = diag.as_mut() {
+            d.record(
+                t,
+                &snap,
+                stitched,
+                &appended_session,
+                &session_transcript,
+                "file",
+            );
+        }
 
         if let Some(em) = emitter.as_mut() {
             em.emit(
@@ -4161,6 +4185,106 @@ fn should_stitch_to_session(snap: &cw_decoder_poc::envelope_decoder::LiveEnvelop
         return false;
     };
     viz.locked_wpm.is_some() && !viz.snr_suppressed
+}
+
+/// Per-cycle diagnostic recorder for the V3 live path.
+///
+/// TEMPORARY — added under #364 follow-up to gather rich data before
+/// hypothesizing about why locked windows still drop characters into
+/// the session transcript. Remove or gate behind a build flag once the
+/// transcript-fidelity work is done.
+///
+/// Activated by setting the env var `QSORIPPER_CW_DIAG_LOG` to a file
+/// path before launching `cw-decoder.exe stream-live-v3` (directly or
+/// via the GUI). One JSON line per decode cycle is appended.
+struct DiagWriter {
+    file: std::fs::File,
+    cycle: u64,
+}
+
+impl DiagWriter {
+    fn from_env() -> Option<Self> {
+        let path = std::env::var("QSORIPPER_CW_DIAG_LOG").ok()?;
+        let path = path.trim();
+        if path.is_empty() {
+            return None;
+        }
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| eprintln!("[diag] cannot open {path}: {e}"))
+            .ok()?;
+        eprintln!("[diag] writing per-cycle diagnostics to {path}");
+        Some(Self { file, cycle: 0 })
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn record(
+        &mut self,
+        t_seconds: f32,
+        snap: &cw_decoder_poc::envelope_decoder::LiveEnvelopeSnapshot,
+        stitched: bool,
+        appended_session: &str,
+        session_transcript: &str,
+        source: &str,
+    ) {
+        use std::io::Write;
+        let viz = snap.viz.as_ref();
+        let locked = viz.is_some_and(|v| v.locked_wpm.is_some());
+        let locked_wpm = viz.and_then(|v| v.locked_wpm);
+        let snr_db = viz.map(|v| v.snr_db).unwrap_or(0.0);
+        let snr_suppressed = viz.is_some_and(|v| v.snr_suppressed);
+        let pitch_hz = viz.map(|v| v.pitch_hz).unwrap_or(0.0);
+        let signal_floor = viz.map(|v| v.signal_floor).unwrap_or(0.0);
+        let noise_floor = viz.map(|v| v.noise_floor).unwrap_or(0.0);
+        let envelope_max = viz.map(|v| v.envelope_max).unwrap_or(0.0);
+        let dyn_range = if envelope_max > 0.0 {
+            (signal_floor - noise_floor) / envelope_max
+        } else {
+            0.0
+        };
+        let dot_seconds = viz.map(|v| v.dot_seconds).unwrap_or(0.0);
+        let viz_wpm = viz.map(|v| v.wpm).unwrap_or(0.0);
+        let n_events = viz.map(|v| v.events.len()).unwrap_or(0);
+        let n_on_durations = viz.map(|v| v.on_durations.len()).unwrap_or(0);
+        let session_len = session_transcript.chars().count();
+        let line = serde_json::json!({
+            "type": "diag_cycle",
+            "source": source,
+            "cycle": self.cycle,
+            "t_s": t_seconds,
+            "snap": {
+                "text": snap.transcript,
+                "appended": snap.appended,
+                "wpm": snap.wpm,
+            },
+            "viz": {
+                "locked": locked,
+                "locked_wpm": locked_wpm,
+                "snr_db": snr_db,
+                "snr_suppressed": snr_suppressed,
+                "dyn_range_ratio": dyn_range,
+                "signal_floor": signal_floor,
+                "noise_floor": noise_floor,
+                "envelope_max": envelope_max,
+                "pitch_hz": pitch_hz,
+                "dot_seconds": dot_seconds,
+                "wpm": viz_wpm,
+                "n_events": n_events,
+                "n_on_durations": n_on_durations,
+            },
+            "session": {
+                "stitched": stitched,
+                "appended": appended_session,
+                "len_chars": session_len,
+            },
+        });
+        if let Err(e) = writeln!(self.file, "{line}") {
+            eprintln!("[diag] write failed: {e}");
+        }
+        self.cycle += 1;
+    }
 }
 
 /// Maximum characters retained in the V3 visualizer's session transcript.

--- a/scripts/summarize-cw-diag.ps1
+++ b/scripts/summarize-cw-diag.ps1
@@ -1,0 +1,104 @@
+<#
+.SYNOPSIS
+Summarizes a per-cycle CW decoder diagnostic NDJSON log.
+
+.DESCRIPTION
+Reads the NDJSON file produced by cw-decoder.exe when the env var
+QSORIPPER_CW_DIAG_LOG is set. Reports cycle counts by status (locked,
+stitched, suppressed), distribution of SNR / dyn_range / WPM, and the
+per-cycle snap text from cycles that were NOT stitched into the session
+transcript (so we can see what fidelity is being lost).
+
+.EXAMPLE
+$env:QSORIPPER_CW_DIAG_LOG = "C:\temp\cw-diag.ndjson"
+# launch GUI, decode for a while, stop
+.\scripts\summarize-cw-diag.ps1 -Path C:\temp\cw-diag.ndjson
+#>
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [string] $Path,
+
+    [int] $DroppedSamples = 30
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $Path)) {
+    throw "Diag log not found: $Path"
+}
+
+$cycles = Get-Content -LiteralPath $Path | ForEach-Object {
+    if ($_.Trim().Length -eq 0) { return }
+    $_ | ConvertFrom-Json
+}
+
+$total      = $cycles.Count
+$locked     = ($cycles | Where-Object { $_.viz.locked }).Count
+$stitched   = ($cycles | Where-Object { $_.session.stitched }).Count
+$suppressed = ($cycles | Where-Object { $_.viz.snr_suppressed }).Count
+
+Write-Host "=== CW Decoder Diagnostic Summary ===" -ForegroundColor Cyan
+Write-Host "Source file:        $Path"
+Write-Host "Total cycles:       $total"
+Write-Host "Locked cycles:      $locked  ($([math]::Round(100*$locked/[math]::Max(1,$total),1))%)"
+Write-Host "Stitched cycles:    $stitched  ($([math]::Round(100*$stitched/[math]::Max(1,$total),1))%)"
+Write-Host "Suppressed cycles:  $suppressed  ($([math]::Round(100*$suppressed/[math]::Max(1,$total),1))%)"
+
+function Quantiles($values, $name) {
+    if ($values.Count -eq 0) { return }
+    $sorted = $values | Sort-Object
+    $p = @(0.0, 0.1, 0.5, 0.9, 1.0) | ForEach-Object {
+        $idx = [int][math]::Floor($_ * ($sorted.Count - 1))
+        [math]::Round($sorted[$idx], 3)
+    }
+    Write-Host ("  {0,-18} min={1}  p10={2}  p50={3}  p90={4}  max={5}" -f $name, $p[0], $p[1], $p[2], $p[3], $p[4])
+}
+
+Write-Host ""
+Write-Host "=== Distribution (locked cycles only) ===" -ForegroundColor Cyan
+$lockedCycles = $cycles | Where-Object { $_.viz.locked }
+Quantiles ($lockedCycles | ForEach-Object { [double]$_.viz.snr_db })          'snr_db'
+Quantiles ($lockedCycles | ForEach-Object { [double]$_.viz.dyn_range_ratio }) 'dyn_range_ratio'
+Quantiles ($lockedCycles | ForEach-Object { [double]$_.viz.wpm })             'wpm'
+Quantiles ($lockedCycles | ForEach-Object { [double]$_.viz.pitch_hz })        'pitch_hz'
+Quantiles ($lockedCycles | ForEach-Object { [int]$_.viz.n_on_durations })     'n_on_durations'
+
+Write-Host ""
+Write-Host "=== Distribution (ALL cycles) ===" -ForegroundColor Cyan
+Quantiles ($cycles | ForEach-Object { [double]$_.viz.snr_db })          'snr_db'
+Quantiles ($cycles | ForEach-Object { [double]$_.viz.dyn_range_ratio }) 'dyn_range_ratio'
+
+Write-Host ""
+Write-Host "=== Cycles with snap.text but NOT stitched ===" -ForegroundColor Yellow
+$dropped = $cycles | Where-Object {
+    -not $_.session.stitched -and $_.snap.text.Length -gt 0
+}
+Write-Host "Count: $($dropped.Count)"
+if ($dropped.Count -gt 0) {
+    Write-Host "Sample (first $DroppedSamples):"
+    $dropped | Select-Object -First $DroppedSamples | ForEach-Object {
+        $reason = if ($_.viz.snr_suppressed) { 'snr_supp' } `
+                  elseif (-not $_.viz.locked) { 'acquiring' } `
+                  else { 'no_viz' }
+        $snr = [math]::Round([double]$_.viz.snr_db, 1)
+        $dr  = [math]::Round([double]$_.viz.dyn_range_ratio, 2)
+        $t   = [math]::Round([double]$_.t_s, 2)
+        Write-Host ("  t={0,6}s  reason={1,-9}  snr={2,5}dB  dr={3,4}  text={4}" -f $t, $reason, $snr, $dr, $_.snap.text)
+    }
+}
+
+Write-Host ""
+Write-Host "=== Stitched cycles (most recent $DroppedSamples) ===" -ForegroundColor Green
+$stitchedCycles = $cycles | Where-Object { $_.session.stitched }
+$tail = $stitchedCycles | Select-Object -Last $DroppedSamples
+foreach ($c in $tail) {
+    $t = [math]::Round([double]$c.t_s, 2)
+    Write-Host ("  t={0,6}s  appended={1,-30} | snap.text={2}" -f $t, ($c.session.appended.Trim()), $c.snap.text)
+}
+
+Write-Host ""
+$lastSession = ($cycles | Where-Object { $_.session.len_chars -gt 0 } | Select-Object -Last 1)
+if ($lastSession) {
+    Write-Host "Final session_transcript length: $($lastSession.session.len_chars) chars" -ForegroundColor Cyan
+}


### PR DESCRIPTION
The V3 lock gate added in #365 has a structural bug: it gates session-transcript stitching on viz.locked_wpm being set, but the underlying lock condition required elements >= 30 in a single decode cycle, where elements is the count of on_durations in the rolling 3-second analysis window. At 30 WPM that window holds at most ~20 on_durations, so the lock never fires and every cycles text is silently dropped. This is the cause of the sparse-transcript symptom we have been chasing.

Diagnostic instrumentation
The first commit adds opt-in per-cycle NDJSON logging activated by env var QSORIPPER_CW_DIAG_LOG. When unset its a no-op. When set to a path, both V3 entry points (stream-live-v3 and stream-live-v3 --file) emit one JSON line per decode cycle with snap text/wpm/appended, full viz frame, computed dyn_range_ratio, stitch decision, and running session length. scripts/summarize-cw-diag.ps1 aggregates the log into cycle counts, quantile distributions, and dropped-cycle samples.

Sweep across four fixtures on baseline (without the fix):

  Fixture  Cycles  HasText  Locked  OnDurMax  PctGE_30
  clean    997     997      0       20        0.0%
  qrn      952     952      0       20        0.0%
  weak     971     971      0       20        0.0%
  chaos    901     433      0       35        8.3%

Locked = 0 across every fixture. On healthy signals on_durations is structurally capped at ~20.

Fix
Two changes in envelope_decoder.rs:

1. Lower lock_after_elements from 30 to 10 to match what a 3-second window can actually hold (clean/weak/qrn all sit at median 13).
2. Add a WPM-consistency gate: the auto-lock now also requires the current cycles WPM to be within +/- 2.0 WPM of the prior cycles WPM. Empirical p90 delta is ~3 WPM on healthy signals and ~7.7 WPM on chaos, so this admits stable signals and rejects noise bounces. Combined with the existing wpm <= MAX_AUTO_WPM (45) cap, chaos QRM (which produces noise WPMs in the 60-80 range) stays rejected.

Sweep across the same four fixtures with the fix:

  Fixture  Cycles  Locked  LockedPct  Stitched  FirstLockSec
  clean    999     987     98.8%      987       3.3
  qrn      956     944     98.7%      944       3.3
  weak     950     938     98.7%      938       3.3
  chaos    942     0       0.0%       0         n/a

Session transcripts on clean/qrn/weak grow to ~4,400 chars of real CW content (DE K, RST, TNX, 73, FB OM, CL, etc.) instead of 1-5 chars on baseline. Chaos remains correctly rejected.

Tests
Added two unit tests in envelope_decoder.rs:
- live_streamer_auto_locks_after_consistent_wpm_window (positive path)
- live_streamer_does_not_auto_lock_above_max_auto_wpm (chaos-rejection path)

Local validation:
- cargo test --release: 102 lib + 13 bin tests pass
- cargo fmt --all clean
- Pre-existing clippy errors in vendor/ditdah/src/decoder.rs are unrelated to this PR (verified by stashing the diff and re-running clippy on baseline)

How to use the diag tooling
  $env:QSORIPPER_CW_DIAG_LOG = "C:\temp\cw-diag.ndjson"
  # launch GUI or CLI as normal, decode for a while
  .\scripts\summarize-cw-diag.ps1 -Path C:\temp\cw-diag.ndjson

The instrumentation is opt-in and inert without the env var. Its useful enough to keep around for future tuning passes, but if you want it removed before merge let me know.