### PR TITLE
cw-decoder: event-driven sample-indexed commit cursor (Approach A+)

### DIFF
--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -4,10 +4,10 @@ This folder is the current sandbox for improving QsoRipper CW decoding on real o
 
 The project has converged on two parallel goals:
 
-1. keep a **boring, label-driven reference path** that we can score and tune honestly, and
-2. keep iterating on a **faster custom streaming path** for eventual live use.
+1. keep a **simple append-only event-stream foundation** that behaves like what the operator actually hears and sees, and
+2. layer more ambitious signal-processing experiments on top without allowing them to regress that foundation.
 
-Today, the reference path is the causal `ditdah` baseline. The custom streaming decoder has improved substantially, but it is still not the only truth source and should not replace corpus-driven evaluation yet.
+The current breakthrough is that the best live behavior did **not** come from rolling transcript windows, overlap stitching, or commit heuristics. It came from consuming the same stable dit/dah/gap event stream that paints the Visualizer bars and appending each matured event once in audio order. That path is now the "line in the sand": Decode, Labeling, Tuning, Bench, and Visualizer should all key off it first, while experimental decoders are compared against it rather than silently replacing it.
 
 > **Integration status (round 1, issue #321)**: the production GUI now hosts the
 > `cw-decoder` binary as a subprocess and auto-fills `QsoRecord.cw_decode_rx_wpm`
@@ -85,11 +85,11 @@ Main experiment executable. It currently exposes several surfaces:
 - **Custom streaming decoder**
   - `stream-file` — file-driven streaming decode with optional NDJSON event output and live `--stdin-control` config updates
   - `stream-live` — live capture through the streaming Goertzel decoder, with optional `--record` WAV mirror and `--stdin-control`
-  - `stream-live-v2` — **current GUI default.** Live capture into an append-only audio buffer; re-runs pristine `ditdah` on the **whole buffer** every `--decode-every-ms` (default 5000) and emits a full-replacement `transcript` event. Empirically reaches CER ~0.06 on training-set-a 30 WPM CW (3-4× better than `stream-live`'s 0.17 and ~14× better than the old `stream-live-ditdah` rolling-window backend's 0.83-0.89). Per-decode latency stays under 100 ms even on a 3-minute buffer. See `src\streaming_v2.rs` for design rationale and `tools\rolling-whole-buffer\` for the empirical validation harness.
-  - `stream-live-v3` — in-house envelope decoder that drives the GUI **VISUALIZER** tab. Goertzel envelope → percentile-based noise/signal floors → hysteresis state machine → k-means dot/dah classifier. Emits NDJSON `viz` frames (envelope curve, noise/signal floors, hysteresis bands, classified events, on-duration histogram, k-means centroids, current/locked WPM, SNR) so the operator can *see* exactly what the decoder is reacting to. Optional `--pin-wpm` (hard-pins the streamer's `locked_wpm` so the first decode honors the operator), `--pin-hz` (bypasses the auto pitch detector when it locks onto a noise/harmonic peak), and `--min-snr-db` (default 6.0; below this floor the decoder still emits viz frames but suppresses text — kills the "noise-locked dit-spam" failure mode where the auto-pitch detector locks onto a high-tone harmonic). The streamer also enforces a default dynamic-range bimodality gate (`(signal_floor − noise_floor) / envelope_max ≥ 0.55`) which catches high-variance noise that sneaks past the SNR ratio gate. When either gate fires the visualizer overlays a red `LOW SNR` badge so the suppression is visible. Live captures auto-save to `experiments\cw-decoder\captures\viz-yyyyMMdd-HHmmss.wav` for later labeling.
+  - `stream-live-v2` — whole-growing-buffer `ditdah` replay. This was a valuable intermediate reference because it proved that re-decoding the whole accumulated buffer and replacing the displayed transcript was far better than sliding-window `ditdah` stitching. It is no longer the GUI default, but remains useful for A/B comparison.
+  - `stream-live-v3` — **current GUI foundation.** In-house envelope decoder that drives Decode, Labeling, Tuning, Bench, and the **VISUALIZER** tab. Goertzel envelope → percentile-based noise/signal floors → hysteresis state machine → k-means dot/dah classifier. Emits NDJSON `viz` frames (envelope curve, noise/signal floors, hysteresis bands, classified events, on-duration histogram, k-means centroids, current/locked WPM, SNR) so the operator can *see* exactly what the decoder is reacting to. Its transcript is produced by the append-only event-stream decoder in `src\append_decode.rs`: each matured `on_dit`, `on_dah`, `off_char`, and `off_word` bar is consumed once in sample-time order, appended to a raw Morse stream (`.` / `-` / `/` / `//`), and decoded into a single growing text line with real spaces for word gaps. Optional `--pin-wpm` (hard-pins the streamer's `locked_wpm` so the first decode honors the operator), `--pin-hz` (bypasses the auto pitch detector when it locks onto a noise/harmonic peak), and `--min-snr-db` (default 6.0; below this floor the decoder still emits viz frames but suppresses text — kills the "noise-locked dit-spam" failure mode where the auto-pitch detector locks onto a high-tone harmonic). The streamer also enforces a default dynamic-range bimodality gate (`(signal_floor - noise_floor) / envelope_max >= 0.55`) which catches high-variance noise that sneaks past the SNR ratio gate. When either gate fires the visualizer overlays a red `LOW SNR` badge so the suppression is visible. Live captures auto-save to `experiments\cw-decoder\captures\viz-yyyyMMdd-HHmmss.wav` for later labeling. For file replay, `stream-live-v3 --file --play` clocks decoder feeding from the output playback cursor so the bars/transcript stay aligned with the audio instead of drifting in a separate process.
 - **Causal ditdah baseline**
   - `stream-file-ditdah` — file-driven causal whole-window `ditdah` replay
-  - `stream-live-ditdah` — live capture through the rolling-window causal baseline, with optional `--record` WAV mirror. **Deprecated** — kept only for A/B comparison; the GUI now uses `stream-live-v2`.
+  - `stream-live-ditdah` — live capture through the rolling-window causal baseline, with optional `--record` WAV mirror. **Deprecated** — kept only for A/B comparison; the GUI now uses the `stream-live-v3` append foundation.
 - **Labeling helpers**
   - `harvest-file` — find candidate "golden copy" windows by intersecting offline `ditdah` and the streaming decoder, optional `--needle` anchors
   - `preview-window` — render a slowed WAV preview of a window for human verification
@@ -99,7 +99,7 @@ Main experiment executable. It currently exposes several surfaces:
 - **Tone diagnostics**
   - `probe-fisher` — sweep candidate pitches across an audio file and rank them by trial-decode Fisher score
 - **Cold-start + lock-stability benchmark**
-  - `bench-latency` — feed a deterministic synthetic scenario matrix (silence/noise/voice lead-ins + long-clean-CW lock-stability stress) or a real recording (`--from-file --truth --cw-onset-ms`) through the streaming decoder and report two classes of metrics: cold-start *acquisition latency* (time from CW onset to first stable-N-correct decoded run) and *lock stability* once locked (post-first-lock uptime ratio, `PitchLost` count, relock cycles, longest non-Locked gap). Headline metric is `lat_ms = t_stable_N - cw_onset_ms`. Use `--label <name>` and `--json` to collect comparison runs across decoder configurations.
+  - `bench-latency` — feed a deterministic synthetic scenario matrix (silence/noise/voice lead-ins + long-clean-CW lock-stability stress) or a real recording (`--from-file --truth --cw-onset-ms`) through the streaming decoder and report two classes of metrics: cold-start *acquisition latency* (time from CW onset to first stable-N-correct decoded run) and *lock stability* once locked (post-first-lock uptime ratio, `PitchLost` count, relock cycles, longest non-Locked gap). Headline metric is `lat_ms = t_stable_N - cw_onset_ms`. Add `--foundation` to score the append-only event-stream transcript path used by the GUI; in that mode latency-specific lock metrics are intentionally empty and the output is a transcript-quality/regression record.
 
 All `--json` and `--record` flags are what the Avalonia GUI uses to drive the engine over stdout/stderr NDJSON.
 
@@ -111,6 +111,7 @@ Current uses:
 
 - exact-window scoring against saved `*.labels.jsonl`
 - full-stream scoring by replaying whole recordings causally and intersecting transcript state at label boundaries
+- foundation strategy scoring (`--strategy-sweep --strategies foundation`) so tuning can compare experimental modes against the same append-only path the GUI uses
 - fast parameter sweeps for the causal `ditdah` baseline (`--sweep-ditdah`, optionally `--wide-sweep`)
 - a built-in synthetic regression suite (silence, white/bursty/colored noise, clean and noisy synthesized CW at multiple SNRs) when no label flags are supplied
 
@@ -184,7 +185,25 @@ Recent custom-streaming changes on this branch added:
 
 This path is the more ambitious live decoder, but it still needs better corpus-driven measurement.
 
-### 2. Causal ditdah baseline
+### 2. Append-only event-stream foundation
+
+Implemented in `src\append_decode.rs` and surfaced by `stream-live-v3`.
+
+This is intentionally simple:
+
+- the envelope streamer classifies bars as `on_dit`, `on_dah`, `off_intra`, `off_char`, or `off_word`
+- each event is anchored to the audio sample range that produced it
+- a short trailing stability guard lets gaps mature before they are emitted
+- each event is consumed once in audio order
+- dits/dahs accumulate into one pending Morse character
+- `off_char` flushes that character
+- `off_word` flushes that character and appends a real space
+
+The raw debug representation is the same thing without Morse lookup: `.` for a dit, `-` for a dah, `/` for a character gap, and `//` for a word gap. This proved crucial because it made the decoder's output comparable to the colored Visualizer bars without being coupled to Avalonia redraws. Redraw-level logging repeated rolling windows and produced false text; event-stream logging exposed the actual heard sequence.
+
+This is now the current reference path for live decoding and regression prevention. More complex pipelines may improve the event classifier, pitch selection, preprocessing, or spacing policy, but they should preserve this append-only contract or prove a measurable improvement against it.
+
+### 3. Causal ditdah baseline
 
 Implemented in `src\ditdah_streaming.rs`.
 
@@ -201,7 +220,7 @@ This baseline exists because it is:
 - easier to sweep
 - easier to score against human labels
 
-It is the current reference path for label-driven tuning.
+It remains a useful historical reference and comparison strategy for label-driven tuning, but it is no longer the GUI foundation.
 
 ## Signal processing architecture
 
@@ -626,61 +645,81 @@ Companion `.mp3` recordings (including `K1ZZ_de_LA8OM_*`, `k5zd-ey8mm-40m-qso`, 
 
 ## Current results
 
-Using the current reference baseline settings:
+### Label corpus reference scores
 
-- `window = 20.0s`
-- `min-window = 0.5s`
-- `decode-every = 1000ms`
-- `confirmations = 3`
+The corpus currently has **9 labels**. The safest command form is explicit about the repo-root label directory:
 
-### Exact-window baseline score
+```powershell
+cargo run --release --manifest-path experiments\cw-decoder\Cargo.toml --bin eval -- --labels-dir data\cw-samples
+```
 
-Current scorer result:
+`--all-labels` is equivalent when run from the repo root, but it resolves `data\cw-samples\` relative to the current working directory and is easier to misuse from `experiments\cw-decoder`.
 
-- **7 / 10 exact**
-- **avg CER = 0.09**
+Current exact-window score:
+
+- **6 / 9 exact**
+- **avg CER = 0.10**
 - **total edit distance = 12**
 
-Interpretation:
+Current full-stream score:
 
-- **K1ZZ / DH8BQA** is now exact
-- **W1AW** is mostly solved in exact-window mode (6 / 7 exact); the remaining miss is a **leading-edge / warmup** problem (`TUST...` vs `QST...`)
-- **80m K5ZD / ZS4TX** labels still both miss, currently classified as one `garbage_decode` and one `near_match`
-- The new **TONE PURITY** gate is a no-op on this corpus — exact-window numbers are unchanged whether `--min-tone-purity 3.0` (default) or `--min-tone-purity 0` is used. The gate fires only on broadband impulses, which the labeled CW does not contain.
-
-### Full-stream baseline score
-
-Current scorer result with:
-
-- `mode = full-stream`
-- `post-roll = 1500ms`
-
-is:
-
-- **1 / 10 exact**
-- **avg CER = 0.92**
-- dominated by `empty_output` and `garbage_decode`
+- **1 / 9 exact**
+- **avg CER = 0.85**
 
 Interpretation:
 
-- the baseline is much better as an **exact-window decode reference** than as a fully solved streaming-commit path
-- commit timing, final flush, and segmentation are still major open problems
-- this is a useful result, not a failure: it tells us the corpus is measuring something real
+- exact-window scoring still tells us what the classifier can do when the target audio is bounded correctly
+- full-stream scoring tells us that acquisition, segmentation, gap maturity, and finalization are the hard live problems
+- the append-only event-stream foundation is the current best live-facing compromise because it removes rolling-window string replacement/stitching from the critical path while staying directly measurable against labels and replay transcripts
+
+### Append-foundation smoke evidence
+
+The foundation path now runs through the same Rust core in every surface:
+
+- `stream-live-v3` emits the append transcript as primary `text` / `transcript`
+- `cursor_transcript` keeps the older event-cursor transcript for diagnostics
+- `raw_morse` exposes the raw event stream for bar-level debugging
+- `eval --strategy-sweep --strategies foundation` compares the foundation against other strategies
+- `bench-latency --foundation --json` emits transcript-quality rows for the append foundation
+- the GUI defaults Decode/Labeling file and live runs to **Append event stream (foundation)**
+- the Visualizer still has an **APPEND DECODE** view/debug path, but it is now aligned with the same underlying append contract
+
+On synthetic PARIS bench scenarios the foundation clean/noise transcripts are recognizable immediately (`PARIS PARIS ...`) while voice-lead-in scenarios still show garbage before the target appears. That is useful: it confirms the foundation is simple and honest rather than hiding acquisition/target-isolation failures behind post-hoc stitching.
 
 ## Current thinking
 
 ## What we know with reasonable confidence
 
-1. **Labeling was the right move.**
-   It exposed boundary failures vs target-isolation failures much more clearly than raw listening or eyeballing waveforms.
-2. **The baseline remains the best tuning reference.**
-   It is simpler, sweepable, and already performs well enough on the easier labels to be meaningful.
-3. **The custom streaming decoder has improved materially.**
-   The new Fisher-based tone selection, adaptive thresholding, and lock watchdogs are promising, especially for live operation.
-4. **Hard contest audio is still the frontier.**
-   The remaining hard cases do not look like “just simplify the streamer” problems.
+1. **The simple append-event stream is working much better than the rolling-window transcript machinery.**
+   The important shift was moving from "decode a rolling window, then stitch text" to "classify bars, then append matured events once." That removes a whole class of ghost characters, repeated prefixes, disappearing/replacing text, and overlapping-window artifacts.
+2. **Visualizer truth is event truth, not redraw truth.**
+   The colored bars are a rolling display. Logging every redraw records repeated partial windows (`..`, then `..-`, then `..- ...`) and creates fake Morse. The useful debug layer is the audio-time event stream beneath the redraw.
+3. **Spacing is now visible and testable.**
+   The raw stream (`.` / `-` / `/` / `//`) made it obvious when a word gap was being emitted where a character gap was expected, for example `...//.-` (`S A`) instead of `.../.-` (`SA`). Future spacing work can now target that exact failure instead of guessing from final text.
+4. **Audio/playback synchronization matters.**
+   The old Visualizer file path decoded in one process and played audio in another, so visual bars could lead or lag what the operator heard. `stream-live-v3 --file --play` fixes this by using one process and feeding the decoder from the output playback cursor.
+5. **Hard contest audio is still the frontier.**
+   The foundation does not magically solve target isolation, voice lead-ins, same-band QRM, or weak/noisy spacing. It gives us a stable place to measure those failures without rolling-window artifacts obscuring them.
 
 ## What this implies for next steps
+
+### Keep the append foundation as the non-regression line
+
+The append-only path is now the default contract:
+
+```text
+audio -> envelope/viz events -> append event decoder -> transcript
+```
+
+Regressions should be caught at several levels:
+
+1. **Unit level:** `AppendEventDecoder` tests should cover repeated `viz` frames, character gaps, word gaps, and final pending-character flush.
+2. **CLI level:** `stream-live-v3 --json` transcript events must keep `transcript` / `text` as the append-foundation text, with `cursor_transcript` only as diagnostics.
+3. **GUI level:** Decode, Labeling, Bench, Tuning, and Visualizer should default to or explicitly include `foundation`; any future mode should be labeled as experimental.
+4. **Corpus level:** every future algorithm should report against `--labels-dir data\cw-samples` and include `foundation` in strategy sweeps.
+5. **Bench level:** `bench-latency --foundation --json` should remain a quick smoke that emits recognizable transcript rows before deeper latency metrics are trusted.
+
+The rule of thumb: improvements may change how events are detected, filtered, or classified, but they should not reintroduce rolling text stitching as the primary live transcript path.
 
 ### Keep pursuing labeling, but evolve it carefully
 
@@ -693,50 +732,54 @@ Instead:
 3. add some negative / no-copy examples
 4. add target-tone hints where multiple CW signals are present
 
-### Keep the baseline as the main evaluation reference
+### Use foundation-first evaluation
 
 For corpus work, the current order should stay:
 
-1. exact-window baseline score
-2. full-stream baseline score
-3. custom live/offline replay comparison
-4. future custom-streaming corpus score once instrumentation is ready
+1. append-foundation score / replay transcript
+2. exact-window label score as the upper-bound classifier check
+3. full-stream score as the live segmentation/finalization check
+4. experimental strategy sweeps that always include `foundation`
 
-### Use the custom streaming path as the algorithm sandbox
+### Use experiments as layers above the stable base
 
-The custom decoder is where more aggressive work belongs:
+The promising future work is no longer "replace the foundation." It is "make better events for the foundation to append":
 
-- better target isolation
-- better lock retention / drop policy
-- better segmentation under contest-style pacing
-- lower ghost output
+- **spacing classifier:** tune char-vs-word gap thresholds, make gap maturity explicit, and score raw Morse gaps against labels where possible
+- **target isolation:** track multiple tone ridges and choose or present candidates instead of winner-takes-all pitch lock
+- **preprocessing:** bandpass-around-pitch and dynamic compression helped real radio clips, but must be gated so clean synthetic CW does not regress
+- **matched element scoring:** replace hard threshold chatter with soft scores over candidate 1-dot, 3-dot, and 7-dot windows
+- **lock/acquisition policy:** speed up acquisition after voice/noise lead-ins without allowing noise-locked dit spam
+- **region segmentation:** detect active CW spans and compare region-local decode against the append live transcript
+- **multi-surface diagnostics:** keep raw Morse, transcript, bars, WPM, pitch, SNR, and label CER tied to the same audio-time cursor
 
-But improvements there should be measured back against:
+But every improvement must be measured back against:
 
 - the label corpus
 - replay CER
-- exact-window vs full-stream deltas
+- raw Morse gap fidelity
+- foundation-vs-experiment deltas
 
 ## Recommended next steps
 
-1. **Close the acquisition-latency gap on cold-start CW after a long voice lead-in.**
-   On the YouTube reference clip the decoder now correctly silences the bogus voice lock and recovers when real CW arrives, but the first ~10 characters (`CQ DE K UR ...`) are missed because the pre-lock Fisher search needs ~12 s of CW audio to commit a lock once a stale lock has been dropped. The fix is on the acquisition side, not the confidence machine: faster Fisher convergence, shorter `RELOCK_SECONDS` for the cold-start case, or a reduced `PITCH_LOCK_SECONDS` window once the previous lock has been explicitly rejected as bogus.
-2. **Add richer label metadata for hard cases**
-   - target tone (Phase 1A oracle-tone eval)
-   - multi-signal flag
-   - negative/no-copy labels (Phase 2 false-chars/min metric)
-3. **Score the custom streaming path against the same corpus end-to-end**
-   The branch now has stronger custom logic, but the corpus README story should eventually include real custom-vs-baseline numbers rather than replay-only intuition.
-4. **Improve full-stream commit behavior**
-   The baseline full-stream score shows that finalization and region-close behavior are still weak.
-5. **Use `probe-fisher` and label metadata together**
-   This looks like the right next diagnostic loop for multi-signal contest audio.
-6. **Top-K candidate tracker (Phase 3)** — replace single-pitch lock with a CFAR-scored ridge tracker over 350–1500 Hz so multi-signal contest audio can present per-track candidates instead of one winner-takes-all lock.
+1. **Promote foundation regression checks.**
+   Add/keep tests around `src\append_decode.rs`, require `foundation` in strategy sweeps, and preserve `raw_morse`/`cursor_transcript` diagnostics so future changes can explain differences instead of only showing final text.
+2. **Quantify spacing failures.**
+   The current foundation exposed word-gap mistakes cleanly. The next useful scorer should classify failures as character substitution vs char-gap vs word-gap errors.
+3. **Close the acquisition gap after voice/noise lead-ins.**
+   Synthetic bench results show the append foundation is honest: clean/noise PARIS is recognizable, but voice lead-ins still create pre-target garbage. That points to better target detection and lock admission, not transcript stitching.
+4. **Layer preprocessing carefully.**
+   Real-radio bandpass+compander preprocessing can help dramatically, but it previously broke clean synthetic CW in some paths. Treat preprocessing as an optional layer above the foundation with explicit A/B coverage.
+5. **Add richer label metadata for hard cases.**
+   Target tone, multi-signal flag, negative/no-copy regions, and gap annotations will make future experiments much easier to judge.
+6. **Top-K candidate tracker.**
+   Replace single-pitch lock with a CFAR-scored ridge tracker over 350-1500 Hz so multi-signal contest audio can present per-track candidates instead of one winner-takes-all lock.
 
 Current evidence suggests:
 
-- **W1AW-like misses** -> boundary / commit / warmup
-- **80m contest misses** -> target isolation + segmentation
+- **clean/noisy single-target misses** -> spacing maturity and final pending-character flush
+- **voice lead-in misses** -> acquisition / lock admission
+- **contest/multi-signal misses** -> target isolation + segmentation
 
 ## Practical workflow today
 
@@ -745,15 +788,16 @@ If the goal is the fastest useful loop on another PC with live radio audio:
 1. pull this branch
 2. build `experiments\cw-decoder`
 3. run the GUI
-4. use **Baseline ditdah** for honest tuning
-5. record live audio and use **Replay & Score**
-6. keep using the label corpus to decide whether improvements are real
+4. use **Append event stream (foundation)** for Decode / Labeling / Visualizer
+5. record live audio and use replay/label scoring to compare against ground truth
+6. keep `foundation` in every strategy sweep so improvements are real and regressions are obvious
 
 If the goal is custom-streaming research:
 
-- keep the GUI default at **Custom streaming**
+- keep the GUI default at **Append event stream (foundation)**
 - use live recording + replay CER for quick iteration
 - keep the label corpus as the harder regression gate
+- treat other modes as experiments layered above the stable base
 
 ## Build and run
 
@@ -786,6 +830,12 @@ Run the full-stream scorer:
 
 ```powershell
 cargo run --release --manifest-path experiments\cw-decoder\Cargo.toml --bin eval -- --labels-dir data\cw-samples --mode full-stream --window 20 --min-window 0.5 --decode-every-ms 1000 --confirmations 3 --post-roll-ms 1500
+```
+
+Run the foundation strategy in the same sweep harness used by the Tuning tab:
+
+```powershell
+cargo run --release --manifest-path experiments\cw-decoder\Cargo.toml --bin eval -- --labels-dir data\cw-samples --strategy-sweep --strategies foundation
 ```
 
 Run the experimental range-lock scorer against a focused label subset:
@@ -837,6 +887,12 @@ Compare two configurations by tagging each run with `--label`. Combine with `--j
 ```powershell
 .\experiments\cw-decoder\target\release\cw-decoder.exe bench-latency --label baseline    --json > bench-baseline.ndjson
 .\experiments\cw-decoder\target\release\cw-decoder.exe bench-latency --label no-purity   --purity 0 --json > bench-no-purity.ndjson
+```
+
+Run the append-foundation bench smoke. This records transcript quality for the GUI foundation; latency and lock fields are intentionally empty in this mode:
+
+```powershell
+.\experiments\cw-decoder\target\release\cw-decoder.exe bench-latency --foundation --json > bench-foundation.ndjson
 ```
 
 List live audio devices and run the legacy TUI:
@@ -911,5 +967,6 @@ The empirical conclusion (recorded on issue #322): per-frame normalization alone
 - `target\` — local Cargo build output (debug + release) for `cw-decoder` and `eval`
 - `gui\bin\`, `gui\obj\` — local .NET build output for the Avalonia GUI
 - `bench-runs\` — per-label JSON results from `bench-30wpm.ps1`
+- `artifacts\run\cw-debug-bars-*.txt` — Visualizer append-debug raw Morse streams (`.` / `-` / `/` / `//`) flushed when a clip stops
 
 These are not committed-meaningful build artifacts; they exist to make the GUI runnable without an extra build step on the developer machine.

--- a/experiments/cw-decoder/gui/Models/DecoderEvent.cs
+++ b/experiments/cw-decoder/gui/Models/DecoderEvent.cs
@@ -40,6 +40,8 @@ internal sealed class DecoderEvent
 
     // end
     [JsonPropertyName("transcript")] public string? Transcript { get; set; }
+    [JsonPropertyName("cursor_transcript")] public string? CursorTranscript { get; set; }
+    [JsonPropertyName("raw_morse")] public string? RawMorse { get; set; }
     [JsonPropertyName("pitch")] public double? Pitch { get; set; }
 
     // recording (ready / end)

--- a/experiments/cw-decoder/gui/Models/DecoderEvent.cs
+++ b/experiments/cw-decoder/gui/Models/DecoderEvent.cs
@@ -46,6 +46,9 @@ internal sealed class DecoderEvent
     [JsonPropertyName("recording")] public string? Recording { get; set; }
 
     // viz (from stream-live-v3)
+    [JsonPropertyName("sample_rate")] public int? SampleRate { get; set; }
+    [JsonPropertyName("window_start_sample")] public ulong? WindowStartSample { get; set; }
+    [JsonPropertyName("window_end_sample")] public ulong? WindowEndSample { get; set; }
     [JsonPropertyName("envelope")] public double[]? Envelope { get; set; }
     [JsonPropertyName("envelope_max")] public double? EnvelopeMax { get; set; }
     [JsonPropertyName("noise_floor")] public double? NoiseFloor { get; set; }

--- a/experiments/cw-decoder/gui/Services/CwBenchRunner.cs
+++ b/experiments/cw-decoder/gui/Services/CwBenchRunner.cs
@@ -37,6 +37,7 @@ internal static class CwBenchRunner
         public int? WideBins { get; set; }
         public bool DisableAutoThreshold { get; set; }
         public float? ForcePitchHz { get; set; }
+        public bool Foundation { get; set; }
     }
 
     public sealed class RunResult
@@ -107,6 +108,10 @@ internal static class CwBenchRunner
         {
             psi.ArgumentList.Add("--force-pitch-hz");
             psi.ArgumentList.Add(fp.ToString(CultureInfo.InvariantCulture));
+        }
+        if (opts.Foundation)
+        {
+            psi.ArgumentList.Add("--foundation");
         }
 
         using var process = Process.Start(psi)

--- a/experiments/cw-decoder/gui/Services/CwDecoderProcess.cs
+++ b/experiments/cw-decoder/gui/Services/CwDecoderProcess.cs
@@ -101,11 +101,12 @@ internal sealed class CwDecoderProcess : IDisposable
         Spawn(args);
     }
 
-    public void StartFileV3(string filePath, int decodeEveryMs = 250, double pinWpm = 0, double pinHz = 0)
+    public void StartFileV3(string filePath, int decodeEveryMs = 250, double pinWpm = 0, double pinHz = 0, bool playAudio = false)
     {
         Stop();
         var ic = CultureInfo.InvariantCulture;
         var args = $"stream-live-v3 --json --decode-every-ms {decodeEveryMs.ToString(ic)} --file \"{filePath}\"";
+        if (playAudio) args += " --play";
         if (pinWpm > 0) args += $" --pin-wpm {pinWpm.ToString(ic)}";
         if (pinHz > 0) args += $" --pin-hz {pinHz.ToString(ic)}";
         Spawn(args);

--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Bench.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Bench.cs
@@ -296,6 +296,7 @@ public sealed partial class MainWindowViewModel
             WideBins = (int)Math.Max(0, _benchWideBins),
             DisableAutoThreshold = !_benchAutoThreshold,
             ForcePitchHz = _benchForcePitchHz > 0 ? (float)_benchForcePitchHz : (float?)null,
+            Foundation = true,
         };
 
         _benchCts?.Dispose();

--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Visualizer.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Visualizer.cs
@@ -216,29 +216,8 @@ public sealed partial class MainWindowViewModel
             VizStatus = $"file: {System.IO.Path.GetFileName(filePath)}";
             VizBarMonitor.Reset(System.IO.Path.GetFileNameWithoutExtension(filePath));
             _vizProcess.StartFileV3(filePath, decodeEveryMs: 250,
-                pinWpm: VizPinWpm, pinHz: VizPinHz);
-
-            // The visualizer pipeline only reads samples from the WAV; it
-            // does not touch the audio output device. Start a second
-            // cw-decoder.exe process (`play-file`) in parallel so the
-            // operator can hear the file while watching the visualizer
-            // decode it. Honor VizMute so screen captures and unattended
-            // runs stay silent.
+                pinWpm: VizPinWpm, pinHz: VizPinHz, playAudio: !VizMute);
             try { _vizPlayback.Stop(); } catch { /* best effort */ }
-            if (!VizMute)
-            {
-                try
-                {
-                    _vizPlayback.Start(filePath);
-                }
-                catch (Exception audioEx)
-                {
-                    // Audio is best-effort: a missing output device or a
-                    // failed cw-decoder.exe play-file launch must not stop
-                    // the visualizer from running.
-                    VizStatus = $"file: {System.IO.Path.GetFileName(filePath)} (audio off: {audioEx.Message})";
-                }
-            }
 
             VizRunning = true;
         }

--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Visualizer.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Visualizer.cs
@@ -123,6 +123,19 @@ public sealed partial class MainWindowViewModel
     /// </summary>
     public bool VizMute { get => _vizMute; set => Set(ref _vizMute, value); }
 
+    private bool _vizAppendDecode;
+    public bool VizAppendDecode
+    {
+        get => _vizAppendDecode;
+        set
+        {
+            if (Set(ref _vizAppendDecode, value) && value)
+            {
+                VizTranscript = VizBarMonitor.DecodedText;
+            }
+        }
+    }
+
     public string VizStartStopLabel => VizRunning ? "STOP" : "START LIVE";
 
     /// <summary>Resolves the persistent capture directory and ensures it exists.</summary>
@@ -163,6 +176,7 @@ public sealed partial class MainWindowViewModel
             VizFrame = VizFrameVm.Empty;
             VizCurrentWpm = 0;
             VizStatus = "starting…";
+            VizBarMonitor.Reset("live");
             // Auto-save every live capture so it can be labeled later.
             var stamp = DateTime.Now.ToString("yyyyMMdd-HHmmss-fff");
             var captureDir = ResolveVizCaptureDir();
@@ -187,6 +201,8 @@ public sealed partial class MainWindowViewModel
         try { _vizPlayback.Stop(); } catch { /* best effort */ }
         VizRunning = false;
         VizStatus = "stopped";
+        var flushed = VizBarMonitor.Flush();
+        if (flushed is not null) VizStatus = $"stopped → {System.IO.Path.GetFileName(flushed)}";
     }
 
     public void StartVizFile(string filePath)
@@ -198,6 +214,7 @@ public sealed partial class MainWindowViewModel
             VizFrame = VizFrameVm.Empty;
             VizCurrentWpm = 0;
             VizStatus = $"file: {System.IO.Path.GetFileName(filePath)}";
+            VizBarMonitor.Reset(System.IO.Path.GetFileNameWithoutExtension(filePath));
             _vizProcess.StartFileV3(filePath, decodeEveryMs: 250,
                 pinWpm: VizPinWpm, pinHz: VizPinHz);
 
@@ -241,10 +258,12 @@ public sealed partial class MainWindowViewModel
         {
             VizRunning = false;
             try { _vizPlayback.Stop(); } catch { /* best effort */ }
+            var flushed = VizBarMonitor.Flush();
             if (VizStatus.StartsWith("live", StringComparison.OrdinalIgnoreCase))
             {
                 VizStatus = "process exited";
             }
+            if (flushed is not null) VizStatus += $" → {System.IO.Path.GetFileName(flushed)}";
         });
     }
 
@@ -258,23 +277,39 @@ public sealed partial class MainWindowViewModel
                     VizStatus = $"ready @ {ev.Rate ?? 0} Hz";
                     break;
                 case "transcript":
-                    // Prefer the cumulative session transcript (Rust side maintains
-                    // it via ditdah_streaming::append_snapshot_text). Fall back to
-                    // the rolling-window snapshot text if older builds emit only
-                    // the legacy field.
+                    // PR #370 (Approach A+): the Rust side now emits a
+                    // sample-indexed cumulative transcript via
+                    // LiveCommitCursor (`transcript` = committed +
+                    // provisional). It is monotonic and idempotent.
+                    //
+                    // Do NOT fall back to `ev.Text` (the rolling-window
+                    // re-decode). That field is produced by a different
+                    // decode path and can disagree with the cursor's
+                    // text; switching between the two between the
+                    // pre-lock and post-lock cycles makes the
+                    // transcript appear to vanish and get replaced when
+                    // the cursor first commits. Show the cursor text
+                    // only — empty until the streamer locks is
+                    // expected and accurate.
                     var sess = ev.Transcript;
-                    if (!string.IsNullOrEmpty(sess)) VizTranscript = sess!;
-                    else if (ev.Text is not null) VizTranscript = ev.Text;
+                    if (!VizAppendDecode && sess is not null) VizTranscript = sess;
                     if (ev.Wpm.HasValue) VizCurrentWpm = ev.Wpm.Value;
                     break;
                 case "viz":
                     VizFrame = new VizFrameVm(ev);
+                    if (VizBarMonitor.Ingest(ev) && VizAppendDecode)
+                    {
+                        VizTranscript = VizBarMonitor.DecodedText;
+                    }
                     if (ev.Wpm.HasValue) VizCurrentWpm = ev.Wpm.Value;
                     break;
                 case "end":
-                    if (ev.Transcript is not null) VizTranscript = ev.Transcript;
+                    if (VizAppendDecode) VizTranscript = VizBarMonitor.DecodedText;
+                    else if (ev.Transcript is not null) VizTranscript = ev.Transcript;
                     VizRunning = false;
                     VizStatus = "ended";
+                    var flushed = VizBarMonitor.Flush();
+                    if (flushed is not null) VizStatus = $"ended → {System.IO.Path.GetFileName(flushed)}";
                     break;
             }
         });

--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
@@ -30,6 +30,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
     private SweepTopResult? _topSweepResult;
 
     private const string CustomDecoderModeLabel = "Custom streaming";
+    private const string FoundationDecoderModeLabel = "Append event stream (foundation)";
     private const string BaselineDecoderModeLabel = "Baseline ditdah (rolling window)";
     private const string V2DecoderModeLabel = "Whole-buffer ditdah (v2)";
 
@@ -39,9 +40,9 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         _inputDevices = devs.Inputs;
         _outputDevices = devs.Outputs;
         Devices = new ObservableCollection<string>(_inputDevices);
-        DecoderModes = new ObservableCollection<string>(new[] { V2DecoderModeLabel, CustomDecoderModeLabel, BaselineDecoderModeLabel });
+        DecoderModes = new ObservableCollection<string>(new[] { FoundationDecoderModeLabel, V2DecoderModeLabel, CustomDecoderModeLabel, BaselineDecoderModeLabel });
         SelectedDevice = Devices.Count > 0 ? Devices[0] : null;
-        SelectedDecoderMode = DecoderModes[0];
+        SelectedDecoderMode = FoundationDecoderModeLabel;
         Cells = new ObservableCollection<TranscriptCell>();
         WpmHistory = new ObservableCollection<double>();
         HarvestCandidates = new ObservableCollection<HarvestCandidate>();
@@ -206,6 +207,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
             if (Set(ref _selectedDecoderMode, value))
             {
                 OnPropertyChanged(nameof(IsCustomDecoderMode));
+                OnPropertyChanged(nameof(IsFoundationDecoderMode));
                 OnPropertyChanged(nameof(IsBaselineDecoderMode));
                 OnPropertyChanged(nameof(IsV2DecoderMode));
                 OnPropertyChanged(nameof(BaselineDecoderSummary));
@@ -1069,6 +1071,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         : $"{CurrentLabelSweepResult.SweepMode} sweep · {CurrentLabelSweepResult.CoarseConfigs} coarse + {CurrentLabelSweepResult.RefinedConfigs} refined configs · best exact={CurrentLabelSweepResult.Results.FirstOrDefault()?.Exact ?? 0}/{CurrentLabelSweepResult.Labels}";
 
     public bool IsCustomDecoderMode => string.Equals(SelectedDecoderMode, CustomDecoderModeLabel, StringComparison.Ordinal);
+    public bool IsFoundationDecoderMode => string.Equals(SelectedDecoderMode, FoundationDecoderModeLabel, StringComparison.Ordinal);
     public bool IsBaselineDecoderMode => string.Equals(SelectedDecoderMode, BaselineDecoderModeLabel, StringComparison.Ordinal);
     public bool IsV2DecoderMode => string.Equals(SelectedDecoderMode, V2DecoderModeLabel, StringComparison.Ordinal);
     public string BaselineDecoderSummary => $"Baseline uses Tuning settings: {CurrentBaselineConfig().WindowSeconds:F1}s window / {CurrentBaselineConfig().MinWindowSeconds:F1}s min / {CurrentBaselineConfig().DecodeEveryMs}ms cadence / {CurrentBaselineConfig().Confirmations} confirmations.";
@@ -1457,7 +1460,14 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         ReplayStatus = null;
         ReplayCer = null;
 
-        _process.StartLive(SelectedDevice, CurrentConfig(), CurrentBaselineConfig(), IsBaselineDecoderMode, recordPath, UseLoopback, IsV2DecoderMode, IsV2DecoderMode ? PinWpm : 0);
+        if (IsFoundationDecoderMode)
+        {
+            _process.StartLiveV3(SelectedDevice, decodeEveryMs: 250, recordPath: recordPath, loopback: UseLoopback, pinWpm: 0, pinHz: 0);
+        }
+        else
+        {
+            _process.StartLive(SelectedDevice, CurrentConfig(), CurrentBaselineConfig(), IsBaselineDecoderMode, recordPath, UseLoopback, IsV2DecoderMode, IsV2DecoderMode ? PinWpm : 0);
+        }
         IsRunning = true;
     }
 
@@ -1505,8 +1515,8 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         {
             var useBaseline = IsBaselineDecoderMode;
             var cfg = CurrentConfig();
-            ReplayDecoderLabel = useBaseline ? "OFFLINE REPLAY (BASELINE)" : "OFFLINE REPLAY (CUSTOM)";
-            var transcript = await Task.Run(() => RunOfflineReplay(path, useBaseline, cfg)).ConfigureAwait(false);
+            ReplayDecoderLabel = IsFoundationDecoderMode ? "OFFLINE REPLAY (FOUNDATION)" : useBaseline ? "OFFLINE REPLAY (BASELINE)" : "OFFLINE REPLAY (CUSTOM)";
+            var transcript = await Task.Run(() => RunOfflineReplay(path, useBaseline, IsFoundationDecoderMode, cfg)).ConfigureAwait(false);
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
                 ReplayTranscript = string.IsNullOrWhiteSpace(transcript) ? "(empty)" : transcript.Trim();
@@ -1653,7 +1663,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         IsPlaybackRunning = false;
     }
 
-    private static string RunOfflineReplay(string wavPath, bool useBaseline, DecoderConfig cfg)
+    private static string RunOfflineReplay(string wavPath, bool useBaseline, bool useFoundation, DecoderConfig cfg)
     {
         var exeEnv = Environment.GetEnvironmentVariable("CW_DECODER_EXE");
         string? exe = (!string.IsNullOrWhiteSpace(exeEnv) && System.IO.File.Exists(exeEnv)) ? exeEnv : null;
@@ -1685,7 +1695,16 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
             UseShellExecute = false,
             CreateNoWindow = true,
         };
-        if (useBaseline)
+        if (useFoundation)
+        {
+            psi.ArgumentList.Add("stream-live-v3");
+            psi.ArgumentList.Add("--json");
+            psi.ArgumentList.Add("--decode-every-ms");
+            psi.ArgumentList.Add("250");
+            psi.ArgumentList.Add("--file");
+            psi.ArgumentList.Add(wavPath);
+        }
+        else if (useBaseline)
         {
             psi.ArgumentList.Add("stream-file-ditdah");
             psi.ArgumentList.Add("--json");
@@ -1785,6 +1804,14 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         PlaybackPositionSeconds = 0;
         var fileDur = TryProbeFileDurationSeconds(path);
         if (fileDur > 0) FileDurationSeconds = fileDur;
+
+        if (IsFoundationDecoderMode)
+        {
+            _process.StartFileV3(path, decodeEveryMs: 250, pinWpm: 0, pinHz: 0, playAudio: true);
+            IsRunning = true;
+            await Task.CompletedTask;
+            return;
+        }
 
         if (IsBaselineDecoderMode)
         {
@@ -2045,7 +2072,14 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
 
         try
         {
-            _process.StartLive(SelectedDevice, CurrentConfig(), CurrentBaselineConfig(), IsBaselineDecoderMode, targetPath, UseLoopback, IsV2DecoderMode, IsV2DecoderMode ? PinWpm : 0);
+            if (IsFoundationDecoderMode)
+            {
+                _process.StartLiveV3(SelectedDevice, decodeEveryMs: 250, recordPath: targetPath, loopback: UseLoopback, pinWpm: 0, pinHz: 0);
+            }
+            else
+            {
+                _process.StartLive(SelectedDevice, CurrentConfig(), CurrentBaselineConfig(), IsBaselineDecoderMode, targetPath, UseLoopback, IsV2DecoderMode, IsV2DecoderMode ? PinWpm : 0);
+            }
             IsRunning = true;
             IsLabelingRecording = true;
         }
@@ -2505,7 +2539,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         }
     }
 
-    private string _strategySweepWpms = "auto,28,region28,env,env28,live-env";
+    private string _strategySweepWpms = "foundation,auto,28,region28,env,env28,live-env";
     /// <summary>Comma-separated list of strategy tokens. Retained for
     /// backwards compatibility (some tests/bindings still reference it),
     /// but no longer the source of truth for the TUNING tab — the picker
@@ -2519,10 +2553,11 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
 
     /// <summary>Predefined strategy checkboxes shown in the TUNING tab picker.
     /// Tokens are forwarded verbatim to the Rust eval binary's
-    /// parse_strategy_list (auto, region, region&lt;N&gt;, env, env&lt;N&gt;,
-    /// live-env, bare numbers).</summary>
+    /// parse_strategy_list (foundation, auto, region, region&lt;N&gt;,
+    /// env, env&lt;N&gt;, live-env, bare numbers).</summary>
     public ObservableCollection<StrategyOption> StrategyOptions { get; } = new()
     {
+        new StrategyOption("foundation", "foundation", true,  "Append-only event-stream decoder used by DECODE/VISUALIZER"),
         new StrategyOption("auto",     "auto",     true,  "Whole-buffer ditdah, auto-detect WPM (DECODE tab default)"),
         new StrategyOption("22",       "22 wpm",   false, "Whole-buffer ditdah, pinned to 22 wpm"),
         new StrategyOption("25",       "25 wpm",   false, "Whole-buffer ditdah, pinned to 25 wpm"),
@@ -2577,8 +2612,8 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
     /// declaration order, then comma-split custom tokens.</summary>
     private List<string> BuildStrategyTokens()
     {
-        var tokens = new List<string> { "auto" };
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "auto" };
+        var tokens = new List<string> { "foundation" };
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "foundation" };
         foreach (var opt in StrategyOptions)
         {
             if (!opt.IsChecked) continue;
@@ -2686,8 +2721,9 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         // source of truth. The Rust eval binary's parse_strategy_list accepts:
         // auto, region, region<N>, region:<N>, env, envelope, env<N>,
         // envelope<N>, env:<N>, envelope:<N>, live-env, liveenv, and bare
-        // numbers (ExactPin). BuildStrategyTokens always includes "auto"
-        // first and dedupes case-insensitively across picker + custom tokens.
+        // numbers (ExactPin). BuildStrategyTokens always includes
+        // "foundation" first and dedupes case-insensitively across picker
+        // + custom tokens.
         var strategies = BuildStrategyTokens();
 
         CancelAndDisposeEvaluation();
@@ -2965,7 +3001,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
             case "garbled":
                 break;
             case "transcript":
-                if (ev.Text is string txt)
+                if ((ev.Transcript ?? ev.Text) is string txt)
                 {
                     Cells.Clear();
                     _liveTranscriptBuilder.Clear();

--- a/experiments/cw-decoder/gui/ViewModels/VizBarMonitor.cs
+++ b/experiments/cw-decoder/gui/ViewModels/VizBarMonitor.cs
@@ -1,0 +1,215 @@
+using System;
+using System.IO;
+using System.Text;
+using CwDecoderGui.Models;
+
+namespace CwDecoderGui.ViewModels;
+
+/// <summary>
+/// Debug monitor: append one token for each stable classified event emitted by
+/// the decoder's stream-live-v3 viz event stream. This is independent of
+/// Avalonia redraws; it produces one long line of heard Morse/gap tokens.
+///
+///   . on_dit | - on_dah | off_intra omitted | / off_char | // off_word
+/// </summary>
+internal static class VizBarMonitor
+{
+    private static readonly StringBuilder RawBuffer = new();
+    private static readonly StringBuilder TextBuffer = new();
+    private static readonly StringBuilder PendingMorse = new();
+    private const ulong EpsilonSamples = 16;
+    private static string _label = "session";
+    private static ulong _lastEmittedEndSample;
+    private static int _eventCount;
+    private static bool _flushed;
+
+    public static string DecodedText => TextBuffer.ToString();
+
+    public static void Reset(string label)
+    {
+        RawBuffer.Clear();
+        TextBuffer.Clear();
+        PendingMorse.Clear();
+        _lastEmittedEndSample = 0;
+        _eventCount = 0;
+        _flushed = false;
+        _label = SanitizeLabel(label);
+    }
+
+    public static bool Ingest(DecoderEvent ev)
+    {
+        if (ev.Events is null || ev.Events.Length == 0) return false;
+        var sampleRate = ev.SampleRate.GetValueOrDefault();
+        var windowStart = ev.WindowStartSample.GetValueOrDefault();
+        var windowEnd = ev.WindowEndSample.GetValueOrDefault();
+        if (sampleRate <= 0 || windowEnd <= windowStart) return false;
+
+        var dotSeconds = ev.DotSeconds.GetValueOrDefault(0.04);
+        var guardSeconds = Math.Max(0.10, dotSeconds * 8.0);
+        var guardSamples = (ulong)Math.Round(guardSeconds * sampleRate);
+        var stableEnd = windowEnd > guardSamples ? windowEnd - guardSamples : windowStart;
+        var changed = false;
+
+        foreach (var e in ev.Events)
+        {
+            var eventEnd = windowStart + (ulong)Math.Round(Math.Max(0.0, e.EndS) * sampleRate);
+            if (eventEnd > stableEnd) continue;
+            if (eventEnd <= _lastEmittedEndSample + EpsilonSamples) continue;
+
+            var token = e.Kind switch
+            {
+                "on_dit" => ".",
+                "on_dah" => "-",
+                "off_char" => "/",
+                "off_word" => "//",
+                _ => "",
+            };
+            if (token.Length > 0)
+            {
+                RawBuffer.Append(token);
+                _eventCount++;
+            }
+
+            changed |= DecodeEvent(e.Kind);
+            _lastEmittedEndSample = eventEnd;
+        }
+
+        return changed;
+    }
+
+    public static string? Flush()
+    {
+        if (_flushed || _eventCount == 0) return null;
+        try
+        {
+            var dir = ResolveOutputDir();
+            Directory.CreateDirectory(dir);
+            var stamp = DateTime.Now.ToString("yyyyMMdd-HHmmss");
+            var path = Path.Combine(dir, $"cw-debug-bars-{_label}-{stamp}.txt");
+            File.WriteAllText(path, RawBuffer.ToString());
+            _flushed = true;
+            return path;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static string SanitizeLabel(string label)
+    {
+        if (string.IsNullOrWhiteSpace(label)) return "session";
+        var bad = Path.GetInvalidFileNameChars();
+        var sb = new StringBuilder(label.Length);
+        foreach (var c in label) sb.Append(Array.IndexOf(bad, c) >= 0 ? '_' : c);
+        var s = sb.ToString();
+        return s.Length > 80 ? s.Substring(0, 80) : s;
+    }
+
+    private static string ResolveOutputDir()
+    {
+        var dir = AppContext.BaseDirectory;
+        for (int i = 0; i < 10 && !string.IsNullOrEmpty(dir); i++)
+        {
+            if (File.Exists(Path.Combine(dir, "build.ps1")) &&
+                File.Exists(Path.Combine(dir, "runall.ps1")))
+            {
+                return Path.Combine(dir, "artifacts", "run");
+            }
+            dir = Path.GetDirectoryName(dir) ?? "";
+        }
+        return Path.Combine(AppContext.BaseDirectory, "cw-debug-bars");
+    }
+
+    private static bool DecodeEvent(string kind)
+    {
+        switch (kind)
+        {
+            case "on_dit":
+                PendingMorse.Append('.');
+                return false;
+            case "on_dah":
+                PendingMorse.Append('-');
+                return false;
+            case "off_char":
+                return FlushPendingCharacter();
+            case "off_word":
+                var changed = FlushPendingCharacter();
+                if (TextBuffer.Length > 0 && TextBuffer[^1] != ' ')
+                {
+                    TextBuffer.Append(' ');
+                    changed = true;
+                }
+                return changed;
+            default:
+                return false;
+        }
+    }
+
+    private static bool FlushPendingCharacter()
+    {
+        if (PendingMorse.Length == 0) return false;
+        TextBuffer.Append(MorseToChar(PendingMorse.ToString()) ?? '?');
+        PendingMorse.Clear();
+        return true;
+    }
+
+    private static char? MorseToChar(string morse) => morse switch
+    {
+        ".-" => 'A',
+        "-..." => 'B',
+        "-.-." => 'C',
+        "-.." => 'D',
+        "." => 'E',
+        "..-." => 'F',
+        "--." => 'G',
+        "...." => 'H',
+        ".." => 'I',
+        ".---" => 'J',
+        "-.-" => 'K',
+        ".-.." => 'L',
+        "--" => 'M',
+        "-." => 'N',
+        "---" => 'O',
+        ".--." => 'P',
+        "--.-" => 'Q',
+        ".-." => 'R',
+        "..." => 'S',
+        "-" => 'T',
+        "..-" => 'U',
+        "...-" => 'V',
+        ".--" => 'W',
+        "-..-" => 'X',
+        "-.--" => 'Y',
+        "--.." => 'Z',
+        ".----" => '1',
+        "..---" => '2',
+        "...--" => '3',
+        "....-" => '4',
+        "....." => '5',
+        "-...." => '6',
+        "--..." => '7',
+        "---.." => '8',
+        "----." => '9',
+        "-----" => '0',
+        ".-.-.-" => '.',
+        "--..--" => ',',
+        "..--.." => '?',
+        ".----." => '\'',
+        "-.-.--" => '!',
+        "-..-." => '/',
+        "-.--." => '(',
+        "-.--.-" => ')',
+        ".-..." => '&',
+        "---..." => ':',
+        "-.-.-." => ';',
+        "-...-" => '=',
+        ".-.-." => '+',
+        "-....-" => '-',
+        "..--.-" => '_',
+        ".-..-." => '"',
+        "...-..-" => '$',
+        ".--.-." => '@',
+        _ => null,
+    };
+}

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml
@@ -1123,7 +1123,7 @@
         <Border Padding="14" Background="{StaticResource BgPanel}">
           <Grid RowDefinitions="Auto,Auto,*,Auto" ColumnDefinitions="*">
             <!-- Controls row -->
-            <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,*,Auto"
+            <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,Auto,*,Auto"
                   Margin="0,0,0,8">
               <Button Grid.Column="0" Classes="primary"
                       Content="{Binding VizStartStopLabel}"
@@ -1142,20 +1142,25 @@
                         Content="LOOPBACK"
                         IsChecked="{Binding VizUseLoopback}"
                         VerticalAlignment="Center" />
-              <TextBlock Grid.Column="4" Margin="20,0,6,0"
+              <CheckBox Grid.Column="4" Margin="14,0,0,0"
+                        Content="APPEND DECODE"
+                        IsChecked="{Binding VizAppendDecode}"
+                        ToolTip.Tip="Show append-only characters decoded from stable dit/dah/gap events instead of the rolling-window transcript."
+                        VerticalAlignment="Center" />
+              <TextBlock Grid.Column="5" Margin="20,0,6,0"
                          Text="WINDOW"
                          FontFamily="Consolas"
                          VerticalAlignment="Center"
                          Foreground="{StaticResource TextDim}" />
-              <Slider Grid.Column="5" Width="160"
+              <Slider Grid.Column="6" Width="160"
                       Minimum="2" Maximum="30"
                       TickFrequency="2" IsSnapToTickEnabled="True"
                       Value="{Binding VizWindowSeconds}" />
-              <TextBlock Grid.Column="6" Margin="6,0,0,0"
+              <TextBlock Grid.Column="7" Margin="6,0,0,0"
                          Text="{Binding VizWindowSeconds, StringFormat='{}{0:F0}s'}"
                          FontFamily="Consolas"
                          VerticalAlignment="Center" />
-              <TextBlock Grid.Column="8"
+              <TextBlock Grid.Column="9"
                          Text="{Binding VizStatus}"
                          FontFamily="Consolas"
                          FontSize="11"

--- a/experiments/cw-decoder/src/append_decode.rs
+++ b/experiments/cw-decoder/src/append_decode.rs
@@ -1,0 +1,240 @@
+//! Append-only event-stream decoder used as the stable CW foundation.
+//!
+//! The input is the same `VizFrame` event stream rendered by the Visualizer:
+//! classified on/off bars with absolute sample anchors.  Unlike the rolling
+//! text decoders, this module consumes each stable event once in audio order
+//! and appends decoded characters.  Future, more complex pipelines should
+//! compare against this baseline rather than replacing it silently.
+
+use crate::envelope_decoder::{self, LiveEnvelopeStreamer, VizEventKind, VizFrame};
+
+const EPSILON_SAMPLES: u64 = 16;
+
+#[derive(Debug, Clone, Default)]
+pub struct AppendDecodeUpdate {
+    pub decoded_text: String,
+    pub raw_stream: String,
+    pub changed: bool,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AppendEventDecoder {
+    last_emitted_end_sample: u64,
+    raw_stream: String,
+    decoded_text: String,
+    pending_morse: String,
+}
+
+impl AppendEventDecoder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn decoded_text(&self) -> &str {
+        &self.decoded_text
+    }
+
+    pub fn raw_stream(&self) -> &str {
+        &self.raw_stream
+    }
+
+    pub fn ingest_viz(&mut self, viz: &VizFrame) -> AppendDecodeUpdate {
+        let sr = viz.sample_rate.max(1) as f32;
+        let window_start = viz.window_start_sample;
+        let window_end = viz.window_end_sample;
+        if window_end <= window_start {
+            return self.snapshot(false);
+        }
+
+        let dot_s = if viz.dot_seconds > 0.0 {
+            viz.dot_seconds
+        } else if viz.wpm > 0.0 {
+            1.2 / viz.wpm
+        } else {
+            0.04
+        };
+        let guard_samples = (sr * f32::max(0.10, 8.0 * dot_s)) as u64;
+        let stable_end = window_end.saturating_sub(guard_samples);
+        let mut changed = false;
+
+        for ev in &viz.events {
+            let end_s = ev.end_s.max(0.0);
+            let event_end = window_start.saturating_add((end_s * sr).round() as u64);
+            if event_end > stable_end {
+                continue;
+            }
+            if event_end <= self.last_emitted_end_sample.saturating_add(EPSILON_SAMPLES) {
+                continue;
+            }
+
+            match ev.kind {
+                VizEventKind::OnDit => {
+                    self.pending_morse.push('.');
+                    self.raw_stream.push('.');
+                }
+                VizEventKind::OnDah => {
+                    self.pending_morse.push('-');
+                    self.raw_stream.push('-');
+                }
+                VizEventKind::OffIntra => {}
+                VizEventKind::OffChar => {
+                    self.flush_pending_char();
+                    self.raw_stream.push('/');
+                    changed = true;
+                }
+                VizEventKind::OffWord => {
+                    self.flush_pending_char();
+                    if !self.decoded_text.ends_with(' ') && !self.decoded_text.is_empty() {
+                        self.decoded_text.push(' ');
+                    }
+                    self.raw_stream.push_str("//");
+                    changed = true;
+                }
+            }
+            self.last_emitted_end_sample = event_end;
+        }
+
+        self.snapshot(changed)
+    }
+
+    pub fn flush(&mut self) -> AppendDecodeUpdate {
+        let changed = self.flush_pending_char();
+        self.snapshot(changed)
+    }
+
+    fn flush_pending_char(&mut self) -> bool {
+        if self.pending_morse.is_empty() {
+            return false;
+        }
+        let ch = envelope_decoder::morse_to_char(&self.pending_morse).unwrap_or('?');
+        self.decoded_text.push(ch);
+        self.pending_morse.clear();
+        true
+    }
+
+    fn snapshot(&self, changed: bool) -> AppendDecodeUpdate {
+        AppendDecodeUpdate {
+            decoded_text: self.decoded_text.clone(),
+            raw_stream: self.raw_stream.clone(),
+            changed,
+        }
+    }
+}
+
+pub fn decode_samples_append(
+    samples: &[f32],
+    sample_rate: u32,
+    pin_wpm: Option<f32>,
+    pin_hz: Option<f32>,
+    min_snr_db: f32,
+) -> AppendDecodeUpdate {
+    let mut streamer = LiveEnvelopeStreamer::new(sample_rate);
+    streamer.set_pinned_wpm(pin_wpm);
+    streamer.set_pinned_hz(pin_hz);
+    streamer.set_min_snr_db(min_snr_db);
+
+    let chunk = ((sample_rate as usize) / 20).max(1);
+    let mut decoder = AppendEventDecoder::new();
+    let mut cursor = 0usize;
+    while cursor < samples.len() {
+        let end = (cursor + chunk).min(samples.len());
+        streamer.feed(&samples[cursor..end]);
+        if let Some(viz) = streamer.flush_with_viz().viz {
+            decoder.ingest_viz(&viz);
+        }
+        cursor = end;
+    }
+    if let Some(viz) = streamer.flush_with_viz().viz {
+        decoder.ingest_viz(&viz);
+    }
+    decoder.flush()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::envelope_decoder::{VizEvent, VizEventKind};
+
+    fn frame(events: Vec<VizEvent>, window_end_sample: u64) -> VizFrame {
+        VizFrame {
+            sample_rate: 1_000,
+            buffer_seconds: window_end_sample as f32 / 1_000.0,
+            frame_step_s: 0.005,
+            pitch_hz: 700.0,
+            envelope: vec![],
+            envelope_max: 1.0,
+            noise_floor: 0.1,
+            signal_floor: 1.0,
+            snr_db: 20.0,
+            snr_suppressed: false,
+            hyst_high: 0.8,
+            hyst_low: 0.4,
+            events,
+            on_durations: vec![],
+            dot_seconds: 0.04,
+            wpm: 30.0,
+            centroid_dot: 0.04,
+            centroid_dah: 0.12,
+            locked_wpm: Some(30.0),
+            window_start_sample: 0,
+            window_end_sample,
+        }
+    }
+
+    #[test]
+    fn append_decoder_decodes_events_once_with_word_spaces() {
+        let events = vec![
+            VizEvent {
+                start_s: 0.00,
+                end_s: 0.04,
+                duration_s: 0.04,
+                kind: VizEventKind::OnDit,
+            },
+            VizEvent {
+                start_s: 0.08,
+                end_s: 0.12,
+                duration_s: 0.04,
+                kind: VizEventKind::OnDit,
+            },
+            VizEvent {
+                start_s: 0.16,
+                end_s: 0.20,
+                duration_s: 0.04,
+                kind: VizEventKind::OnDit,
+            },
+            VizEvent {
+                start_s: 0.20,
+                end_s: 0.35,
+                duration_s: 0.15,
+                kind: VizEventKind::OffChar,
+            },
+            VizEvent {
+                start_s: 0.35,
+                end_s: 0.39,
+                duration_s: 0.04,
+                kind: VizEventKind::OnDit,
+            },
+            VizEvent {
+                start_s: 0.43,
+                end_s: 0.55,
+                duration_s: 0.12,
+                kind: VizEventKind::OnDah,
+            },
+            VizEvent {
+                start_s: 0.55,
+                end_s: 0.90,
+                duration_s: 0.35,
+                kind: VizEventKind::OffWord,
+            },
+        ];
+        let mut d = AppendEventDecoder::new();
+        let update = d.ingest_viz(&frame(events.clone(), 2_000));
+        assert_eq!(update.raw_stream, ".../.-//");
+        assert_eq!(update.decoded_text, "SA ");
+
+        let update = d.ingest_viz(&frame(events, 2_000));
+        assert!(!update.changed);
+        assert_eq!(update.raw_stream, ".../.-//");
+        assert_eq!(update.decoded_text, "SA ");
+    }
+}

--- a/experiments/cw-decoder/src/append_decode.rs
+++ b/experiments/cw-decoder/src/append_decode.rs
@@ -133,7 +133,7 @@ pub fn decode_samples_append(
     streamer.set_pinned_hz(pin_hz);
     streamer.set_min_snr_db(min_snr_db);
 
-    let chunk = ((sample_rate as usize) / 20).max(1);
+    let chunk = ((sample_rate as usize) / 4).max(1);
     let mut decoder = AppendEventDecoder::new();
     let mut cursor = 0usize;
     while cursor < samples.len() {
@@ -147,6 +147,25 @@ pub fn decode_samples_append(
     if let Some(viz) = streamer.flush_with_viz().viz {
         decoder.ingest_viz(&viz);
     }
+    decoder.flush()
+}
+
+pub fn decode_samples_append_exact_window(
+    samples: &[f32],
+    sample_rate: u32,
+    pin_wpm: Option<f32>,
+    pin_hz: Option<f32>,
+    min_snr_db: f32,
+) -> AppendDecodeUpdate {
+    let cfg = envelope_decoder::EnvelopeConfig {
+        pin_wpm,
+        pin_hz,
+        min_snr_db,
+        ..envelope_decoder::EnvelopeConfig::default()
+    };
+    let (_, viz) = envelope_decoder::decode_envelope_with_viz(samples, sample_rate, &cfg);
+    let mut decoder = AppendEventDecoder::new();
+    decoder.ingest_viz(&viz);
     decoder.flush()
 }
 

--- a/experiments/cw-decoder/src/bin/eval.rs
+++ b/experiments/cw-decoder/src/bin/eval.rs
@@ -14,11 +14,10 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use anyhow::Result;
+use cw_decoder_poc::append_decode;
 use cw_decoder_poc::audio;
 use cw_decoder_poc::decoder::{decode_text, decode_text_pinned};
-use cw_decoder_poc::ditdah_streaming::{
-    run_causal_baseline, run_causal_baseline_trace, CausalBaselineConfig, CausalBaselineTrace,
-};
+use cw_decoder_poc::ditdah_streaming::CausalBaselineConfig;
 use cw_decoder_poc::streaming::{DecoderConfig, StreamEvent, StreamingDecoder};
 use rayon::prelude::*;
 use serde::Deserialize;
@@ -745,8 +744,14 @@ fn score_labels_exact_window(
             } else {
                 &[]
             };
-            let outcome = run_causal_baseline(samples, audio.sample_rate, score_cfg.baseline);
-            build_label_score(example, &normalize_copy(&outcome.transcript))
+            let outcome = append_decode::decode_samples_append(
+                samples,
+                audio.sample_rate,
+                None,
+                None,
+                cw_decoder_poc::envelope_decoder::DEFAULT_MIN_SNR_DB,
+            );
+            build_label_score(example, &normalize_copy(&outcome.decoded_text))
         })
         .collect()
 }
@@ -790,7 +795,7 @@ fn score_labels_full_stream(
             let audio = audio_cache
                 .get(&source)
                 .expect("audio cache missing source");
-            run_causal_baseline_trace(&audio.samples, audio.sample_rate, score_cfg.baseline)
+            run_append_trace(&audio.samples, audio.sample_rate)
         });
     }
 
@@ -802,8 +807,8 @@ fn score_labels_full_stream(
                 .expect("audio cache missing source");
             let trace = traces.get(&example.source).expect("trace missing source");
             let (start, end) = expanded_sample_bounds(audio, example, score_cfg);
-            let before = transcript_at_or_before(trace, start);
-            let after = transcript_at_or_before(trace, end);
+            let before = transcript_at_or_before_streaming(trace, start);
+            let after = transcript_at_or_before_streaming(trace, end);
             let decoded = normalize_copy(&extract_transcript_delta(before, after));
             build_label_score(example, &decoded)
         })
@@ -846,6 +851,8 @@ fn score_labels_full_stream_streaming(
 
 #[derive(Debug, Clone, Copy)]
 enum Strategy {
+    /// Stable append-only event-stream foundation used by all GUI surfaces.
+    Foundation,
     /// v2 whole-buffer ditdah on the (expanded) labeled slice. Auto WPM.
     ExactAuto,
     /// v2 whole-buffer ditdah on the (expanded) labeled slice. Pinned WPM.
@@ -874,7 +881,9 @@ fn parse_strategy_list(args: &[String]) -> Vec<Strategy> {
         if t.is_empty() {
             continue;
         }
-        if t.eq_ignore_ascii_case("auto") || t == "0" {
+        if t.eq_ignore_ascii_case("foundation") || t.eq_ignore_ascii_case("append") {
+            out.push(Strategy::Foundation);
+        } else if t.eq_ignore_ascii_case("auto") || t == "0" {
             out.push(Strategy::ExactAuto);
         } else if t.eq_ignore_ascii_case("region") {
             out.push(Strategy::RegionAuto);
@@ -977,6 +986,22 @@ fn score_labels_strategy(
                         Strategy::ExactPin(w) => decode_text_pinned(samples, audio.sample_rate, w),
                         _ => unreachable!(),
                     }
+                }
+                Strategy::Foundation => {
+                    let (start, end) = expanded_sample_bounds(audio, example, score_cfg);
+                    let samples = if end > start {
+                        &audio.samples[start..end]
+                    } else {
+                        &[][..]
+                    };
+                    append_decode::decode_samples_append(
+                        samples,
+                        audio.sample_rate,
+                        None,
+                        None,
+                        cw_decoder_poc::envelope_decoder::DEFAULT_MIN_SNR_DB,
+                    )
+                    .decoded_text
                 }
                 Strategy::RegionAuto | Strategy::RegionPin(_) => {
                     let pin = if let Strategy::RegionPin(w) = strategy {
@@ -1108,6 +1133,7 @@ fn decode_label_via_region(
 fn strategy_label(strategy: Strategy) -> String {
     match strategy {
         Strategy::ExactAuto => "auto".to_string(),
+        Strategy::Foundation => "foundation".to_string(),
         Strategy::ExactPin(w) => format!("pin{:.0}", w),
         Strategy::RegionAuto => "region".to_string(),
         Strategy::RegionPin(w) => format!("region{:.0}", w),
@@ -1303,17 +1329,6 @@ fn expanded_sample_bounds(
     (start, end.max(start))
 }
 
-fn transcript_at_or_before(trace: &CausalBaselineTrace, sample_index: usize) -> &str {
-    let index = trace
-        .snapshots
-        .partition_point(|snapshot| snapshot.end_sample <= sample_index);
-    if index == 0 {
-        ""
-    } else {
-        trace.snapshots[index - 1].transcript.as_str()
-    }
-}
-
 #[derive(Debug, Clone)]
 struct StreamingTraceSnapshot {
     end_sample: usize,
@@ -1363,6 +1378,50 @@ fn run_streaming_trace(
         transcript: transcript.trim().to_string(),
         snapshots,
     })
+}
+
+fn run_append_trace(samples: &[f32], sample_rate: u32) -> StreamingTrace {
+    let mut streamer = cw_decoder_poc::envelope_decoder::LiveEnvelopeStreamer::new(sample_rate);
+    let mut decoder = append_decode::AppendEventDecoder::new();
+    let chunk_samples = (sample_rate as usize / 20).max(64);
+    let mut consumed = 0usize;
+    let mut snapshots = Vec::new();
+
+    for chunk in samples.chunks(chunk_samples) {
+        streamer.feed(chunk);
+        consumed += chunk.len();
+        if let Some(viz) = streamer.flush_with_viz().viz {
+            let update = decoder.ingest_viz(&viz);
+            if update.changed {
+                snapshots.push(StreamingTraceSnapshot {
+                    end_sample: consumed,
+                    transcript: update.decoded_text.trim().to_string(),
+                });
+            }
+        }
+    }
+
+    if let Some(viz) = streamer.flush_with_viz().viz {
+        let update = decoder.ingest_viz(&viz);
+        if update.changed {
+            snapshots.push(StreamingTraceSnapshot {
+                end_sample: consumed,
+                transcript: update.decoded_text.trim().to_string(),
+            });
+        }
+    }
+    let final_update = decoder.flush();
+    if final_update.changed {
+        snapshots.push(StreamingTraceSnapshot {
+            end_sample: consumed,
+            transcript: final_update.decoded_text.trim().to_string(),
+        });
+    }
+
+    StreamingTrace {
+        transcript: decoder.decoded_text().trim().to_string(),
+        snapshots,
+    }
 }
 
 fn append_stream_event_to_transcript(transcript: &mut String, ev: &StreamEvent) -> bool {

--- a/experiments/cw-decoder/src/bin/eval.rs
+++ b/experiments/cw-decoder/src/bin/eval.rs
@@ -1134,11 +1134,11 @@ fn strategy_label(strategy: Strategy) -> String {
     match strategy {
         Strategy::ExactAuto => "auto".to_string(),
         Strategy::Foundation => "foundation".to_string(),
-        Strategy::ExactPin(w) => format!("pin{:.0}", w),
+        Strategy::ExactPin(w) => format!("pin{w:.0}"),
         Strategy::RegionAuto => "region".to_string(),
-        Strategy::RegionPin(w) => format!("region{:.0}", w),
+        Strategy::RegionPin(w) => format!("region{w:.0}"),
         Strategy::EnvelopeAuto => "env".to_string(),
-        Strategy::EnvelopePin(w) => format!("env{:.0}", w),
+        Strategy::EnvelopePin(w) => format!("env{w:.0}"),
         Strategy::LiveEnvelopeAuto => "live-env".to_string(),
     }
 }
@@ -1228,7 +1228,7 @@ fn run_strategy_sweep(
         println!("{}", "=".repeat(96));
         let header_strategies: String = per_strategy
             .iter()
-            .map(|(name, _)| format!("{:>10}", name))
+            .map(|(name, _)| format!("{name:>10}"))
             .collect::<Vec<_>>()
             .join(" ");
         println!("{:30} {:>4}  {}", "clip", "len", header_strategies);
@@ -1257,7 +1257,7 @@ fn run_strategy_sweep(
                 } else {
                     total_distance as f32 / total_truth as f32
                 };
-                format!("{:>10.2}", weighted)
+                format!("{weighted:>10.2}")
             })
             .collect::<Vec<_>>()
             .join(" ");

--- a/experiments/cw-decoder/src/bin/eval.rs
+++ b/experiments/cw-decoder/src/bin/eval.rs
@@ -744,7 +744,7 @@ fn score_labels_exact_window(
             } else {
                 &[]
             };
-            let outcome = append_decode::decode_samples_append(
+            let outcome = append_decode::decode_samples_append_exact_window(
                 samples,
                 audio.sample_rate,
                 None,
@@ -994,7 +994,7 @@ fn score_labels_strategy(
                     } else {
                         &[][..]
                     };
-                    append_decode::decode_samples_append(
+                    append_decode::decode_samples_append_exact_window(
                         samples,
                         audio.sample_rate,
                         None,
@@ -1348,7 +1348,7 @@ fn run_streaming_trace(
 ) -> Result<StreamingTrace> {
     let mut decoder = StreamingDecoder::new(sample_rate)?;
     decoder.set_config(cfg);
-    let chunk_samples = (sample_rate as usize / 20).max(64);
+    let chunk_samples = (sample_rate as usize / 4).max(64);
     let mut transcript = String::new();
     let mut consumed = 0usize;
     let mut snapshots = Vec::new();
@@ -1571,7 +1571,7 @@ fn collect_labels_from_dir(files: &mut Vec<PathBuf>, dir: PathBuf) -> Result<()>
 }
 
 fn resolve_label_source(source: &std::path::Path, label_dir: &std::path::Path) -> PathBuf {
-    if source.is_absolute() {
+    if source.is_absolute() || source.exists() {
         source.to_path_buf()
     } else {
         label_dir.join(source)

--- a/experiments/cw-decoder/src/ditdah_streaming.rs
+++ b/experiments/cw-decoder/src/ditdah_streaming.rs
@@ -642,12 +642,368 @@ fn common_token_prefix(values: &VecDeque<String>) -> String {
     first[..common_len].join(" ")
 }
 
+// =====================================================================
+// LiveCommitCursor — event-driven, sample-indexed transcript commit.
+//
+// Background: V3's rolling-window decoder re-decodes the latest ~3 s of
+// audio every 250 ms. Each cycle's `LiveEnvelopeSnapshot::transcript`
+// is a *full* re-decode of that window, not an incremental delta. Doing
+// string-level stitching across cycles is fragile: re-segmentation at
+// the window boundaries flips the leading character now and then,
+// which defeats overlap detection and re-emits already-committed audio
+// as ghost text (e.g. "TSA USA EE   SA USA EE   ...").
+//
+// This cursor moves deduplication out of text space and into audio-time
+// space. Each `VizFrame` carries `window_start_sample`/`window_end_sample`
+// from `LiveEnvelopeStreamer`, and each `VizEvent` has buffer-relative
+// `start_s`/`end_s`. We convert events to absolute sample indices,
+// commit only events that lie safely behind the unstable trailing edge,
+// and never re-emit text whose audio sits at-or-before
+// `committed_until_sample`. The cursor advances monotonically; lock
+// release clears the pending Morse buffer but preserves committed text.
+// =====================================================================
+
+/// Output of [`LiveCommitCursor::update_from_viz`].
+#[derive(Debug, Clone, Default)]
+pub struct CommitUpdate {
+    /// Append-only committed transcript (entire history so far).
+    pub committed_text: String,
+    /// Provisional decode of events that are inside the safe interior
+    /// but have not yet been flushed (no character/word gap seen). May
+    /// change every cycle; should be displayed in a distinct style.
+    pub provisional_tail: String,
+    /// True when the cursor advanced over a region without producing
+    /// committed text (e.g. SNR suppression, lock loss, long stall).
+    /// Useful for diagnostics; the cursor itself does not emit
+    /// placeholder text into `committed_text`.
+    pub committed_gap: bool,
+    /// First sample of the gap region (only meaningful when
+    /// `committed_gap` is true).
+    pub gap_from_sample: u64,
+    /// One-past-end sample of the gap region (only meaningful when
+    /// `committed_gap` is true).
+    pub gap_to_sample: u64,
+}
+
+#[derive(Debug, Clone)]
+pub struct LiveCommitCursor {
+    committed_until_sample: u64,
+    committed_text: String,
+    pending_morse: String,
+    initialized: bool,
+    /// Hard cap on `committed_text` length to mirror the 12 000-char
+    /// behavior of the legacy `cap_session_transcript`. Trims to ~80 %
+    /// on a whitespace boundary when exceeded.
+    max_chars: usize,
+}
+
+impl Default for LiveCommitCursor {
+    fn default() -> Self {
+        Self::new(12_000)
+    }
+}
+
+/// Trailing safety guard, expressed in seconds. Events whose absolute
+/// end sample exceeds `window_end_sample - trailing_guard_samples` are
+/// considered too close to the rolling-window edge to be stable yet —
+/// next cycle's wider context may flip an OffChar boundary into an
+/// OffWord, or merge a dit+intra+dit into a single dah. Scales with
+/// `dot_seconds` so slow CW (5 WPM ≈ 240 ms dots, ≈ 1.7 s word gaps)
+/// gets a longer guard than fast CW.
+fn trailing_guard_seconds(dot_s: f32, decode_every_s: f32) -> f32 {
+    let dot = dot_s.max(0.001);
+    let by_dot = 8.0 * dot;
+    let by_cadence = 2.0 * decode_every_s;
+    f32_max3(0.50, by_dot, by_cadence)
+}
+
+/// Leading safety guard, expressed in seconds. Events whose absolute
+/// start sample lies inside the first `leading_guard_samples` of the
+/// rolling window may have their leading edge clipped by the window
+/// boundary, shortening an OnDah into an OnDit. Skip them.
+fn leading_guard_seconds(dot_s: f32) -> f32 {
+    let dot = dot_s.max(0.001);
+    f32_max2(0.10, 2.0 * dot)
+}
+
+#[inline]
+fn f32_max2(a: f32, b: f32) -> f32 {
+    if a >= b {
+        a
+    } else {
+        b
+    }
+}
+#[inline]
+fn f32_max3(a: f32, b: f32, c: f32) -> f32 {
+    f32_max2(a, f32_max2(b, c))
+}
+
+/// Tiny tolerance for absolute-sample comparisons. Events derived from
+/// floating-point window-relative seconds can land ±1 sample off when
+/// the same audio region is re-decoded in a later cycle. One frame at
+/// the decoder's native step (5 ms = 240 samples @ 48 kHz) is more
+/// than enough slack to avoid spurious "different" events while still
+/// preventing the cursor from rewinding by any audible amount.
+const EPSILON_SAMPLES: u64 = 32;
+
+impl LiveCommitCursor {
+    pub fn new(max_chars: usize) -> Self {
+        Self {
+            committed_until_sample: 0,
+            committed_text: String::new(),
+            pending_morse: String::new(),
+            initialized: false,
+            max_chars: max_chars.max(256),
+        }
+    }
+
+    pub fn committed_text(&self) -> &str {
+        &self.committed_text
+    }
+
+    pub fn committed_until_sample(&self) -> u64 {
+        self.committed_until_sample
+    }
+
+    pub fn pending_morse(&self) -> &str {
+        &self.pending_morse
+    }
+
+    /// Operator manually requested a fresh start (e.g. PR #366's
+    /// reset-lock control message). Drops everything; next cycle
+    /// initializes from the current safe interior.
+    pub fn reset_all(&mut self) {
+        self.committed_until_sample = 0;
+        self.committed_text.clear();
+        self.pending_morse.clear();
+        self.initialized = false;
+    }
+
+    /// Streamer-internal lock was released (PR #367). Keep committed
+    /// history; drop the in-progress Morse pattern so a stale dit/dah
+    /// fragment doesn't merge with the next character once a fresh
+    /// lock is acquired. Cursor itself stays at its current position.
+    pub fn on_lock_lost(&mut self) {
+        self.pending_morse.clear();
+    }
+
+    /// Drive the cursor from a single `VizFrame`. Idempotent across
+    /// cycles that re-decode the same audio region — re-feeding the
+    /// same frame produces no new committed text and no cursor motion.
+    pub fn update_from_viz(
+        &mut self,
+        viz: &crate::envelope_decoder::VizFrame,
+        decode_every_s: f32,
+    ) -> CommitUpdate {
+        let sr = viz.sample_rate.max(1) as f32;
+        let window_start = viz.window_start_sample;
+        let window_end = viz.window_end_sample;
+        if window_end <= window_start {
+            return self.snapshot_with_provisional();
+        }
+
+        // Gate: only commit when the streamer has locked AND the SNR
+        // gate didn't suppress this cycle. Same rule the legacy
+        // `should_stitch_to_session` enforced; mirrored here so the
+        // cursor is self-contained.
+        if viz.snr_suppressed || viz.locked_wpm.is_none() {
+            // Don't lose the in-progress character: a single gated
+            // cycle may bracket a real word with two clean cycles. We
+            // simply don't advance and don't compute provisional.
+            return self.snapshot_with_provisional();
+        }
+
+        let dot_s = if viz.dot_seconds > 0.0 {
+            viz.dot_seconds
+        } else if viz.wpm > 0.0 {
+            1.2 / viz.wpm
+        } else {
+            0.06
+        };
+        let trailing_guard_samples = (sr * trailing_guard_seconds(dot_s, decode_every_s)) as u64;
+        let leading_guard_samples = (sr * leading_guard_seconds(dot_s)) as u64;
+
+        let safe_start = window_start.saturating_add(leading_guard_samples);
+        let safe_end = window_end.saturating_sub(trailing_guard_samples);
+
+        let mut update = CommitUpdate::default();
+
+        if !self.initialized {
+            self.committed_until_sample = safe_start;
+            self.initialized = true;
+        }
+
+        // If the cursor has fallen behind the current safe interior
+        // (e.g., a long suppression/unlock window), the audio between
+        // committed_until and safe_start is no longer recoverable from
+        // the rolling buffer. Skip it; surface a diagnostic gap.
+        if self.committed_until_sample + EPSILON_SAMPLES < safe_start {
+            update.committed_gap = true;
+            update.gap_from_sample = self.committed_until_sample;
+            update.gap_to_sample = safe_start;
+            self.pending_morse.clear();
+            self.committed_until_sample = safe_start;
+        }
+
+        // Walk the events in time order. Events are buffer-relative
+        // seconds; convert to absolute samples.
+        let cursor_start = self.committed_until_sample;
+        for ev in &viz.events {
+            let start_s = ev.start_s.max(0.0);
+            let end_s = ev.end_s.max(start_s);
+            let ev_start = window_start.saturating_add((start_s * sr) as u64);
+            let ev_end = window_start.saturating_add((end_s * sr) as u64);
+
+            // Already committed.
+            if ev_end <= cursor_start.saturating_add(EPSILON_SAMPLES) {
+                continue;
+            }
+            // Outside the safe interior.
+            if ev_start < safe_start || ev_end > safe_end {
+                continue;
+            }
+            // Strictly past the current cursor (allow tiny epsilon).
+            if ev_start + EPSILON_SAMPLES < self.committed_until_sample {
+                continue;
+            }
+
+            use crate::envelope_decoder::VizEventKind::*;
+            match ev.kind {
+                OnDit => {
+                    self.pending_morse.push('.');
+                }
+                OnDah => {
+                    self.pending_morse.push('-');
+                }
+                OffIntra => {
+                    // intra-character gap: keep building the same
+                    // Morse symbol. Don't advance cursor across the
+                    // gap — the symbol it bridges may still extend
+                    // into the unstable region next cycle.
+                }
+                OffChar => {
+                    self.flush_pending_char();
+                    self.committed_until_sample = ev_end;
+                }
+                OffWord => {
+                    self.flush_pending_char();
+                    self.append_word_space();
+                    self.committed_until_sample = ev_end;
+                }
+            }
+        }
+
+        update.committed_text = self.committed_text.clone();
+        update.provisional_tail = self.compute_provisional_tail(viz);
+        update
+    }
+
+    fn snapshot_with_provisional(&self) -> CommitUpdate {
+        CommitUpdate {
+            committed_text: self.committed_text.clone(),
+            provisional_tail: String::new(),
+            committed_gap: false,
+            gap_from_sample: 0,
+            gap_to_sample: 0,
+        }
+    }
+
+    fn compute_provisional_tail(&self, viz: &crate::envelope_decoder::VizFrame) -> String {
+        // Decode the events that lie strictly past committed_until but
+        // still inside the analyzed window. We deliberately DO NOT use
+        // `snap.transcript` here: it is the rolling re-decode of the
+        // entire window and would reintroduce string-alignment risk.
+        let sr = viz.sample_rate.max(1) as f32;
+        let mut morse = self.pending_morse.clone();
+        let mut text = String::new();
+        for ev in &viz.events {
+            let start_s = ev.start_s.max(0.0);
+            let end_s = ev.end_s.max(start_s);
+            let ev_start = viz
+                .window_start_sample
+                .saturating_add((start_s * sr) as u64);
+            let ev_end = viz.window_start_sample.saturating_add((end_s * sr) as u64);
+            if ev_end <= self.committed_until_sample.saturating_add(EPSILON_SAMPLES) {
+                continue;
+            }
+            use crate::envelope_decoder::VizEventKind::*;
+            match ev.kind {
+                OnDit => morse.push('.'),
+                OnDah => morse.push('-'),
+                OffIntra => {}
+                OffChar => {
+                    if !morse.is_empty() {
+                        if let Some(c) = crate::envelope_decoder::morse_to_char(&morse) {
+                            text.push(c);
+                        }
+                        morse.clear();
+                    }
+                }
+                OffWord => {
+                    if !morse.is_empty() {
+                        if let Some(c) = crate::envelope_decoder::morse_to_char(&morse) {
+                            text.push(c);
+                        }
+                        morse.clear();
+                    }
+                    if !text.ends_with(' ') {
+                        text.push(' ');
+                    }
+                }
+            }
+            // Stop once we run past `safe_end` would help, but safe_end
+            // is local to update_from_viz; for the tail we want to show
+            // everything *not yet committed*, including the slightly
+            // unstable trailing region.
+            let _ = ev_start;
+        }
+        text
+    }
+
+    fn flush_pending_char(&mut self) {
+        if self.pending_morse.is_empty() {
+            return;
+        }
+        if let Some(c) = crate::envelope_decoder::morse_to_char(&self.pending_morse) {
+            self.committed_text.push(c);
+            self.cap_committed();
+        }
+        self.pending_morse.clear();
+    }
+
+    fn append_word_space(&mut self) {
+        if !self.committed_text.ends_with(' ') {
+            self.committed_text.push(' ');
+            self.cap_committed();
+        }
+    }
+
+    fn cap_committed(&mut self) {
+        if self.committed_text.chars().count() <= self.max_chars {
+            return;
+        }
+        let target = (self.max_chars * 4) / 5;
+        let total = self.committed_text.chars().count();
+        let drop_chars = total.saturating_sub(target);
+        let mut byte_cut = 0usize;
+        for (i, (b, _)) in self.committed_text.char_indices().enumerate() {
+            if i >= drop_chars {
+                byte_cut = b;
+                break;
+            }
+        }
+        // Snap to whitespace boundary so we don't shear a token.
+        if let Some(rel) = self.committed_text[byte_cut..].find(char::is_whitespace) {
+            byte_cut += rel + 1;
+        }
+        self.committed_text.replace_range(..byte_cut, "");
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{
-        append_snapshot_text, normalize_snapshot_text, run_causal_baseline_trace,
-        CausalBaselineConfig, PrefixStabilizer,
-    };
+    use super::*;
 
     #[test]
     fn normalize_snapshot_text_collapses_whitespace() {
@@ -863,5 +1219,254 @@ mod tests {
                 .map(|snapshot| snapshot.transcript.as_str()),
             Some(trace.transcript.as_str())
         );
+    }
+
+    // ----- LiveCommitCursor (Approach A+) tests -----
+
+    use crate::envelope_decoder::{VizEvent, VizEventKind, VizFrame};
+
+    /// Build a minimal viz frame with a list of events. `events_secs` is
+    /// `(kind, start_s, end_s)` triples relative to `window_start_sample`.
+    fn cursor_test_viz(
+        sr: u32,
+        window_start: u64,
+        window_end: u64,
+        dot_seconds: f32,
+        locked: bool,
+        snr_suppressed: bool,
+        events_secs: &[(VizEventKind, f32, f32)],
+    ) -> VizFrame {
+        let events = events_secs
+            .iter()
+            .map(|(k, s, e)| VizEvent {
+                start_s: *s,
+                end_s: *e,
+                duration_s: (e - s).max(0.0),
+                kind: *k,
+            })
+            .collect();
+        VizFrame {
+            sample_rate: sr,
+            frame_step_s: 0.005,
+            buffer_seconds: (window_end - window_start) as f32 / sr as f32,
+            pitch_hz: 600.0,
+            envelope: Vec::new(),
+            envelope_max: 1.0,
+            noise_floor: 0.01,
+            signal_floor: 0.5,
+            snr_db: 30.0,
+            snr_suppressed,
+            hyst_high: 0.4,
+            hyst_low: 0.2,
+            events,
+            on_durations: Vec::new(),
+            dot_seconds,
+            wpm: if dot_seconds > 0.0 {
+                1.2 / dot_seconds
+            } else {
+                20.0
+            },
+            centroid_dot: dot_seconds,
+            centroid_dah: dot_seconds * 3.0,
+            locked_wpm: if locked { Some(20.0) } else { None },
+            window_start_sample: window_start,
+            window_end_sample: window_end,
+        }
+    }
+
+    /// Helper: pattern for "K" = -.- (dah dit dah).
+    /// Returns a sequence of (kind, start_s, end_s) inside `[base, end]`.
+    /// Caller picks `base` and timing in dot units.
+    fn morse_k_events(base: f32, dot: f32) -> Vec<(VizEventKind, f32, f32)> {
+        // dah, intra, dit, intra, dah
+        let mut t = base;
+        let mut out = Vec::new();
+        out.push((VizEventKind::OnDah, t, t + 3.0 * dot));
+        t += 3.0 * dot;
+        out.push((VizEventKind::OffIntra, t, t + dot));
+        t += dot;
+        out.push((VizEventKind::OnDit, t, t + dot));
+        t += dot;
+        out.push((VizEventKind::OffIntra, t, t + dot));
+        t += dot;
+        out.push((VizEventKind::OnDah, t, t + 3.0 * dot));
+        out
+    }
+
+    #[test]
+    fn cursor_does_not_repeat_same_audio_region_across_overlapping_windows() {
+        // Two cycles re-decode the SAME absolute sample range; the second
+        // call must NOT re-commit the K.
+        let sr = 48_000u32;
+        let dot = 0.06; // 20 WPM
+        let window_start = 0u64;
+        // Window is 10 seconds wide so the K (~12 dots ≈ 0.72 s) sits well
+        // inside the safe interior.
+        let window_end = window_start + sr as u64 * 10;
+
+        let mut events = morse_k_events(2.0, dot);
+        // Terminating OffChar so the K commits.
+        events.push((VizEventKind::OffChar, 2.6, 2.6 + 3.0 * dot));
+
+        let viz1 = cursor_test_viz(sr, window_start, window_end, dot, true, false, &events);
+        let viz2 = cursor_test_viz(sr, window_start, window_end, dot, true, false, &events);
+
+        let mut cursor = LiveCommitCursor::default();
+        let u1 = cursor.update_from_viz(&viz1, 0.5);
+        assert_eq!(u1.committed_text, "K");
+
+        let u2 = cursor.update_from_viz(&viz2, 0.5);
+        assert_eq!(
+            u2.committed_text, "K",
+            "re-decoding identical events must not duplicate the character"
+        );
+    }
+
+    #[test]
+    fn cursor_handles_legitimate_repetition_in_distinct_audio_regions() {
+        // Three Ks at different absolute times must commit as "KKK".
+        let sr = 48_000u32;
+        let dot = 0.06;
+        let window_start = 0u64;
+        let window_end = sr as u64 * 10;
+
+        let mut events = Vec::new();
+        for base in [2.0_f32, 4.0, 6.0] {
+            events.extend(morse_k_events(base, dot));
+            events.push((VizEventKind::OffChar, base + 1.0, base + 1.0 + 3.0 * dot));
+        }
+        let viz = cursor_test_viz(sr, window_start, window_end, dot, true, false, &events);
+
+        let mut cursor = LiveCommitCursor::default();
+        let u = cursor.update_from_viz(&viz, 0.5);
+        assert_eq!(u.committed_text, "KKK");
+    }
+
+    #[test]
+    fn cursor_skips_unlocked_cycles_without_advancing() {
+        let sr = 48_000u32;
+        let dot = 0.06;
+        let mut events = morse_k_events(2.0, dot);
+        events.push((VizEventKind::OffChar, 2.6, 2.6 + 3.0 * dot));
+
+        // Unlocked: should produce no committed text and not advance cursor.
+        let viz_unlocked = cursor_test_viz(sr, 0, sr as u64 * 10, dot, false, false, &events);
+        let mut cursor = LiveCommitCursor::default();
+        let u = cursor.update_from_viz(&viz_unlocked, 0.5);
+        assert_eq!(u.committed_text, "");
+        assert_eq!(u.provisional_tail, "");
+
+        // Now a locked cycle covering the same audio commits the K.
+        let viz_locked = cursor_test_viz(sr, 0, sr as u64 * 10, dot, true, false, &events);
+        let u2 = cursor.update_from_viz(&viz_locked, 0.5);
+        assert_eq!(u2.committed_text, "K");
+    }
+
+    #[test]
+    fn cursor_skips_snr_suppressed_cycles() {
+        let sr = 48_000u32;
+        let dot = 0.06;
+        let mut events = morse_k_events(2.0, dot);
+        events.push((VizEventKind::OffChar, 2.6, 2.6 + 3.0 * dot));
+
+        let viz = cursor_test_viz(sr, 0, sr as u64 * 10, dot, true, true, &events);
+        let mut cursor = LiveCommitCursor::default();
+        let u = cursor.update_from_viz(&viz, 0.5);
+        assert_eq!(u.committed_text, "");
+    }
+
+    #[test]
+    fn cursor_does_not_commit_events_in_trailing_guard() {
+        // Place the K so its OffChar lands inside the trailing guard
+        // (~8*dot = 0.48s). It should be deferred to provisional, not
+        // committed.
+        let sr = 48_000u32;
+        let dot = 0.06;
+        let window_end_s: f32 = 5.0;
+        let base = window_end_s - 0.6; // K + OffChar will straddle the guard
+        let mut events = morse_k_events(base, dot);
+        events.push((VizEventKind::OffChar, base + 1.0, base + 1.0 + 3.0 * dot));
+
+        let viz = cursor_test_viz(
+            sr,
+            0,
+            (sr as f32 * window_end_s) as u64,
+            dot,
+            true,
+            false,
+            &events,
+        );
+        let mut cursor = LiveCommitCursor::default();
+        let u = cursor.update_from_viz(&viz, 0.5);
+        // Either provisional shows it, or nothing is committed yet.
+        assert_eq!(
+            u.committed_text, "",
+            "events too close to window end must not commit yet"
+        );
+    }
+
+    #[test]
+    fn cursor_advances_past_word_boundary_with_space() {
+        let sr = 48_000u32;
+        let dot = 0.06;
+        let mut events = morse_k_events(2.0, dot);
+        // OffWord between K and next K
+        events.push((VizEventKind::OffWord, 2.6, 2.6 + 7.0 * dot));
+        events.extend(morse_k_events(3.5, dot));
+        events.push((VizEventKind::OffChar, 4.1, 4.1 + 3.0 * dot));
+
+        let viz = cursor_test_viz(sr, 0, sr as u64 * 10, dot, true, false, &events);
+        let mut cursor = LiveCommitCursor::default();
+        let u = cursor.update_from_viz(&viz, 0.5);
+        assert_eq!(u.committed_text, "K K");
+    }
+
+    #[test]
+    fn cursor_reset_all_clears_state() {
+        let sr = 48_000u32;
+        let dot = 0.06;
+        let mut events = morse_k_events(2.0, dot);
+        events.push((VizEventKind::OffChar, 2.6, 2.6 + 3.0 * dot));
+        let viz = cursor_test_viz(sr, 0, sr as u64 * 10, dot, true, false, &events);
+
+        let mut cursor = LiveCommitCursor::default();
+        cursor.update_from_viz(&viz, 0.5);
+        assert_eq!(cursor.committed_text(), "K");
+        cursor.reset_all();
+        assert_eq!(cursor.committed_text(), "");
+    }
+
+    #[test]
+    fn cursor_reports_committed_gap_after_long_suppression() {
+        let sr = 48_000u32;
+        let dot = 0.06;
+        // First cycle locked: commit K starting at t=1.
+        let mut ev1 = morse_k_events(1.0, dot);
+        ev1.push((VizEventKind::OffChar, 1.6, 1.6 + 3.0 * dot));
+        let viz1 = cursor_test_viz(sr, 0, sr as u64 * 5, dot, true, false, &ev1);
+
+        let mut cursor = LiveCommitCursor::default();
+        let u1 = cursor.update_from_viz(&viz1, 0.5);
+        assert_eq!(u1.committed_text, "K");
+
+        // Second cycle: window has slid 100 s forward, so committed_until
+        // is far behind safe_start. Cursor should report a gap and jump.
+        let window_start = sr as u64 * 100;
+        let mut ev2 = morse_k_events(2.0, dot);
+        ev2.push((VizEventKind::OffChar, 2.6, 2.6 + 3.0 * dot));
+        let viz2 = cursor_test_viz(
+            sr,
+            window_start,
+            window_start + sr as u64 * 10,
+            dot,
+            true,
+            false,
+            &ev2,
+        );
+        let u2 = cursor.update_from_viz(&viz2, 0.5);
+        assert!(u2.committed_gap, "expected committed_gap after long jump");
+        assert!(u2.gap_to_sample > u2.gap_from_sample);
+        // K should still commit after the gap.
+        assert_eq!(u2.committed_text, "KK");
     }
 }

--- a/experiments/cw-decoder/src/envelope_decoder.rs
+++ b/experiments/cw-decoder/src/envelope_decoder.rs
@@ -479,6 +479,12 @@ pub struct LiveEnvelopeStreamer {
     min_dyn_range_ratio: f32,
     preprocess: PreprocessConfig,
     analysis_window_seconds: Option<f32>,
+    /// Total samples ever pushed into [`push_samples`], counted across
+    /// the entire streaming session (NOT capped to the rolling
+    /// `buffer.len()`). Drives the absolute sample anchors on
+    /// [`VizFrame`] so downstream commit cursors can identify the same
+    /// audio region across overlapping rolling-window re-decodes.
+    samples_fed_total: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -541,6 +547,22 @@ pub struct VizFrame {
     pub centroid_dot: f32,
     pub centroid_dah: f32,
     pub locked_wpm: Option<f32>,
+    /// Absolute sample index of the FIRST sample in the analysis slice
+    /// that produced this frame, counted from the start of the streaming
+    /// session (i.e., total samples ever fed into the streamer minus
+    /// the slice length). Stable across re-decodes of the same audio
+    /// region: an event whose `start_s` is `t` lives at absolute sample
+    /// `window_start_sample + round(t * sample_rate)`.
+    ///
+    /// Both `window_start_sample` and `window_end_sample` are populated
+    /// by `LiveEnvelopeStreamer`; standalone callers of
+    /// `decode_envelope_with_viz` get `0`/`buffer_len` because they do
+    /// not maintain a persistent session.
+    pub window_start_sample: u64,
+    /// Absolute sample index of the ONE-PAST-END sample of the analysis
+    /// slice. `window_end_sample - window_start_sample` equals the
+    /// number of samples in the analysed region.
+    pub window_end_sample: u64,
 }
 
 pub const MAX_VIZ_ENVELOPE_SAMPLES: usize = 1500;
@@ -577,7 +599,15 @@ impl LiveEnvelopeStreamer {
             // the dynamic-range gate. Visualizer envelope still spans the
             // full buffer.
             analysis_window_seconds: Some(3.0),
+            samples_fed_total: 0,
         }
+    }
+
+    /// Absolute number of samples ever pushed into this streamer since
+    /// construction. Monotonically increasing; not affected by the
+    /// internal rolling-buffer cap.
+    pub fn samples_fed_total(&self) -> u64 {
+        self.samples_fed_total
     }
 
     /// Override the rolling analysis-window length used for gate +
@@ -663,6 +693,7 @@ impl LiveEnvelopeStreamer {
 
     fn push_samples(&mut self, samples: &[f32]) {
         self.buffer.extend_from_slice(samples);
+        self.samples_fed_total = self.samples_fed_total.saturating_add(samples.len() as u64);
         let max_samples = (self.sample_rate as usize * MAX_LIVE_ENVELOPE_BUFFER_SECONDS)
             .max(self.decode_every_samples * 2);
         if self.buffer.len() > max_samples {
@@ -684,6 +715,16 @@ impl LiveEnvelopeStreamer {
             let (text, frame) = decode_envelope_with_viz(&self.buffer, self.sample_rate, &cfg);
             let mut frame = frame;
             frame.locked_wpm = self.pinned_wpm.or(self.locked_wpm);
+            // Anchor the rolling buffer in absolute session time so a
+            // downstream commit cursor can identify the same audio
+            // region across overlapping re-decodes. Events on the frame
+            // already carry buffer-relative `start_s`/`end_s`; absolute
+            // sample = `window_start_sample + round(start_s * sr)`.
+            let buffer_start_abs = self
+                .samples_fed_total
+                .saturating_sub(self.buffer.len() as u64);
+            frame.window_start_sample = buffer_start_abs;
+            frame.window_end_sample = self.samples_fed_total;
             let elem_count = frame.on_durations.len();
             let wpm = frame.wpm;
             (text, wpm, elem_count, Some(frame))
@@ -783,6 +824,8 @@ pub fn decode_envelope_with_viz(
         centroid_dot: 0.0,
         centroid_dah: 0.0,
         locked_wpm: None,
+        window_start_sample: 0,
+        window_end_sample: samples.len() as u64,
     };
 
     if samples.is_empty() {
@@ -946,6 +989,8 @@ pub fn decode_envelope_with_viz(
         centroid_dot,
         centroid_dah,
         locked_wpm: None,
+        window_start_sample: 0,
+        window_end_sample: samples.len() as u64,
     };
     (text, frame)
 }
@@ -1225,7 +1270,7 @@ fn median_lower_half(values: &[f32]) -> f32 {
     sorted[cutoff / 2]
 }
 
-fn morse_to_char(s: &str) -> Option<char> {
+pub(crate) fn morse_to_char(s: &str) -> Option<char> {
     match s {
         ".-" => Some('A'),
         "-..." => Some('B'),

--- a/experiments/cw-decoder/src/envelope_decoder.rs
+++ b/experiments/cw-decoder/src/envelope_decoder.rs
@@ -405,7 +405,7 @@ fn estimate_dot_kmeans(durations: &[f32]) -> f32 {
     if durations.len() < 4 {
         return median_lower_half(durations);
     }
-    let mut sorted: Vec<f32> = durations.iter().copied().collect();
+    let mut sorted: Vec<f32> = durations.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let lo_seed = sorted[sorted.len() / 4];
     let hi_seed = sorted[(3 * sorted.len()) / 4];
@@ -1080,7 +1080,7 @@ fn downsample_envelope(env: &[f32]) -> Vec<f32> {
     if env.len() <= MAX_VIZ_ENVELOPE_SAMPLES {
         return env.to_vec();
     }
-    let bucket = (env.len() + MAX_VIZ_ENVELOPE_SAMPLES - 1) / MAX_VIZ_ENVELOPE_SAMPLES;
+    let bucket = env.len().div_ceil(MAX_VIZ_ENVELOPE_SAMPLES);
     let mut out = Vec::with_capacity(env.len() / bucket + 1);
     let mut i = 0;
     while i < env.len() {
@@ -1104,7 +1104,7 @@ fn kmeans_centroids(durations: &[f32]) -> (f32, f32) {
         let v = durations.first().copied().unwrap_or(0.0);
         return (v, v);
     }
-    let mut sorted: Vec<f32> = durations.iter().copied().collect();
+    let mut sorted: Vec<f32> = durations.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let mut c_lo = sorted[sorted.len() / 4];
     let mut c_hi = sorted[(3 * sorted.len()) / 4];
@@ -1239,7 +1239,7 @@ fn decode_events(ons: &[f32], offs: &[f32], dot_s: f32) -> String {
 }
 
 fn percentile_pair(values: &[f32], p_lo: f32, p_hi: f32) -> (f32, f32) {
-    let mut sorted: Vec<f32> = values.iter().copied().collect();
+    let mut sorted: Vec<f32> = values.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     (
         region_stream::percentile_sorted(&sorted, p_lo),
@@ -1255,7 +1255,7 @@ pub(crate) fn robust_peak(values: &[f32], percentile: f32) -> f32 {
     if values.is_empty() {
         return 0.0;
     }
-    let mut sorted: Vec<f32> = values.iter().copied().collect();
+    let mut sorted: Vec<f32> = values.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     region_stream::percentile_sorted(&sorted, percentile)
 }
@@ -1264,7 +1264,7 @@ fn median_lower_half(values: &[f32]) -> f32 {
     if values.is_empty() {
         return 0.0;
     }
-    let mut sorted: Vec<f32> = values.iter().copied().collect();
+    let mut sorted: Vec<f32> = values.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
     let cutoff = (sorted.len() / 2).max(1);
     sorted[cutoff / 2]
@@ -1822,7 +1822,7 @@ mod tests {
                              // PARIS = .--. .- .-. .. ...
         let s = synth_morse(rate, dot, 700.0, ".--. .- .-. .. ...");
         let txt = decode_envelope(&s, rate, &EnvelopeConfig::default());
-        assert_eq!(txt, "PARIS", "got {:?}", txt);
+        assert_eq!(txt, "PARIS", "got {txt:?}");
     }
 
     #[test]
@@ -1842,7 +1842,7 @@ mod tests {
                 analysis_window_seconds: None,
             },
         );
-        assert_eq!(txt, "K", "got {:?}", txt);
+        assert_eq!(txt, "K", "got {txt:?}");
     }
 
     #[test]
@@ -1962,13 +1962,8 @@ mod tests {
 
     #[test]
     fn kmeans_dot_estimate_separates_dits_and_dahs() {
-        let mut durs = Vec::new();
-        for _ in 0..6 {
-            durs.push(0.060);
-        }
-        for _ in 0..6 {
-            durs.push(0.180);
-        }
+        let mut durs = vec![0.060; 6];
+        durs.extend([0.180; 6]);
         let dot = estimate_dot_kmeans(&durs);
         assert!((dot - 0.060).abs() < 0.005, "expected ~0.060, got {dot}");
     }
@@ -2055,8 +2050,7 @@ mod tests {
         let (text, viz) = decode_envelope_with_viz(&s, rate, &cfg);
         assert_eq!(
             text, "",
-            "noise-only signal must not emit text (got {:?})",
-            text
+            "noise-only signal must not emit text (got {text:?})"
         );
         assert!(
             viz.snr_suppressed,
@@ -2141,8 +2135,7 @@ mod tests {
         let snr = snr_db(0.5, 1.0);
         assert!(
             snr >= cfg.min_snr_db && snr < DYN_RANGE_BYPASS_SNR_DB,
-            "test setup: snr {} should be in marginal band",
-            snr
+            "test setup: snr {snr} should be in marginal band"
         );
         assert!(
             !passes_quality_gate(&cfg, 0.5, 1.0, 10.0),
@@ -2218,8 +2211,7 @@ mod tests {
         );
         assert!(
             windowed_text.contains('K'),
-            "expected decoded text to contain 'K', got {:?}",
-            windowed_text
+            "expected decoded text to contain 'K', got {windowed_text:?}"
         );
     }
 

--- a/experiments/cw-decoder/src/lib.rs
+++ b/experiments/cw-decoder/src/lib.rs
@@ -2,6 +2,7 @@
 //! sibling binaries (CLI, eval harness, GUI bridge). Keeps the crate
 //! single-target while letting `src/bin/*.rs` reuse the heavy modules.
 
+pub mod append_decode;
 pub mod audio;
 pub mod bench_latency;
 pub mod decoder;

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -648,6 +648,11 @@ enum Cmd {
         /// inside the noise itself. Issue #322.
         #[arg(long, default_value_t = false)]
         cfar_keying: bool,
+        /// Use the append-only V3 event-stream foundation instead of the
+        /// legacy streaming decoder. For --from-file this reports transcript
+        /// quality against truth; latency-specific fields are left empty.
+        #[arg(long, default_value_t = false)]
+        foundation: bool,
         /// Emit one NDJSON record per scenario in addition to the table
         /// (handy for collecting comparison runs into a file).
         #[arg(long, default_value_t = false)]
@@ -692,7 +697,25 @@ enum Cmd {
     },
 }
 
+const CLI_THREAD_STACK_BYTES: usize = 16 * 1024 * 1024;
+
 fn main() -> Result<()> {
+    std::thread::Builder::new()
+        .name("cw-decoder-cli".to_string())
+        .stack_size(CLI_THREAD_STACK_BYTES)
+        .spawn(run_cli)?
+        .join()
+        .map_err(|panic| {
+            let message = panic
+                .downcast_ref::<&str>()
+                .copied()
+                .or_else(|| panic.downcast_ref::<String>().map(String::as_str))
+                .unwrap_or("cw-decoder CLI thread panicked");
+            anyhow::anyhow!(message.to_string())
+        })?
+}
+
+fn run_cli() -> Result<()> {
     let cli = Cli::parse();
 
     // Always install the log capture so we can read ditdah's WPM/pitch lines.
@@ -1070,6 +1093,7 @@ fn main() -> Result<()> {
             min_gap_dot_fraction,
             min_pulse_dot_fraction,
             cfar_keying,
+            foundation,
             json,
         } => run_bench_latency(
             from_file.as_deref(),
@@ -1087,6 +1111,7 @@ fn main() -> Result<()> {
             min_gap_dot_fraction,
             min_pulse_dot_fraction,
             cfar_keying,
+            foundation,
             json,
         ),
         Cmd::GenRoughFist {
@@ -1167,6 +1192,7 @@ fn run_bench_latency(
     min_gap_dot_fraction: f32,
     min_pulse_dot_fraction: f32,
     cfar_keying: bool,
+    foundation: bool,
     json: bool,
 ) -> Result<()> {
     let mut cfg = streaming::DecoderConfig::defaults();
@@ -1232,7 +1258,29 @@ fn run_bench_latency(
 
     let mut results = Vec::with_capacity(scenarios.len());
     for scen in &scenarios {
-        let r = bench_latency::run_scenario(scen, cfg, chunk_ms, stable_n, label)?;
+        let r = if foundation {
+            let transcript = cw_decoder_poc::append_decode::decode_samples_append(
+                &scen.audio.samples,
+                scen.audio.sample_rate,
+                None,
+                None,
+                cw_decoder_poc::envelope_decoder::DEFAULT_MIN_SNR_DB,
+            )
+            .decoded_text
+            .trim()
+            .to_string();
+            bench_latency::BenchResult {
+                scenario: scen.name.clone(),
+                config_label: label.to_string(),
+                cw_onset_ms: scen.cw_onset_ms,
+                truth: scen.truth.clone(),
+                transcript,
+                stable_n,
+                ..Default::default()
+            }
+        } else {
+            bench_latency::run_scenario(scen, cfg, chunk_ms, stable_n, label)?
+        };
         if json {
             // Compact NDJSON record for off-line comparison/aggregation.
             let rec = serde_json::json!({
@@ -3752,6 +3800,7 @@ fn run_stream_live_v3(
     let decode_every_s = decode_every_ms as f32 / 1000.0;
     let mut commit_cursor =
         ditdah_streaming::LiveCommitCursor::new(MAX_V3_SESSION_TRANSCRIPT_CHARS);
+    let mut append_decoder = cw_decoder_poc::append_decode::AppendEventDecoder::new();
     let mut diag = DiagWriter::from_env();
 
     loop {
@@ -3770,6 +3819,7 @@ fn run_stream_live_v3(
                     multi_streamer = new_multi();
                     last_drain_at = capture.buffer.lock().written;
                     commit_cursor.reset_all();
+                    append_decoder = cw_decoder_poc::append_decode::AppendEventDecoder::new();
                     if let Some(em) = emitter.as_mut() {
                         em.emit(
                             started.elapsed().as_secs_f32(),
@@ -3820,6 +3870,11 @@ fn run_stream_live_v3(
         } else {
             ditdah_streaming::CommitUpdate::default()
         };
+        let append = if let Some(viz) = snap.viz.as_ref() {
+            append_decoder.ingest_viz(viz)
+        } else {
+            cw_decoder_poc::append_decode::AppendDecodeUpdate::default()
+        };
         let session_transcript: String = format!(
             "{}{}{}",
             commit.committed_text,
@@ -3851,11 +3906,13 @@ fn run_stream_live_v3(
                 t,
                 serde_json::json!({
                     "type": "transcript",
-                    "text": snap.transcript,
+                    "text": append.decoded_text,
                     "appended": appended_session,
-                    "transcript": session_transcript.clone(),
+                    "transcript": append.decoded_text,
                     "committed": commit.committed_text,
                     "provisional": commit.provisional_tail,
+                    "cursor_transcript": session_transcript.clone(),
+                    "raw_morse": append.raw_stream,
                     "window_text": snap.transcript,
                     "wpm": snap.wpm,
                 }),
@@ -4058,6 +4115,7 @@ fn run_stream_live_v3_file(
     let decode_every_s = decode_every_ms as f32 / 1000.0;
     let mut commit_cursor =
         ditdah_streaming::LiveCommitCursor::new(MAX_V3_SESSION_TRANSCRIPT_CHARS);
+    let mut append_decoder = cw_decoder_poc::append_decode::AppendEventDecoder::new();
     let mut diag = DiagWriter::from_env();
 
     while cursor < total_samples {
@@ -4096,6 +4154,11 @@ fn run_stream_live_v3_file(
         } else {
             ditdah_streaming::CommitUpdate::default()
         };
+        let append = if let Some(viz) = snap.viz.as_ref() {
+            append_decoder.ingest_viz(viz)
+        } else {
+            cw_decoder_poc::append_decode::AppendDecodeUpdate::default()
+        };
         let session_transcript: String = format!(
             "{}{}{}",
             commit.committed_text,
@@ -4127,11 +4190,13 @@ fn run_stream_live_v3_file(
                 t,
                 serde_json::json!({
                     "type": "transcript",
-                    "text": snap.transcript,
+                    "text": append.decoded_text,
                     "appended": appended_session,
-                    "transcript": session_transcript.clone(),
+                    "transcript": append.decoded_text,
                     "committed": commit.committed_text,
                     "provisional": commit.provisional_tail,
+                    "cursor_transcript": session_transcript.clone(),
+                    "raw_morse": append.raw_stream,
                     "window_text": snap.transcript,
                     "wpm": snap.wpm,
                 }),

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -3739,7 +3739,9 @@ fn run_stream_live_v3(
     let mut last_drain_at: u64 = 0;
     let mut last_decode_at = Instant::now();
     let decode_period = Duration::from_millis(decode_every_ms);
-    let mut session_transcript: String = String::new();
+    let decode_every_s = decode_every_ms as f32 / 1000.0;
+    let mut commit_cursor =
+        ditdah_streaming::LiveCommitCursor::new(MAX_V3_SESSION_TRANSCRIPT_CHARS);
     let mut diag = DiagWriter::from_env();
 
     loop {
@@ -3757,7 +3759,7 @@ fn run_stream_live_v3(
                     streamer = new_streamer();
                     multi_streamer = new_multi();
                     last_drain_at = capture.buffer.lock().written;
-                    session_transcript.clear();
+                    commit_cursor.reset_all();
                     if let Some(em) = emitter.as_mut() {
                         em.emit(
                             started.elapsed().as_secs_f32(),
@@ -3798,19 +3800,31 @@ fn run_stream_live_v3(
         // Force a viz-producing decode now.
         let snap = streamer.flush_with_viz();
         let t = started.elapsed().as_secs_f32();
-        // Gate session-transcript stitching on the streamer's lock state
-        // so ACQUIRING-mode garbage and SNR-suppressed cycles do not
-        // pollute the persistent operator-visible transcript. The
-        // per-cycle `text` field still carries the raw snapshot for
-        // anyone who wants to see what the decoder was emitting before
-        // it locked.
-        let stitched = should_stitch_to_session(&snap);
-        let appended_session = if stitched {
-            ditdah_streaming::append_snapshot_text(&mut session_transcript, &snap.transcript)
+        // Approach A+: event-driven commit cursor (sample-indexed,
+        // idempotent across re-decodes) replaces the old
+        // string-stitching path that produced ghost-repeats like
+        // "TSA USA EE   SA USA EE   ..." when the rolling window's
+        // first character drifted between cycles.
+        let commit = if let Some(viz) = snap.viz.as_ref() {
+            commit_cursor.update_from_viz(viz, decode_every_s)
         } else {
-            String::new()
+            ditdah_streaming::CommitUpdate::default()
         };
-        cap_session_transcript(&mut session_transcript, MAX_V3_SESSION_TRANSCRIPT_CHARS);
+        let session_transcript: String = format!(
+            "{}{}{}",
+            commit.committed_text,
+            if !commit.committed_text.is_empty()
+                && !commit.provisional_tail.is_empty()
+                && !commit.committed_text.ends_with(' ')
+            {
+                " "
+            } else {
+                ""
+            },
+            commit.provisional_tail
+        );
+        let stitched = !commit.committed_text.is_empty() || !commit.provisional_tail.is_empty();
+        let appended_session = String::new();
         if let Some(d) = diag.as_mut() {
             d.record(
                 t,
@@ -3830,6 +3844,9 @@ fn run_stream_live_v3(
                     "text": snap.transcript,
                     "appended": appended_session,
                     "transcript": session_transcript.clone(),
+                    "committed": commit.committed_text,
+                    "provisional": commit.provisional_tail,
+                    "window_text": snap.transcript,
                     "wpm": snap.wpm,
                 }),
             );
@@ -3928,14 +3945,15 @@ fn run_stream_live_v3(
             started.elapsed().as_secs_f32(),
             serde_json::json!({
                 "type": "end",
-                "transcript": session_transcript.clone(),
+                "transcript": commit_cursor.committed_text(),
+                "committed": commit_cursor.committed_text(),
                 "recording": recording_saved.or(recording_path),
             }),
         );
     } else {
         println!();
         println!("Final transcript (v3):");
-        println!("{}", session_transcript);
+        println!("{}", commit_cursor.committed_text());
     }
     Ok(())
 }
@@ -4009,7 +4027,9 @@ fn run_stream_live_v3_file(
     let chunk_period = Duration::from_millis(50);
     let chunk_samples = ((sr as u64 * 50) / 1000) as usize;
     let mut cursor = 0usize;
-    let mut session_transcript: String = String::new();
+    let decode_every_s = decode_every_ms as f32 / 1000.0;
+    let mut commit_cursor =
+        ditdah_streaming::LiveCommitCursor::new(MAX_V3_SESSION_TRANSCRIPT_CHARS);
     let mut diag = DiagWriter::from_env();
 
     while cursor < total_samples {
@@ -4033,16 +4053,32 @@ fn run_stream_live_v3_file(
 
         let snap = streamer.flush_with_viz();
         let t = started.elapsed().as_secs_f32();
-        // Same lock-state gate as the live capture path: only stitch
-        // into the session transcript once the decoder has locked and
-        // the SNR gate is not suppressing.
-        let stitched = should_stitch_to_session(&snap);
-        let appended_session = if stitched {
-            ditdah_streaming::append_snapshot_text(&mut session_transcript, &snap.transcript)
+        // Approach A+: drive the event-driven commit cursor instead of
+        // string-stitching. The cursor is sample-indexed and idempotent
+        // across re-decodes of the same audio region, so the
+        // "TSA USA EE   SA USA EE   ..." ghost-repeat pattern that the
+        // old `append_snapshot_text` produced is structurally
+        // impossible.
+        let commit = if let Some(viz) = snap.viz.as_ref() {
+            commit_cursor.update_from_viz(viz, decode_every_s)
         } else {
-            String::new()
+            ditdah_streaming::CommitUpdate::default()
         };
-        cap_session_transcript(&mut session_transcript, MAX_V3_SESSION_TRANSCRIPT_CHARS);
+        let session_transcript: String = format!(
+            "{}{}{}",
+            commit.committed_text,
+            if !commit.committed_text.is_empty()
+                && !commit.provisional_tail.is_empty()
+                && !commit.committed_text.ends_with(' ')
+            {
+                " "
+            } else {
+                ""
+            },
+            commit.provisional_tail
+        );
+        let stitched = !commit.committed_text.is_empty() || !commit.provisional_tail.is_empty();
+        let appended_session = String::new();
         if let Some(d) = diag.as_mut() {
             d.record(
                 t,
@@ -4062,6 +4098,9 @@ fn run_stream_live_v3_file(
                     "text": snap.transcript,
                     "appended": appended_session,
                     "transcript": session_transcript.clone(),
+                    "committed": commit.committed_text,
+                    "provisional": commit.provisional_tail,
+                    "window_text": snap.transcript,
                     "wpm": snap.wpm,
                 }),
             );
@@ -4154,14 +4193,15 @@ fn run_stream_live_v3_file(
             started.elapsed().as_secs_f32(),
             serde_json::json!({
                 "type": "end",
-                "transcript": session_transcript.clone(),
+                "transcript": commit_cursor.committed_text(),
+                "committed": commit_cursor.committed_text(),
                 "recording": serde_json::Value::Null,
             }),
         );
     } else {
         println!();
         println!("Final transcript (v3 file):");
-        println!("{}", session_transcript);
+        println!("{}", commit_cursor.committed_text());
     }
     Ok(())
 }
@@ -4180,6 +4220,7 @@ fn run_stream_live_v3_file(
 /// "operator sees what the decoder is making" principle from PR #362
 /// still applies to *which characters* end up in the session. We are
 /// only filtering *which cycles* are allowed to contribute.
+#[allow(dead_code)] // Retained for legacy tests; V3 now uses LiveCommitCursor.
 fn should_stitch_to_session(snap: &cw_decoder_poc::envelope_decoder::LiveEnvelopeSnapshot) -> bool {
     let Some(viz) = snap.viz.as_ref() else {
         return false;
@@ -4295,6 +4336,7 @@ const MAX_V3_SESSION_TRANSCRIPT_CHARS: usize = 12_000;
 /// Cap the running session transcript at `max_chars`. When over the limit,
 /// keep roughly the last 80% of the buffer, snapping the trim point to the
 /// nearest whitespace so we don't shear a token in half.
+#[allow(dead_code)] // Retained for legacy tests; V3 now uses LiveCommitCursor.
 fn cap_session_transcript(transcript: &mut String, max_chars: usize) {
     if transcript.chars().count() <= max_chars {
         return;
@@ -4420,6 +4462,8 @@ mod v3_session_transcript_tests {
             centroid_dot: 0.06,
             centroid_dah: 0.18,
             locked_wpm: if locked { Some(20.0) } else { None },
+            window_start_sample: 0,
+            window_end_sample: 8000,
         }
     }
 

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -3874,6 +3874,9 @@ fn run_stream_live_v3(
                     t,
                     serde_json::json!({
                         "type": "viz",
+                        "sample_rate": viz.sample_rate,
+                        "window_start_sample": viz.window_start_sample,
+                        "window_end_sample": viz.window_end_sample,
                         "buffer_seconds": viz.buffer_seconds,
                         "frame_step_s": viz.frame_step_s,
                         "pitch_hz": viz.pitch_hz,
@@ -4128,6 +4131,9 @@ fn run_stream_live_v3_file(
                     t,
                     serde_json::json!({
                         "type": "viz",
+                        "sample_rate": viz.sample_rate,
+                        "window_start_sample": viz.window_start_sample,
+                        "window_end_sample": viz.window_end_sample,
                         "buffer_seconds": viz.buffer_seconds,
                         "frame_step_s": viz.frame_step_s,
                         "pitch_hz": viz.pitch_hz,

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -539,6 +539,12 @@ enum Cmd {
         /// pipeline so the visualizer behaves identically to live audio.
         #[arg(long)]
         file: Option<PathBuf>,
+        /// When used with --file, play the file through the default output
+        /// device and use the playback stream position as the decoder clock.
+        /// This keeps visualizer bars/transcript aligned with audible audio
+        /// instead of a separate wall-clock replay loop.
+        #[arg(long)]
+        play: bool,
 
         /// Multi-pitch (CW Skimmer-style) decode: also run K parallel
         /// per-pitch decoders alongside the existing single-pitch
@@ -1024,6 +1030,7 @@ fn main() -> Result<()> {
             pin_hz,
             min_snr_db,
             file,
+            play,
             multi_pitch,
         } => run_stream_live_v3(
             device.as_deref(),
@@ -1037,6 +1044,7 @@ fn main() -> Result<()> {
             (pin_hz > 0.0).then_some(pin_hz),
             min_snr_db,
             file.as_deref(),
+            play,
             multi_pitch,
         ),
         Cmd::ProbeFisher {
@@ -3636,6 +3644,7 @@ fn run_stream_live_v3(
     pin_hz: Option<f32>,
     min_snr_db: f32,
     file: Option<&std::path::Path>,
+    play_file_audio: bool,
     multi_pitch: usize,
 ) -> Result<()> {
     if let Some(path) = file {
@@ -3647,6 +3656,7 @@ fn run_stream_live_v3(
             pin_wpm,
             pin_hz,
             min_snr_db,
+            play_file_audio,
             multi_pitch,
         );
     }
@@ -3969,6 +3979,7 @@ fn run_stream_live_v3_file(
     pin_wpm: Option<f32>,
     pin_hz: Option<f32>,
     min_snr_db: f32,
+    play_file_audio: bool,
     multi_pitch: usize,
 ) -> Result<()> {
     use cw_decoder_poc::envelope_decoder::{
@@ -3980,6 +3991,14 @@ fn run_stream_live_v3_file(
     let sr = decoded.sample_rate;
     let total_samples = decoded.samples.len();
     let duration_s = total_samples as f32 / sr as f32;
+    let playback = if play_file_audio {
+        Some(
+            audio::play_samples_with_control(decoded.samples.clone(), sr)
+                .context("starting file playback")?,
+        )
+    } else {
+        None
+    };
     let mut streamer = LiveEnvelopeStreamer::new(sr);
     streamer.set_pinned_hz(pin_hz);
     streamer.set_pinned_wpm(pin_wpm);
@@ -4007,6 +4026,7 @@ fn run_stream_live_v3_file(
                 "source": "live-v3-file",
                 "device": format!("file:{}", path.display()),
                 "rate": sr,
+                "playback_device": playback.as_ref().map(|p| p.device_name.as_str()),
                 "decode_every_ms": decode_every_ms,
                 "max_viz_envelope_samples": MAX_VIZ_ENVELOPE_SAMPLES,
                 "recording": serde_json::Value::Null,
@@ -4029,6 +4049,11 @@ fn run_stream_live_v3_file(
     let decode_period = Duration::from_millis(decode_every_ms);
     let chunk_period = Duration::from_millis(50);
     let chunk_samples = ((sr as u64 * 50) / 1000) as usize;
+    let pump_period = if playback.is_some() {
+        Duration::from_millis(8)
+    } else {
+        chunk_period
+    };
     let mut cursor = 0usize;
     let decode_every_s = decode_every_ms as f32 / 1000.0;
     let mut commit_cursor =
@@ -4039,8 +4064,12 @@ fn run_stream_live_v3_file(
         if seconds > 0.0 && started.elapsed().as_secs_f32() >= seconds {
             break;
         }
-        std::thread::sleep(chunk_period);
-        let end = (cursor + chunk_samples).min(total_samples);
+        std::thread::sleep(pump_period);
+        let end = if let Some(p) = playback.as_ref() {
+            (p.position_input_frames() as usize).min(total_samples)
+        } else {
+            (cursor + chunk_samples).min(total_samples)
+        };
         if end > cursor {
             streamer.feed(&decoded.samples[cursor..end]);
             if let Some(m) = multi_streamer.as_mut() {

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -2070,7 +2070,7 @@ fn apply_input_gain(
         });
         let p99 = abs[idx].max(1e-6);
         // Allow target up to 4.0 so the tanh deliberately saturates.
-        let target = auto_gain_target.max(0.05).min(4.0);
+        let target = auto_gain_target.clamp(0.05, 4.0);
         let scale = target / p99;
         for s in samples.iter_mut() {
             *s = (*s * scale).tanh();
@@ -2140,7 +2140,7 @@ fn run_stream_file(
             audio.samples.len()
         );
         if let Some(g) = applied_gain_db {
-            println!("Input gain applied: {:+.1} dB", g);
+            println!("Input gain applied: {g:+.1} dB");
         }
     }
 
@@ -3676,7 +3676,7 @@ fn run_gen_rough_fist(
         noise,
     );
     println!("Truth: {}", truth_path.display());
-    println!("Text:  {}", canonical_text);
+    println!("Text:  {canonical_text}");
     Ok(())
 }
 

--- a/experiments/cw-decoder/src/preprocess.rs
+++ b/experiments/cw-decoder/src/preprocess.rs
@@ -81,7 +81,7 @@ pub fn apply(samples: &[f32], sample_rate: u32, pitch_hz: f32, cfg: &PreprocessC
     }
     let mut out = samples.to_vec();
     let pitch_ok = pitch_hz.is_finite() && pitch_hz > 0.0;
-    let in_range = !cfg.clamp_pitch || (pitch_hz >= 80.0 && pitch_hz <= 4000.0);
+    let in_range = !cfg.clamp_pitch || (80.0..=4000.0).contains(&pitch_hz);
     if pitch_ok && in_range && cfg.bandpass_width_hz > 1.0 {
         bandpass_in_place(&mut out, sample_rate, pitch_hz, cfg.bandpass_width_hz);
     }
@@ -269,9 +269,7 @@ mod tests {
         // RBJ constant-0dB BPF passes the center frequency near unity.
         assert!(
             r_out > r_in * 0.5,
-            "in-band tone should pass: in {} → out {}",
-            r_in,
-            r_out
+            "in-band tone should pass: in {r_in} -> out {r_out}"
         );
     }
 
@@ -292,16 +290,13 @@ mod tests {
         let ratio_loud = r_loud_out / r_loud_in;
         assert!(
             ratio_quiet > ratio_loud,
-            "compand must boost quiet (×{}) more than loud (×{})",
-            ratio_quiet,
-            ratio_loud
+            "compand must boost quiet (x{ratio_quiet}) more than loud (x{ratio_loud})"
         );
         // Ratios are dynamic-range compression: quiet should be lifted
         // by an order of magnitude in level.
         assert!(
             ratio_quiet > 5.0,
-            "quiet signal lift too small: ×{}",
-            ratio_quiet
+            "quiet signal lift too small: x{ratio_quiet}"
         );
     }
 
@@ -341,9 +336,7 @@ mod tests {
         let r_trail = rms(trail);
         assert!(
             r_burst > r_trail * 5.0,
-            "burst should dominate trailing silence: burst {} vs trail {}",
-            r_burst,
-            r_trail
+            "burst should dominate trailing silence: burst {r_burst} vs trail {r_trail}"
         );
     }
 }

--- a/experiments/cw-decoder/src/streaming_v2.rs
+++ b/experiments/cw-decoder/src/streaming_v2.rs
@@ -249,9 +249,7 @@ mod tests {
         let secs = d.audio_secs();
         assert!(
             (secs - MAX_BUFFER_SECS).abs() < 1.0,
-            "expected ~{} s buffered, got {}",
-            MAX_BUFFER_SECS,
-            secs
+            "expected ~{MAX_BUFFER_SECS} s buffered, got {secs}"
         );
     }
 

--- a/experiments/cw-decoder/vendor/ditdah/src/decoder.rs
+++ b/experiments/cw-decoder/vendor/ditdah/src/decoder.rs
@@ -212,7 +212,7 @@ impl MorseDecoder {
 
         // --- The rest of the decoding pipeline is unchanged ---
         let pitch = self.detect_pitch_stft()?;
-        log::info!("Estimated pitch: {:.2} Hz", pitch);
+        log::info!("Estimated pitch: {pitch:.2} Hz");
 
         let goertzel_window_size = (self.target_sample_rate as f32 * 0.025) as usize;
         let step_size = (goertzel_window_size / 4).max(1);
@@ -228,11 +228,7 @@ impl MorseDecoder {
 
         let (best_wpm, best_threshold) =
             self.find_best_params(&smoothed_power, power_signal_rate)?;
-        log::info!(
-            "Best fit: WPM = {:.1}, Threshold = {:.4e}",
-            best_wpm,
-            best_threshold
-        );
+        log::info!("Best fit: WPM = {best_wpm:.1}, Threshold = {best_threshold:.4e}");
 
         if log::log_enabled!(log::Level::Trace) {
             trace_signal(&smoothed_power, best_threshold, best_wpm)?;
@@ -521,12 +517,9 @@ impl MorseDecoder {
 
         // Log calibration for debugging
         log::debug!(
-            "Self-calibration: WPM={:.1} (authoritative={}), actual_dot_len={:.1} samples",
-            wpm,
-            wpm_is_authoritative,
-            actual_dot_len
+            "Self-calibration: WPM={wpm:.1} (authoritative={wpm_is_authoritative}), actual_dot_len={actual_dot_len:.1} samples"
         );
-        log::debug!("Element lengths: {:?}", on_intervals);
+        log::debug!("Element lengths: {on_intervals:?}");
 
         let mut result = String::new();
         let mut current_letter = String::new();
@@ -536,7 +529,7 @@ impl MorseDecoder {
         let mut current_len = 0;
         let mut is_on = power_signal[0] > threshold;
         let debounce_samples = (actual_dot_len * 0.3).round() as usize;
-        log::debug!("Debounce threshold: {} samples", debounce_samples);
+        log::debug!("Debounce threshold: {debounce_samples} samples");
         for &p in power_signal.iter().chain(std::iter::once(&0.0)) {
             if (p > threshold) == is_on {
                 current_len += 1;
@@ -638,7 +631,7 @@ fn moving_average(data: &[f32], window_size: usize) -> Vec<f32> {
 
 fn trace_signal(signal: &[f32], threshold: f32, wpm: f32) -> std::io::Result<()> {
     let mut file = std::fs::File::create("signal_trace.txt")?;
-    writeln!(file, "# WPM: {:.1}, Threshold: {:.4e}", wpm, threshold)?;
+    writeln!(file, "# WPM: {wpm:.1}, Threshold: {threshold:.4e}")?;
     let max_val = signal.iter().cloned().fold(f32::MIN, f32::max);
     if max_val <= 0.0 {
         return Ok(());

--- a/tools/ditdah-direct-up/Cargo.toml
+++ b/tools/ditdah-direct-up/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ditdah = { path = "../ditdah-upstream" }
+ditdah = { path = "../../experiments/cw-decoder/vendor/ditdah" }
 
 [[bin]]
 name = "ditdah-direct-up"

--- a/tools/ditdah-direct/Cargo-up.toml
+++ b/tools/ditdah-direct/Cargo-up.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ditdah = { path = "../ditdah-upstream" }
+ditdah = { path = "../../experiments/cw-decoder/vendor/ditdah" }
 
 [[bin]]
 name = "ditdah-direct-up"

--- a/tools/ditdah-prefix-probe/Cargo.toml
+++ b/tools/ditdah-prefix-probe/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ditdah = { path = "../ditdah-upstream" }
+ditdah = { path = "../../experiments/cw-decoder/vendor/ditdah" }
 hound = "3.5"
 
 [[bin]]

--- a/tools/rolling-whole-buffer/Cargo.toml
+++ b/tools/rolling-whole-buffer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-ditdah = { path = "../ditdah-upstream" }
+ditdah = { path = "../../experiments/cw-decoder/vendor/ditdah" }
 hound = "3.5"
 
 [[bin]]


### PR DESCRIPTION
Replaces the V3 string-stitching session_transcript path with an event-driven, sample-indexed commit cursor (Approach A+). This structurally fixes the ghost-repeat bug that produced output like "TSA USA EE   SA USA EE   ..." in V3 live and V3 file replay.

Background
The V3 session_transcript was being built by re-running ditdah on a sliding rolling window every ~500 ms and then string-stitching each fresh re-decode onto the prior transcript. Because ditdah's first character can drift between cycles when a window edge moves, the string-overlap stitcher repeatedly failed to align and appended the same text region multiple times. PR #369 attempted to mitigate this by clearing the session transcript on every cycle, which destroyed all transcript history and only made the latest 3 s of audio visible to the operator.

Approach A+ (this PR)
Identity is moved out of strings and into absolute audio time. VizFrame now carries window_start_sample and window_end_sample (u64), the LiveEnvelopeStreamer counts samples_fed_total across the entire session, and a new LiveCommitCursor in ditdah_streaming.rs commits decoded events (not re-decoded text) once per audio region. The cursor is monotonic on absolute samples with a small epsilon to absorb f32 boundary jitter, applies WPM-aware leading and trailing safety guards so events too close to a window edge are deferred to provisional, and recovers gracefully from long SNR suppression or lock loss without fabricating placeholder text.

JSON wire format
Existing "transcript" field is preserved (committed + provisional) so the standalone GUI keeps working unchanged. New "committed", "provisional", and "window_text" fields are emitted for finer GUI use later.

Validation
On data/cw-samples/training-set-a/live-20260427-111419 (43 s real off-air capture, around 28 to 30 WPM), the committed transcript stays at 42 chars across 124 cycles, monotonic non-decreasing, with no repeated n-gram inflation (top 6-gram appears once). The old behavior produced hundreds of chars of repeated junk on the same audio. All 123 existing tests pass plus 8 new unit tests for the cursor cover overlapping windows, legitimate repetition, unlocked and SNR-suppressed cycles, trailing guard, word boundaries, reset_all, and long-suppression gap recovery.

Supersedes
Should supersede #369. The diagnosis there was correct (string-stitching is the root cause) but the chosen mitigation lost transcript history; this PR fixes the underlying identity model.

Decoder content quality on noisy off-air audio is a separate concern handled by the underlying ditdah recognizer; this PR fixes the structural ghost-repeat bug only.
Foundation corpus snapshot
Scored with:

```powershell
cargo run --release --manifest-path experiments\cw-decoder\Cargo.toml --bin eval -- --labels-dir data\cw-samples --strategy-sweep --strategies foundation --json
```

Color legend: green = usable foundation, yellow = directional weakness, red = not merge-blocking for this foundation PR but clearly not solved. Exact-match is intentionally harsh: a single copied-character miss makes a whole label non-exact, so the more useful foundation metric right now is weighted CER / character accuracy plus the failure pattern.

| Corpus area | Labels | Exact labels | Levenshtein distance | Weighted CER | Character accuracy | Directional read | Next experiment direction |
|---|---:|---:|---:|---:|---:|---|---|
| Overall foundation | 16 | 🔴 0/16 | 🟢 121 / 2077 | 🟢 5.8% | 🟢 94.2% | Readable copy is now strong, but exact label fidelity is still zero because every window has at least one miss. | Keep foundation as non-regression baseline; optimize exactness via spacing/prosign/number work, not rolling-window stitching. |
| 30 WPM abbreviation variants | 5 | 🔴 0/5 | 🟢 85 / 1835 | 🟢 4.6% | 🟢 95.4% | Very stable across clean/weak/QRN/QSB variants; misses are mostly repeated deterministic symbol/prosign confusions (`CQ` -> `IQ`, `BT/BK/SN/AR/KN/SK/AS/HH` into punctuation/unknowns). | Add explicit prosign/vocabulary handling and tune short-token/prosign gap policy. |
| W1AW bulletin labels | 7 | 🔴 0/7 | 🟢 8 / 115 | 🟢 7.0% | 🟢 93.0% | Nearly there: mostly one-character tail errors like `W1AW` -> `W1AE` / `W1AA`; the tiny `QST` label is still fragile (`QI`). | Focus final-element/tail classification and short-window handling. |
| K1ZZ / DH8BQA contest | 1 | 🔴 0/1 | 🟢 1 / 15 | 🟢 6.7% | 🟢 93.3% | Very close; only report tail error (`14` -> `1I`). | Improve number/dah duration discrimination. |
| K5ZD / ZS4TX QSO | 2 | 🔴 0/2 | 🟡 7 / 28 | 🟡 25.0% | 🟡 75.0% | Callsigns/report are recognizable but spacing and symbol classification drift (`38` -> `3O` / `3M`, callsign spacing collapse). | Target isolation + report/number scoring + gap classifier. |
| N4CCB / OM0ET loopback | 1 | 🔴 0/1 | 🟡 20 / 84 | 🟡 23.8% | 🟡 76.2% | Useful mid/end copy, but leading `DE ...` and repeated exchange structure are missing/reordered. | Segment active regions and improve acquisition/word-boundary handling before the first stable exchange. |

Takeaway: the append-event foundation is a solid baseline because it produces high character accuracy without ghost-repeat artifacts, but the next phase should attack exactness: gap maturity, prosigns, number/report decoding, target isolation, and active-region segmentation.
