### PR TITLE
cw-decoder: wire region-isolated transcript into live streaming + GUIs (100% match on real-world QSO sample)

### DIFF
--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -9,6 +9,87 @@ The project has converged on two parallel goals:
 
 The current breakthrough is that the best live behavior did **not** come from rolling transcript windows, overlap stitching, or commit heuristics. It came from consuming the same stable dit/dah/gap event stream that paints the Visualizer bars and appending each matured event once in audio order. That path is now the "line in the sand": Decode, Labeling, Tuning, Bench, and Visualizer should all key off it first, while experimental decoders are compared against it rather than silently replacing it.
 
+> **Foundational baseline (May 2026): region-isolated streaming transcript.**
+>
+> A full QEX-style technical write-up of this baseline (architecture,
+> design rationale, results, and future directions) lives at
+> [`docs/cw-decoder-architecture.html`](docs/cw-decoder-architecture.html).
+> Open it in any browser for the rendered article; it is the canonical
+> reference for the architecture summarized here.
+>
+> The append-only event-stream foundation is excellent for *driving the
+> visualizer* (waveform, lock state, pitch, WPM, classified events). But
+> for the **transcript** itself, real-world QSO audio with multiple
+> bursts at very different WPMs separated by background static (operator
+> pauses, TX/RX cycles, ragchew vs contest mixes) needs a different
+> decoder shape: detect each burst as a region, decode each region
+> independently with its own pitch/WPM/k-means lock, and append the
+> region's text once it has been stable for a trailing-static window.
+>
+> The reference implementation lives in
+> `src\region_streamer.rs` (`RegionStreamer`) and
+> `src\region_stream.rs` (`decode_region_stream`). It is exposed three
+> ways:
+>
+> - **Batch mode** — `cw-decoder stream-region --file <path>` — runs
+>   region detection over the entire file and emits one transcript per
+>   region. This is the canonical reference output.
+> - **Live streaming** — `cw-decoder stream-live-v3 --region-transcript`
+>   — runs `RegionStreamer` *alongside* the V3 envelope streamer. The
+>   envelope path keeps driving viz events; only the cumulative
+>   `transcript` field on emitted `text` / `appended` / `end` events is
+>   sourced from region-isolated decode. `RegionStreamer::trim_committed`
+>   bounds memory growth in long live sessions and `RegionStreamer::reset`
+>   honors stdin-control `ResetLock` requests cleanly without restarting
+>   the process.
+> - **Both UI surfaces wire `--region-transcript`** by default:
+>   - Production logger GUI (F7 live mic) —
+>     `src\dotnet\QsoRipper.Gui\Services\CwDecoderProcessSampleSource.cs`
+>   - Experimental CW visualizer GUI (live mic + file replay) —
+>     `experiments\cw-decoder\gui\Services\CwDecoderProcess.cs`
+>
+> **Reference success metric.** This baseline produces a 100% exact-match
+> transcript for the multi-burst real-world sample
+> `cw-samples\training-set-b\radio-20260502-105714.mp3` (truth file
+> `radio-20260502-105714.truth.txt`):
+>
+> ```text
+> IHU NVCHU 7QP W7N 7QP W7N
+> ```
+>
+> Both `stream-region` (batch) and `stream-live-v3 --region-transcript`
+> (live streaming) produce that exact string with the default
+> `RegionStreamerConfig::default()` config (merge_gap=0.5s,
+> min_region=0.3s, threshold_factor=0.30, pad=0.15s,
+> stable_latency=0.6s) and `--decode-every-ms 250`.
+>
+> **Future experiments must not regress this baseline.** Before merging
+> any change that touches `region_streamer.rs`, `region_stream.rs`,
+> `stream-live-v3`, the GUI launchers, or the underlying decoder
+> primitives, re-run the cross-validation:
+>
+> ```powershell
+> cd C:\Users\randy\Git\qsoripper
+> $exe  = "experiments\cw-decoder\target\release\cw-decoder.exe"
+> $f    = "C:\Users\randy\OneDrive\Documents\Home\Hobbies\Ham Radio\QSORipper\QSO Audio Samples\cw-samples\training-set-b\radio-20260502-105714.mp3"
+> $truth = (Get-Content "C:\Users\randy\OneDrive\Documents\Home\Hobbies\Ham Radio\QSORipper\QSO Audio Samples\cw-samples\training-set-b\radio-20260502-105714.truth.txt" -Raw).Trim()
+> & $exe stream-region --file $f --json --no-realtime --decode-every-ms 250 |
+>     Select-String '"type":"end"' | Select-Object -Last 1
+> & $exe stream-live-v3 --file $f --json --region-transcript --decode-every-ms 250 |
+>     Select-String '"type":"end"' | Select-Object -Last 1
+> # Both `transcript` fields must equal $truth.
+> ```
+>
+> If you need to roll back to this baseline at any point, the reference
+> commits are PR #375 (region-based streaming decoder, batch path) and
+> PR #376 (live streaming + GUI wiring) on branch
+> `u/randy/region-based-streaming-cw`.
+>
+> The append-only event-stream foundation in `append_decode.rs` is
+> still the source of truth for the visualizer's bar painting and for
+> the `cw_decode_rx_wpm` aggregator that feeds the production logger;
+> region-isolated decode supplements it for transcript text only.
+
 > **Integration status (round 1, issue #321)**: the production GUI now hosts the
 > `cw-decoder` binary as a subprocess and auto-fills `QsoRecord.cw_decode_rx_wpm`
 > on logged CW QSOs (time-weighted mean over the QSO start/end window, ADIF

--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -61,7 +61,13 @@ The current breakthrough is that the best live behavior did **not** come from ro
 > (live streaming) produce that exact string with the default
 > `RegionStreamerConfig::default()` config (merge_gap=0.5s,
 > min_region=0.3s, threshold_factor=0.30, pad=0.15s,
-> stable_latency=0.6s) and `--decode-every-ms 250`.
+> min_tonal_prominence_ratio=8.0, stable_latency=0.6s) and
+> `--decode-every-ms 250`.
+>
+> The baseline now also includes deterministic synthetic impairment
+> coverage in `region_streamer.rs`: clean four-burst copy, quiet static
+> gaps, noise-only no-ghost-text, and a moderate white-noise + QSB +
+> offset-QRM exchange (`CQ TEST KC7AVA 73`).
 >
 > **Future experiments must not regress this baseline.** Before merging
 > any change that touches `region_streamer.rs`, `region_stream.rs`,
@@ -78,6 +84,7 @@ The current breakthrough is that the best live behavior did **not** come from ro
 > & $exe stream-live-v3 --file $f --json --region-transcript --decode-every-ms 250 |
 >     Select-String '"type":"end"' | Select-Object -Last 1
 > # Both `transcript` fields must equal $truth.
+> cargo test --manifest-path experiments\cw-decoder\Cargo.toml region_streamer::tests::synthetic
 > ```
 >
 > If you need to roll back to this baseline at any point, the reference

--- a/experiments/cw-decoder/docs/cw-decoder-architecture.html
+++ b/experiments/cw-decoder/docs/cw-decoder-architecture.html
@@ -218,7 +218,7 @@
 
   <h1 class="title">Region-Isolated Streaming for Real-World CW Copy</h1>
   <p class="subtitle">A practical decoder architecture that holds 100% copy on multi-burst, mixed-speed off-air audio with operator pauses</p>
-  <p class="byline">Randy Treit, K&Oslash;RJT &mdash; with collaboration from the QsoRipper agent toolchain</p>
+  <p class="byline">Randy Treit, KC7AVA &mdash; with collaboration from the QsoRipper agent toolchain</p>
   <p class="affiliation">QsoRipper Project &middot; <code>experiments/cw-decoder</code></p>
 
   <div class="abstract">

--- a/experiments/cw-decoder/docs/cw-decoder-architecture.html
+++ b/experiments/cw-decoder/docs/cw-decoder-architecture.html
@@ -1,0 +1,824 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Region-Isolated Streaming for Real-World CW Copy &mdash; QsoRipper Technical Report</title>
+<style>
+  :root {
+    --navy: #102a54;
+    --rule: #102a54;
+    --accent: #b21f1f;
+    --muted: #555;
+    --bg: #faf8f3;
+    --code-bg: #f1ede4;
+  }
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: #111;
+    font-family: "Georgia", "Times New Roman", serif;
+    font-size: 15px;
+    line-height: 1.5;
+  }
+  .page {
+    max-width: 980px;
+    margin: 24px auto 64px;
+    padding: 0 28px;
+  }
+  .masthead {
+    border-top: 6px double var(--navy);
+    border-bottom: 1px solid var(--navy);
+    padding: 14px 0 10px;
+    margin-bottom: 18px;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-variant: small-caps;
+    letter-spacing: 0.05em;
+    color: var(--navy);
+  }
+  .masthead .pub { font-weight: bold; font-size: 1.1em; }
+  .masthead .meta { font-size: 0.85em; color: var(--muted); letter-spacing: 0.04em; }
+
+  h1.title {
+    font-size: 1.85em;
+    color: var(--navy);
+    margin: 0 0 4px;
+    line-height: 1.2;
+    font-weight: bold;
+  }
+  .subtitle {
+    font-style: italic;
+    color: var(--muted);
+    margin: 0 0 8px;
+    font-size: 1.05em;
+  }
+  .byline {
+    font-size: 0.95em;
+    margin: 0 0 4px;
+  }
+  .affiliation {
+    font-size: 0.85em;
+    color: var(--muted);
+    font-style: italic;
+    margin: 0 0 18px;
+  }
+
+  .abstract {
+    border-left: 4px solid var(--navy);
+    background: #fff;
+    padding: 12px 16px;
+    margin: 0 0 24px;
+    font-size: 0.97em;
+  }
+  .abstract .label {
+    font-variant: small-caps;
+    letter-spacing: 0.06em;
+    color: var(--navy);
+    font-weight: bold;
+    margin-right: 6px;
+  }
+
+  .columns {
+    column-count: 2;
+    column-gap: 28px;
+    column-rule: 1px solid #ddd;
+    text-align: justify;
+    hyphens: auto;
+  }
+  /* Some elements look poor when split across columns. */
+  figure, pre, table, .callout, h2, h3 {
+    break-inside: avoid;
+  }
+
+  h2 {
+    font-size: 1.15em;
+    color: var(--navy);
+    border-bottom: 1px solid var(--navy);
+    padding-bottom: 2px;
+    margin: 22px 0 8px;
+    font-variant: small-caps;
+    letter-spacing: 0.04em;
+  }
+  h3 {
+    font-size: 1.0em;
+    color: #222;
+    margin: 16px 0 6px;
+    font-style: italic;
+  }
+  p { margin: 0 0 10px; }
+
+  pre, code {
+    font-family: "Consolas", "Menlo", monospace;
+    font-size: 0.85em;
+  }
+  pre {
+    background: var(--code-bg);
+    padding: 10px 12px;
+    border-left: 3px solid var(--navy);
+    overflow-x: auto;
+    line-height: 1.4;
+    margin: 8px 0 14px;
+  }
+  code {
+    background: var(--code-bg);
+    padding: 0 3px;
+    border-radius: 2px;
+  }
+  pre code {
+    background: transparent;
+    padding: 0;
+  }
+
+  figure {
+    margin: 12px 0;
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 10px;
+    text-align: center;
+  }
+  figure svg { max-width: 100%; height: auto; }
+  figcaption {
+    font-size: 0.83em;
+    color: var(--muted);
+    margin-top: 6px;
+    text-align: left;
+    font-style: italic;
+  }
+  figcaption strong { font-style: normal; color: var(--navy); }
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 8px 0 14px;
+    font-size: 0.9em;
+  }
+  th, td {
+    border-bottom: 1px solid #bbb;
+    padding: 5px 8px;
+    text-align: left;
+    vertical-align: top;
+  }
+  th {
+    border-bottom: 2px solid var(--navy);
+    color: var(--navy);
+    font-variant: small-caps;
+    letter-spacing: 0.04em;
+  }
+  tr.match td:first-child { color: #1b6b1b; font-weight: bold; }
+
+  .callout {
+    background: #fff;
+    border: 1px solid var(--navy);
+    border-left: 6px solid var(--navy);
+    padding: 10px 14px;
+    margin: 12px 0;
+    font-size: 0.93em;
+  }
+  .callout .label {
+    font-variant: small-caps;
+    color: var(--navy);
+    font-weight: bold;
+    letter-spacing: 0.06em;
+    margin-right: 6px;
+  }
+
+  .refs ol { padding-left: 22px; }
+  .refs li { margin-bottom: 5px; font-size: 0.9em; }
+
+  .footer {
+    border-top: 6px double var(--navy);
+    margin-top: 28px;
+    padding-top: 10px;
+    font-size: 0.82em;
+    color: var(--muted);
+    text-align: center;
+  }
+
+  .key { color: var(--accent); font-weight: bold; }
+  .small-caps { font-variant: small-caps; letter-spacing: 0.04em; }
+
+  ul, ol { padding-left: 22px; }
+  li { margin-bottom: 4px; }
+
+  @media (max-width: 720px) {
+    .columns { column-count: 1; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <div class="masthead">
+    <span class="pub">QsoRipper Technical Report</span>
+    <span class="meta">A Forum for Communications Experimenters &middot; May 2026</span>
+  </div>
+
+  <h1 class="title">Region-Isolated Streaming for Real-World CW Copy</h1>
+  <p class="subtitle">A practical decoder architecture that holds 100% copy on multi-burst, mixed-speed off-air audio with operator pauses</p>
+  <p class="byline">Randy Treit, K&Oslash;RJT &mdash; with collaboration from the QsoRipper agent toolchain</p>
+  <p class="affiliation">QsoRipper Project &middot; <code>experiments/cw-decoder</code></p>
+
+  <div class="abstract">
+    <p><span class="label">Abstract.</span>
+      Off-air CW audio rarely behaves like a textbook practice file. An operator
+      sends a short burst at 13 WPM, pauses through 1&ndash;3 seconds of band hiss,
+      then sends another burst at 30 WPM, then pauses again. Most streaming
+      decoders &mdash; including our own earlier &ldquo;V3 envelope&rdquo; foundation &mdash;
+      handle the first burst well, but smear the second through residual lock
+      state, mis-classify dits and dahs at the new speed, or hallucinate
+      &ldquo;ghost&rdquo; characters from the static between bursts. This report describes
+      a region-isolated streaming architecture that detects each active CW burst
+      as a discrete region, decodes each region independently with its own
+      pitch and speed lock, and only commits the region&rsquo;s text to the
+      transcript once a trailing-static window confirms the burst has ended.
+      The architecture preserves the rich visualizer event stream of the
+      previous foundation, runs in true real-time on a stock laptop, and
+      delivers a 100% character-exact transcript on the target multi-burst
+      reference recording.
+    </p>
+  </div>
+
+  <div class="columns">
+
+  <h2>1. The Problem</h2>
+
+  <p>
+    QsoRipper is a keyboard-first ham-radio logging system whose CW
+    subsystem must do two things at once: paint a visualization of what
+    the radio is hearing right now (waveform, lock state, classified
+    elements, current and historical WPM) and append a clean text
+    transcript of every Morse character that actually came through. The
+    visualizer is forgiving &mdash; it is fine to show a flicker when the
+    band changes &mdash; but the transcript is not. Operators rely on it for
+    contest exchanges, callsign capture, and post-QSO reconstruction.
+    A single ghost word at the start of a transmission is worse than no
+    decode at all.
+  </p>
+
+  <p>
+    The reference test case for this work is
+    <code>radio-20260502-105714.mp3</code>, an off-air capture from the
+    author&rsquo;s Kenwood TS-590SG. The file contains four CW bursts at
+    visibly different speeds, separated by background hiss:
+  </p>
+
+  <ol>
+    <li><code>IHU</code> &mdash; ~13 WPM</li>
+    <li><code>NVCHU</code> &mdash; ~8 WPM</li>
+    <li><code>7QP W7N</code> &mdash; ~30 WPM</li>
+    <li><code>7QP W7N</code> &mdash; ~30 WPM (repeat)</li>
+  </ol>
+
+  <p>
+    The ground-truth file
+    <code>radio-20260502-105714.truth.txt</code> is the operator&rsquo;s
+    canonical copy: <code>IHU NVCHU 7QP W7N 7QP W7N</code>. The success
+    criterion was simple: produce that string, character for character,
+    when the same audio is streamed through the production logger&rsquo;s
+    F7 live-mic capture path. Anything less &mdash; a missing letter, a
+    ghost letter, a merged word &mdash; was treated as failure.
+  </p>
+
+  <h2>2. Why the Previous Foundation Came Up Short</h2>
+
+  <p>
+    The pre-existing &ldquo;V3 envelope&rdquo; decoder
+    (<code>stream-live-v3</code>) is built around a single
+    <code>LiveEnvelopeStreamer</code> that ingests audio continuously,
+    estimates a Goertzel envelope at the locked pitch, runs a
+    percentile-based hysteresis state machine to classify on/off
+    intervals, and feeds a k-means dot/dah classifier with a
+    sample-indexed commit cursor. It is excellent at painting the
+    visualizer and at producing a stable transcript on long, single-speed
+    transmissions. It powers the <code>cw_decode_rx_wpm</code> field that
+    the production logger writes to ADIF as
+    <code>APP_QSORIPPER_RX_WPM</code>.
+  </p>
+
+  <p>
+    On <code>radio-20260502-105714.mp3</code>, however, V3 produced a
+    transcript that drifted progressively further from truth as it moved
+    from burst to burst. The root causes were structural:
+  </p>
+
+  <ul>
+    <li>
+      <span class="key">Sticky speed lock.</span> The locked WPM from
+      burst&nbsp;1 (13 WPM) is still the working hypothesis when burst&nbsp;2
+      starts at 8 WPM. The k-means classifier mis-labels dahs from the
+      slower burst as dits, dits as inter-element gaps.
+    </li>
+    <li>
+      <span class="key">Stale noise floor.</span> The percentile-based
+      noise/signal floors are estimated over a sliding window. When
+      static between bursts dominates the window, the threshold drifts
+      and trailing dits of the previous burst can re-fire as ghost
+      elements.
+    </li>
+    <li>
+      <span class="key">Append-cursor smearing.</span> The
+      sample-indexed commit cursor advances monotonically. If a region
+      decodes wrong on the first pass, that wrong decode is locked into
+      the transcript &mdash; later cycles cannot undo it without producing
+      a worse artifact (the &ldquo;TSA USA EE TSA USA EE&rdquo;
+      ghost-repeat pattern).
+    </li>
+  </ul>
+
+  <p>
+    A natural fix was to add more tuning knobs to V3: tighter relock
+    thresholds, more aggressive noise-floor decay, content-stability
+    gates on the commit cursor. Each of those helped a little and broke
+    something else. After several rounds of this, we stepped back and
+    considered a different decomposition.
+  </p>
+
+  <h2>3. Region-Isolated Decoding</h2>
+
+  <p>
+    The insight is that real-world QSO audio is naturally segmented by
+    the operator. A burst is a discrete unit of intent: the operator
+    keys, sends some elements, releases. Between bursts, the receiver
+    sits in band noise. If we could detect those bursts as
+    <em>regions</em> and decode each region independently &mdash; with its
+    own fresh pitch lock, its own k-means classifier, its own WPM
+    estimate &mdash; the cross-burst contamination disappears by
+    construction. There is nothing to leak.
+  </p>
+
+  <figure>
+    <svg viewBox="0 0 760 200" xmlns="http://www.w3.org/2000/svg">
+      <!-- Time axis -->
+      <line x1="20" y1="120" x2="740" y2="120" stroke="#222" stroke-width="1"/>
+      <text x="20" y="138" font-size="11" fill="#555">t = 0</text>
+      <text x="710" y="138" font-size="11" fill="#555">end</text>
+
+      <!-- Noise floor band -->
+      <rect x="20" y="115" width="720" height="10" fill="#ddd" opacity="0.6"/>
+
+      <!-- Bursts -->
+      <rect x="60"  y="60" width="80"  height="60" fill="#102a54" opacity="0.85"/>
+      <text x="100" y="55" font-size="11" text-anchor="middle" fill="#102a54">IHU</text>
+      <text x="100" y="142" font-size="9" text-anchor="middle" fill="#555">~13 WPM</text>
+
+      <rect x="200" y="40" width="120" height="80" fill="#102a54" opacity="0.85"/>
+      <text x="260" y="35" font-size="11" text-anchor="middle" fill="#102a54">NVCHU</text>
+      <text x="260" y="142" font-size="9" text-anchor="middle" fill="#555">~8 WPM</text>
+
+      <rect x="380" y="70" width="140" height="50" fill="#102a54" opacity="0.85"/>
+      <text x="450" y="65" font-size="11" text-anchor="middle" fill="#102a54">7QP W7N</text>
+      <text x="450" y="142" font-size="9" text-anchor="middle" fill="#555">~30 WPM</text>
+
+      <rect x="570" y="70" width="140" height="50" fill="#102a54" opacity="0.85"/>
+      <text x="640" y="65" font-size="11" text-anchor="middle" fill="#102a54">7QP W7N</text>
+      <text x="640" y="142" font-size="9" text-anchor="middle" fill="#555">~30 WPM</text>
+
+      <!-- Region brackets -->
+      <g stroke="#b21f1f" stroke-width="1.5" fill="none">
+        <path d="M55 165 L55 175 L145 175 L145 165"/>
+        <path d="M195 165 L195 175 L325 175 L325 165"/>
+        <path d="M375 165 L375 175 L525 175 L525 165"/>
+        <path d="M565 165 L565 175 L715 175 L715 165"/>
+      </g>
+      <text x="100" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;1</text>
+      <text x="260" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;2</text>
+      <text x="450" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;3</text>
+      <text x="640" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;4</text>
+    </svg>
+    <figcaption>
+      <strong>Figure 1.</strong> Schematic envelope of
+      <code>radio-20260502-105714.mp3</code>. Four CW bursts (dark
+      bars) at three distinct speeds are separated by background hiss
+      (gray band). Each burst becomes one decode region (red brackets);
+      the inter-burst static is never decoded.
+    </figcaption>
+  </figure>
+
+  <h3>3.1 Detection</h3>
+
+  <p>
+    Region detection is implemented in
+    <code>region_stream.rs</code>::<code>decode_region_stream</code>. The
+    function performs a coarse Goertzel pitch sweep over the entire
+    buffer, picks the dominant tone, and computes a frame-level energy
+    envelope at that pitch. From the envelope it derives two robust
+    floors via percentiles:
+  </p>
+
+  <pre><code>noise_floor  = quantile(env, 0.30)
+signal_floor = quantile(env, 0.95)
+threshold    = noise_floor
+             + threshold_factor &times; (signal_floor - noise_floor)</code></pre>
+
+  <p>
+    With <code>threshold_factor = 0.30</code>, the decision boundary
+    sits 30% of the way up the dynamic range &mdash; well clear of band
+    noise, well below saturation. Frames above threshold are marked
+    &ldquo;active&rdquo;. Active runs are merged across short gaps
+    (<code>merge_gap_s = 0.5 s</code> by default), and runs shorter
+    than <code>min_region_s = 0.3 s</code> are rejected as transient
+    static spikes. Each surviving run is padded symmetrically by
+    <code>pad_s = 0.15 s</code> so leading and trailing dits are not
+    clipped.
+  </p>
+
+  <h3>3.2 Per-region decode</h3>
+
+  <p>
+    For each detected region, the audio slice is handed to the
+    <code>ditdah</code> baseline decoder with no carry-over state. The
+    decoder estimates pitch and dot length fresh, runs its own k-means
+    classification, and emits a transcript fragment. Because each
+    region is short and homogeneous (one operator, one burst, one
+    speed), the baseline decoder &mdash; which was always strong on
+    short clean clips &mdash; performs near-perfectly.
+  </p>
+
+  <h3>3.3 The streaming wrapper</h3>
+
+  <p>
+    <code>region_streamer.rs</code> wraps the batch detector for true
+    streaming use. It maintains a rolling sample buffer; on every
+    <code>try_commit()</code> call it re-runs detection over the
+    current buffer and reports any region whose end time is followed
+    by at least <code>stable_latency_s = 0.6 s</code> of trailing
+    static. That trailing-static window is the commit gate &mdash; it
+    guarantees that no further morse from the same burst can still be
+    arriving when we lock in the region&rsquo;s text.
+  </p>
+
+  <pre><code>// Append-only commit, deduplicated across decode cycles.
+for region in detected:
+    if region.start &le; last_committed_end:
+        continue                    // already committed
+    if region.end &gt; head - stable_latency:
+        break                       // not stable yet
+    transcript.append(region.text)
+    last_committed_end = region.end</code></pre>
+
+  <p>
+    For long-running live capture, <code>trim_committed()</code> drops
+    the buffer back to a configurable lookback (default 6 s past the
+    last committed region), and <code>reset()</code> clears all state
+    in response to the operator&rsquo;s <code>Ctrl+Alt+W</code> relock
+    request, all without restarting the decoder process.
+  </p>
+
+  <h2>4. Integration with the V3 Visualizer</h2>
+
+  <p>
+    A key design constraint was that the visualizer must keep working.
+    Operators rely on the live waveform, the lock indicator, the
+    pitch readout, and the rolling WPM gauge to know whether the
+    decoder is healthy. The V3 envelope path produces all of those as a
+    side effect of its frame-level processing; the region streamer
+    produces none of them.
+  </p>
+
+  <p>
+    The integration therefore runs both decoders in parallel. The new
+    <code>--region-transcript</code> flag on
+    <code>stream-live-v3</code> instantiates a <code>RegionStreamer</code>
+    alongside the existing <code>LiveEnvelopeStreamer</code>. Audio
+    chunks are fed to both. The envelope streamer continues to emit
+    NDJSON <code>viz</code> frames on every decode cycle, exactly as
+    before. The region streamer&rsquo;s
+    <code>try_commit()</code> result overrides only one field on the
+    emitted <code>text</code> / <code>appended</code> / <code>end</code>
+    events: the cumulative <code>transcript</code> string.
+  </p>
+
+  <figure>
+    <svg viewBox="0 0 760 240" xmlns="http://www.w3.org/2000/svg">
+      <!-- Audio source -->
+      <rect x="20" y="100" width="120" height="40" fill="#fff" stroke="#102a54" stroke-width="1.5"/>
+      <text x="80" y="125" font-size="12" text-anchor="middle" fill="#102a54">Audio chunks</text>
+      <text x="80" y="155" font-size="10" text-anchor="middle" fill="#555">(mic / file replay)</text>
+
+      <!-- Fanout -->
+      <line x1="140" y1="120" x2="220" y2="60"  stroke="#102a54" stroke-width="1.5"/>
+      <line x1="140" y1="120" x2="220" y2="180" stroke="#102a54" stroke-width="1.5"/>
+
+      <!-- Envelope path -->
+      <rect x="220" y="40" width="200" height="60" fill="#fff" stroke="#102a54" stroke-width="1.5"/>
+      <text x="320" y="60" font-size="12" text-anchor="middle" fill="#102a54">LiveEnvelopeStreamer</text>
+      <text x="320" y="78" font-size="10" text-anchor="middle" fill="#555">Goertzel + hysteresis</text>
+      <text x="320" y="92" font-size="10" text-anchor="middle" fill="#555">k-means dot/dah, viz frames</text>
+
+      <!-- Region path -->
+      <rect x="220" y="160" width="200" height="60" fill="#fff" stroke="#b21f1f" stroke-width="1.5"/>
+      <text x="320" y="180" font-size="12" text-anchor="middle" fill="#b21f1f">RegionStreamer</text>
+      <text x="320" y="198" font-size="10" text-anchor="middle" fill="#555">burst detection +</text>
+      <text x="320" y="212" font-size="10" text-anchor="middle" fill="#555">per-region ditdah decode</text>
+
+      <!-- Merge -->
+      <line x1="420" y1="70"  x2="500" y2="120" stroke="#102a54" stroke-width="1.5"/>
+      <line x1="420" y1="190" x2="500" y2="120" stroke="#b21f1f" stroke-width="1.5"/>
+
+      <!-- Output -->
+      <rect x="500" y="80" width="240" height="80" fill="#fff" stroke="#102a54" stroke-width="1.5"/>
+      <text x="620" y="105" font-size="12" text-anchor="middle" fill="#102a54">NDJSON event stream</text>
+      <text x="620" y="125" font-size="10" text-anchor="middle" fill="#555">viz frames &larr; envelope</text>
+      <text x="620" y="142" font-size="10" text-anchor="middle" fill="#b21f1f">transcript &larr; region</text>
+    </svg>
+    <figcaption>
+      <strong>Figure 2.</strong> Dual-path integration. Audio is fanned
+      out to both decoders. The envelope path retains full ownership
+      of the visualizer&rsquo;s real-time frames; the region path owns
+      only the cumulative transcript field. Both UIs (production
+      logger F7 capture and the experimental visualizer) consume the
+      merged NDJSON stream unchanged.
+    </figcaption>
+  </figure>
+
+  <p>
+    Both UI surfaces &mdash; the production logger&rsquo;s
+    <code>CwDecoderProcessSampleSource</code> and the experimental
+    visualizer&rsquo;s <code>CwDecoderProcess</code> &mdash; spawn the
+    decoder with <code>--region-transcript</code> by default. Operators
+    do not see a new mode switch; they simply get a transcript that
+    matches what they actually heard.
+  </p>
+
+  <h2>5. Results</h2>
+
+  <p>
+    On the target reference recording, the architecture meets the
+    success criterion exactly:
+  </p>
+
+  <table>
+    <thead>
+      <tr><th>Path</th><th>Output transcript</th><th>vs. truth</th></tr>
+    </thead>
+    <tbody>
+      <tr class="match">
+        <td>truth.txt</td>
+        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
+        <td>&mdash;</td>
+      </tr>
+      <tr class="match">
+        <td><code>stream-region</code> (batch)</td>
+        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
+        <td>0 char diff</td>
+      </tr>
+      <tr class="match">
+        <td><code>stream-live-v3 --region-transcript</code></td>
+        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
+        <td>0 char diff</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>
+    A cross-validation run over additional samples confirms that the
+    streaming wrapper reproduces the batch reference on real CW audio:
+  </p>
+
+  <table>
+    <thead>
+      <tr><th>Sample</th><th>Description</th><th>Match</th></tr>
+    </thead>
+    <tbody>
+      <tr class="match">
+        <td><code>radio-20260502-105714.mp3</code></td>
+        <td>4 bursts, mixed WPM, real radio</td>
+        <td>yes</td>
+      </tr>
+      <tr class="match">
+        <td><code>cw_30wpm_abbrev_clean.wav</code></td>
+        <td>continuous, clean 30 WPM</td>
+        <td>yes</td>
+      </tr>
+      <tr class="match">
+        <td><code>cw_30wpm_abbrev_weak.wav</code></td>
+        <td>continuous, weak 30 WPM</td>
+        <td>yes</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>
+    On two extreme noise-only clips that contain no real CW content, the
+    incremental streaming and the batch reference produce different
+    sequences of garbage characters. This is an inherent property of
+    incremental versus batch noise-floor estimation and does not affect
+    real-CW operation. It is discussed in <a href="#future">Section&nbsp;7</a>.
+  </p>
+
+  <div class="callout">
+    <p><span class="label">Validation gates.</span>
+      The change clears <code>cargo&nbsp;fmt</code>,
+      <code>cargo&nbsp;clippy&nbsp;-D&nbsp;warnings</code>, the full
+      <code>cargo&nbsp;test</code> suite (129 passing, one pre-existing
+      environmental skip unrelated to this work),
+      <code>dotnet&nbsp;publish&nbsp;CwDecoderGui&nbsp;-c&nbsp;Release</code>,
+      and <code>dotnet&nbsp;build&nbsp;QsoRipper.Gui&nbsp;-c&nbsp;Release</code>.
+    </p>
+  </div>
+
+  <h2>6. Discussion</h2>
+
+  <h3>6.1 Latency</h3>
+
+  <p>
+    The trailing-static commit gate trades latency for correctness. With
+    <code>stable_latency_s = 0.6 s</code>, a region&rsquo;s text appears
+    in the transcript roughly 0.6 s after the operator releases the key
+    at the end of a burst. For logging and post-QSO copy this is
+    negligible. For real-time pile-up triage it would be perceptible;
+    the parameter is exposed as <code>--region-stable-latency-s</code>
+    and can be reduced at the cost of occasional re-decode churn.
+  </p>
+
+  <h3>6.2 Why batch and stream agree on real CW</h3>
+
+  <p>
+    The streaming wrapper and the batch reference call the same
+    <code>decode_region_stream</code> over the same audio. The only
+    difference is that the streaming wrapper invokes it incrementally
+    on a growing buffer. As long as the noise-floor percentiles are
+    stable across cycles &mdash; which they are once a real CW signal is
+    present &mdash; the detected regions are identical and the per-region
+    decoder is deterministic. On clips with no real signal, the
+    percentiles drift with the buffer length and incremental commits
+    can capture transient noise spikes that the batch reference
+    smooths out.
+  </p>
+
+  <h3>6.3 Relation to the append-only event-stream foundation</h3>
+
+  <p>
+    The append-only event-stream decoder in
+    <code>append_decode.rs</code> is not deprecated. It remains the
+    source of truth for the visualizer&rsquo;s bar painting and for
+    the time-weighted <code>cw_decode_rx_wpm</code> aggregator that
+    feeds ADIF. The region-isolated path supplements that foundation
+    for the transcript field; the two are now both &ldquo;line in the
+    sand&rdquo; baselines, each governing its own concern.
+  </p>
+
+  <h2 id="future">7. Future Directions</h2>
+
+  <p>
+    Several extensions are natural next steps:
+  </p>
+
+  <ul>
+    <li>
+      <span class="key">Content-stability gate.</span> Require a
+      candidate region to produce identical decoded text across
+      <i>N</i> consecutive <code>try_commit</code> cycles before
+      committing. This would converge the streaming and batch outputs
+      on noisy non-CW clips at the cost of one decode period of
+      additional latency. A prototype was implemented and reverted to
+      keep the current behavior surgical and faithful to the batch
+      reference; it is the obvious next iteration.
+    </li>
+    <li>
+      <span class="key">Adaptive trailing-static window.</span>
+      Slow CW (5&ndash;8 WPM) has intra-character gaps approaching the
+      current 0.6 s commit gate. An adaptive
+      <code>stable_latency_s = max(0.6, 4 &times; estimated_dot_period)</code>
+      would let the gate scale with the operator&rsquo;s speed without
+      manual tuning.
+    </li>
+    <li>
+      <span class="key">Multi-pitch region routing.</span> When two
+      stations share the passband at different pitches, the existing
+      <code>LiveMultiPitchStreamer</code> already separates them at the
+      envelope level. Routing per-pitch envelopes into per-pitch
+      <code>RegionStreamer</code> instances would let us produce two
+      simultaneous transcripts &mdash; useful for SO2R and contest
+      monitoring.
+    </li>
+    <li>
+      <span class="key">Confidence and provisional text.</span>
+      The current commit gate is binary: a region is either committed
+      or invisible. A provisional-text channel that surfaces in-flight
+      regions with a confidence band would let the GUI render copy as
+      it forms, without disturbing the committed transcript.
+    </li>
+    <li>
+      <span class="key">Integration into the engine-side
+      <code>CwDecodeService</code>.</span> The decoder presently runs
+      as a subprocess of each UI. Promoting it to a gRPC service in
+      <code>src/rust/qsoripper-server</code> would let multiple clients
+      (Avalonia GUI, web dashboard, future TUI) share a single decoder
+      instance and a single set of region commits.
+    </li>
+    <li>
+      <span class="key">Larger labeled corpus.</span> The strongest
+      protection against regression is a broad, real-world test set.
+      Expanding the existing <code>training-set-a</code> /
+      <code>training-set-b</code> with more multi-burst, mixed-speed,
+      mixed-conditions captures &mdash; each with an operator-supplied
+      truth file &mdash; is the cheapest way to keep raising the bar.
+    </li>
+  </ul>
+
+  <h2>8. Reproducing the Result</h2>
+
+  <p>
+    The complete cross-validation can be reproduced from a clean
+    checkout in a few minutes:
+  </p>
+
+  <pre><code>cd C:\Users\randy\Git\qsoripper
+cargo build --manifest-path experiments\cw-decoder\Cargo.toml --release
+
+$exe   = "experiments\cw-decoder\target\release\cw-decoder.exe"
+$base  = "C:\...\cw-samples\training-set-b"
+$f     = "$base\radio-20260502-105714.mp3"
+$truth = (Get-Content "$base\radio-20260502-105714.truth.txt" -Raw).Trim()
+
+# Batch reference.
+&amp; $exe stream-region --file $f --json --no-realtime `
+    --decode-every-ms 250 |
+    Select-String '"type":"end"' | Select-Object -Last 1
+
+# Live streaming path used by both UIs.
+&amp; $exe stream-live-v3 --file $f --json --region-transcript `
+    --decode-every-ms 250 |
+    Select-String '"type":"end"' | Select-Object -Last 1
+
+# Both transcript fields should equal $truth:
+#   IHU NVCHU 7QP W7N 7QP W7N</code></pre>
+
+  <h2>9. Conclusion</h2>
+
+  <p>
+    Multi-burst, mixed-speed off-air CW is a different problem from
+    long single-speed practice files, and it benefits from a different
+    decomposition. By detecting each operator burst as a region,
+    decoding each region independently, and committing only after a
+    trailing-static window, we achieve 100% character-exact transcripts
+    on real-world QSO audio that previously defeated our envelope-only
+    foundation. The architecture preserves the rich visualizer event
+    stream, integrates cleanly into both UI surfaces, and is now the
+    documented baseline against which future CW decoding experiments
+    will be measured. Future work will refine the commit gate, extend
+    to multi-pitch and provisional output, and grow the labeled corpus
+    that protects this baseline from regression.
+  </p>
+
+  <h2>Acknowledgments</h2>
+
+  <p>
+    Thanks to the upstream <code>ditdah</code> baseline decoder for the
+    short-clip Morse decoding that each region relies on, and to the
+    QsoRipper agent toolchain (Claude, GitHub Copilot CLI) for
+    rubber-ducking the architecture and helping cross-validate it
+    against the labeled corpus.
+  </p>
+
+  <h2 class="refs-h">References</h2>
+
+  <div class="refs">
+    <ol>
+      <li>
+        QsoRipper repository,
+        <code>experiments/cw-decoder/</code> &mdash; primary source for
+        the implementation discussed in this report.
+      </li>
+      <li>
+        QsoRipper PR&nbsp;#375, &ldquo;cw-decoder: region-based streaming
+        decoder (100% match on real-world QSO sample)&rdquo;, batch
+        path.
+      </li>
+      <li>
+        QsoRipper PR&nbsp;#376, &ldquo;cw-decoder: wire region-isolated
+        transcript into live streaming + GUIs&rdquo;.
+      </li>
+      <li>
+        ARRL, <i>The ARRL Handbook for Radio Communications</i>,
+        chapter on Morse code timing and PARIS-derived WPM.
+      </li>
+      <li>
+        Goertzel, G., &ldquo;An Algorithm for the Evaluation of Finite
+        Trigonometric Series&rdquo;, <i>American Mathematical Monthly</i>,
+        Vol.&nbsp;65, No.&nbsp;1, 1958, pp.&nbsp;34&ndash;35.
+      </li>
+      <li>
+        Lloyd, S. P., &ldquo;Least Squares Quantization in PCM&rdquo;,
+        <i>IEEE Transactions on Information Theory</i>,
+        Vol.&nbsp;28, No.&nbsp;2, 1982, pp.&nbsp;129&ndash;137 (the
+        k-means classifier underlying the dot/dah decision).
+      </li>
+    </ol>
+  </div>
+
+  </div><!-- /columns -->
+
+  <div class="footer">
+    QsoRipper Technical Report &middot; <i>Region-Isolated Streaming for
+    Real-World CW Copy</i> &middot; rev. May 2026.
+    Source: <code>experiments/cw-decoder/docs/cw-decoder-architecture.html</code>.
+  </div>
+
+</div>
+</body>
+</html>

--- a/experiments/cw-decoder/docs/cw-decoder-architecture.html
+++ b/experiments/cw-decoder/docs/cw-decoder-architecture.html
@@ -425,6 +425,18 @@ threshold    = noise_floor
     clipped.
   </p>
 
+  <p>
+    A later synthetic impairment sweep added one more guard that belongs
+    in the baseline: before a detected run is decoded, it must show
+    narrowband CW-like prominence. The implementation compares Goertzel
+    power at the selected pitch against the run&rsquo;s broadband frame
+    energy and rejects runs below
+    <code>min_tonal_prominence_ratio = 8.0</code>. This prevents pure
+    background static from being promoted into fake regions simply
+    because a percentile threshold can always split random noise into
+    &ldquo;above&rdquo; and &ldquo;below&rdquo; frames.
+  </p>
+
   <h3>3.2 Per-region decode</h3>
 
   <p>
@@ -602,12 +614,41 @@ for region in detected:
   </table>
 
   <p>
-    On two extreme noise-only clips that contain no real CW content, the
-    incremental streaming and the batch reference produce different
-    sequences of garbage characters. This is an inherent property of
-    incremental versus batch noise-floor estimation and does not affect
-    real-CW operation. It is discussed in <a href="#future">Section&nbsp;7</a>.
+    A synthetic impairment suite now exercises the baseline beyond the
+    reference MP3. It generates deterministic CW with quiet static gaps,
+    additive white noise, QSB amplitude fading, an offset continuous-tone
+    QRM carrier, and a combined noise/QSB/QRM exchange. The suite also
+    includes a noise-only stream that previously produced ghost text;
+    after the tonal-prominence guard, it remains empty.
   </p>
+
+  <table>
+    <thead>
+      <tr><th>Synthetic condition</th><th>Expected behavior</th><th>Result</th></tr>
+    </thead>
+    <tbody>
+      <tr class="match">
+        <td>clean four-burst reference shape</td>
+        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code>, four regions</td>
+        <td>pass</td>
+      </tr>
+      <tr class="match">
+        <td>quiet static between bursts</td>
+        <td>same exact copy, no extra regions</td>
+        <td>pass</td>
+      </tr>
+      <tr class="match">
+        <td>noise-only static stream</td>
+        <td>empty transcript</td>
+        <td>pass</td>
+      </tr>
+      <tr class="match">
+        <td>moderate white noise + QSB + offset QRM</td>
+        <td><code>CQ TEST KC7AVA 73</code></td>
+        <td>pass</td>
+      </tr>
+    </tbody>
+  </table>
 
   <div class="callout">
     <p><span class="label">Validation gates.</span>

--- a/experiments/cw-decoder/gui/Services/CwDecoderProcess.cs
+++ b/experiments/cw-decoder/gui/Services/CwDecoderProcess.cs
@@ -92,7 +92,12 @@ internal sealed class CwDecoderProcess : IDisposable
     {
         Stop();
         var ic = CultureInfo.InvariantCulture;
-        var args = $"stream-live-v3 --json --stdin-control --decode-every-ms {decodeEveryMs.ToString(ic)}";
+        // --region-transcript runs a RegionStreamer alongside the
+        // envelope decoder so the visualizer keeps its viz events but
+        // the transcript field is sourced from region-isolated decode.
+        // Handles real-world QSO audio with pauses between bursts at
+        // very different WPMs.
+        var args = $"stream-live-v3 --json --stdin-control --region-transcript --decode-every-ms {decodeEveryMs.ToString(ic)}";
         if (pinWpm > 0) args += $" --pin-wpm {pinWpm.ToString(ic)}";
         if (pinHz > 0) args += $" --pin-hz {pinHz.ToString(ic)}";
         if (!string.IsNullOrWhiteSpace(device)) args += $" --device \"{device}\"";
@@ -105,7 +110,8 @@ internal sealed class CwDecoderProcess : IDisposable
     {
         Stop();
         var ic = CultureInfo.InvariantCulture;
-        var args = $"stream-live-v3 --json --decode-every-ms {decodeEveryMs.ToString(ic)} --file \"{filePath}\"";
+        // See StartLiveV3 for --region-transcript rationale.
+        var args = $"stream-live-v3 --json --region-transcript --decode-every-ms {decodeEveryMs.ToString(ic)} --file \"{filePath}\"";
         if (playAudio) args += " --play";
         if (pinWpm > 0) args += $" --pin-wpm {pinWpm.ToString(ic)}";
         if (pinHz > 0) args += $" --pin-hz {pinHz.ToString(ic)}";

--- a/experiments/cw-decoder/src/envelope_decoder.rs
+++ b/experiments/cw-decoder/src/envelope_decoder.rs
@@ -2071,12 +2071,7 @@ mod tests {
         let timed = timed_from_pattern(dot, ".--. .- .-. .. ...");
         let est = estimate_dot_period(&timed).expect("intra-element pairs present");
         // Period method should recover 40 ms within 5%.
-        assert!(
-            (est - dot).abs() < 0.05 * dot,
-            "expected ~{}, got {}",
-            dot,
-            est
-        );
+        assert!((est - dot).abs() < 0.05 * dot, "expected ~{dot}, got {est}");
     }
 
     #[test]

--- a/experiments/cw-decoder/src/lib.rs
+++ b/experiments/cw-decoder/src/lib.rs
@@ -14,6 +14,7 @@ pub mod log_capture;
 pub mod preprocess;
 pub mod preview;
 pub mod region_stream;
+pub mod region_streamer;
 pub mod streaming;
 pub mod streaming_v2;
 pub mod tui;

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -559,6 +559,51 @@ enum Cmd {
         #[arg(long, alias = "multi", default_value_t = 0)]
         multi_pitch: usize,
     },
+    /// Region-based streaming decoder. Detects active morse bursts
+    /// (separated by background static), decodes each burst with the
+    /// ditdah baseline at its own auto-WPM, and emits append-only
+    /// transcript JSON events. Designed for real-world QSO audio with
+    /// pauses between transmissions and bursts at very different speeds.
+    ///
+    /// Currently file-only. Emits the same `transcript` event shape as
+    /// stream-live-v3 so the GUI's CwQsoTranscriptAggregator picks it up
+    /// transparently.
+    StreamRegion {
+        /// Decode an audio file (mp3/wav/m4a/...) at real-time pace.
+        #[arg(long)]
+        file: PathBuf,
+        /// Emit NDJSON events to stdout (one per line).
+        #[arg(long)]
+        json: bool,
+        /// Re-run region detection every N ms. Default 500 ms.
+        #[arg(long, default_value_t = 500)]
+        decode_every_ms: u64,
+        /// Trailing-static seconds required before a region is committed.
+        /// Higher values reduce mid-burst churn at the cost of latency.
+        #[arg(long, default_value_t = 0.6)]
+        stable_latency_s: f32,
+        /// Treat regions separated by less than this gap (seconds) as one
+        /// burst. Defaults are tuned for the common case where bursts are
+        /// separated by static of ~1 s or more.
+        #[arg(long, default_value_t = 0.5)]
+        merge_gap_s: f32,
+        /// Drop detected runs shorter than this many seconds (rejects
+        /// transient static spikes).
+        #[arg(long, default_value_t = 0.3)]
+        min_region_s: f32,
+        /// Threshold = noise_floor + factor * (signal_floor - noise_floor).
+        /// 0.30 works well across the test set; raise for noisier feeds.
+        #[arg(long, default_value_t = 0.30)]
+        threshold_factor: f32,
+        /// Symmetrical padding (seconds) added to each detected region
+        /// before decoding so leading/trailing dits aren't clipped.
+        #[arg(long, default_value_t = 0.15)]
+        pad_s: f32,
+        /// Replay the file as fast as possible instead of at real-time
+        /// pace. Useful for tests and one-shot batch decodes.
+        #[arg(long)]
+        no_realtime: bool,
+    },
     /// Diagnostic: scan candidate pitches across an audio file and print
     /// the trial-decode Fisher score per pitch. Use this to compare
     /// faint signals vs noise and tune lock thresholds.
@@ -1077,6 +1122,27 @@ fn run_cli() -> Result<()> {
             file.as_deref(),
             play,
             multi_pitch,
+        ),
+        Cmd::StreamRegion {
+            file,
+            json,
+            decode_every_ms,
+            stable_latency_s,
+            merge_gap_s,
+            min_region_s,
+            threshold_factor,
+            pad_s,
+            no_realtime,
+        } => run_stream_region_file(
+            &file,
+            json,
+            decode_every_ms,
+            stable_latency_s,
+            merge_gap_s,
+            min_region_s,
+            threshold_factor,
+            pad_s,
+            !no_realtime,
         ),
         Cmd::ProbeFisher {
             path,
@@ -4490,7 +4556,164 @@ fn run_stream_live_v3_file(
     Ok(())
 }
 
-/// Returns true when the per-cycle decoder snapshot is trustworthy
+/// Region-based streaming decoder (file mode).
+///
+/// Streams the file at real-time pace into a [`RegionStreamer`] that
+/// detects active morse bursts (separated by background static),
+/// decodes each burst at its own auto-WPM with the ditdah baseline,
+/// and emits append-only `transcript` JSON events to stdout.
+///
+/// Validated end-to-end on the `radio-20260502-105714.mp3` real-world
+/// sample (4 bursts at 13/8/39/29 WPM separated by ~1-7s of static)
+/// where it produces an exact match for the ground truth transcript.
+fn run_stream_region_file(
+    path: &std::path::Path,
+    json: bool,
+    decode_every_ms: u64,
+    stable_latency_s: f32,
+    merge_gap_s: f32,
+    min_region_s: f32,
+    threshold_factor: f32,
+    pad_s: f32,
+    realtime: bool,
+) -> Result<()> {
+    use cw_decoder_poc::region_stream::RegionStreamConfig;
+    use cw_decoder_poc::region_streamer::{RegionStreamer, RegionStreamerConfig};
+    use std::time::{Duration, Instant};
+
+    let decoded = audio::decode_file(path)?;
+    let sr = decoded.sample_rate;
+    let total_samples = decoded.samples.len();
+    let duration_s = total_samples as f32 / sr.max(1) as f32;
+
+    let region_cfg = RegionStreamConfig {
+        merge_gap_s,
+        min_region_s,
+        threshold_factor,
+        pad_s,
+        ..RegionStreamConfig::default()
+    };
+
+    let cfg = RegionStreamerConfig {
+        region: region_cfg,
+        stable_latency_s,
+    };
+    let mut streamer = RegionStreamer::with_config(sr, cfg);
+
+    let mut emitter = if json {
+        Some(json::JsonEmitter::new())
+    } else {
+        None
+    };
+    if let Some(em) = emitter.as_mut() {
+        em.emit(
+            0.0,
+            serde_json::json!({
+                "type": "ready",
+                "source": "stream-region-file",
+                "device": format!("file:{}", path.display()),
+                "rate": sr,
+                "decode_every_ms": decode_every_ms,
+                "duration_s": duration_s,
+                "stable_latency_s": stable_latency_s,
+                "merge_gap_s": merge_gap_s,
+                "min_region_s": min_region_s,
+                "threshold_factor": threshold_factor,
+                "pad_s": pad_s,
+            }),
+        );
+    } else {
+        println!(
+            "Streaming file (region-based): {} @ {} Hz ({:.2}s); decode every {} ms; stable_latency={:.2}s",
+            path.display(),
+            sr,
+            duration_s,
+            decode_every_ms,
+            stable_latency_s,
+        );
+    }
+
+    let chunk_period = Duration::from_millis(50);
+    let chunk_samples = ((sr as u64 * 50) / 1000).max(1) as usize;
+    let started = Instant::now();
+    let mut last_decode_at = Instant::now() - Duration::from_millis(decode_every_ms);
+    let decode_period = Duration::from_millis(decode_every_ms);
+    let mut cursor = 0usize;
+
+    while cursor < total_samples {
+        let end = (cursor + chunk_samples).min(total_samples);
+        let chunk = &decoded.samples[cursor..end];
+        cursor = end;
+        streamer.ingest(chunk);
+
+        if last_decode_at.elapsed() >= decode_period {
+            last_decode_at = Instant::now();
+            let committed = streamer.try_commit();
+            let t = started.elapsed().as_secs_f32();
+            emit_region_transcript(emitter.as_mut(), t, streamer.transcript(), &committed);
+        }
+
+        if realtime {
+            std::thread::sleep(chunk_period);
+        }
+    }
+
+    // Final commit: force-flush any in-flight regions.
+    let final_committed = streamer.flush();
+    let t = started.elapsed().as_secs_f32();
+    emit_region_transcript(emitter.as_mut(), t, streamer.transcript(), &final_committed);
+
+    if let Some(em) = emitter.as_mut() {
+        em.emit(
+            t,
+            serde_json::json!({
+                "type": "end",
+                "transcript": streamer.transcript(),
+                "committed": streamer.transcript(),
+            }),
+        );
+    } else {
+        println!();
+        println!("Final transcript (region-based):");
+        println!("{}", streamer.transcript());
+    }
+    Ok(())
+}
+
+fn emit_region_transcript(
+    emitter: Option<&mut json::JsonEmitter>,
+    t: f32,
+    transcript: &str,
+    just_committed: &[cw_decoder_poc::region_streamer::CommittedRegion],
+) {
+    if let Some(em) = emitter {
+        let appended: String = just_committed
+            .iter()
+            .map(|r| r.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        em.emit(
+            t,
+            serde_json::json!({
+                "type": "transcript",
+                "text": transcript,
+                "appended": appended,
+                "transcript": transcript,
+                "committed": transcript,
+                "provisional": "",
+                "wpm": 0.0,
+            }),
+        );
+    } else if !just_committed.is_empty() {
+        for r in just_committed {
+            println!(
+                "[t={:>6.2}s region {:.2}-{:.2}] {}",
+                t, r.start_s, r.end_s, r.text
+            );
+        }
+    }
+}
+
 /// enough to be stitched into the persistent session transcript.
 ///
 /// The streamer enters `LOCKED` (i.e. `viz.locked_wpm = Some(_)`) only

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -558,6 +558,30 @@ enum Cmd {
         /// alongside the single-track `transcript` event.
         #[arg(long, alias = "multi", default_value_t = 0)]
         multi_pitch: usize,
+
+        /// Use the region-based decoder for the transcript field.
+        /// When set, a RegionStreamer is run alongside the envelope
+        /// pipeline; viz events still come from the envelope decoder
+        /// (so the visualizer keeps working) but the `transcript` event
+        /// `text`/`appended` fields and the final `end` transcript come
+        /// from region-isolated ditdah decode. This is the
+        /// "human-level" path that handles real-world QSO audio with
+        /// pauses between bursts at different WPMs. Recommended for all
+        /// production live capture.
+        #[arg(long)]
+        region_transcript: bool,
+
+        /// Trailing-static seconds required before a region is committed
+        /// when `--region-transcript` is set. Higher = less mid-burst
+        /// churn at the cost of latency. Default 0.6 s.
+        #[arg(long, default_value_t = 0.6)]
+        region_stable_latency_s: f32,
+
+        /// During live capture, drop buffered audio that ends more than
+        /// this many seconds before the last committed region. Bounds
+        /// memory growth across long QSO sessions. Default 5 s.
+        #[arg(long, default_value_t = 5.0)]
+        region_keep_back_s: f32,
     },
     /// Region-based streaming decoder. Detects active morse bursts
     /// (separated by background static), decodes each burst with the
@@ -1108,6 +1132,9 @@ fn run_cli() -> Result<()> {
             file,
             play,
             multi_pitch,
+            region_transcript,
+            region_stable_latency_s,
+            region_keep_back_s,
         } => run_stream_live_v3(
             device.as_deref(),
             seconds,
@@ -1122,6 +1149,9 @@ fn run_cli() -> Result<()> {
             file.as_deref(),
             play,
             multi_pitch,
+            region_transcript,
+            region_stable_latency_s,
+            region_keep_back_s,
         ),
         Cmd::StreamRegion {
             file,
@@ -3942,6 +3972,9 @@ fn run_stream_live_v3(
     file: Option<&std::path::Path>,
     play_file_audio: bool,
     multi_pitch: usize,
+    region_transcript: bool,
+    region_stable_latency_s: f32,
+    region_keep_back_s: f32,
 ) -> Result<()> {
     if let Some(path) = file {
         return run_stream_live_v3_file(
@@ -3954,11 +3987,14 @@ fn run_stream_live_v3(
             min_snr_db,
             play_file_audio,
             multi_pitch,
+            region_transcript,
+            region_stable_latency_s,
         );
     }
     use cw_decoder_poc::envelope_decoder::{
         LiveEnvelopeStreamer, LiveMultiPitchStreamer, VizEventKind, MAX_VIZ_ENVELOPE_SAMPLES,
     };
+    use cw_decoder_poc::region_streamer::{RegionStreamer, RegionStreamerConfig};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
@@ -3988,6 +4024,29 @@ fn run_stream_live_v3(
         }
     };
     let mut multi_streamer = new_multi();
+
+    let new_region = || {
+        if !region_transcript {
+            None
+        } else {
+            // Start from the streamer's TUNED defaults (merge_gap=0.5,
+            // min_region=0.3, pad=0.15, threshold=0.30) — the raw
+            // RegionStreamConfig::default() uses merge_gap=3.0 which
+            // glues real-world bursts that are <3s apart into one
+            // region and silently drops the trailing burst.
+            let defaults = RegionStreamerConfig::default();
+            let mut region = defaults.region;
+            if let Some(w) = pin_wpm {
+                region.pin_wpm = Some(w);
+            }
+            let cfg = RegionStreamerConfig {
+                region,
+                stable_latency_s: region_stable_latency_s.max(0.0),
+            };
+            Some(RegionStreamer::with_config(capture.sample_rate, cfg))
+        }
+    };
+    let mut region_streamer = new_region();
 
     let stop = Arc::new(AtomicBool::new(false));
     {
@@ -4065,6 +4124,7 @@ fn run_stream_live_v3(
                 if matches!(msg, StdinControlMessage::ResetLock) {
                     streamer = new_streamer();
                     multi_streamer = new_multi();
+                    region_streamer = new_region();
                     last_drain_at = capture.buffer.lock().written;
                     commit_cursor.reset_all();
                     append_decoder = cw_decoder_poc::append_decode::AppendEventDecoder::new();
@@ -4098,6 +4158,9 @@ fn run_stream_live_v3(
             if let Some(m) = multi_streamer.as_mut() {
                 let _ = m.feed(&chunk);
             }
+            if let Some(r) = region_streamer.as_mut() {
+                r.ingest(&chunk);
+            }
         }
 
         if last_decode_at.elapsed() < decode_period {
@@ -4108,6 +4171,27 @@ fn run_stream_live_v3(
         // Force a viz-producing decode now.
         let snap = streamer.flush_with_viz();
         let t = started.elapsed().as_secs_f32();
+        // When --region-transcript is set, drive the cumulative
+        // transcript field from the region-isolated decoder. This
+        // handles real-world QSO audio with pauses between bursts at
+        // very different WPMs (e.g. 8 vs 39 WPM) where a single-pass
+        // envelope decoder is structurally limited to one WPM lock.
+        let region_commits = region_streamer
+            .as_mut()
+            .map(|r| r.try_commit())
+            .unwrap_or_default();
+        let region_text_full = region_streamer
+            .as_ref()
+            .map(|r| r.transcript().to_string())
+            .unwrap_or_default();
+        let region_appended: String = region_commits
+            .iter()
+            .map(|r| r.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if let Some(r) = region_streamer.as_mut() {
+            r.trim_committed(region_keep_back_s);
+        }
         // Approach A+: event-driven commit cursor (sample-indexed,
         // idempotent across re-decodes) replaces the old
         // string-stitching path that produced ghost-repeats like
@@ -4149,20 +4233,34 @@ fn run_stream_live_v3(
             );
         }
 
+        // Effective transcript-event payload. Region path overrides
+        // text/appended when active.
+        let use_region = region_streamer.is_some();
+        let eff_text = if use_region {
+            region_text_full.clone()
+        } else {
+            append.decoded_text.clone()
+        };
+        let eff_appended = if use_region {
+            region_appended.clone()
+        } else {
+            appended_session.clone()
+        };
         if let Some(em) = emitter.as_mut() {
             em.emit(
                 t,
                 serde_json::json!({
                     "type": "transcript",
-                    "text": append.decoded_text,
-                    "appended": appended_session,
-                    "transcript": append.decoded_text,
-                    "committed": commit.committed_text,
-                    "provisional": commit.provisional_tail,
+                    "text": eff_text,
+                    "appended": eff_appended,
+                    "transcript": eff_text,
+                    "committed": if use_region { region_text_full.clone() } else { commit.committed_text.clone() },
+                    "provisional": if use_region { String::new() } else { commit.provisional_tail.clone() },
                     "cursor_transcript": session_transcript.clone(),
                     "raw_morse": append.raw_stream,
                     "window_text": snap.transcript,
                     "wpm": snap.wpm,
+                    "region_mode": use_region,
                 }),
             );
             if let Some(viz) = snap.viz {
@@ -4259,20 +4357,36 @@ fn run_stream_live_v3(
     let recording_saved = capture
         .finalize_recording()
         .map(|p| p.display().to_string());
+    // Final flush for region streamer to commit any in-flight burst.
+    let final_region_text = if let Some(r) = region_streamer.as_mut() {
+        let _ = r.flush();
+        r.transcript().to_string()
+    } else {
+        String::new()
+    };
     if let Some(em) = emitter.as_mut() {
+        let final_text = if region_streamer.is_some() {
+            final_region_text
+        } else {
+            commit_cursor.committed_text().to_string()
+        };
         em.emit(
             started.elapsed().as_secs_f32(),
             serde_json::json!({
                 "type": "end",
-                "transcript": commit_cursor.committed_text(),
-                "committed": commit_cursor.committed_text(),
+                "transcript": final_text,
+                "committed": final_text,
                 "recording": recording_saved.or(recording_path),
             }),
         );
     } else {
         println!();
         println!("Final transcript (v3):");
-        println!("{}", commit_cursor.committed_text());
+        if region_streamer.is_some() {
+            println!("{final_region_text}");
+        } else {
+            println!("{}", commit_cursor.committed_text());
+        }
     }
     Ok(())
 }
@@ -4287,10 +4401,13 @@ fn run_stream_live_v3_file(
     min_snr_db: f32,
     play_file_audio: bool,
     multi_pitch: usize,
+    region_transcript: bool,
+    region_stable_latency_s: f32,
 ) -> Result<()> {
     use cw_decoder_poc::envelope_decoder::{
         LiveEnvelopeStreamer, LiveMultiPitchStreamer, VizEventKind, MAX_VIZ_ENVELOPE_SAMPLES,
     };
+    use cw_decoder_poc::region_streamer::{RegionStreamer, RegionStreamerConfig};
     use std::time::{Duration, Instant};
 
     let decoded = audio::decode_file(path)?;
@@ -4317,6 +4434,24 @@ fn run_stream_live_v3_file(
         s.set_pinned_wpm(pin_wpm);
         s.set_min_snr_db(min_snr_db);
         Some(s)
+    };
+
+    let mut region_streamer = if region_transcript {
+        // See run_stream_live_v3 for rationale on starting from the
+        // RegionStreamerConfig::default() tuned defaults rather than
+        // raw RegionStreamConfig::default().
+        let defaults = RegionStreamerConfig::default();
+        let mut region = defaults.region;
+        if let Some(w) = pin_wpm {
+            region.pin_wpm = Some(w);
+        }
+        let cfg = RegionStreamerConfig {
+            region,
+            stable_latency_s: region_stable_latency_s.max(0.0),
+        };
+        Some(RegionStreamer::with_config(sr, cfg))
+    } else {
+        None
     };
 
     let mut emitter = if json {
@@ -4382,6 +4517,9 @@ fn run_stream_live_v3_file(
             if let Some(m) = multi_streamer.as_mut() {
                 let _ = m.feed(&decoded.samples[cursor..end]);
             }
+            if let Some(r) = region_streamer.as_mut() {
+                r.ingest(&decoded.samples[cursor..end]);
+            }
             cursor = end;
         }
 
@@ -4392,6 +4530,16 @@ fn run_stream_live_v3_file(
 
         let snap = streamer.flush_with_viz();
         let t = started.elapsed().as_secs_f32();
+        // Region path runs alongside envelope to handle multi-burst
+        // real-world QSO audio with pauses + speed changes.
+        let _region_commits = region_streamer
+            .as_mut()
+            .map(|r| r.try_commit())
+            .unwrap_or_default();
+        let region_text_full = region_streamer
+            .as_ref()
+            .map(|r| r.transcript().to_string())
+            .unwrap_or_default();
         // Approach A+: drive the event-driven commit cursor instead of
         // string-stitching. The cursor is sample-indexed and idempotent
         // across re-decodes of the same audio region, so the
@@ -4434,20 +4582,27 @@ fn run_stream_live_v3_file(
             );
         }
 
+        let use_region = region_streamer.is_some();
+        let eff_text = if use_region {
+            region_text_full.clone()
+        } else {
+            append.decoded_text.clone()
+        };
         if let Some(em) = emitter.as_mut() {
             em.emit(
                 t,
                 serde_json::json!({
                     "type": "transcript",
-                    "text": append.decoded_text,
+                    "text": eff_text,
                     "appended": appended_session,
-                    "transcript": append.decoded_text,
-                    "committed": commit.committed_text,
-                    "provisional": commit.provisional_tail,
+                    "transcript": eff_text,
+                    "committed": if use_region { region_text_full.clone() } else { commit.committed_text.clone() },
+                    "provisional": if use_region { String::new() } else { commit.provisional_tail.clone() },
                     "cursor_transcript": session_transcript.clone(),
                     "raw_morse": append.raw_stream,
                     "window_text": snap.transcript,
                     "wpm": snap.wpm,
+                    "region_mode": use_region,
                 }),
             );
             if let Some(viz) = snap.viz {
@@ -4538,20 +4693,35 @@ fn run_stream_live_v3_file(
         }
     }
 
+    let final_region_text = if let Some(r) = region_streamer.as_mut() {
+        let _ = r.flush();
+        r.transcript().to_string()
+    } else {
+        String::new()
+    };
     if let Some(em) = emitter.as_mut() {
+        let final_text = if region_streamer.is_some() {
+            final_region_text
+        } else {
+            commit_cursor.committed_text().to_string()
+        };
         em.emit(
             started.elapsed().as_secs_f32(),
             serde_json::json!({
                 "type": "end",
-                "transcript": commit_cursor.committed_text(),
-                "committed": commit_cursor.committed_text(),
+                "transcript": final_text,
+                "committed": final_text,
                 "recording": serde_json::Value::Null,
             }),
         );
     } else {
         println!();
         println!("Final transcript (v3 file):");
-        println!("{}", commit_cursor.committed_text());
+        if region_streamer.is_some() {
+            println!("{final_region_text}");
+        } else {
+            println!("{}", commit_cursor.committed_text());
+        }
     }
     Ok(())
 }

--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -45,6 +45,10 @@ pub struct RegionStreamConfig {
     pub pad_s: f32,
     /// Optional pinned WPM for the per-region decode. None = ditdah auto.
     pub pin_wpm: Option<f32>,
+    /// Minimum Goertzel-vs-broadband energy ratio required before a detected
+    /// active run is decoded. White noise can still produce percentile-threshold
+    /// runs; this guard requires those runs to contain a narrowband CW tone.
+    pub min_tonal_prominence_ratio: f32,
 }
 
 impl Default for RegionStreamConfig {
@@ -60,6 +64,7 @@ impl Default for RegionStreamConfig {
             min_region_s: 0.6,
             pad_s: 0.10,
             pin_wpm: None,
+            min_tonal_prominence_ratio: 8.0,
         }
     }
 }
@@ -96,6 +101,16 @@ pub fn decode_region_stream(
     let regions_raw = detect_active_regions(samples, sample_rate, pitch_hz, cfg);
     let mut decoded = Vec::with_capacity(regions_raw.len());
     for (start_s, end_s) in regions_raw {
+        let region_s = (start_s.max(0.0) * sample_rate as f32) as usize;
+        let region_e = ((end_s * sample_rate as f32) as usize).min(samples.len());
+        if region_e <= region_s {
+            continue;
+        }
+        let prominence =
+            tonal_prominence_ratio(&samples[region_s..region_e], sample_rate, pitch_hz, cfg);
+        if prominence < cfg.min_tonal_prominence_ratio.max(0.0) {
+            continue;
+        }
         let pad = cfg.pad_s.max(0.0);
         let s = ((start_s - pad).max(0.0) * sample_rate as f32) as usize;
         let e = (((end_s + pad) * sample_rate as f32) as usize).min(samples.len());
@@ -127,6 +142,38 @@ pub fn decode_region_stream(
         regions: decoded,
         text,
     }
+}
+
+fn tonal_prominence_ratio(
+    samples: &[f32],
+    sample_rate: u32,
+    pitch_hz: f32,
+    cfg: &RegionStreamConfig,
+) -> f32 {
+    let frame_len = ((cfg.frame_len_s * sample_rate as f32).round() as usize).max(64);
+    let frame_step = ((cfg.frame_step_s * sample_rate as f32).round() as usize).max(8);
+    if samples.len() < frame_len {
+        return 0.0;
+    }
+
+    let mut power_sum = 0.0_f64;
+    let mut energy_sum = 0.0_f64;
+    let mut count = 0u32;
+    let mut offset = 0usize;
+    while offset + frame_len <= samples.len() {
+        let frame = &samples[offset..offset + frame_len];
+        power_sum += goertzel_power(frame, sample_rate, pitch_hz) as f64;
+        energy_sum += frame
+            .iter()
+            .map(|sample| (*sample as f64) * (*sample as f64))
+            .sum::<f64>();
+        count += 1;
+        offset += frame_step;
+    }
+    if count == 0 || energy_sum <= f64::EPSILON {
+        return 0.0;
+    }
+    (power_sum / energy_sum) as f32
 }
 
 /// One spectral peak from the goertzel sweep used by the multi-pitch

--- a/experiments/cw-decoder/src/region_streamer.rs
+++ b/experiments/cw-decoder/src/region_streamer.rs
@@ -125,6 +125,44 @@ impl RegionStreamer {
         &self.committed_text
     }
 
+    /// Buffered audio length in seconds (relative to the current buffer
+    /// start, i.e. always >= 0 and bounded by the trim policy).
+    pub fn buffered_seconds(&self) -> f32 {
+        self.head_s
+    }
+
+    /// Reset all streaming state: drop the buffer, clear the committed
+    /// transcript, and reset the commit cursor. Used by the live mic
+    /// path's "ResetLock" stdin-control message so the operator can
+    /// start a new session without restarting the decoder process.
+    pub fn reset(&mut self) {
+        self.buffer.clear();
+        self.last_committed_end_s = 0.0;
+        self.head_s = 0.0;
+        self.committed_text.clear();
+    }
+
+    /// Drop everything in the buffer that ends more than `keep_back_s`
+    /// seconds before the last committed region. Bounds memory growth
+    /// during long-running live capture without losing any in-flight
+    /// (uncommitted) audio. Safe to call after `try_commit`. The
+    /// committed transcript is preserved.
+    pub fn trim_committed(&mut self, keep_back_s: f32) {
+        let cutoff = (self.last_committed_end_s - keep_back_s.max(0.0)).max(0.0);
+        if cutoff <= 0.0 {
+            return;
+        }
+        let sr = self.sample_rate.max(1) as f32;
+        let cut_samples = (cutoff * sr) as usize;
+        if cut_samples == 0 || cut_samples >= self.buffer.len() {
+            return;
+        }
+        self.buffer.drain(..cut_samples);
+        let shift = cut_samples as f32 / sr;
+        self.last_committed_end_s = (self.last_committed_end_s - shift).max(0.0);
+        self.head_s = self.buffer.len() as f32 / sr;
+    }
+
     fn commit_stable_regions(&mut self, force_all: bool) -> Vec<CommittedRegion> {
         if self.buffer.is_empty() {
             return Vec::new();
@@ -218,5 +256,28 @@ mod tests {
         let _ = s.flush();
         let _ = s.flush();
         assert_eq!(s.transcript(), "");
+    }
+
+    #[test]
+    fn streamer_reset_clears_all_state() {
+        let sr = 8_000;
+        let mut s = RegionStreamer::new(sr);
+        s.ingest(&synthesize_silence(sr, 0.5));
+        s.ingest(&morse_e(sr, 12.0));
+        assert!(s.buffered_seconds() > 0.0);
+        s.reset();
+        assert_eq!(s.transcript(), "");
+        assert_eq!(s.buffered_seconds(), 0.0);
+        assert!(s.try_commit().is_empty());
+    }
+
+    #[test]
+    fn streamer_trim_committed_is_no_op_when_nothing_committed() {
+        let sr = 8_000;
+        let mut s = RegionStreamer::new(sr);
+        s.ingest(&synthesize_silence(sr, 1.0));
+        let before = s.buffered_seconds();
+        s.trim_committed(0.5);
+        assert_eq!(s.buffered_seconds(), before);
     }
 }

--- a/experiments/cw-decoder/src/region_streamer.rs
+++ b/experiments/cw-decoder/src/region_streamer.rs
@@ -203,6 +203,7 @@ impl RegionStreamer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::f32::consts::TAU;
 
     fn synthesize_tone(sample_rate: u32, freq_hz: f32, duration_s: f32) -> Vec<f32> {
         let n = (duration_s * sample_rate as f32) as usize;
@@ -279,5 +280,256 @@ mod tests {
         let before = s.buffered_seconds();
         s.trim_committed(0.5);
         assert_eq!(s.buffered_seconds(), before);
+    }
+
+    fn morse_code(ch: char) -> Option<&'static str> {
+        match ch {
+            'A' => Some(".-"),
+            'B' => Some("-..."),
+            'C' => Some("-.-."),
+            'D' => Some("-.."),
+            'E' => Some("."),
+            'F' => Some("..-."),
+            'G' => Some("--."),
+            'H' => Some("...."),
+            'I' => Some(".."),
+            'J' => Some(".---"),
+            'K' => Some("-.-"),
+            'L' => Some(".-.."),
+            'M' => Some("--"),
+            'N' => Some("-."),
+            'O' => Some("---"),
+            'P' => Some(".--."),
+            'Q' => Some("--.-"),
+            'R' => Some(".-."),
+            'S' => Some("..."),
+            'T' => Some("-"),
+            'U' => Some("..-"),
+            'V' => Some("...-"),
+            'W' => Some(".--"),
+            'X' => Some("-..-"),
+            'Y' => Some("-.--"),
+            'Z' => Some("--.."),
+            '0' => Some("-----"),
+            '1' => Some(".----"),
+            '2' => Some("..---"),
+            '3' => Some("...--"),
+            '4' => Some("....-"),
+            '5' => Some("....."),
+            '6' => Some("-...."),
+            '7' => Some("--..."),
+            '8' => Some("---.."),
+            '9' => Some("----."),
+            _ => None,
+        }
+    }
+
+    fn push_silence(out: &mut Vec<f32>, sample_rate: u32, seconds: f32, phase_samples: &mut usize) {
+        let n = (seconds * sample_rate as f32).round() as usize;
+        out.resize(out.len() + n, 0.0);
+        *phase_samples += n;
+    }
+
+    fn push_tone(
+        out: &mut Vec<f32>,
+        sample_rate: u32,
+        pitch_hz: f32,
+        seconds: f32,
+        amp: f32,
+        phase_samples: &mut usize,
+    ) {
+        let n = (seconds * sample_rate as f32).round() as usize;
+        let ramp_n = ((sample_rate as f32) * 0.004).round() as usize;
+        for k in 0..n {
+            let rise = if ramp_n > 0 && k < ramp_n {
+                0.5 * (1.0 - ((std::f32::consts::PI * k as f32) / ramp_n as f32).cos())
+            } else {
+                1.0
+            };
+            let fall = if ramp_n > 0 && k + ramp_n > n {
+                let kk = (n - k) as f32;
+                0.5 * (1.0 - ((std::f32::consts::PI * kk) / ramp_n as f32).cos())
+            } else {
+                1.0
+            };
+            let t = *phase_samples as f32 / sample_rate as f32;
+            out.push((TAU * pitch_hz * t).sin() * amp * rise.min(fall));
+            *phase_samples += 1;
+        }
+    }
+
+    fn synth_morse(sample_rate: u32, pitch_hz: f32, wpm: f32, text: &str, amp: f32) -> Vec<f32> {
+        let dot_s = 1.2 / wpm;
+        let mut out = Vec::new();
+        let mut phase_samples = 0usize;
+        let chars: Vec<char> = text.to_uppercase().chars().collect();
+        for (idx, ch) in chars.iter().copied().enumerate() {
+            if ch.is_whitespace() {
+                push_silence(&mut out, sample_rate, dot_s * 7.0, &mut phase_samples);
+                continue;
+            }
+            let Some(code) = morse_code(ch) else {
+                continue;
+            };
+            for (element_idx, element) in code.chars().enumerate() {
+                let units = if element == '.' { 1.0 } else { 3.0 };
+                push_tone(
+                    &mut out,
+                    sample_rate,
+                    pitch_hz,
+                    dot_s * units,
+                    amp,
+                    &mut phase_samples,
+                );
+                if element_idx + 1 < code.len() {
+                    push_silence(&mut out, sample_rate, dot_s, &mut phase_samples);
+                }
+            }
+            if idx + 1 < chars.len() && !chars[idx + 1].is_whitespace() {
+                push_silence(&mut out, sample_rate, dot_s * 3.0, &mut phase_samples);
+            }
+        }
+        out
+    }
+
+    fn white_noise(len: usize, amp: f32, seed: u64) -> Vec<f32> {
+        let mut state = seed;
+        (0..len)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                let v = ((state >> 33) as u32) as f32 / u32::MAX as f32;
+                (v * 2.0 - 1.0) * amp
+            })
+            .collect()
+    }
+
+    fn add_white_noise(samples: &mut [f32], amp: f32, seed: u64) {
+        let noise = white_noise(samples.len(), amp, seed);
+        for (sample, noise) in samples.iter_mut().zip(noise) {
+            *sample += noise;
+        }
+    }
+
+    fn add_qsb(samples: &mut [f32], sample_rate: u32, depth: f32, rate_hz: f32, floor: f32) {
+        for (i, sample) in samples.iter_mut().enumerate() {
+            let t = i as f32 / sample_rate as f32;
+            let fade = floor + (1.0 - floor) * (0.5 + 0.5 * (TAU * rate_hz * t).sin());
+            *sample *= 1.0 - depth + depth * fade;
+        }
+    }
+
+    fn add_qrm_tone(samples: &mut [f32], sample_rate: u32, freq_hz: f32, amp: f32) {
+        for (i, sample) in samples.iter_mut().enumerate() {
+            let t = i as f32 / sample_rate as f32;
+            *sample += (TAU * freq_hz * t).sin() * amp;
+        }
+    }
+
+    fn normalize_for_assertion(text: &str) -> String {
+        text.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    fn region_stream_transcript(
+        sample_rate: u32,
+        samples: &[f32],
+    ) -> (String, Vec<CommittedRegion>) {
+        let mut streamer = RegionStreamer::new(sample_rate);
+        let chunk = (sample_rate as f32 * 0.25).round() as usize;
+        let mut committed = Vec::new();
+        for frame in samples.chunks(chunk.max(1)) {
+            streamer.ingest(frame);
+            committed.extend(streamer.try_commit());
+        }
+        committed.extend(streamer.flush());
+        (
+            normalize_for_assertion(streamer.transcript()),
+            committed
+                .into_iter()
+                .filter(|region| !region.text.trim().is_empty())
+                .collect(),
+        )
+    }
+
+    fn build_multiburst(sample_rate: u32, gaps_are_static: bool) -> (Vec<f32>, String) {
+        let truth = "IHU NVCHU 7QP W7N 7QP W7N";
+        let bursts = [
+            ("IHU", 13.0_f32),
+            ("NVCHU", 8.0),
+            ("7QP W7N", 39.0),
+            ("7QP W7N", 29.0),
+        ];
+        let mut samples = synthesize_silence(sample_rate, 0.8);
+        for (idx, (text, wpm)) in bursts.iter().enumerate() {
+            samples.extend(synth_morse(sample_rate, 700.0, *wpm, text, 0.55));
+            if idx + 1 < bursts.len() {
+                let mut gap = synthesize_silence(sample_rate, 1.2 + idx as f32 * 0.35);
+                if gaps_are_static {
+                    add_white_noise(&mut gap, 0.025, 0xA11CE + idx as u64);
+                }
+                samples.extend(gap);
+            }
+        }
+        samples.extend(synthesize_silence(sample_rate, 1.0));
+        (samples, truth.to_string())
+    }
+
+    #[test]
+    fn synthetic_multiburst_clean_matches_reference_copy() {
+        let sr = 12_000;
+        let (samples, truth) = build_multiburst(sr, false);
+        let (transcript, regions) = region_stream_transcript(sr, &samples);
+        assert_eq!(transcript, truth);
+        assert_eq!(
+            regions.len(),
+            4,
+            "reference training-set-b shape should remain four committed bursts: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn synthetic_static_gaps_do_not_create_ghost_regions() {
+        let sr = 12_000;
+        let (samples, truth) = build_multiburst(sr, true);
+        let (transcript, regions) = region_stream_transcript(sr, &samples);
+        assert_eq!(transcript, truth);
+        assert_eq!(
+            regions.len(),
+            4,
+            "quiet background static between bursts must not create extra committed text: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn synthetic_noise_only_stream_stays_empty() {
+        let sr = 12_000;
+        let samples = white_noise((sr as f32 * 8.0) as usize, 0.035, 0x51A71C);
+        let (transcript, regions) = region_stream_transcript(sr, &samples);
+        assert_eq!(transcript, "");
+        assert!(
+            regions.is_empty(),
+            "noise-only stream must not produce ghost regions: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn synthetic_moderate_noise_qsb_and_qrm_still_exact_copy() {
+        let sr = 12_000;
+        let mut samples = synthesize_silence(sr, 0.8);
+        samples.extend(synth_morse(sr, 700.0, 18.0, "CQ TEST KC7AVA 73", 0.55));
+        samples.extend(synthesize_silence(sr, 1.0));
+
+        add_white_noise(&mut samples, 0.018, 0xC0DEC0DE);
+        add_qsb(&mut samples, sr, 0.65, 0.45, 0.35);
+        add_qrm_tone(&mut samples, sr, 830.0, 0.045);
+
+        let (transcript, regions) = region_stream_transcript(sr, &samples);
+        assert_eq!(transcript, "CQ TEST KC7AVA 73");
+        assert_eq!(
+            regions.len(),
+            1,
+            "single synthetic exchange should commit as one region: {regions:?}"
+        );
     }
 }

--- a/experiments/cw-decoder/src/region_streamer.rs
+++ b/experiments/cw-decoder/src/region_streamer.rs
@@ -1,0 +1,222 @@
+//! Region-based streaming CW decoder.
+//!
+//! On each decode cycle, runs [`decode_region_stream`] over the rolling audio
+//! buffer to find active morse bursts (separated by background static), and
+//! decodes each completed burst with the ditdah baseline.
+//!
+//! Unlike the v3 envelope streamer, regions are committed in append-only
+//! order: a region only enters the transcript once it has been "stable" for
+//! at least [`RegionStreamerConfig::stable_latency_s`] seconds (i.e. trailing
+//! static has been observed long enough that no further morse from that
+//! burst is expected). This eliminates the mid-region rewrites that occur
+//! when a single burst is still being received.
+//!
+//! Designed for the real-world case where an operator transmits, pauses
+//! during static, then transmits again at a different speed (e.g.
+//! `IHU NVCHU 7QP W7N 7QP W7N` with bursts at 13 / 8 / 39 / 29 WPM).
+
+use crate::region_stream::{decode_region_stream, RegionStreamConfig};
+
+/// Tunables for the region-based streamer.
+#[derive(Debug, Clone)]
+pub struct RegionStreamerConfig {
+    /// Underlying region detection / decode config.
+    pub region: RegionStreamConfig,
+    /// Trailing-static seconds required before a region is committed. Must
+    /// exceed the longest expected intra-burst gap. Default 0.6s, which is
+    /// larger than a word gap at 5 WPM (1.2s dot * 5 = 6.0s — actually for
+    /// 5 WPM the word gap is 1.2s, so bursts that include 5 WPM word gaps
+    /// would need a higher latency; default tuned for the common 8+ WPM case).
+    pub stable_latency_s: f32,
+}
+
+impl Default for RegionStreamerConfig {
+    fn default() -> Self {
+        // Defaults in [`RegionStreamConfig::default`] (merge_gap_s = 3.0,
+        // min_region_s = 0.6) are too eager for real-world bursts that
+        // are separated by ~0.5-2.5s of static and may be as short as a
+        // single trigraph. Tighten them so each burst stays its own
+        // region.
+        let region = RegionStreamConfig {
+            merge_gap_s: 0.5,
+            min_region_s: 0.3,
+            threshold_factor: 0.30,
+            pad_s: 0.15,
+            ..RegionStreamConfig::default()
+        };
+        Self {
+            region,
+            stable_latency_s: 0.6,
+        }
+    }
+}
+
+/// One region newly committed by [`RegionStreamer::ingest`].
+#[derive(Debug, Clone)]
+pub struct CommittedRegion {
+    pub start_s: f32,
+    pub end_s: f32,
+    pub text: String,
+}
+
+/// Stateful streaming wrapper around [`decode_region_stream`].
+///
+/// Buffers samples in absolute session time, runs region detection on every
+/// `ingest` call, and reports newly stable regions in append-only order.
+#[derive(Debug)]
+pub struct RegionStreamer {
+    sample_rate: u32,
+    cfg: RegionStreamerConfig,
+    buffer: Vec<f32>,
+    /// End time (seconds, relative to buffer start) of the last region that
+    /// has already been committed. Used to deduplicate emissions across
+    /// successive decode cycles.
+    last_committed_end_s: f32,
+    /// Append-only running transcript of all committed regions, joined by
+    /// single spaces.
+    committed_text: String,
+    /// Total seconds of audio that have been ingested so far. Equals
+    /// `buffer.len() / sample_rate` while no buffer trimming is performed.
+    head_s: f32,
+}
+
+impl RegionStreamer {
+    pub fn new(sample_rate: u32) -> Self {
+        Self::with_config(sample_rate, RegionStreamerConfig::default())
+    }
+
+    pub fn with_config(sample_rate: u32, cfg: RegionStreamerConfig) -> Self {
+        Self {
+            sample_rate,
+            cfg,
+            buffer: Vec::new(),
+            last_committed_end_s: 0.0,
+            committed_text: String::new(),
+            head_s: 0.0,
+        }
+    }
+
+    /// Append samples to the rolling buffer. Cheap; does no decoding.
+    /// Call [`Self::try_commit`] periodically on a decode cadence to
+    /// actually run region detection and emit committed regions.
+    pub fn ingest(&mut self, samples: &[f32]) {
+        self.buffer.extend_from_slice(samples);
+        self.head_s = self.buffer.len() as f32 / self.sample_rate.max(1) as f32;
+    }
+
+    /// Run region detection over the current buffer and return any
+    /// regions that have just become stable (committed). Should be
+    /// invoked on a fixed cadence (typically every 250-500 ms of
+    /// wallclock time) — not on every chunk feed, because region
+    /// detection scans the entire buffer.
+    pub fn try_commit(&mut self) -> Vec<CommittedRegion> {
+        self.commit_stable_regions(false)
+    }
+
+    /// Treat the current buffer as the final audio, committing any
+    /// remaining regions regardless of trailing-static latency. Call once
+    /// at end-of-stream.
+    pub fn flush(&mut self) -> Vec<CommittedRegion> {
+        self.commit_stable_regions(true)
+    }
+
+    /// Full append-only transcript so far.
+    pub fn transcript(&self) -> &str {
+        &self.committed_text
+    }
+
+    fn commit_stable_regions(&mut self, force_all: bool) -> Vec<CommittedRegion> {
+        if self.buffer.is_empty() {
+            return Vec::new();
+        }
+        let result = decode_region_stream(&self.buffer, self.sample_rate, &self.cfg.region);
+        let stability_threshold = if force_all {
+            self.head_s + 1.0 // commit everything
+        } else {
+            self.head_s - self.cfg.stable_latency_s
+        };
+
+        let mut newly = Vec::new();
+        for region in &result.regions {
+            if region.start_s <= self.last_committed_end_s {
+                continue; // already committed in an earlier cycle
+            }
+            if region.end_s > stability_threshold {
+                break; // region is still active; wait for more trailing static
+            }
+            newly.push(CommittedRegion {
+                start_s: region.start_s,
+                end_s: region.end_s,
+                text: region.text.clone(),
+            });
+            self.last_committed_end_s = region.end_s;
+        }
+
+        for region in &newly {
+            if !self.committed_text.is_empty() {
+                self.committed_text.push(' ');
+            }
+            self.committed_text.push_str(&region.text);
+        }
+        newly
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synthesize_tone(sample_rate: u32, freq_hz: f32, duration_s: f32) -> Vec<f32> {
+        let n = (duration_s * sample_rate as f32) as usize;
+        (0..n)
+            .map(|i| {
+                let t = i as f32 / sample_rate as f32;
+                (2.0 * std::f32::consts::PI * freq_hz * t).sin() * 0.5
+            })
+            .collect()
+    }
+
+    fn synthesize_silence(sample_rate: u32, duration_s: f32) -> Vec<f32> {
+        vec![0.0; (duration_s * sample_rate as f32) as usize]
+    }
+
+    /// Build PARIS-style morse "E" (single dit) tone bursts at a known WPM.
+    fn morse_e(sample_rate: u32, wpm: f32) -> Vec<f32> {
+        let dot_s = 1.2 / wpm;
+        synthesize_tone(sample_rate, 700.0, dot_s)
+    }
+
+    #[test]
+    fn streamer_yields_no_regions_for_empty_buffer() {
+        let mut s = RegionStreamer::new(44_100);
+        s.ingest(&[]);
+        assert!(s.try_commit().is_empty());
+        assert_eq!(s.transcript(), "");
+    }
+
+    #[test]
+    fn streamer_holds_back_active_region_until_stable() {
+        let sr = 44_100;
+        let mut s = RegionStreamer::new(sr);
+        // 1s of leading silence + a single dit (~0.1s @ 12 WPM) — not yet
+        // stable because no trailing static observed.
+        let mut audio = synthesize_silence(sr, 1.0);
+        audio.extend(morse_e(sr, 12.0));
+        s.ingest(&audio);
+        let committed = s.try_commit();
+        assert!(
+            committed.is_empty(),
+            "active region must be held back until trailing static is seen"
+        );
+    }
+
+    #[test]
+    fn streamer_does_not_emit_duplicate_regions() {
+        let sr = 8_000;
+        let mut s = RegionStreamer::new(sr);
+        // Force-commit empty buffer — should not panic and yields nothing.
+        let _ = s.flush();
+        let _ = s.flush();
+        assert_eq!(s.transcript(), "");
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
@@ -128,11 +128,18 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
             CreateNoWindow = true,
             WorkingDirectory = Path.GetDirectoryName(exe)!,
         };
-        psi.ArgumentList.Add("stream-live-v2");
+        psi.ArgumentList.Add("stream-live-v3");
         psi.ArgumentList.Add("--json");
         psi.ArgumentList.Add("--stdin-control");
+        // Region-isolated transcript: handles real-world QSO audio with
+        // pauses between bursts at very different WPMs (e.g. operator
+        // pauses, TX/RX cycles, ragchew vs contest mixes). The viz path
+        // still emits envelope/events so any future visualizer tab keeps
+        // working; only the cumulative transcript field is sourced from
+        // region-streamer.
+        psi.ArgumentList.Add("--region-transcript");
         psi.ArgumentList.Add("--decode-every-ms");
-        psi.ArgumentList.Add("5000");
+        psi.ArgumentList.Add("500");
         if (loopback)
         {
             // WASAPI loopback: capture from a system OUTPUT device so audio


### PR DESCRIPTION
Adds a new `--region-transcript` flag to `stream-live-v3` that runs a `RegionStreamer` alongside the envelope decoder. The envelope path continues to drive viz events (waveform, lock state, pitch, WPM) so the visualizer keeps its rich UI; the `transcript` field on emitted `text`/`appended`/`end` events is sourced from region-isolated decode instead of envelope-driven commit cursor stitching.

This delivers 100 percent exact-match decode on real-world QSO audio with multiple bursts at different WPMs separated by background static. `radio-20260502-105714.mp3` decodes to `IHU NVCHU 7QP W7N 7QP W7N` which matches `radio-20260502-105714.truth.txt` exactly, where the envelope-only path previously produced ghost text and merged-burst errors. Both clean (`cw_30wpm_abbrev_clean.wav`) and weak (`cw_30wpm_abbrev_weak.wav`) continuous-CW samples also produce identical transcripts via stream-region and stream-live-v3 --region-transcript.

Wires both UI surfaces so the live decode path through any UI delivers the same robust streaming behavior:
- Production logger GUI (F7 live mic recording) via `QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs`
- Experimental CW visualizer GUI (live mic + file replay) via `experiments/cw-decoder/gui/Services/CwDecoderProcess.cs`

`RegionStreamer` adds `reset()`, `trim_committed()`, and `buffered_seconds()` so the live mic path can bound memory growth and honor stdin-control ResetLock requests without restarting the process.

Validation:
- cargo fmt + cargo clippy (-D warnings) + cargo test all green (129 tests pass; one pre-existing env-only regression test that requires a local W1AW sample file is unrelated)
- dotnet publish CwDecoderGui Release succeeds
- dotnet build QsoRipper.Gui Release succeeds
- 100 percent exact match against radio-20260502-105714.truth.txt verified through both stream-region and stream-live-v3 --region-transcript code paths