### PR TITLE
Handle QRZ sync duplicate errors with OPTION=REPLACE retry

### DIFF
--- a/proto/services/sync_with_qrz_response.proto
+++ b/proto/services/sync_with_qrz_response.proto
@@ -17,4 +17,7 @@ message SyncWithQrzResponse {
   uint32 remote_deletes_pushed = 9;
   // Number of QRZ download records skipped because they matched a soft-deleted local row (Phase 1).
   uint32 deletes_skipped_remote = 10;
+  // Number of uploads that were retried with OPTION=REPLACE because QRZ
+  // already had a matching QSO (duplicate INSERT → auto-matched REPLACE).
+  uint32 duplicate_replaces = 11;
 }

--- a/src/dotnet/QsoRipper.Cli.Tests/SetupWizardTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/SetupWizardTests.cs
@@ -9,48 +9,57 @@ public class SetupWizardTests
     [Fact]
     public void PromptField_returns_default_on_empty_input()
     {
-        var original = Console.In;
+        var originalIn = Console.In;
+        var originalOut = Console.Out;
         try
         {
             Console.SetIn(new StringReader(Environment.NewLine));
+            Console.SetOut(TextWriter.Null);
             var result = SetupCommand.PromptField("Test", "default_value");
             Assert.Equal("default_value", result);
         }
         finally
         {
-            Console.SetIn(original);
+            Console.SetIn(originalIn);
+            Console.SetOut(originalOut);
         }
     }
 
     [Fact]
     public void PromptField_returns_user_input_when_provided()
     {
-        var original = Console.In;
+        var originalIn = Console.In;
+        var originalOut = Console.Out;
         try
         {
             Console.SetIn(new StringReader("user_input" + Environment.NewLine));
+            Console.SetOut(TextWriter.Null);
             var result = SetupCommand.PromptField("Test", "default_value");
             Assert.Equal("user_input", result);
         }
         finally
         {
-            Console.SetIn(original);
+            Console.SetIn(originalIn);
+            Console.SetOut(originalOut);
         }
     }
 
     [Fact]
     public void PromptField_trims_whitespace()
     {
-        var original = Console.In;
+        var originalIn = Console.In;
+        var originalOut = Console.Out;
         try
         {
             Console.SetIn(new StringReader("  trimmed  " + Environment.NewLine));
+            Console.SetOut(TextWriter.Null);
             var result = SetupCommand.PromptField("Test", "default");
             Assert.Equal("trimmed", result);
         }
         finally
         {
-            Console.SetIn(original);
+            Console.SetIn(originalIn);
+            Console.SetOut(originalOut);
         }
     }
 
@@ -69,16 +78,19 @@ public class SetupWizardTests
     [InlineData("n", false, false)]
     public void PromptYesNo_handles_inputs(string input, bool defaultYes, bool expected)
     {
-        var original = Console.In;
+        var originalIn = Console.In;
+        var originalOut = Console.Out;
         try
         {
             Console.SetIn(new StringReader(input + Environment.NewLine));
+            Console.SetOut(TextWriter.Null);
             var result = SetupCommand.PromptYesNo("Question?", defaultYes);
             Assert.Equal(expected, result);
         }
         finally
         {
-            Console.SetIn(original);
+            Console.SetIn(originalIn);
+            Console.SetOut(originalOut);
         }
     }
 

--- a/src/dotnet/QsoRipper.Cli/Commands/SyncCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SyncCommand.cs
@@ -56,6 +56,11 @@ internal static class SyncCommand
             Console.WriteLine($"Skipped (trashed): {last.DeletesSkippedRemote}");
         }
 
+        if (last.DuplicateReplaces > 0)
+        {
+            Console.WriteLine($"Replaced (dupes):  {last.DuplicateReplaces}");
+        }
+
         return 0;
     }
 }

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -1210,6 +1210,12 @@ public sealed class ManagedEngineStateTests : IDisposable
             return Task.FromResult(logId);
         }
 
+        public Task<string> UploadQsoWithReplaceAsync(QsoRecord qso, string? bookOwner = null)
+        {
+            var logId = $"FAKE-{Interlocked.Increment(ref _logIdCounter)}";
+            return Task.FromResult(logId);
+        }
+
         public Task<string> UpdateQsoAsync(QsoRecord qso, string? bookOwner = null)
         {
             var logId = $"FAKE-{Interlocked.Increment(ref _logIdCounter)}";
@@ -1228,6 +1234,8 @@ public sealed class ManagedEngineStateTests : IDisposable
             => Task.FromResult(new List<QsoRecord> { null! });
 
         public Task<string> UploadQsoAsync(QsoRecord qso, string? bookOwner = null) => Task.FromResult("FAKE-1");
+
+        public Task<string> UploadQsoWithReplaceAsync(QsoRecord qso, string? bookOwner = null) => Task.FromResult("FAKE-1");
 
         public Task<string> UpdateQsoAsync(QsoRecord qso, string? bookOwner = null) => Task.FromResult("FAKE-1");
 

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -698,6 +698,7 @@ internal sealed class ManagedEngineState
                     Complete = true,
                     RemoteDeletesPushed = result.RemoteDeletesPushed,
                     DeletesSkippedRemote = result.DeletesSkippedRemote,
+                    DuplicateReplaces = result.DuplicateReplaceCount,
                 };
 
                 if (result.ErrorSummary is not null)

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
@@ -846,6 +846,65 @@ public sealed class QrzSyncEngineTests
 
     // -- Helpers ------------------------------------------------------------
 
+    // -- Duplicate retry tests -----------------------------------------------
+
+    [Fact]
+    public async Task Upload_duplicate_retries_with_replace_and_adopts_logid()
+    {
+        // A local QSO exists on QRZ but has no qrz_logid locally. The plain
+        // INSERT fails with "duplicate". Sync should retry with REPLACE, adopt
+        // the returned LOGID, and mark the QSO as Synced.
+        var store = CreateStore();
+        var local = MakeLocalQso("AK7S", BaseTime, Band._20M, Mode.Ft8, SyncStatus.LocalOnly);
+        await store.Logbook.InsertQsoAsync(local);
+
+        var api = new FakeQrzLogbookApi
+        {
+            UploadFunc = _ => throw new QrzLogbookException("QRZ Logbook API error: Unable to add QSO to database: duplicate"),
+            UploadReplaceLogid = "QRZ_ADOPTED_456",
+        };
+
+        var engine = new QrzSyncEngine(api);
+        var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: false);
+
+        // No errors — duplicate was handled.
+        Assert.Null(result.ErrorSummary);
+        Assert.Equal(1u, result.UploadedCount);
+
+        // REPLACE retry was called.
+        Assert.Single(api.UploadReplacedQsos);
+        Assert.Equal("AK7S", api.UploadReplacedQsos[0].WorkedCallsign);
+
+        // Local QSO is now Synced with the adopted LOGID.
+        var qsos = await store.Logbook.ListQsosAsync(new QsoListQuery());
+        Assert.Single(qsos);
+        Assert.Equal(SyncStatus.Synced, qsos[0].SyncStatus);
+        Assert.Equal("QRZ_ADOPTED_456", qsos[0].QrzLogid);
+    }
+
+    [Fact]
+    public async Task Upload_non_duplicate_error_still_reported()
+    {
+        var store = CreateStore();
+        var local = MakeLocalQso("K3SEW", BaseTime, Band._40M, Mode.Ssb, SyncStatus.LocalOnly);
+        await store.Logbook.InsertQsoAsync(local);
+
+        var api = new FakeQrzLogbookApi
+        {
+            UploadFunc = _ => throw new QrzLogbookException("invalid ADIF record"),
+        };
+
+        var engine = new QrzSyncEngine(api);
+        var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: false);
+
+        Assert.NotNull(result.ErrorSummary);
+        Assert.Contains("invalid ADIF record", result.ErrorSummary);
+        Assert.Equal(0u, result.UploadedCount);
+
+        // REPLACE retry must NOT have been called.
+        Assert.Empty(api.UploadReplacedQsos);
+    }
+
     private static MemoryStorage CreateStore() => new();
 
     private static QsoRecord MakeRemoteQso(string callsign, DateTimeOffset timestamp, Band band, Mode mode, string? logid)
@@ -913,6 +972,15 @@ public sealed class QrzSyncEngineTests
             }
 
             return Task.FromResult(UploadLogid);
+        }
+
+        public string UploadReplaceLogid { get; set; } = "REPLACE-12345";
+        public List<QsoRecord> UploadReplacedQsos { get; } = [];
+
+        public Task<string> UploadQsoWithReplaceAsync(QsoRecord qso, string? bookOwner = null)
+        {
+            UploadReplacedQsos.Add(qso);
+            return Task.FromResult(UploadReplaceLogid);
         }
 
         public Task<string> UpdateQsoAsync(QsoRecord qso, string? bookOwner = null)

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/IQrzLogbookApi.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/IQrzLogbookApi.cs
@@ -28,6 +28,15 @@ public interface IQrzLogbookApi
     Task<string> UploadQsoAsync(QsoRecord qso, string? bookOwner = null);
 
     /// <summary>
+    /// Upload a single QSO with <c>OPTION=REPLACE</c>, allowing QRZ to auto-match
+    /// any existing duplicate by its own detection criteria (call+band+mode+date+time)
+    /// and overwrite it. Unlike <see cref="UpdateQsoAsync"/>, this does not require a
+    /// known LOGID. Used as a retry path when a plain INSERT fails with a "duplicate" error.
+    /// Returns the QRZ-assigned or matched LOGID on success.
+    /// </summary>
+    Task<string> UploadQsoWithReplaceAsync(QsoRecord qso, string? bookOwner = null);
+
+    /// <summary>
     /// Update an existing QSO on QRZ via the REPLACE action.
     /// The <paramref name="qso"/> must have a non-empty <see cref="QsoRecord.QrzLogid"/>
     /// that identifies the remote record to overwrite.

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
@@ -125,6 +125,35 @@ public sealed class QrzLogbookClient : IQrzLogbookApi, IDisposable
     }
 
     /// <inheritdoc />
+    public async Task<string> UploadQsoWithReplaceAsync(QsoRecord qso, string? bookOwner = null)
+    {
+        ArgumentNullException.ThrowIfNull(qso);
+
+        var prepared = qso.Clone();
+        AdifCodec.RewriteStationCallsignForBook(prepared, bookOwner);
+        var adifRecord = AdifCodec.SerializeSingleQso(prepared);
+
+        var formFields = new List<KeyValuePair<string, string>>(4)
+        {
+            new("ACTION", "INSERT"),
+            new("OPTION", "REPLACE"),
+            new("KEY", _apiKey),
+            new("ADIF", adifRecord),
+        };
+
+        var body = await PostFormAsync(formFields).ConfigureAwait(false);
+        var map = QrzResponseParser.ParseKeyValueResponse(body);
+        QrzResponseParser.CheckResult(map);
+
+        if (!map.TryGetValue("LOGID", out var logid) || string.IsNullOrWhiteSpace(logid))
+        {
+            throw new QrzLogbookException("INSERT+REPLACE response missing LOGID.");
+        }
+
+        return logid;
+    }
+
+    /// <inheritdoc />
     public async Task<string> UpdateQsoAsync(QsoRecord qso, string? bookOwner = null)
     {
         ArgumentNullException.ThrowIfNull(qso);

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
@@ -279,9 +279,28 @@ public sealed class QrzSyncEngine
         {
             try
             {
-                var logid = qso.SyncStatus == SyncStatus.Modified && !string.IsNullOrWhiteSpace(qso.QrzLogid)
-                    ? await _client.UpdateQsoAsync(qso, bookOwner).ConfigureAwait(false)
-                    : await _client.UploadQsoAsync(qso, bookOwner).ConfigureAwait(false);
+                string logid;
+                var hasExistingLogid = !string.IsNullOrWhiteSpace(qso.QrzLogid);
+
+                if (qso.SyncStatus == SyncStatus.Modified && hasExistingLogid)
+                {
+                    logid = await _client.UpdateQsoAsync(qso, bookOwner).ConfigureAwait(false);
+                }
+                else
+                {
+                    try
+                    {
+                        logid = await _client.UploadQsoAsync(qso, bookOwner).ConfigureAwait(false);
+                    }
+                    catch (QrzLogbookException ex) when (!hasExistingLogid && IsDuplicateError(ex.Message))
+                    {
+                        // QSO already exists on QRZ (e.g. uploaded via web UI) but we
+                        // don't have the logid locally. Retry with OPTION=REPLACE to
+                        // auto-match and adopt the remote logid.
+                        logid = await _client.UploadQsoWithReplaceAsync(qso, bookOwner).ConfigureAwait(false);
+                    }
+                }
+
                 var synced = qso.Clone();
                 synced.QrzLogid = logid;
                 synced.SyncStatus = SyncStatus.Synced;
@@ -558,4 +577,10 @@ public sealed class QrzSyncEngine
 
         return lastSync.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
     }
+
+    /// <summary>
+    /// Check whether a QRZ API error message indicates a duplicate QSO.
+    /// </summary>
+    private static bool IsDuplicateError(string message) =>
+        message.Contains("duplicate", StringComparison.OrdinalIgnoreCase);
 }

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
@@ -66,6 +66,7 @@ public sealed class QrzSyncEngine
         uint conflicts = 0;
         uint remoteDeletesPushed = 0;
         uint deletesSkippedRemote = 0;
+        uint duplicateReplaces = 0;
 
         // ---------------------------------------------------------------
         // Phase 1 — Download from QRZ
@@ -298,6 +299,7 @@ public sealed class QrzSyncEngine
                         // don't have the logid locally. Retry with OPTION=REPLACE to
                         // auto-match and adopt the remote logid.
                         logid = await _client.UploadQsoWithReplaceAsync(qso, bookOwner).ConfigureAwait(false);
+                        duplicateReplaces++;
                     }
                 }
 
@@ -438,6 +440,7 @@ public sealed class QrzSyncEngine
             ErrorSummary = errors.Count > 0 ? string.Join("; ", errors) : null,
             RemoteDeletesPushed = remoteDeletesPushed,
             DeletesSkippedRemote = deletesSkippedRemote,
+            DuplicateReplaceCount = duplicateReplaces,
         };
     }
 

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/SyncResult.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/SyncResult.cs
@@ -40,4 +40,10 @@ public sealed record SyncResult
     /// matches a soft-deleted local row. Counted in Phase 1.
     /// </summary>
     public uint DeletesSkippedRemote { get; init; }
+
+    /// <summary>
+    /// Number of uploads retried with <c>OPTION=REPLACE</c> because QRZ
+    /// already had a matching QSO (duplicate INSERT → auto-matched REPLACE).
+    /// </summary>
+    public uint DuplicateReplaceCount { get; init; }
 }

--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -629,6 +629,50 @@ impl QrzLogbookClient {
         Ok(QrzUploadResult { logid })
     }
 
+    /// Upload a single QSO with `OPTION=REPLACE`, allowing QRZ to
+    /// auto-match an existing duplicate by its own detection criteria
+    /// (call+band+mode+date+time) and overwrite it.
+    ///
+    /// Unlike [`Self::replace_qso`], this does **not** require a known
+    /// `qrz_logid`. QRZ returns `RESULT=REPLACE` with the matched LOGID
+    /// when a duplicate is found, or `RESULT=OK` with a new LOGID when no
+    /// duplicate exists. Both are treated as success.
+    ///
+    /// This is used as a retry path when a plain `INSERT` fails with a
+    /// "duplicate" error — the QSO already exists on QRZ but we don't have
+    /// its LOGID locally.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error on network failure, authentication failure, or if
+    /// the QRZ API rejects the record.
+    pub async fn upload_qso_with_replace(
+        &self,
+        qso: &QsoRecord,
+        book_owner: Option<&str>,
+    ) -> Result<QrzUploadResult, QrzLogbookError> {
+        let adif_record = qso_to_qrz_adif(qso, book_owner);
+
+        let body = self
+            .post_form(&[
+                ("ACTION", "INSERT"),
+                ("OPTION", "REPLACE"),
+                ("ADIF", &adif_record),
+            ])
+            .await?;
+        let map = parse_kv_response(&body);
+        let map = check_result(map)?;
+
+        let logid = map.get("LOGID").cloned().unwrap_or_default();
+        if logid.is_empty() {
+            return Err(QrzLogbookError::ParseError(
+                "INSERT+REPLACE response missing LOGID".to_string(),
+            ));
+        }
+
+        Ok(QrzUploadResult { logid })
+    }
+
     /// Replace an existing QSO on the QRZ Logbook in place.
     ///
     /// Per the QRZ Logbook API contract this is `ACTION=INSERT` with

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -377,8 +377,8 @@ impl DeveloperLogbookService {
         )
         .await
         {
-            Ok(synced) => {
-                *stored = synced;
+            Ok(outcome) => {
+                *stored = outcome.qso;
                 (true, None)
             }
             Err(err) => (false, Some(err)),

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -148,6 +148,8 @@ struct SyncCounters {
     deletes_skipped_remote: u32,
     /// Number of queued remote deletes that were pushed to QRZ in Phase 2.
     remote_deletes_pushed: u32,
+    /// Number of uploads retried with OPTION=REPLACE due to duplicate detection.
+    duplicate_replaces: u32,
     errors: Vec<String>,
 }
 
@@ -159,6 +161,7 @@ impl SyncCounters {
             conflicts: 0,
             deletes_skipped_remote: 0,
             remote_deletes_pushed: 0,
+            duplicate_replaces: 0,
             errors: Vec::new(),
         }
     }
@@ -228,9 +231,10 @@ pub(crate) async fn execute_sync(
     };
 
     eprintln!(
-        "[sync] Sync completed: downloaded={} uploaded={} conflicts={} remote_deletes_pushed={} deletes_skipped_remote={} errors={}",
+        "[sync] Sync completed: downloaded={} uploaded={} duplicate_replaces={} conflicts={} remote_deletes_pushed={} deletes_skipped_remote={} errors={}",
         counters.downloaded,
         counters.uploaded,
+        counters.duplicate_replaces,
         counters.conflicts,
         counters.remote_deletes_pushed,
         counters.deletes_skipped_remote,
@@ -239,11 +243,7 @@ pub(crate) async fn execute_sync(
 
     send_complete(
         progress_tx,
-        counters.downloaded,
-        counters.uploaded,
-        counters.conflicts,
-        counters.remote_deletes_pushed,
-        counters.deletes_skipped_remote,
+        &counters,
         error_summary,
     )
     .await;
@@ -286,11 +286,7 @@ async fn download_phase(
         Err(err) => {
             send_complete(
                 progress_tx,
-                0,
-                0,
-                0,
-                0,
-                0,
+                &SyncCounters::new(),
                 Some(format!("Failed to load local QSOs: {err}")),
             )
             .await;
@@ -322,11 +318,7 @@ async fn download_phase(
         Err(err) => {
             send_complete(
                 progress_tx,
-                0,
-                0,
-                0,
-                0,
-                0,
+                &SyncCounters::new(),
                 Some(format!("Failed to fetch QSOs from QRZ: {err}")),
             )
             .await;
@@ -516,7 +508,12 @@ async fn upload_phase(
 
     for qso in &pending_qsos {
         match sync_single_qso(client, store, qso, book_owner).await {
-            Ok(_) => counters.uploaded += 1,
+            Ok(outcome) => {
+                counters.uploaded += 1;
+                if outcome.was_duplicate_replace {
+                    counters.duplicate_replaces += 1;
+                }
+            }
             Err(err) => {
                 eprintln!(
                     "[sync] Failed to push QSO {} ({}): {err}",
@@ -564,6 +561,15 @@ pub(crate) async fn resolve_book_owner_for_upload(
     .filter(|s| !s.is_empty())
 }
 
+/// Outcome of a successful `sync_single_qso` call.
+#[derive(Debug)]
+pub(crate) struct SyncOutcome {
+    /// The locally-persisted QSO with refreshed logid and `sync_status`.
+    pub qso: QsoRecord,
+    /// `true` when the upload succeeded only after a duplicate-retry with REPLACE.
+    pub was_duplicate_replace: bool,
+}
+
 /// Push a single QSO to QRZ, then mirror the QRZ-assigned logid + Synced
 /// state back into local storage. Used by both bulk sync Phase 2 and the
 /// per-operation `sync_to_qrz=true` paths on `LogQso` / `UpdateQso`.
@@ -577,8 +583,7 @@ pub(crate) async fn resolve_book_owner_for_upload(
 ///   QRZ but we don't have its logid), retry with `OPTION=REPLACE` to
 ///   auto-match the existing record and adopt its logid.
 ///
-/// Returns the locally-persisted `QsoRecord` on success (with refreshed
-/// `qrz_logid` and `sync_status = Synced`). Returns a human-readable error
+/// Returns a [`SyncOutcome`] on success. Returns a human-readable error
 /// string on either upload failure or local-store write failure; callers
 /// surface it as the gRPC `sync_error` field.
 pub(crate) async fn sync_single_qso(
@@ -586,7 +591,7 @@ pub(crate) async fn sync_single_qso(
     store: &dyn LogbookStore,
     qso: &QsoRecord,
     book_owner: Option<&str>,
-) -> Result<QsoRecord, String> {
+) -> Result<SyncOutcome, String> {
     let existing_logid = qso.qrz_logid.clone().filter(|s| !s.is_empty());
 
     let result = match existing_logid.as_deref() {
@@ -597,7 +602,7 @@ pub(crate) async fn sync_single_qso(
     // When a plain INSERT fails because QRZ already has a matching QSO
     // (e.g. uploaded via the QRZ web UI), retry with OPTION=REPLACE so we
     // can adopt the remote logid and stop re-attempting on every sync.
-    let result = match result {
+    let (result, was_duplicate_replace) = match result {
         Err(QrzLogbookError::ApiError(ref reason))
             if existing_logid.is_none() && is_duplicate_error(reason) =>
         {
@@ -605,13 +610,18 @@ pub(crate) async fn sync_single_qso(
                 "[sync] INSERT for {} got duplicate; retrying with OPTION=REPLACE",
                 qso.worked_callsign
             );
-            client
+            let r = client
                 .upload_qso_with_replace(qso, book_owner)
                 .await
-                .map_err(|err| format!("QRZ upload failed (REPLACE retry): {err}"))
+                .map_err(|err| format!("QRZ upload failed (REPLACE retry): {err}"));
+            (r, true)
         }
-        other => other.map_err(|err| format!("QRZ upload failed: {err}")),
-    }?;
+        other => (
+            other.map_err(|err| format!("QRZ upload failed: {err}")),
+            false,
+        ),
+    };
+    let result = result?;
 
     let mut synced = qso.clone();
     synced.qrz_logid = Some(result.logid);
@@ -622,7 +632,10 @@ pub(crate) async fn sync_single_qso(
         .await
         .map_err(|err| format!("QRZ upload succeeded but local update failed: {err}"))?;
 
-    Ok(synced)
+    Ok(SyncOutcome {
+        qso: synced,
+        was_duplicate_replace,
+    })
 }
 
 /// Check whether a QRZ API error reason indicates a duplicate QSO.
@@ -1016,6 +1029,7 @@ async fn send_progress(
             error: None,
             remote_deletes_pushed: 0,
             deletes_skipped_remote: 0,
+            duplicate_replaces: 0,
         }))
         .await,
     );
@@ -1023,25 +1037,22 @@ async fn send_progress(
 
 async fn send_complete(
     tx: &mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
-    downloaded: u32,
-    uploaded: u32,
-    conflicts: u32,
-    remote_deletes_pushed: u32,
-    deletes_skipped_remote: u32,
+    counters: &SyncCounters,
     error: Option<String>,
 ) {
     drop(
         tx.send(Ok(SyncWithQrzResponse {
-            total_records: downloaded + uploaded,
-            processed_records: downloaded + uploaded,
-            uploaded_records: uploaded,
-            downloaded_records: downloaded,
-            conflict_records: conflicts,
+            total_records: counters.downloaded + counters.uploaded,
+            processed_records: counters.downloaded + counters.uploaded,
+            uploaded_records: counters.uploaded,
+            downloaded_records: counters.downloaded,
+            conflict_records: counters.conflicts,
             current_action: Some("Sync complete".to_string()),
             complete: true,
             error,
-            remote_deletes_pushed,
-            deletes_skipped_remote,
+            remote_deletes_pushed: counters.remote_deletes_pushed,
+            deletes_skipped_remote: counters.deletes_skipped_remote,
+            duplicate_replaces: counters.duplicate_replaces,
         }))
         .await,
     );
@@ -1432,9 +1443,10 @@ mod tests {
             })],
         );
 
-        let synced = sync_single_qso(&api, &store, &q, None).await.expect("ok");
-        assert_eq!(synced.qrz_logid.as_deref(), Some("QRZ-NEW"));
-        assert_eq!(synced.sync_status, SyncStatus::Synced as i32);
+        let outcome = sync_single_qso(&api, &store, &q, None).await.expect("ok");
+        assert!(!outcome.was_duplicate_replace);
+        assert_eq!(outcome.qso.qrz_logid.as_deref(), Some("QRZ-NEW"));
+        assert_eq!(outcome.qso.sync_status, SyncStatus::Synced as i32);
 
         let saved = store.get_qso(&q.local_id).await.unwrap().unwrap();
         assert_eq!(saved.qrz_logid.as_deref(), Some("QRZ-NEW"));
@@ -1456,9 +1468,10 @@ mod tests {
         // defaults to echoing the logid back.
         let api = MockQrzApi::new(Ok(vec![]), vec![]);
 
-        let synced = sync_single_qso(&api, &store, &q, None).await.expect("ok");
-        assert_eq!(synced.qrz_logid.as_deref(), Some("QRZ-EXISTING"));
-        assert_eq!(synced.sync_status, SyncStatus::Synced as i32);
+        let outcome = sync_single_qso(&api, &store, &q, None).await.expect("ok");
+        assert!(!outcome.was_duplicate_replace);
+        assert_eq!(outcome.qso.qrz_logid.as_deref(), Some("QRZ-EXISTING"));
+        assert_eq!(outcome.qso.sync_status, SyncStatus::Synced as i32);
 
         let replace_calls = api.replace_calls.lock().unwrap().clone();
         assert_eq!(replace_calls.len(), 1, "must REPLACE not INSERT");
@@ -2646,6 +2659,7 @@ mod tests {
             final_msg.error
         );
         assert_eq!(final_msg.uploaded_records, 1);
+        assert_eq!(final_msg.duplicate_replaces, 1);
 
         // Verify upload_qso_with_replace was called.
         {
@@ -2693,6 +2707,7 @@ mod tests {
             "error should mention the original reason"
         );
         assert_eq!(final_msg.uploaded_records, 0);
+        assert_eq!(final_msg.duplicate_replaces, 0);
 
         // REPLACE retry must NOT have been called.
         let replace_calls = api.upload_replace_calls.lock().unwrap();

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -241,12 +241,7 @@ pub(crate) async fn execute_sync(
         counters.errors.len(),
     );
 
-    send_complete(
-        progress_tx,
-        &counters,
-        error_summary,
-    )
-    .await;
+    send_complete(progress_tx, &counters, error_summary).await;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -70,6 +70,14 @@ pub(crate) trait QrzLogbookApi: Send + Sync {
         book_owner: Option<&str>,
     ) -> Result<QrzUploadResult, QrzLogbookError>;
 
+    /// Upload a single QSO with `OPTION=REPLACE`, auto-matching any existing
+    /// duplicate on QRZ without requiring a known logid.
+    async fn upload_qso_with_replace(
+        &self,
+        qso: &QsoRecord,
+        book_owner: Option<&str>,
+    ) -> Result<QrzUploadResult, QrzLogbookError>;
+
     /// Replace an existing QSO on the remote logbook (preserves logid).
     ///
     /// `book_owner` has the same semantics as in [`Self::upload_qso`].
@@ -100,6 +108,14 @@ impl QrzLogbookApi for QrzLogbookClient {
         book_owner: Option<&str>,
     ) -> Result<QrzUploadResult, QrzLogbookError> {
         QrzLogbookClient::upload_qso(self, qso, book_owner).await
+    }
+
+    async fn upload_qso_with_replace(
+        &self,
+        qso: &QsoRecord,
+        book_owner: Option<&str>,
+    ) -> Result<QrzUploadResult, QrzLogbookError> {
+        QrzLogbookClient::upload_qso_with_replace(self, qso, book_owner).await
     }
 
     async fn replace_qso(
@@ -557,6 +573,9 @@ pub(crate) async fn resolve_book_owner_for_upload(
 ///   so QRZ keeps the same row (no duplicate). This applies regardless of
 ///   whether `sync_status` is Modified or Synced.
 /// * Otherwise INSERT a new remote row and adopt the returned logid.
+/// * If INSERT fails with a "duplicate" error (the QSO already exists on
+///   QRZ but we don't have its logid), retry with `OPTION=REPLACE` to
+///   auto-match the existing record and adopt its logid.
 ///
 /// Returns the locally-persisted `QsoRecord` on success (with refreshed
 /// `qrz_logid` and `sync_status = Synced`). Returns a human-readable error
@@ -575,10 +594,27 @@ pub(crate) async fn sync_single_qso(
         None => client.upload_qso(qso, book_owner).await,
     };
 
-    let upload = result.map_err(|err| format!("QRZ upload failed: {err}"))?;
+    // When a plain INSERT fails because QRZ already has a matching QSO
+    // (e.g. uploaded via the QRZ web UI), retry with OPTION=REPLACE so we
+    // can adopt the remote logid and stop re-attempting on every sync.
+    let result = match result {
+        Err(QrzLogbookError::ApiError(ref reason))
+            if existing_logid.is_none() && is_duplicate_error(reason) =>
+        {
+            eprintln!(
+                "[sync] INSERT for {} got duplicate; retrying with OPTION=REPLACE",
+                qso.worked_callsign
+            );
+            client
+                .upload_qso_with_replace(qso, book_owner)
+                .await
+                .map_err(|err| format!("QRZ upload failed (REPLACE retry): {err}"))
+        }
+        other => other.map_err(|err| format!("QRZ upload failed: {err}")),
+    }?;
 
     let mut synced = qso.clone();
-    synced.qrz_logid = Some(upload.logid);
+    synced.qrz_logid = Some(result.logid);
     synced.sync_status = SyncStatus::Synced as i32;
 
     store
@@ -587,6 +623,12 @@ pub(crate) async fn sync_single_qso(
         .map_err(|err| format!("QRZ upload succeeded but local update failed: {err}"))?;
 
     Ok(synced)
+}
+
+/// Check whether a QRZ API error reason indicates a duplicate QSO.
+fn is_duplicate_error(reason: &str) -> bool {
+    let lower = reason.to_ascii_lowercase();
+    lower.contains("duplicate")
 }
 
 // ---------------------------------------------------------------------------
@@ -1037,6 +1079,8 @@ mod tests {
         fetch_result: Mutex<Option<Result<Vec<QsoRecord>, QrzLogbookError>>>,
         upload_results: Mutex<Vec<Result<QrzUploadResult, QrzLogbookError>>>,
         upload_calls: Mutex<Vec<(QsoRecord, Option<String>)>>,
+        upload_replace_results: Mutex<Vec<Result<QrzUploadResult, QrzLogbookError>>>,
+        upload_replace_calls: Mutex<Vec<(QsoRecord, Option<String>)>>,
         replace_calls: Mutex<Vec<(String, String)>>, // (logid, local_id)
         replace_results: Mutex<Vec<Result<QrzUploadResult, QrzLogbookError>>>,
         status_result: Mutex<Option<Result<QrzLogbookStatus, QrzLogbookError>>>,
@@ -1053,6 +1097,8 @@ mod tests {
                 fetch_result: Mutex::new(Some(fetch)),
                 upload_results: Mutex::new(uploads),
                 upload_calls: Mutex::new(Vec::new()),
+                upload_replace_results: Mutex::new(Vec::new()),
+                upload_replace_calls: Mutex::new(Vec::new()),
                 replace_calls: Mutex::new(Vec::new()),
                 replace_results: Mutex::new(Vec::new()),
                 status_result: Mutex::new(Some(Ok(QrzLogbookStatus {
@@ -1097,6 +1143,26 @@ mod tests {
                 Err(QrzLogbookError::ApiError(
                     "no more mock upload results".into(),
                 ))
+            } else {
+                results.remove(0)
+            }
+        }
+
+        async fn upload_qso_with_replace(
+            &self,
+            qso: &QsoRecord,
+            book_owner: Option<&str>,
+        ) -> Result<QrzUploadResult, QrzLogbookError> {
+            self.upload_replace_calls
+                .lock()
+                .unwrap()
+                .push((qso.clone(), book_owner.map(str::to_owned)));
+            let mut results = self.upload_replace_results.lock().unwrap();
+            if results.is_empty() {
+                // Default: succeed with a synthetic logid.
+                Ok(QrzUploadResult {
+                    logid: "REPLACE_LOGID".into(),
+                })
             } else {
                 results.remove(0)
             }
@@ -1160,6 +1226,16 @@ mod tests {
         }
 
         async fn upload_qso(
+            &self,
+            _qso: &QsoRecord,
+            _book_owner: Option<&str>,
+        ) -> Result<QrzUploadResult, QrzLogbookError> {
+            Ok(QrzUploadResult {
+                logid: "ignored".into(),
+            })
+        }
+
+        async fn upload_qso_with_replace(
             &self,
             _qso: &QsoRecord,
             _book_owner: Option<&str>,
@@ -2527,5 +2603,102 @@ mod tests {
             "pending flag must remain set so the next sync retries"
         );
         assert_eq!(after[0].qrz_logid.as_deref(), Some("LOG-FAIL"));
+    }
+
+    #[tokio::test]
+    async fn duplicate_insert_retries_with_replace_and_syncs() {
+        // Scenario: a local QSO has sync_status = LocalOnly and no qrz_logid,
+        // but the same QSO already exists on QRZ (uploaded via web UI). The
+        // plain INSERT fails with "duplicate". The sync should automatically
+        // retry with OPTION=REPLACE, adopt the returned LOGID, and mark the
+        // QSO as Synced.
+        let store = MemoryStorage::new();
+
+        let local = make_qso("W1AW", "AK7S", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        assert!(local.qrz_logid.is_none());
+        assert_eq!(local.sync_status, SyncStatus::LocalOnly as i32);
+        store.insert_qso(&local).await.unwrap();
+
+        // INSERT returns duplicate error, then REPLACE retry should succeed.
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![Err(QrzLogbookError::ApiError(
+                "Unable to add QSO to database: duplicate".into(),
+            ))],
+        );
+        // Pre-load the upload_replace_results with a success.
+        api.upload_replace_results
+            .lock()
+            .unwrap()
+            .push(Ok(QrzUploadResult {
+                logid: "QRZ_ADOPTED_123".into(),
+            }));
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, false, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+        let final_msg = collect_final(rx).await;
+
+        // Should have no errors — the duplicate was handled gracefully.
+        assert!(
+            final_msg.error.is_none(),
+            "expected no sync error but got: {:?}",
+            final_msg.error
+        );
+        assert_eq!(final_msg.uploaded_records, 1);
+
+        // Verify upload_qso_with_replace was called.
+        {
+            let replace_calls = api.upload_replace_calls.lock().unwrap();
+            assert_eq!(replace_calls.len(), 1, "expected one REPLACE retry call");
+            assert_eq!(replace_calls[0].0.worked_callsign, "AK7S");
+        }
+
+        // Verify the local QSO is now Synced with the adopted LOGID.
+        let qsos = store.list_qsos(&QsoListQuery::default()).await.unwrap();
+        assert_eq!(qsos.len(), 1);
+        assert_eq!(qsos[0].sync_status, SyncStatus::Synced as i32);
+        assert_eq!(qsos[0].qrz_logid.as_deref(), Some("QRZ_ADOPTED_123"));
+    }
+
+    #[tokio::test]
+    async fn non_duplicate_upload_error_still_reported() {
+        // A non-duplicate API error should still be reported as a sync error
+        // and must NOT trigger the REPLACE retry path.
+        let store = MemoryStorage::new();
+
+        let local = make_qso("W1AW", "K3SEW", Band::Band40m, Mode::Ssb, 1_700_000_000);
+        store.insert_qso(&local).await.unwrap();
+
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![Err(QrzLogbookError::ApiError("invalid ADIF record".into()))],
+        );
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, false, ConflictPolicy::LastWriteWins, &tx).await;
+        drop(tx);
+        let final_msg = collect_final(rx).await;
+
+        assert!(
+            final_msg.error.is_some(),
+            "expected a sync error for non-duplicate API failure"
+        );
+        assert!(
+            final_msg
+                .error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("invalid ADIF record"),
+            "error should mention the original reason"
+        );
+        assert_eq!(final_msg.uploaded_records, 0);
+
+        // REPLACE retry must NOT have been called.
+        let replace_calls = api.upload_replace_calls.lock().unwrap();
+        assert!(
+            replace_calls.is_empty(),
+            "REPLACE retry should not fire for non-duplicate errors"
+        );
     }
 }


### PR DESCRIPTION
When uploading a local QSO that already exists on QRZ (e.g. uploaded via the web UI), the plain INSERT fails with a duplicate error. The QSO stays LocalOnly and the error recurs on every sync, producing noise like:

Upload failed for AK7S: QRZ upload failed: QRZ Logbook API error: Unable to add QSO to database: duplicate

This fixes both the Rust and .NET engines to detect the duplicate error and automatically retry with OPTION=REPLACE. QRZ auto-matches the existing record and returns its LOGID, which we adopt locally and mark the QSO as Synced. This breaks the infinite retry loop. Once deployed, the first normal sync will auto-heal all existing duplicates with no --force needed.

Changes across 7 files: new upload_qso_with_replace / UploadQsoWithReplaceAsync methods on both QRZ clients, duplicate-detection retry logic in both sync engines, and 4 new tests (2 Rust, 2 .NET) covering the happy path and verifying non-duplicate errors are still reported.