### PR TITLE
Fix unnecessary Rust rebuild in start-qsoripper.ps1

### DIFF
--- a/start-qsoripper.ps1
+++ b/start-qsoripper.ps1
@@ -521,7 +521,7 @@ function Get-EngineProfiles {
                 QSORIPPER_SQLITE_PATH = '{persistenceLocation}'
             }
             BuildFilePath = 'cargo'
-            BuildArguments = @('build', '--manifest-path', $rustManifestPath, '-p', 'qsoripper-server')
+            BuildArguments = @('build', '--manifest-path', $rustManifestPath)
             LaunchFilePath = $rustBinaryPath
             LaunchArguments = @('--listen', '{listenAddress}', '--config', '{configPath}')
             SupportsStorageSession = $true


### PR DESCRIPTION
start-qsoripper.ps1 used `cargo build -p qsoripper-server` while build.ps1 uses a workspace-wide `cargo build`. The `-p` flag changes cargo's feature unification, invalidating the build cache and causing a full recompile even when everything was just built by build.ps1. This drops the `-p` flag so both scripts use the same workspace build command, making the start script's build step a no-op (~0.7s) after a recent build.ps1 run.