### PR TITLE
cw-decoder: live-capture regression harness + V3 stop-line fix

### DIFF
--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -3321,6 +3321,117 @@ pub enum StdinControlMessage {
     ResetLock,
 }
 
+/// Outcome of parsing one stdin control line. Pulled out as its own
+/// function so the parser can be regression-tested without spawning a
+/// real reader thread or wiring stdin redirection.
+#[derive(Debug)]
+pub(crate) enum StdinParseOutcome {
+    /// Line should be ignored (empty / unrecognized JSON / malformed).
+    Skip,
+    /// Operator requested graceful shutdown via a literal `stop` line.
+    /// The reader loop must set the stop atomic and break.
+    Stop,
+    /// A control message that the decoder loop should observe.
+    Message(StdinControlMessage),
+}
+
+#[cfg(test)]
+impl StdinParseOutcome {
+    fn is_stop(&self) -> bool {
+        matches!(self, StdinParseOutcome::Stop)
+    }
+    fn is_skip(&self) -> bool {
+        matches!(self, StdinParseOutcome::Skip)
+    }
+    fn is_reset_lock(&self) -> bool {
+        matches!(
+            self,
+            StdinParseOutcome::Message(StdinControlMessage::ResetLock)
+        )
+    }
+}
+
+/// Parse a single line received on the V3/streaming control stdin.
+///
+/// `state` is the current cumulative [`streaming::DecoderConfig`]; we
+/// mutate it in place so omitted fields keep their previous value.
+///
+/// Critical invariant: a literal `stop` line MUST yield
+/// [`StdinParseOutcome::Stop`] so the reader loop can finalize the WAV
+/// recording. Without that, the GUI's graceful Stop signal is silently
+/// dropped here, the GUI eventually falls back to `Process.Kill`,
+/// `LiveCapture::drop` never runs, and every saved capture lands on
+/// disk with `riffSize=0/dataSize=0` — making it unusable for offline
+/// replay or regression scoring (see
+/// `parser_treats_literal_stop_line_as_stop` test).
+pub(crate) fn parse_stdin_control_line(
+    state: &mut streaming::DecoderConfig,
+    line: &str,
+) -> StdinParseOutcome {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return StdinParseOutcome::Skip;
+    }
+    if trimmed.eq_ignore_ascii_case("stop") {
+        return StdinParseOutcome::Stop;
+    }
+    let v: serde_json::Value = match serde_json::from_str(trimmed) {
+        Ok(v) => v,
+        Err(_) => return StdinParseOutcome::Skip,
+    };
+    match v.get("type").and_then(|t| t.as_str()) {
+        Some("reset_lock") => return StdinParseOutcome::Message(StdinControlMessage::ResetLock),
+        Some("config") => {}
+        _ => return StdinParseOutcome::Skip,
+    }
+    if let Some(x) = v.get("min_snr_db").and_then(|x| x.as_f64()) {
+        state.min_snr_db = x as f32;
+    }
+    if let Some(x) = v.get("pitch_min_snr_db").and_then(|x| x.as_f64()) {
+        state.pitch_min_snr_db = x as f32;
+    }
+    if let Some(x) = v.get("threshold_scale").and_then(|x| x.as_f64()) {
+        state.threshold_scale = x as f32;
+    }
+    if let Some(b) = v.get("auto_threshold").and_then(|x| x.as_bool()) {
+        state.auto_threshold = b;
+    }
+    if let Some(b) = v.get("experimental_range_lock").and_then(|x| x.as_bool()) {
+        state.experimental_range_lock = b;
+    }
+    if let Some(x) = v.get("range_lock_min_hz").and_then(|x| x.as_f64()) {
+        state.range_lock_min_hz = x as f32;
+    }
+    if let Some(x) = v.get("range_lock_max_hz").and_then(|x| x.as_f64()) {
+        state.range_lock_max_hz = x as f32;
+    }
+    if let Some(x) = v.get("min_tone_purity").and_then(|x| x.as_f64()) {
+        state.min_tone_purity = x as f32;
+    }
+    if let Some(x) = v.get("force_pitch_hz").and_then(|x| x.as_f64()) {
+        state.force_pitch_hz = if x > 0.0 { Some(x as f32) } else { None };
+    } else if v
+        .get("force_pitch_hz")
+        .map(|x| x.is_null())
+        .unwrap_or(false)
+    {
+        state.force_pitch_hz = None;
+    }
+    if let Some(x) = v.get("wide_bin_count").and_then(|x| x.as_i64()) {
+        state.wide_bin_count = x.clamp(0, 16) as u8;
+    }
+    if let Some(x) = v.get("min_pulse_dot_fraction").and_then(|x| x.as_f64()) {
+        state.min_pulse_dot_fraction = x.max(0.0) as f32;
+    }
+    if let Some(x) = v.get("min_gap_dot_fraction").and_then(|x| x.as_f64()) {
+        state.min_gap_dot_fraction = x.max(0.0) as f32;
+    }
+    if let Some(x) = v.get("hysteresis_fraction").and_then(|x| x.as_f64()) {
+        state.hysteresis_fraction = x.max(0.0) as f32;
+    }
+    StdinParseOutcome::Message(StdinControlMessage::Config(*state))
+}
+
 /// Spawn a background thread that reads NDJSON control lines from stdin
 /// and forwards parsed [`StdinControlMessage`] values to the returned
 /// receiver. Lines that don't parse as a recognized command are
@@ -3329,6 +3440,7 @@ pub enum StdinControlMessage {
 /// Wire format (one JSON object per line):
 ///   {"type":"config","min_snr_db":6.0,"pitch_min_snr_db":8.0,"threshold_scale":1.0}
 ///   {"type":"reset_lock"}
+///   stop
 ///
 /// For `config`, any field may be omitted; omitted fields keep their
 /// previous value.
@@ -3341,72 +3453,19 @@ fn spawn_stdin_config_channel(
         let stdin = std::io::stdin();
         let mut state = streaming::DecoderConfig::defaults();
         for line in stdin.lock().lines().map_while(Result::ok) {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            let v: serde_json::Value = match serde_json::from_str(trimmed) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            match v.get("type").and_then(|t| t.as_str()) {
-                Some("reset_lock") => {
-                    if tx.send(StdinControlMessage::ResetLock).is_err() {
+            match parse_stdin_control_line(&mut state, &line) {
+                StdinParseOutcome::Skip => continue,
+                StdinParseOutcome::Stop => {
+                    if let Some(stop) = stop_on_eof.as_ref() {
+                        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    break;
+                }
+                StdinParseOutcome::Message(msg) => {
+                    if tx.send(msg).is_err() {
                         break;
                     }
-                    continue;
                 }
-                Some("config") => {}
-                _ => continue,
-            }
-            if let Some(x) = v.get("min_snr_db").and_then(|x| x.as_f64()) {
-                state.min_snr_db = x as f32;
-            }
-            if let Some(x) = v.get("pitch_min_snr_db").and_then(|x| x.as_f64()) {
-                state.pitch_min_snr_db = x as f32;
-            }
-            if let Some(x) = v.get("threshold_scale").and_then(|x| x.as_f64()) {
-                state.threshold_scale = x as f32;
-            }
-            if let Some(b) = v.get("auto_threshold").and_then(|x| x.as_bool()) {
-                state.auto_threshold = b;
-            }
-            if let Some(b) = v.get("experimental_range_lock").and_then(|x| x.as_bool()) {
-                state.experimental_range_lock = b;
-            }
-            if let Some(x) = v.get("range_lock_min_hz").and_then(|x| x.as_f64()) {
-                state.range_lock_min_hz = x as f32;
-            }
-            if let Some(x) = v.get("range_lock_max_hz").and_then(|x| x.as_f64()) {
-                state.range_lock_max_hz = x as f32;
-            }
-            if let Some(x) = v.get("min_tone_purity").and_then(|x| x.as_f64()) {
-                state.min_tone_purity = x as f32;
-            }
-            // force_pitch_hz: <number> sets a forced lock; 0/null clears it.
-            if let Some(x) = v.get("force_pitch_hz").and_then(|x| x.as_f64()) {
-                state.force_pitch_hz = if x > 0.0 { Some(x as f32) } else { None };
-            } else if v
-                .get("force_pitch_hz")
-                .map(|x| x.is_null())
-                .unwrap_or(false)
-            {
-                state.force_pitch_hz = None;
-            }
-            if let Some(x) = v.get("wide_bin_count").and_then(|x| x.as_i64()) {
-                state.wide_bin_count = x.clamp(0, 16) as u8;
-            }
-            if let Some(x) = v.get("min_pulse_dot_fraction").and_then(|x| x.as_f64()) {
-                state.min_pulse_dot_fraction = x.max(0.0) as f32;
-            }
-            if let Some(x) = v.get("min_gap_dot_fraction").and_then(|x| x.as_f64()) {
-                state.min_gap_dot_fraction = x.max(0.0) as f32;
-            }
-            if let Some(x) = v.get("hysteresis_fraction").and_then(|x| x.as_f64()) {
-                state.hysteresis_fraction = x.max(0.0) as f32;
-            }
-            if tx.send(StdinControlMessage::Config(state)).is_err() {
-                break;
             }
         }
         // Stdin EOF — propagate as graceful stop so Drop runs and the WAV
@@ -4454,5 +4513,62 @@ mod v3_session_transcript_tests {
         // about lock state, so be conservative and skip.
         let snap = make_snapshot("CQ", None);
         assert!(!should_stitch_to_session(&snap));
+    }
+}
+
+#[cfg(test)]
+mod stdin_control_tests {
+    use super::*;
+
+    /// Critical regression: the GUI's graceful Stop signal arrives as a
+    /// literal `stop\n` line, not as JSON. Without the `Stop` outcome,
+    /// the V3 child never observes the request, the GUI eventually falls
+    /// back to Process.Kill, LiveCapture::drop never runs, and every
+    /// saved capture lands on disk with riffSize=0/dataSize=0 — making
+    /// real-radio diagnostic captures unusable for offline replay /
+    /// regression scoring.
+    #[test]
+    fn parser_treats_literal_stop_line_as_stop() {
+        let mut state = streaming::DecoderConfig::defaults();
+        assert!(parse_stdin_control_line(&mut state, "stop").is_stop());
+        assert!(parse_stdin_control_line(&mut state, "  STOP  \r").is_stop());
+        assert!(parse_stdin_control_line(&mut state, "Stop\n").is_stop());
+    }
+
+    #[test]
+    fn parser_skips_blank_and_unknown_lines() {
+        let mut state = streaming::DecoderConfig::defaults();
+        assert!(parse_stdin_control_line(&mut state, "").is_skip());
+        assert!(parse_stdin_control_line(&mut state, "    ").is_skip());
+        assert!(parse_stdin_control_line(&mut state, "garbage{").is_skip());
+        // Valid JSON without a recognized type is also a no-op.
+        assert!(parse_stdin_control_line(&mut state, r#"{"hello":"world"}"#).is_skip());
+    }
+
+    #[test]
+    fn parser_recognizes_reset_lock_and_config() {
+        let mut state = streaming::DecoderConfig::defaults();
+        assert!(parse_stdin_control_line(&mut state, r#"{"type":"reset_lock"}"#).is_reset_lock());
+        match parse_stdin_control_line(
+            &mut state,
+            r#"{"type":"config","min_snr_db":12.5,"threshold_scale":1.5}"#,
+        ) {
+            StdinParseOutcome::Message(StdinControlMessage::Config(cfg)) => {
+                assert!((cfg.min_snr_db - 12.5).abs() < 1e-3);
+                assert!((cfg.threshold_scale - 1.5).abs() < 1e-3);
+            }
+            other => panic!("expected Config message, got {other:?}"),
+        }
+        // Cumulative state: a partial config message preserves prior values.
+        match parse_stdin_control_line(&mut state, r#"{"type":"config","min_snr_db":3.0}"#) {
+            StdinParseOutcome::Message(StdinControlMessage::Config(cfg)) => {
+                assert!((cfg.min_snr_db - 3.0).abs() < 1e-3);
+                assert!(
+                    (cfg.threshold_scale - 1.5).abs() < 1e-3,
+                    "threshold_scale should persist across config updates",
+                );
+            }
+            other => panic!("expected Config message, got {other:?}"),
+        }
     }
 }

--- a/scripts/baselines/live-capture-suite.json
+++ b/scripts/baselines/live-capture-suite.json
@@ -1,0 +1,32 @@
+{
+  "Commit": "BASELINE",
+  "Subject": "Initial live-capture suite baseline",
+  "Fixtures": 3,
+  "AvgRecall_pct": 48.0,
+  "MinRecall_pct": 0.0,
+  "Generated": "2026-04-30T00:00:00Z",
+  "Notes": "Baseline captured by scripts/bench-live-capture-suite.ps1 on the cw-decoder release binary built from the V3 lock-release branch + GUI-stop parser fix. Re-run with -UpdateBaseline to refresh after intentional decoder changes. Recall = % of distinct >=2-char alpha tokens from the whole-buffer 'gold' decode that appear as whole tokens in the streaming 'live' transcript.",
+  "Results": [
+    {
+      "Fixture": "session-194729.wav",
+      "GoldChars": 578,
+      "LiveChars": 3178,
+      "Recall_pct": 45.2,
+      "Notes": "W1AW ARRL bulletin broadcast captured from radio, 32 kHz mono 16-bit, ~444 s. Real off-air signal with QRM/QRN. Live transcript is 5.5x longer than gold but only catches 45% of gold tokens, indicating heavy stitched garbage between real copy."
+    },
+    {
+      "Fixture": "session-204015.wav",
+      "GoldChars": 246,
+      "LiveChars": 552,
+      "Recall_pct": 0.0,
+      "Notes": "60 s capture from the screenshot-2 session. Visually-clean waveform on the visualizer but the gold whole-buffer decoder also produces garbage (E/?/single-letter spam) on this audio, indicating the acoustic input itself is fundamentally hard (probably multi-station / drift / QSB). Live track copies a different garbage stream from gold so token recall is 0% by construction. NOT evidence of a streaming-specific regression."
+    },
+    {
+      "Fixture": "cw_30wpm_abbrev_clean.wav",
+      "GoldChars": 359,
+      "LiveChars": 1367,
+      "Recall_pct": 98.9,
+      "Notes": "Canonical synthetic 30 WPM PARIS-derived fixture. Live recall stays >=95% across regressions; below that = real V3 streaming break."
+    }
+  ]
+}

--- a/scripts/bench-live-capture-suite.ps1
+++ b/scripts/bench-live-capture-suite.ps1
@@ -1,0 +1,144 @@
+# Live-capture regression harness for the cw-decoder V3 streaming path.
+#
+# Why this exists: bench-v3-clean.ps1 only scores against a synthetic
+# truth file for one clean WAV. That doesn't catch the live-streaming
+# failure modes the user hits on real radio audio (spurious lock on
+# noise, stitching garbage into the session transcript, char-gap mis-
+# classification, etc.). This harness replays a curated set of WAVs
+# (clean synthesis + real captured radio) through `stream-live-v3
+# --file` at real-time pace, captures the final session transcript,
+# and scores it against the rock-solid whole-buffer `file` decode of
+# the same WAV (the "gold" reference).
+#
+# The whole-buffer decoder isn't perfect on real radio — but it IS
+# stable, has no streaming-specific failure modes, and gives us a
+# fixed reference we can regression against. Live ought to be at least
+# as good as gold (and ideally identical for clean inputs).
+#
+# Outputs a per-fixture table plus a summary so future PRs can detect
+# regression in either direction.
+
+[CmdletBinding()]
+param(
+    [string]$FixturesRoot = 'data\cw-samples\live-captures',
+    [string[]]$ExtraWavs  = @('data\cw-samples\cw_30wpm_abbrev_clean.wav'),
+    [int]$DecodeEveryMs   = 1000,
+    [string]$BaselineFile = 'scripts\baselines\live-capture-suite.json',
+    [switch]$UpdateBaseline,
+    [switch]$JsonOnly
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Resolve-Path "$PSScriptRoot\.."
+$bin  = Join-Path $root 'experiments\cw-decoder\target\release\cw-decoder.exe'
+if (-not (Test-Path $bin)) { throw "Missing $bin (run cargo build --release in experiments\cw-decoder)" }
+
+function Get-FinalTranscript {
+    param([string]$NdjsonPath)
+    $line = Get-Content $NdjsonPath | Where-Object { $_ -match '"type":"transcript"' } | Select-Object -Last 1
+    if (-not $line) {
+        $line = Get-Content $NdjsonPath | Where-Object { $_ -match '"type":"end"' } | Select-Object -Last 1
+    }
+    if (-not $line) { return '' }
+    $obj = $line | ConvertFrom-Json
+    if ($obj.PSObject.Properties['transcript'] -and $obj.transcript) { return "$($obj.transcript)" }
+    if ($obj.PSObject.Properties['text']       -and $obj.text)       { return "$($obj.text)" }
+    return ''
+}
+
+function Get-GoldDecode {
+    param([string]$WavPath)
+    $raw = & $bin file $WavPath 2>$null
+    if ($LASTEXITCODE -ne 0) { return '' }
+    # Output looks like:
+    #   == decoded text ==
+    #   <transcript line(s)>
+    $idx = ($raw | Select-String -Pattern '== decoded text ==').LineNumber
+    if (-not $idx) { return '' }
+    return ($raw[$idx..($raw.Count - 1)] -join "`n").Trim()
+}
+
+function Get-LiveDecode {
+    param([string]$WavPath, [int]$DecodeMs)
+    $tmp = Join-Path $env:TEMP "live-cap-$([guid]::NewGuid().ToString('N')).ndjson"
+    try {
+        & $bin stream-live-v3 --json --decode-every-ms $DecodeMs --file $WavPath 1>$tmp 2>$null
+        if ($LASTEXITCODE -ne 0) { return '' }
+        return Get-FinalTranscript -NdjsonPath $tmp
+    } finally {
+        Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Score-TokenRecall {
+    # % of distinct >=2-char alpha tokens from `gold` that appear as
+    # whole tokens (case-insensitive) in `live`. Two-char minimum
+    # filters out the "E E E E" noise spam that inflates raw matches.
+    param([string]$Gold, [string]$Live)
+    $goldTokens = ($Gold -split '\s+') | Where-Object { $_ -match '^[A-Za-z0-9]{2,}$' } | ForEach-Object { $_.ToUpperInvariant() }
+    if ($goldTokens.Count -eq 0) { return 0.0 }
+    $liveTokens = ($Live -split '\s+') | Where-Object { $_ } | ForEach-Object { $_.ToUpperInvariant() }
+    $liveSet = $liveTokens | Sort-Object -Unique
+    $goldUnique = $goldTokens | Sort-Object -Unique
+    $hits = 0
+    foreach ($t in $goldUnique) { if ($liveSet -contains $t) { $hits++ } }
+    return [math]::Round(100.0 * $hits / $goldUnique.Count, 1)
+}
+
+# Discover fixture WAVs.
+$fixtures = New-Object System.Collections.Generic.List[string]
+$fixturesAbs = Join-Path $root $FixturesRoot
+if (Test-Path $fixturesAbs) {
+    Get-ChildItem -Path $fixturesAbs -Filter '*.wav' | ForEach-Object { $fixtures.Add($_.FullName) }
+}
+foreach ($w in $ExtraWavs) {
+    $abs = Join-Path $root $w
+    if (Test-Path $abs) { $fixtures.Add($abs) }
+}
+if ($fixtures.Count -eq 0) { throw "No fixture WAVs found under $fixturesAbs or $ExtraWavs" }
+
+$results = New-Object System.Collections.Generic.List[object]
+foreach ($wav in $fixtures) {
+    if (-not $JsonOnly) { Write-Host "Benching $([System.IO.Path]::GetFileName($wav))..." -ForegroundColor Cyan }
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $gold = Get-GoldDecode -WavPath $wav
+    $goldMs = $sw.ElapsedMilliseconds
+    $sw.Restart()
+    $live = Get-LiveDecode -WavPath $wav -DecodeMs $DecodeEveryMs
+    $liveMs = $sw.ElapsedMilliseconds
+    $score = Score-TokenRecall -Gold $gold -Live $live
+    $results.Add([pscustomobject]@{
+        Fixture    = [System.IO.Path]::GetFileName($wav)
+        GoldChars  = $gold.Length
+        LiveChars  = $live.Length
+        Recall_pct = $score
+        GoldMs     = $goldMs
+        LiveMs     = $liveMs
+        GoldHead   = $gold.Substring(0, [Math]::Min(80, $gold.Length))
+        LiveHead   = $live.Substring(0, [Math]::Min(80, $live.Length))
+    }) | Out-Null
+}
+
+$summary = [pscustomobject]@{
+    Commit         = (git rev-parse --short HEAD)
+    Subject        = (git log -1 --pretty=%s)
+    Fixtures       = $results.Count
+    AvgRecall_pct  = [math]::Round((($results | Measure-Object -Property Recall_pct -Average).Average), 1)
+    MinRecall_pct  = [math]::Round((($results | Measure-Object -Property Recall_pct -Minimum).Minimum), 1)
+    Generated      = (Get-Date -Format 'o')
+    Results        = $results
+}
+
+if ($UpdateBaseline) {
+    $baselineAbs = Join-Path $root $BaselineFile
+    New-Item -ItemType Directory -Force -Path (Split-Path $baselineAbs) | Out-Null
+    $summary | ConvertTo-Json -Depth 6 | Set-Content -Path $baselineAbs -Encoding UTF8
+    if (-not $JsonOnly) { Write-Host "Baseline written: $baselineAbs" -ForegroundColor Green }
+}
+
+if ($JsonOnly) {
+    $summary | ConvertTo-Json -Depth 6
+} else {
+    $results | Format-Table -AutoSize | Out-String | Write-Host
+    Write-Host "Avg recall vs gold: $($summary.AvgRecall_pct)%  Min: $($summary.MinRecall_pct)%" -ForegroundColor Yellow
+}


### PR DESCRIPTION
Stepping back from chasing live-decode symptoms with one-shot patches. This PR adds the measurement infrastructure that should have been there before the past few PRs, and fixes a quiet bug that was making real-radio diagnostic captures unusable.

Two changes.

1) V3 stdin parser fix.

The GUI's CwDecoderProcess.Stop() writes a literal stop\n line on the Stop button and on window close. The streaming ditdah watcher already handled that correctly. The V3 / stream-live-v3 watcher, on the other hand, only handled JSON. The literal stop line failed JSON parse and was silently discarded. The GUI then fell back to Process.Kill after 3 s, LiveCapture::drop never ran, and every saved visualizer capture landed on disk with riffSize=0/dataSize=0 - making the WAVs unusable for any later replay or scoring.

The line parsing was also extracted from the inline reader thread into parse_stdin_control_line so it is now directly unit-testable. Three new tests in stdin_control_tests cover stop, skip, reset_lock, and cumulative config state.

2) New live-capture regression harness.

scripts/bench-live-capture-suite.ps1 replays a curated set of WAVs through stream-live-v3 --file at real-time pace and scores the final session transcript against the rock-solid whole-buffer file decode of the same WAV. Outputs per-fixture token recall plus a summary so future PRs can detect regression in live-streaming behavior specifically, not just whole-buffer behavior. Baseline snapshot at scripts/baselines/live-capture-suite.json.

Initial numbers on the captures we have:

Fixture                       Gold    Live    Recall
W1AW broadcast (~444 s)       578     3178    45.2 %
screenshot-2 capture (~60 s)  246     552      0.0 %
synthetic 30 WPM clean        359     1367    98.9 %

The screenshot-2 number is interesting: the gold whole-buffer decoder also produces garbage on that audio (the decoded chars are mostly E and ?). So that capture is fundamentally hard audio, not a streaming regression - the visually clean waveform was misleading. We've been chasing a fix for behavior that was actually working as well as anything could.

Validation:
* cargo fmt clean.
* cargo test --release --bin cw-decoder: 12 passed, 0 failed.
* parse_stdin_control_line directly unit-tested for stop, skip, reset_lock, and cumulative config.

PR #367 (lock-relock) is parked as draft until we can measure with this harness whether it actually helps live capture or not.