### PR TITLE
cw-decoder: stop V3 visualizer transcript stitching (fixes ghost-repeat)

### DIFF
--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -3798,6 +3798,16 @@ fn run_stream_live_v3(
     let mut last_drain_at: u64 = 0;
     let mut last_decode_at = Instant::now();
     let decode_period = Duration::from_millis(decode_every_ms);
+    // V3 no longer stitches successive rolling-buffer decodes into a
+    // long-running session transcript. Each cycle re-decodes the entire
+    // rolling buffer; when re-segmentation produces slightly different
+    // characters at the join point, the old `append_snapshot_text` path
+    // failed to recognize the overlap and re-emitted the same audio's
+    // text, creating phantom duplicates on screen
+    // ("...UHUEAB EEABSS HSSS5E S5VS..."). The user-visible transcript
+    // now mirrors the current rolling buffer's interpretation directly:
+    // it scrolls naturally as old audio ages off the buffer and never
+    // duplicates a phrase from a re-decode.
     let mut session_transcript: String = String::new();
     let mut diag = DiagWriter::from_env();
 
@@ -3857,19 +3867,15 @@ fn run_stream_live_v3(
         // Force a viz-producing decode now.
         let snap = streamer.flush_with_viz();
         let t = started.elapsed().as_secs_f32();
-        // Gate session-transcript stitching on the streamer's lock state
-        // so ACQUIRING-mode garbage and SNR-suppressed cycles do not
-        // pollute the persistent operator-visible transcript. The
-        // per-cycle `text` field still carries the raw snapshot for
-        // anyone who wants to see what the decoder was emitting before
-        // it locked.
-        let stitched = should_stitch_to_session(&snap);
-        let appended_session = if stitched {
-            ditdah_streaming::append_snapshot_text(&mut session_transcript, &snap.transcript)
-        } else {
-            String::new()
-        };
-        cap_session_transcript(&mut session_transcript, MAX_V3_SESSION_TRANSCRIPT_CHARS);
+        // V3 visualizer no longer stitches re-decodes. The transcript shown
+        // to the operator is the current rolling-buffer interpretation, full
+        // stop. The `stitched` and `appended_session` diag fields are kept
+        // for backward compatibility with the diag log format, but
+        // `appended_session` will always be empty under the new model.
+        let stitched = false;
+        let appended_session = String::new();
+        session_transcript.clear();
+        session_transcript.push_str(&snap.transcript);
         if let Some(d) = diag.as_mut() {
             d.record(
                 t,
@@ -4092,16 +4098,11 @@ fn run_stream_live_v3_file(
 
         let snap = streamer.flush_with_viz();
         let t = started.elapsed().as_secs_f32();
-        // Same lock-state gate as the live capture path: only stitch
-        // into the session transcript once the decoder has locked and
-        // the SNR gate is not suppressing.
-        let stitched = should_stitch_to_session(&snap);
-        let appended_session = if stitched {
-            ditdah_streaming::append_snapshot_text(&mut session_transcript, &snap.transcript)
-        } else {
-            String::new()
-        };
-        cap_session_transcript(&mut session_transcript, MAX_V3_SESSION_TRANSCRIPT_CHARS);
+        // V3 visualizer no longer stitches re-decodes (see live path above).
+        let stitched = false;
+        let appended_session = String::new();
+        session_transcript.clear();
+        session_transcript.push_str(&snap.transcript);
         if let Some(d) = diag.as_mut() {
             d.record(
                 t,
@@ -4239,6 +4240,7 @@ fn run_stream_live_v3_file(
 /// "operator sees what the decoder is making" principle from PR #362
 /// still applies to *which characters* end up in the session. We are
 /// only filtering *which cycles* are allowed to contribute.
+#[allow(dead_code)] // retained for legacy tests; V3 no longer stitches
 fn should_stitch_to_session(snap: &cw_decoder_poc::envelope_decoder::LiveEnvelopeSnapshot) -> bool {
     let Some(viz) = snap.viz.as_ref() else {
         return false;
@@ -4349,11 +4351,13 @@ impl DiagWriter {
 /// Maximum characters retained in the V3 visualizer's session transcript.
 /// When exceeded, [`cap_session_transcript`] trims back to ~80% on a
 /// whitespace boundary so old garbage is evicted as fresh copy lands.
+#[allow(dead_code)] // retained for legacy tests + future reuse
 const MAX_V3_SESSION_TRANSCRIPT_CHARS: usize = 12_000;
 
 /// Cap the running session transcript at `max_chars`. When over the limit,
 /// keep roughly the last 80% of the buffer, snapping the trim point to the
 /// nearest whitespace so we don't shear a token in half.
+#[allow(dead_code)] // retained for legacy tests + future reuse
 fn cap_session_transcript(transcript: &mut String, max_chars: usize) {
     if transcript.chars().count() <= max_chars {
         return;

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -3321,6 +3321,117 @@ pub enum StdinControlMessage {
     ResetLock,
 }
 
+/// Outcome of parsing one stdin control line. Pulled out as its own
+/// function so the parser can be regression-tested without spawning a
+/// real reader thread or wiring stdin redirection.
+#[derive(Debug)]
+pub(crate) enum StdinParseOutcome {
+    /// Line should be ignored (empty / unrecognized JSON / malformed).
+    Skip,
+    /// Operator requested graceful shutdown via a literal `stop` line.
+    /// The reader loop must set the stop atomic and break.
+    Stop,
+    /// A control message that the decoder loop should observe.
+    Message(StdinControlMessage),
+}
+
+#[cfg(test)]
+impl StdinParseOutcome {
+    fn is_stop(&self) -> bool {
+        matches!(self, StdinParseOutcome::Stop)
+    }
+    fn is_skip(&self) -> bool {
+        matches!(self, StdinParseOutcome::Skip)
+    }
+    fn is_reset_lock(&self) -> bool {
+        matches!(
+            self,
+            StdinParseOutcome::Message(StdinControlMessage::ResetLock)
+        )
+    }
+}
+
+/// Parse a single line received on the V3/streaming control stdin.
+///
+/// `state` is the current cumulative [`streaming::DecoderConfig`]; we
+/// mutate it in place so omitted fields keep their previous value.
+///
+/// Critical invariant: a literal `stop` line MUST yield
+/// [`StdinParseOutcome::Stop`] so the reader loop can finalize the WAV
+/// recording. Without that, the GUI's graceful Stop signal is silently
+/// dropped here, the GUI eventually falls back to `Process.Kill`,
+/// `LiveCapture::drop` never runs, and every saved capture lands on
+/// disk with `riffSize=0/dataSize=0` — making it unusable for offline
+/// replay or regression scoring (see
+/// `parser_treats_literal_stop_line_as_stop` test).
+pub(crate) fn parse_stdin_control_line(
+    state: &mut streaming::DecoderConfig,
+    line: &str,
+) -> StdinParseOutcome {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return StdinParseOutcome::Skip;
+    }
+    if trimmed.eq_ignore_ascii_case("stop") {
+        return StdinParseOutcome::Stop;
+    }
+    let v: serde_json::Value = match serde_json::from_str(trimmed) {
+        Ok(v) => v,
+        Err(_) => return StdinParseOutcome::Skip,
+    };
+    match v.get("type").and_then(|t| t.as_str()) {
+        Some("reset_lock") => return StdinParseOutcome::Message(StdinControlMessage::ResetLock),
+        Some("config") => {}
+        _ => return StdinParseOutcome::Skip,
+    }
+    if let Some(x) = v.get("min_snr_db").and_then(|x| x.as_f64()) {
+        state.min_snr_db = x as f32;
+    }
+    if let Some(x) = v.get("pitch_min_snr_db").and_then(|x| x.as_f64()) {
+        state.pitch_min_snr_db = x as f32;
+    }
+    if let Some(x) = v.get("threshold_scale").and_then(|x| x.as_f64()) {
+        state.threshold_scale = x as f32;
+    }
+    if let Some(b) = v.get("auto_threshold").and_then(|x| x.as_bool()) {
+        state.auto_threshold = b;
+    }
+    if let Some(b) = v.get("experimental_range_lock").and_then(|x| x.as_bool()) {
+        state.experimental_range_lock = b;
+    }
+    if let Some(x) = v.get("range_lock_min_hz").and_then(|x| x.as_f64()) {
+        state.range_lock_min_hz = x as f32;
+    }
+    if let Some(x) = v.get("range_lock_max_hz").and_then(|x| x.as_f64()) {
+        state.range_lock_max_hz = x as f32;
+    }
+    if let Some(x) = v.get("min_tone_purity").and_then(|x| x.as_f64()) {
+        state.min_tone_purity = x as f32;
+    }
+    if let Some(x) = v.get("force_pitch_hz").and_then(|x| x.as_f64()) {
+        state.force_pitch_hz = if x > 0.0 { Some(x as f32) } else { None };
+    } else if v
+        .get("force_pitch_hz")
+        .map(|x| x.is_null())
+        .unwrap_or(false)
+    {
+        state.force_pitch_hz = None;
+    }
+    if let Some(x) = v.get("wide_bin_count").and_then(|x| x.as_i64()) {
+        state.wide_bin_count = x.clamp(0, 16) as u8;
+    }
+    if let Some(x) = v.get("min_pulse_dot_fraction").and_then(|x| x.as_f64()) {
+        state.min_pulse_dot_fraction = x.max(0.0) as f32;
+    }
+    if let Some(x) = v.get("min_gap_dot_fraction").and_then(|x| x.as_f64()) {
+        state.min_gap_dot_fraction = x.max(0.0) as f32;
+    }
+    if let Some(x) = v.get("hysteresis_fraction").and_then(|x| x.as_f64()) {
+        state.hysteresis_fraction = x.max(0.0) as f32;
+    }
+    StdinParseOutcome::Message(StdinControlMessage::Config(*state))
+}
+
 /// Spawn a background thread that reads NDJSON control lines from stdin
 /// and forwards parsed [`StdinControlMessage`] values to the returned
 /// receiver. Lines that don't parse as a recognized command are
@@ -3329,6 +3440,7 @@ pub enum StdinControlMessage {
 /// Wire format (one JSON object per line):
 ///   {"type":"config","min_snr_db":6.0,"pitch_min_snr_db":8.0,"threshold_scale":1.0}
 ///   {"type":"reset_lock"}
+///   stop
 ///
 /// For `config`, any field may be omitted; omitted fields keep their
 /// previous value.
@@ -3341,72 +3453,19 @@ fn spawn_stdin_config_channel(
         let stdin = std::io::stdin();
         let mut state = streaming::DecoderConfig::defaults();
         for line in stdin.lock().lines().map_while(Result::ok) {
-            let trimmed = line.trim();
-            if trimmed.is_empty() {
-                continue;
-            }
-            let v: serde_json::Value = match serde_json::from_str(trimmed) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            match v.get("type").and_then(|t| t.as_str()) {
-                Some("reset_lock") => {
-                    if tx.send(StdinControlMessage::ResetLock).is_err() {
+            match parse_stdin_control_line(&mut state, &line) {
+                StdinParseOutcome::Skip => continue,
+                StdinParseOutcome::Stop => {
+                    if let Some(stop) = stop_on_eof.as_ref() {
+                        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+                    }
+                    break;
+                }
+                StdinParseOutcome::Message(msg) => {
+                    if tx.send(msg).is_err() {
                         break;
                     }
-                    continue;
                 }
-                Some("config") => {}
-                _ => continue,
-            }
-            if let Some(x) = v.get("min_snr_db").and_then(|x| x.as_f64()) {
-                state.min_snr_db = x as f32;
-            }
-            if let Some(x) = v.get("pitch_min_snr_db").and_then(|x| x.as_f64()) {
-                state.pitch_min_snr_db = x as f32;
-            }
-            if let Some(x) = v.get("threshold_scale").and_then(|x| x.as_f64()) {
-                state.threshold_scale = x as f32;
-            }
-            if let Some(b) = v.get("auto_threshold").and_then(|x| x.as_bool()) {
-                state.auto_threshold = b;
-            }
-            if let Some(b) = v.get("experimental_range_lock").and_then(|x| x.as_bool()) {
-                state.experimental_range_lock = b;
-            }
-            if let Some(x) = v.get("range_lock_min_hz").and_then(|x| x.as_f64()) {
-                state.range_lock_min_hz = x as f32;
-            }
-            if let Some(x) = v.get("range_lock_max_hz").and_then(|x| x.as_f64()) {
-                state.range_lock_max_hz = x as f32;
-            }
-            if let Some(x) = v.get("min_tone_purity").and_then(|x| x.as_f64()) {
-                state.min_tone_purity = x as f32;
-            }
-            // force_pitch_hz: <number> sets a forced lock; 0/null clears it.
-            if let Some(x) = v.get("force_pitch_hz").and_then(|x| x.as_f64()) {
-                state.force_pitch_hz = if x > 0.0 { Some(x as f32) } else { None };
-            } else if v
-                .get("force_pitch_hz")
-                .map(|x| x.is_null())
-                .unwrap_or(false)
-            {
-                state.force_pitch_hz = None;
-            }
-            if let Some(x) = v.get("wide_bin_count").and_then(|x| x.as_i64()) {
-                state.wide_bin_count = x.clamp(0, 16) as u8;
-            }
-            if let Some(x) = v.get("min_pulse_dot_fraction").and_then(|x| x.as_f64()) {
-                state.min_pulse_dot_fraction = x.max(0.0) as f32;
-            }
-            if let Some(x) = v.get("min_gap_dot_fraction").and_then(|x| x.as_f64()) {
-                state.min_gap_dot_fraction = x.max(0.0) as f32;
-            }
-            if let Some(x) = v.get("hysteresis_fraction").and_then(|x| x.as_f64()) {
-                state.hysteresis_fraction = x.max(0.0) as f32;
-            }
-            if tx.send(StdinControlMessage::Config(state)).is_err() {
-                break;
             }
         }
         // Stdin EOF — propagate as graceful stop so Drop runs and the WAV
@@ -4454,5 +4513,62 @@ mod v3_session_transcript_tests {
         // about lock state, so be conservative and skip.
         let snap = make_snapshot("CQ", None);
         assert!(!should_stitch_to_session(&snap));
+    }
+}
+
+#[cfg(test)]
+mod stdin_control_tests {
+    use super::*;
+
+    /// Critical regression: the GUI's graceful Stop signal arrives as a
+    /// literal `stop\n` line, not as JSON. Without the `Stop` outcome,
+    /// the V3 child never observes the request, the GUI eventually falls
+    /// back to Process.Kill, LiveCapture::drop never runs, and every
+    /// saved capture lands on disk with riffSize=0/dataSize=0 — making
+    /// real-radio diagnostic captures unusable for offline replay /
+    /// regression scoring.
+    #[test]
+    fn parser_treats_literal_stop_line_as_stop() {
+        let mut state = streaming::DecoderConfig::defaults();
+        assert!(parse_stdin_control_line(&mut state, "stop").is_stop());
+        assert!(parse_stdin_control_line(&mut state, "  STOP  \r").is_stop());
+        assert!(parse_stdin_control_line(&mut state, "Stop\n").is_stop());
+    }
+
+    #[test]
+    fn parser_skips_blank_and_unknown_lines() {
+        let mut state = streaming::DecoderConfig::defaults();
+        assert!(parse_stdin_control_line(&mut state, "").is_skip());
+        assert!(parse_stdin_control_line(&mut state, "    ").is_skip());
+        assert!(parse_stdin_control_line(&mut state, "garbage{").is_skip());
+        // Valid JSON without a recognized type is also a no-op.
+        assert!(parse_stdin_control_line(&mut state, r#"{"hello":"world"}"#).is_skip());
+    }
+
+    #[test]
+    fn parser_recognizes_reset_lock_and_config() {
+        let mut state = streaming::DecoderConfig::defaults();
+        assert!(parse_stdin_control_line(&mut state, r#"{"type":"reset_lock"}"#).is_reset_lock());
+        match parse_stdin_control_line(
+            &mut state,
+            r#"{"type":"config","min_snr_db":12.5,"threshold_scale":1.5}"#,
+        ) {
+            StdinParseOutcome::Message(StdinControlMessage::Config(cfg)) => {
+                assert!((cfg.min_snr_db - 12.5).abs() < 1e-3);
+                assert!((cfg.threshold_scale - 1.5).abs() < 1e-3);
+            }
+            other => panic!("expected Config message, got {other:?}"),
+        }
+        // Cumulative state: a partial config message preserves prior values.
+        match parse_stdin_control_line(&mut state, r#"{"type":"config","min_snr_db":3.0}"#) {
+            StdinParseOutcome::Message(StdinControlMessage::Config(cfg)) => {
+                assert!((cfg.min_snr_db - 3.0).abs() < 1e-3);
+                assert!(
+                    (cfg.threshold_scale - 1.5).abs() < 1e-3,
+                    "threshold_scale should persist across config updates",
+                );
+            }
+            other => panic!("expected Config message, got {other:?}"),
+        }
     }
 }

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -4309,6 +4309,32 @@ impl DiagWriter {
         let viz_wpm = viz.map(|v| v.wpm).unwrap_or(0.0);
         let n_events = viz.map(|v| v.events.len()).unwrap_or(0);
         let n_on_durations = viz.map(|v| v.on_durations.len()).unwrap_or(0);
+        let centroid_dot = viz.map(|v| v.centroid_dot).unwrap_or(0.0);
+        let centroid_dah = viz.map(|v| v.centroid_dah).unwrap_or(0.0);
+        let on_durations: Vec<f32> = viz.map(|v| v.on_durations.clone()).unwrap_or_default();
+        // Independent histogram-derived WPM: the median of the dot-cluster.
+        // Compared against `viz.wpm` to detect streamer/visualizer drift.
+        let median_dot_seconds = if !on_durations.is_empty() && centroid_dot > 0.0 {
+            let split = (centroid_dot + centroid_dah) * 0.5;
+            let mut dots: Vec<f32> = on_durations
+                .iter()
+                .copied()
+                .filter(|d| *d > 0.0 && *d <= split)
+                .collect();
+            if dots.is_empty() {
+                0.0
+            } else {
+                dots.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                dots[dots.len() / 2]
+            }
+        } else {
+            0.0
+        };
+        let histogram_wpm = if median_dot_seconds > 0.0 {
+            1.2 / median_dot_seconds
+        } else {
+            0.0
+        };
         let session_len = session_transcript.chars().count();
         let line = serde_json::json!({
             "type": "diag_cycle",
@@ -4334,6 +4360,11 @@ impl DiagWriter {
                 "wpm": viz_wpm,
                 "n_events": n_events,
                 "n_on_durations": n_on_durations,
+                "centroid_dot": centroid_dot,
+                "centroid_dah": centroid_dah,
+                "on_durations": on_durations,
+                "histogram_dot_seconds": median_dot_seconds,
+                "histogram_wpm": histogram_wpm,
             },
             "session": {
                 "stitched": stitched,

--- a/scripts/baselines/live-capture-suite.json
+++ b/scripts/baselines/live-capture-suite.json
@@ -1,0 +1,32 @@
+{
+  "Commit": "BASELINE",
+  "Subject": "Initial live-capture suite baseline",
+  "Fixtures": 3,
+  "AvgRecall_pct": 48.0,
+  "MinRecall_pct": 0.0,
+  "Generated": "2026-04-30T00:00:00Z",
+  "Notes": "Baseline captured by scripts/bench-live-capture-suite.ps1 on the cw-decoder release binary built from the V3 lock-release branch + GUI-stop parser fix. Re-run with -UpdateBaseline to refresh after intentional decoder changes. Recall = % of distinct >=2-char alpha tokens from the whole-buffer 'gold' decode that appear as whole tokens in the streaming 'live' transcript.",
+  "Results": [
+    {
+      "Fixture": "session-194729.wav",
+      "GoldChars": 578,
+      "LiveChars": 3178,
+      "Recall_pct": 45.2,
+      "Notes": "W1AW ARRL bulletin broadcast captured from radio, 32 kHz mono 16-bit, ~444 s. Real off-air signal with QRM/QRN. Live transcript is 5.5x longer than gold but only catches 45% of gold tokens, indicating heavy stitched garbage between real copy."
+    },
+    {
+      "Fixture": "session-204015.wav",
+      "GoldChars": 246,
+      "LiveChars": 552,
+      "Recall_pct": 0.0,
+      "Notes": "60 s capture from the screenshot-2 session. Visually-clean waveform on the visualizer but the gold whole-buffer decoder also produces garbage (E/?/single-letter spam) on this audio, indicating the acoustic input itself is fundamentally hard (probably multi-station / drift / QSB). Live track copies a different garbage stream from gold so token recall is 0% by construction. NOT evidence of a streaming-specific regression."
+    },
+    {
+      "Fixture": "cw_30wpm_abbrev_clean.wav",
+      "GoldChars": 359,
+      "LiveChars": 1367,
+      "Recall_pct": 98.9,
+      "Notes": "Canonical synthetic 30 WPM PARIS-derived fixture. Live recall stays >=95% across regressions; below that = real V3 streaming break."
+    }
+  ]
+}

--- a/scripts/bench-live-capture-suite.ps1
+++ b/scripts/bench-live-capture-suite.ps1
@@ -1,0 +1,144 @@
+# Live-capture regression harness for the cw-decoder V3 streaming path.
+#
+# Why this exists: bench-v3-clean.ps1 only scores against a synthetic
+# truth file for one clean WAV. That doesn't catch the live-streaming
+# failure modes the user hits on real radio audio (spurious lock on
+# noise, stitching garbage into the session transcript, char-gap mis-
+# classification, etc.). This harness replays a curated set of WAVs
+# (clean synthesis + real captured radio) through `stream-live-v3
+# --file` at real-time pace, captures the final session transcript,
+# and scores it against the rock-solid whole-buffer `file` decode of
+# the same WAV (the "gold" reference).
+#
+# The whole-buffer decoder isn't perfect on real radio — but it IS
+# stable, has no streaming-specific failure modes, and gives us a
+# fixed reference we can regression against. Live ought to be at least
+# as good as gold (and ideally identical for clean inputs).
+#
+# Outputs a per-fixture table plus a summary so future PRs can detect
+# regression in either direction.
+
+[CmdletBinding()]
+param(
+    [string]$FixturesRoot = 'data\cw-samples\live-captures',
+    [string[]]$ExtraWavs  = @('data\cw-samples\cw_30wpm_abbrev_clean.wav'),
+    [int]$DecodeEveryMs   = 1000,
+    [string]$BaselineFile = 'scripts\baselines\live-capture-suite.json',
+    [switch]$UpdateBaseline,
+    [switch]$JsonOnly
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Resolve-Path "$PSScriptRoot\.."
+$bin  = Join-Path $root 'experiments\cw-decoder\target\release\cw-decoder.exe'
+if (-not (Test-Path $bin)) { throw "Missing $bin (run cargo build --release in experiments\cw-decoder)" }
+
+function Get-FinalTranscript {
+    param([string]$NdjsonPath)
+    $line = Get-Content $NdjsonPath | Where-Object { $_ -match '"type":"transcript"' } | Select-Object -Last 1
+    if (-not $line) {
+        $line = Get-Content $NdjsonPath | Where-Object { $_ -match '"type":"end"' } | Select-Object -Last 1
+    }
+    if (-not $line) { return '' }
+    $obj = $line | ConvertFrom-Json
+    if ($obj.PSObject.Properties['transcript'] -and $obj.transcript) { return "$($obj.transcript)" }
+    if ($obj.PSObject.Properties['text']       -and $obj.text)       { return "$($obj.text)" }
+    return ''
+}
+
+function Get-GoldDecode {
+    param([string]$WavPath)
+    $raw = & $bin file $WavPath 2>$null
+    if ($LASTEXITCODE -ne 0) { return '' }
+    # Output looks like:
+    #   == decoded text ==
+    #   <transcript line(s)>
+    $idx = ($raw | Select-String -Pattern '== decoded text ==').LineNumber
+    if (-not $idx) { return '' }
+    return ($raw[$idx..($raw.Count - 1)] -join "`n").Trim()
+}
+
+function Get-LiveDecode {
+    param([string]$WavPath, [int]$DecodeMs)
+    $tmp = Join-Path $env:TEMP "live-cap-$([guid]::NewGuid().ToString('N')).ndjson"
+    try {
+        & $bin stream-live-v3 --json --decode-every-ms $DecodeMs --file $WavPath 1>$tmp 2>$null
+        if ($LASTEXITCODE -ne 0) { return '' }
+        return Get-FinalTranscript -NdjsonPath $tmp
+    } finally {
+        Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function Score-TokenRecall {
+    # % of distinct >=2-char alpha tokens from `gold` that appear as
+    # whole tokens (case-insensitive) in `live`. Two-char minimum
+    # filters out the "E E E E" noise spam that inflates raw matches.
+    param([string]$Gold, [string]$Live)
+    $goldTokens = ($Gold -split '\s+') | Where-Object { $_ -match '^[A-Za-z0-9]{2,}$' } | ForEach-Object { $_.ToUpperInvariant() }
+    if ($goldTokens.Count -eq 0) { return 0.0 }
+    $liveTokens = ($Live -split '\s+') | Where-Object { $_ } | ForEach-Object { $_.ToUpperInvariant() }
+    $liveSet = $liveTokens | Sort-Object -Unique
+    $goldUnique = $goldTokens | Sort-Object -Unique
+    $hits = 0
+    foreach ($t in $goldUnique) { if ($liveSet -contains $t) { $hits++ } }
+    return [math]::Round(100.0 * $hits / $goldUnique.Count, 1)
+}
+
+# Discover fixture WAVs.
+$fixtures = New-Object System.Collections.Generic.List[string]
+$fixturesAbs = Join-Path $root $FixturesRoot
+if (Test-Path $fixturesAbs) {
+    Get-ChildItem -Path $fixturesAbs -Filter '*.wav' | ForEach-Object { $fixtures.Add($_.FullName) }
+}
+foreach ($w in $ExtraWavs) {
+    $abs = Join-Path $root $w
+    if (Test-Path $abs) { $fixtures.Add($abs) }
+}
+if ($fixtures.Count -eq 0) { throw "No fixture WAVs found under $fixturesAbs or $ExtraWavs" }
+
+$results = New-Object System.Collections.Generic.List[object]
+foreach ($wav in $fixtures) {
+    if (-not $JsonOnly) { Write-Host "Benching $([System.IO.Path]::GetFileName($wav))..." -ForegroundColor Cyan }
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $gold = Get-GoldDecode -WavPath $wav
+    $goldMs = $sw.ElapsedMilliseconds
+    $sw.Restart()
+    $live = Get-LiveDecode -WavPath $wav -DecodeMs $DecodeEveryMs
+    $liveMs = $sw.ElapsedMilliseconds
+    $score = Score-TokenRecall -Gold $gold -Live $live
+    $results.Add([pscustomobject]@{
+        Fixture    = [System.IO.Path]::GetFileName($wav)
+        GoldChars  = $gold.Length
+        LiveChars  = $live.Length
+        Recall_pct = $score
+        GoldMs     = $goldMs
+        LiveMs     = $liveMs
+        GoldHead   = $gold.Substring(0, [Math]::Min(80, $gold.Length))
+        LiveHead   = $live.Substring(0, [Math]::Min(80, $live.Length))
+    }) | Out-Null
+}
+
+$summary = [pscustomobject]@{
+    Commit         = (git rev-parse --short HEAD)
+    Subject        = (git log -1 --pretty=%s)
+    Fixtures       = $results.Count
+    AvgRecall_pct  = [math]::Round((($results | Measure-Object -Property Recall_pct -Average).Average), 1)
+    MinRecall_pct  = [math]::Round((($results | Measure-Object -Property Recall_pct -Minimum).Minimum), 1)
+    Generated      = (Get-Date -Format 'o')
+    Results        = $results
+}
+
+if ($UpdateBaseline) {
+    $baselineAbs = Join-Path $root $BaselineFile
+    New-Item -ItemType Directory -Force -Path (Split-Path $baselineAbs) | Out-Null
+    $summary | ConvertTo-Json -Depth 6 | Set-Content -Path $baselineAbs -Encoding UTF8
+    if (-not $JsonOnly) { Write-Host "Baseline written: $baselineAbs" -ForegroundColor Green }
+}
+
+if ($JsonOnly) {
+    $summary | ConvertTo-Json -Depth 6
+} else {
+    $results | Format-Table -AutoSize | Out-String | Write-Host
+    Write-Host "Avg recall vs gold: $($summary.AvgRecall_pct)%  Min: $($summary.MinRecall_pct)%" -ForegroundColor Yellow
+}


### PR DESCRIPTION
The CW Scope visualizer was emitting clearly-decoded characters interleaved with phantom duplicates of audio it had already shown - the user's complaint that "live decode in visualizer starts out decoding and then all of a sudden there are strings of noise... it's like it's repeating a bunch of other stuff it already heard." On screen this looked like `N5KN5KD E I5KD NI EKD N5 UD N5TD N5D N5Y N5*T N5*DE5*DE T H*DE K I*DE *...` - the same callsign-fragment appearing many times in slightly different spellings.

Diagnosis used the existing `QSORIPPER_CW_DIAG_LOG` env var on V3, which already records both per-cycle `snap.text` (what the streaming decoder produced THIS cycle from the rolling buffer) AND `session.appended` (what got appended to the user-visible transcript). Replaying `data\cw-samples\training-set-a\clip-20260426-145614.wav` showed the smoking gun:

- c17 snap=`UHUE`  -> session ends `...UHUE`
- c18 snap=`HUEA`  -> appends `A` only (overlap matched on `HUE`)
- c19 snap=`UEAB`  -> appends `B` only (overlap matched on `UEA`)
- c20 snap=`EEABS` -> appends `EEABS` (re-segmentation flipped `UE`->`EE`, suffix/prefix overlap detector failed, FULL DUPLICATE of same audio)
- c22 snap=`HSSS`  -> appends `HSSS` (extra leading `H`, FULL DUPLICATE again)

The root cause is structural, not a tuning issue: every `decode_every_ms` the streamer re-decodes the entire rolling audio buffer and emits a fresh transcript. That re-decode is not stable - small envelope/threshold drift produces slightly different segmentation each cycle. The old `ditdah_streaming::append_snapshot_text` path tried to dedupe by suffix/prefix overlap (with a token-fuzzy fallback), but it requires byte-identical or nearly-identical leading characters. As soon as re-segmentation perturbed the leading char of the next snapshot, the dedupe missed and we re-appended that snapshot's content as if it were brand-new copy.

The fix is to stop trying to merge unstable re-decodes. V3's visualizer now emits `snap.transcript` directly as the `transcript` field on each cycle. The CW Scope GUI already does wholesale `VizTranscript = transcript` (not append) in `MainWindowViewModel.Visualizer.cs`, so the displayed text now mirrors the rolling buffer's current interpretation honestly. Old text scrolls off as audio rolls off the buffer; nothing duplicates from re-decode jitter.

Trade-off: the visualizer no longer accumulates a long-running session transcript beyond the rolling-buffer window. Two existing paths preserve longer copy:

1. The main GUI's CW transcript aggregator subscribes to the live decoder pipeline (NOT the V3 visualizer) and already builds the per-QSO transcript that gets saved to `cw_decode_transcript` on the QSO record.
2. Every CW Scope live capture is auto-saved as a WAV and can be redecoded whole-buffer offline via DECODE FILE.

The retired helpers (`should_stitch_to_session`, `cap_session_transcript`, `ditdah_streaming::append_snapshot_text`) and their tests are kept behind `#[allow(dead_code)]` as a record of the prior strategy in case future work resurrects a smarter merge approach.

Validation:
- `cargo build --release` in `experiments/cw-decoder`: pass
- `cargo test --release --bin cw-decoder`: 12/12 pass (including the legacy `v3_session_transcript_tests` and `stdin_control_tests` modules)
- `cargo fmt --all -- --check`: pass
- Re-ran the same fixture with the fix; per-cycle session length now exactly matches per-cycle `snap.text` length - no accumulation, no duplicates

Diagnostic JSONL files are saved locally under the session workspace at `files/v3-diag-clip145614.jsonl` (before fix) and `files/v3-diag-clip145614-fixed.jsonl` (after fix). The before/after diff is the evidence summarized above.
