### PR TITLE
cw-decoder: synthetic QSO suite + isolated-K fix + hybrid burst pitch discovery (12/12 exact copy)

### DIFF
--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -67,7 +67,10 @@ The current breakthrough is that the best live behavior did **not** come from ro
 > The baseline now also includes deterministic synthetic impairment
 > coverage in `region_streamer.rs`: clean four-burst copy, quiet static
 > gaps, noise-only no-ghost-text, and a moderate white-noise + QSB +
-> offset-QRM exchange (`CQ TEST KC7AVA 73`).
+> offset-QRM exchange (`CQ TEST KC7AVA 73`). `synthetic_qso.rs` also
+> carries regression coverage for the live-CQ failure mode where an
+> isolated final over marker `K` (`-.-`) was auto-calibrated as `S`
+> (`...`) when it was decoded as its own short region.
 >
 > For broader QSO-debug traffic, use the synthetic suite generator:
 >

--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -69,6 +69,19 @@ The current breakthrough is that the best live behavior did **not** come from ro
 > gaps, noise-only no-ghost-text, and a moderate white-noise + QSB +
 > offset-QRM exchange (`CQ TEST KC7AVA 73`).
 >
+> For broader QSO-debug traffic, use the synthetic suite generator:
+>
+> ```powershell
+> cargo run --manifest-path experiments\cw-decoder\Cargo.toml --bin cw-decoder -- `
+>   gen-qso-suite --output .artifacts\cw-qso-suite --ragchew 6 --contest 6
+> ```
+>
+> The generator emits deterministic ragchew and contest WAVs, `.truth.txt`
+> sidecars, and `manifest.ndjson`, then validates each sample through the
+> region decoder. Use `--require-exact` when you want CI-style non-zero
+> exit on any transcript mismatch; leave it off for exploratory debugging
+> runs where failures are the point.
+>
 > **Future experiments must not regress this baseline.** Before merging
 > any change that touches `region_streamer.rs`, `region_stream.rs`,
 > `stream-live-v3`, the GUI launchers, or the underlying decoder

--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -85,6 +85,18 @@ The current breakthrough is that the best live behavior did **not** come from ro
 > exit on any transcript mismatch; leave it off for exploratory debugging
 > runs where failures are the point.
 >
+> **Multi-pitch burst discovery (June 2026).** The pitch-routing front
+> end of `decode_region_stream` was upgraded from a whole-buffer mean-
+> Goertzel sweep to a hybrid windowed/mean approach in
+> `region_stream::discover_burst_pitches`. The whole-buffer mean smears
+> long-form ragchew turns at distinct pitches into one artifact peak;
+> the windowed source (10 s window, 5 s hop, with a noise-floor
+> confidence gate) surfaces each turn's pitch independently. The mean
+> source still runs alongside to preserve dense-cluster contest cases.
+> The combined synthetic suite now scores 12/12 exact copy (was 6/12);
+> validated through both `decode_region_stream` (batch) and
+> `RegionStreamer` (live streaming) paths at 12/16/48 kHz sample rates.
+>
 > **Future experiments must not regress this baseline.** Before merging
 > any change that touches `region_streamer.rs`, `region_stream.rs`,
 > `stream-live-v3`, the GUI launchers, or the underlying decoder

--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -9,6 +9,87 @@ The project has converged on two parallel goals:
 
 The current breakthrough is that the best live behavior did **not** come from rolling transcript windows, overlap stitching, or commit heuristics. It came from consuming the same stable dit/dah/gap event stream that paints the Visualizer bars and appending each matured event once in audio order. That path is now the "line in the sand": Decode, Labeling, Tuning, Bench, and Visualizer should all key off it first, while experimental decoders are compared against it rather than silently replacing it.
 
+> **Foundational baseline (May 2026): region-isolated streaming transcript.**
+>
+> A full QEX-style technical write-up of this baseline (architecture,
+> design rationale, results, and future directions) lives at
+> [`docs/cw-decoder-architecture.html`](docs/cw-decoder-architecture.html).
+> Open it in any browser for the rendered article; it is the canonical
+> reference for the architecture summarized here.
+>
+> The append-only event-stream foundation is excellent for *driving the
+> visualizer* (waveform, lock state, pitch, WPM, classified events). But
+> for the **transcript** itself, real-world QSO audio with multiple
+> bursts at very different WPMs separated by background static (operator
+> pauses, TX/RX cycles, ragchew vs contest mixes) needs a different
+> decoder shape: detect each burst as a region, decode each region
+> independently with its own pitch/WPM/k-means lock, and append the
+> region's text once it has been stable for a trailing-static window.
+>
+> The reference implementation lives in
+> `src\region_streamer.rs` (`RegionStreamer`) and
+> `src\region_stream.rs` (`decode_region_stream`). It is exposed three
+> ways:
+>
+> - **Batch mode** — `cw-decoder stream-region --file <path>` — runs
+>   region detection over the entire file and emits one transcript per
+>   region. This is the canonical reference output.
+> - **Live streaming** — `cw-decoder stream-live-v3 --region-transcript`
+>   — runs `RegionStreamer` *alongside* the V3 envelope streamer. The
+>   envelope path keeps driving viz events; only the cumulative
+>   `transcript` field on emitted `text` / `appended` / `end` events is
+>   sourced from region-isolated decode. `RegionStreamer::trim_committed`
+>   bounds memory growth in long live sessions and `RegionStreamer::reset`
+>   honors stdin-control `ResetLock` requests cleanly without restarting
+>   the process.
+> - **Both UI surfaces wire `--region-transcript`** by default:
+>   - Production logger GUI (F7 live mic) —
+>     `src\dotnet\QsoRipper.Gui\Services\CwDecoderProcessSampleSource.cs`
+>   - Experimental CW visualizer GUI (live mic + file replay) —
+>     `experiments\cw-decoder\gui\Services\CwDecoderProcess.cs`
+>
+> **Reference success metric.** This baseline produces a 100% exact-match
+> transcript for the multi-burst real-world sample
+> `cw-samples\training-set-b\radio-20260502-105714.mp3` (truth file
+> `radio-20260502-105714.truth.txt`):
+>
+> ```text
+> IHU NVCHU 7QP W7N 7QP W7N
+> ```
+>
+> Both `stream-region` (batch) and `stream-live-v3 --region-transcript`
+> (live streaming) produce that exact string with the default
+> `RegionStreamerConfig::default()` config (merge_gap=0.5s,
+> min_region=0.3s, threshold_factor=0.30, pad=0.15s,
+> stable_latency=0.6s) and `--decode-every-ms 250`.
+>
+> **Future experiments must not regress this baseline.** Before merging
+> any change that touches `region_streamer.rs`, `region_stream.rs`,
+> `stream-live-v3`, the GUI launchers, or the underlying decoder
+> primitives, re-run the cross-validation:
+>
+> ```powershell
+> cd C:\Users\randy\Git\qsoripper
+> $exe  = "experiments\cw-decoder\target\release\cw-decoder.exe"
+> $f    = "C:\Users\randy\OneDrive\Documents\Home\Hobbies\Ham Radio\QSORipper\QSO Audio Samples\cw-samples\training-set-b\radio-20260502-105714.mp3"
+> $truth = (Get-Content "C:\Users\randy\OneDrive\Documents\Home\Hobbies\Ham Radio\QSORipper\QSO Audio Samples\cw-samples\training-set-b\radio-20260502-105714.truth.txt" -Raw).Trim()
+> & $exe stream-region --file $f --json --no-realtime --decode-every-ms 250 |
+>     Select-String '"type":"end"' | Select-Object -Last 1
+> & $exe stream-live-v3 --file $f --json --region-transcript --decode-every-ms 250 |
+>     Select-String '"type":"end"' | Select-Object -Last 1
+> # Both `transcript` fields must equal $truth.
+> ```
+>
+> If you need to roll back to this baseline at any point, the reference
+> commits are PR #375 (region-based streaming decoder, batch path) and
+> PR #376 (live streaming + GUI wiring) on branch
+> `u/randy/region-based-streaming-cw`.
+>
+> The append-only event-stream foundation in `append_decode.rs` is
+> still the source of truth for the visualizer's bar painting and for
+> the `cw_decode_rx_wpm` aggregator that feeds the production logger;
+> region-isolated decode supplements it for transcript text only.
+
 > **Integration status (round 1, issue #321)**: the production GUI now hosts the
 > `cw-decoder` binary as a subprocess and auto-fills `QsoRecord.cw_decode_rx_wpm`
 > on logged CW QSOs (time-weighted mean over the QSO start/end window, ADIF

--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -61,7 +61,13 @@ The current breakthrough is that the best live behavior did **not** come from ro
 > (live streaming) produce that exact string with the default
 > `RegionStreamerConfig::default()` config (merge_gap=0.5s,
 > min_region=0.3s, threshold_factor=0.30, pad=0.15s,
-> stable_latency=0.6s) and `--decode-every-ms 250`.
+> min_tonal_prominence_ratio=8.0, stable_latency=0.6s) and
+> `--decode-every-ms 250`.
+>
+> The baseline now also includes deterministic synthetic impairment
+> coverage in `region_streamer.rs`: clean four-burst copy, quiet static
+> gaps, noise-only no-ghost-text, and a moderate white-noise + QSB +
+> offset-QRM exchange (`CQ TEST KC7AVA 73`).
 >
 > **Future experiments must not regress this baseline.** Before merging
 > any change that touches `region_streamer.rs`, `region_stream.rs`,
@@ -78,6 +84,7 @@ The current breakthrough is that the best live behavior did **not** come from ro
 > & $exe stream-live-v3 --file $f --json --region-transcript --decode-every-ms 250 |
 >     Select-String '"type":"end"' | Select-Object -Last 1
 > # Both `transcript` fields must equal $truth.
+> cargo test --manifest-path experiments\cw-decoder\Cargo.toml region_streamer::tests::synthetic
 > ```
 >
 > If you need to roll back to this baseline at any point, the reference

--- a/experiments/cw-decoder/docs/cw-decoder-architecture.html
+++ b/experiments/cw-decoder/docs/cw-decoder-architecture.html
@@ -218,7 +218,7 @@
 
   <h1 class="title">Region-Isolated Streaming for Real-World CW Copy</h1>
   <p class="subtitle">A practical decoder architecture that holds 100% copy on multi-burst, mixed-speed off-air audio with operator pauses</p>
-  <p class="byline">Randy Treit, K&Oslash;RJT &mdash; with collaboration from the QsoRipper agent toolchain</p>
+  <p class="byline">Randy Treit, KC7AVA &mdash; with collaboration from the QsoRipper agent toolchain</p>
   <p class="affiliation">QsoRipper Project &middot; <code>experiments/cw-decoder</code></p>
 
   <div class="abstract">

--- a/experiments/cw-decoder/docs/cw-decoder-architecture.html
+++ b/experiments/cw-decoder/docs/cw-decoder-architecture.html
@@ -1,0 +1,824 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Region-Isolated Streaming for Real-World CW Copy &mdash; QsoRipper Technical Report</title>
+<style>
+  :root {
+    --navy: #102a54;
+    --rule: #102a54;
+    --accent: #b21f1f;
+    --muted: #555;
+    --bg: #faf8f3;
+    --code-bg: #f1ede4;
+  }
+  html, body {
+    margin: 0;
+    padding: 0;
+    background: var(--bg);
+    color: #111;
+    font-family: "Georgia", "Times New Roman", serif;
+    font-size: 15px;
+    line-height: 1.5;
+  }
+  .page {
+    max-width: 980px;
+    margin: 24px auto 64px;
+    padding: 0 28px;
+  }
+  .masthead {
+    border-top: 6px double var(--navy);
+    border-bottom: 1px solid var(--navy);
+    padding: 14px 0 10px;
+    margin-bottom: 18px;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    font-variant: small-caps;
+    letter-spacing: 0.05em;
+    color: var(--navy);
+  }
+  .masthead .pub { font-weight: bold; font-size: 1.1em; }
+  .masthead .meta { font-size: 0.85em; color: var(--muted); letter-spacing: 0.04em; }
+
+  h1.title {
+    font-size: 1.85em;
+    color: var(--navy);
+    margin: 0 0 4px;
+    line-height: 1.2;
+    font-weight: bold;
+  }
+  .subtitle {
+    font-style: italic;
+    color: var(--muted);
+    margin: 0 0 8px;
+    font-size: 1.05em;
+  }
+  .byline {
+    font-size: 0.95em;
+    margin: 0 0 4px;
+  }
+  .affiliation {
+    font-size: 0.85em;
+    color: var(--muted);
+    font-style: italic;
+    margin: 0 0 18px;
+  }
+
+  .abstract {
+    border-left: 4px solid var(--navy);
+    background: #fff;
+    padding: 12px 16px;
+    margin: 0 0 24px;
+    font-size: 0.97em;
+  }
+  .abstract .label {
+    font-variant: small-caps;
+    letter-spacing: 0.06em;
+    color: var(--navy);
+    font-weight: bold;
+    margin-right: 6px;
+  }
+
+  .columns {
+    column-count: 2;
+    column-gap: 28px;
+    column-rule: 1px solid #ddd;
+    text-align: justify;
+    hyphens: auto;
+  }
+  /* Some elements look poor when split across columns. */
+  figure, pre, table, .callout, h2, h3 {
+    break-inside: avoid;
+  }
+
+  h2 {
+    font-size: 1.15em;
+    color: var(--navy);
+    border-bottom: 1px solid var(--navy);
+    padding-bottom: 2px;
+    margin: 22px 0 8px;
+    font-variant: small-caps;
+    letter-spacing: 0.04em;
+  }
+  h3 {
+    font-size: 1.0em;
+    color: #222;
+    margin: 16px 0 6px;
+    font-style: italic;
+  }
+  p { margin: 0 0 10px; }
+
+  pre, code {
+    font-family: "Consolas", "Menlo", monospace;
+    font-size: 0.85em;
+  }
+  pre {
+    background: var(--code-bg);
+    padding: 10px 12px;
+    border-left: 3px solid var(--navy);
+    overflow-x: auto;
+    line-height: 1.4;
+    margin: 8px 0 14px;
+  }
+  code {
+    background: var(--code-bg);
+    padding: 0 3px;
+    border-radius: 2px;
+  }
+  pre code {
+    background: transparent;
+    padding: 0;
+  }
+
+  figure {
+    margin: 12px 0;
+    background: #fff;
+    border: 1px solid #ccc;
+    padding: 10px;
+    text-align: center;
+  }
+  figure svg { max-width: 100%; height: auto; }
+  figcaption {
+    font-size: 0.83em;
+    color: var(--muted);
+    margin-top: 6px;
+    text-align: left;
+    font-style: italic;
+  }
+  figcaption strong { font-style: normal; color: var(--navy); }
+
+  table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 8px 0 14px;
+    font-size: 0.9em;
+  }
+  th, td {
+    border-bottom: 1px solid #bbb;
+    padding: 5px 8px;
+    text-align: left;
+    vertical-align: top;
+  }
+  th {
+    border-bottom: 2px solid var(--navy);
+    color: var(--navy);
+    font-variant: small-caps;
+    letter-spacing: 0.04em;
+  }
+  tr.match td:first-child { color: #1b6b1b; font-weight: bold; }
+
+  .callout {
+    background: #fff;
+    border: 1px solid var(--navy);
+    border-left: 6px solid var(--navy);
+    padding: 10px 14px;
+    margin: 12px 0;
+    font-size: 0.93em;
+  }
+  .callout .label {
+    font-variant: small-caps;
+    color: var(--navy);
+    font-weight: bold;
+    letter-spacing: 0.06em;
+    margin-right: 6px;
+  }
+
+  .refs ol { padding-left: 22px; }
+  .refs li { margin-bottom: 5px; font-size: 0.9em; }
+
+  .footer {
+    border-top: 6px double var(--navy);
+    margin-top: 28px;
+    padding-top: 10px;
+    font-size: 0.82em;
+    color: var(--muted);
+    text-align: center;
+  }
+
+  .key { color: var(--accent); font-weight: bold; }
+  .small-caps { font-variant: small-caps; letter-spacing: 0.04em; }
+
+  ul, ol { padding-left: 22px; }
+  li { margin-bottom: 4px; }
+
+  @media (max-width: 720px) {
+    .columns { column-count: 1; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <div class="masthead">
+    <span class="pub">QsoRipper Technical Report</span>
+    <span class="meta">A Forum for Communications Experimenters &middot; May 2026</span>
+  </div>
+
+  <h1 class="title">Region-Isolated Streaming for Real-World CW Copy</h1>
+  <p class="subtitle">A practical decoder architecture that holds 100% copy on multi-burst, mixed-speed off-air audio with operator pauses</p>
+  <p class="byline">Randy Treit, K&Oslash;RJT &mdash; with collaboration from the QsoRipper agent toolchain</p>
+  <p class="affiliation">QsoRipper Project &middot; <code>experiments/cw-decoder</code></p>
+
+  <div class="abstract">
+    <p><span class="label">Abstract.</span>
+      Off-air CW audio rarely behaves like a textbook practice file. An operator
+      sends a short burst at 13 WPM, pauses through 1&ndash;3 seconds of band hiss,
+      then sends another burst at 30 WPM, then pauses again. Most streaming
+      decoders &mdash; including our own earlier &ldquo;V3 envelope&rdquo; foundation &mdash;
+      handle the first burst well, but smear the second through residual lock
+      state, mis-classify dits and dahs at the new speed, or hallucinate
+      &ldquo;ghost&rdquo; characters from the static between bursts. This report describes
+      a region-isolated streaming architecture that detects each active CW burst
+      as a discrete region, decodes each region independently with its own
+      pitch and speed lock, and only commits the region&rsquo;s text to the
+      transcript once a trailing-static window confirms the burst has ended.
+      The architecture preserves the rich visualizer event stream of the
+      previous foundation, runs in true real-time on a stock laptop, and
+      delivers a 100% character-exact transcript on the target multi-burst
+      reference recording.
+    </p>
+  </div>
+
+  <div class="columns">
+
+  <h2>1. The Problem</h2>
+
+  <p>
+    QsoRipper is a keyboard-first ham-radio logging system whose CW
+    subsystem must do two things at once: paint a visualization of what
+    the radio is hearing right now (waveform, lock state, classified
+    elements, current and historical WPM) and append a clean text
+    transcript of every Morse character that actually came through. The
+    visualizer is forgiving &mdash; it is fine to show a flicker when the
+    band changes &mdash; but the transcript is not. Operators rely on it for
+    contest exchanges, callsign capture, and post-QSO reconstruction.
+    A single ghost word at the start of a transmission is worse than no
+    decode at all.
+  </p>
+
+  <p>
+    The reference test case for this work is
+    <code>radio-20260502-105714.mp3</code>, an off-air capture from the
+    author&rsquo;s Kenwood TS-590SG. The file contains four CW bursts at
+    visibly different speeds, separated by background hiss:
+  </p>
+
+  <ol>
+    <li><code>IHU</code> &mdash; ~13 WPM</li>
+    <li><code>NVCHU</code> &mdash; ~8 WPM</li>
+    <li><code>7QP W7N</code> &mdash; ~30 WPM</li>
+    <li><code>7QP W7N</code> &mdash; ~30 WPM (repeat)</li>
+  </ol>
+
+  <p>
+    The ground-truth file
+    <code>radio-20260502-105714.truth.txt</code> is the operator&rsquo;s
+    canonical copy: <code>IHU NVCHU 7QP W7N 7QP W7N</code>. The success
+    criterion was simple: produce that string, character for character,
+    when the same audio is streamed through the production logger&rsquo;s
+    F7 live-mic capture path. Anything less &mdash; a missing letter, a
+    ghost letter, a merged word &mdash; was treated as failure.
+  </p>
+
+  <h2>2. Why the Previous Foundation Came Up Short</h2>
+
+  <p>
+    The pre-existing &ldquo;V3 envelope&rdquo; decoder
+    (<code>stream-live-v3</code>) is built around a single
+    <code>LiveEnvelopeStreamer</code> that ingests audio continuously,
+    estimates a Goertzel envelope at the locked pitch, runs a
+    percentile-based hysteresis state machine to classify on/off
+    intervals, and feeds a k-means dot/dah classifier with a
+    sample-indexed commit cursor. It is excellent at painting the
+    visualizer and at producing a stable transcript on long, single-speed
+    transmissions. It powers the <code>cw_decode_rx_wpm</code> field that
+    the production logger writes to ADIF as
+    <code>APP_QSORIPPER_RX_WPM</code>.
+  </p>
+
+  <p>
+    On <code>radio-20260502-105714.mp3</code>, however, V3 produced a
+    transcript that drifted progressively further from truth as it moved
+    from burst to burst. The root causes were structural:
+  </p>
+
+  <ul>
+    <li>
+      <span class="key">Sticky speed lock.</span> The locked WPM from
+      burst&nbsp;1 (13 WPM) is still the working hypothesis when burst&nbsp;2
+      starts at 8 WPM. The k-means classifier mis-labels dahs from the
+      slower burst as dits, dits as inter-element gaps.
+    </li>
+    <li>
+      <span class="key">Stale noise floor.</span> The percentile-based
+      noise/signal floors are estimated over a sliding window. When
+      static between bursts dominates the window, the threshold drifts
+      and trailing dits of the previous burst can re-fire as ghost
+      elements.
+    </li>
+    <li>
+      <span class="key">Append-cursor smearing.</span> The
+      sample-indexed commit cursor advances monotonically. If a region
+      decodes wrong on the first pass, that wrong decode is locked into
+      the transcript &mdash; later cycles cannot undo it without producing
+      a worse artifact (the &ldquo;TSA USA EE TSA USA EE&rdquo;
+      ghost-repeat pattern).
+    </li>
+  </ul>
+
+  <p>
+    A natural fix was to add more tuning knobs to V3: tighter relock
+    thresholds, more aggressive noise-floor decay, content-stability
+    gates on the commit cursor. Each of those helped a little and broke
+    something else. After several rounds of this, we stepped back and
+    considered a different decomposition.
+  </p>
+
+  <h2>3. Region-Isolated Decoding</h2>
+
+  <p>
+    The insight is that real-world QSO audio is naturally segmented by
+    the operator. A burst is a discrete unit of intent: the operator
+    keys, sends some elements, releases. Between bursts, the receiver
+    sits in band noise. If we could detect those bursts as
+    <em>regions</em> and decode each region independently &mdash; with its
+    own fresh pitch lock, its own k-means classifier, its own WPM
+    estimate &mdash; the cross-burst contamination disappears by
+    construction. There is nothing to leak.
+  </p>
+
+  <figure>
+    <svg viewBox="0 0 760 200" xmlns="http://www.w3.org/2000/svg">
+      <!-- Time axis -->
+      <line x1="20" y1="120" x2="740" y2="120" stroke="#222" stroke-width="1"/>
+      <text x="20" y="138" font-size="11" fill="#555">t = 0</text>
+      <text x="710" y="138" font-size="11" fill="#555">end</text>
+
+      <!-- Noise floor band -->
+      <rect x="20" y="115" width="720" height="10" fill="#ddd" opacity="0.6"/>
+
+      <!-- Bursts -->
+      <rect x="60"  y="60" width="80"  height="60" fill="#102a54" opacity="0.85"/>
+      <text x="100" y="55" font-size="11" text-anchor="middle" fill="#102a54">IHU</text>
+      <text x="100" y="142" font-size="9" text-anchor="middle" fill="#555">~13 WPM</text>
+
+      <rect x="200" y="40" width="120" height="80" fill="#102a54" opacity="0.85"/>
+      <text x="260" y="35" font-size="11" text-anchor="middle" fill="#102a54">NVCHU</text>
+      <text x="260" y="142" font-size="9" text-anchor="middle" fill="#555">~8 WPM</text>
+
+      <rect x="380" y="70" width="140" height="50" fill="#102a54" opacity="0.85"/>
+      <text x="450" y="65" font-size="11" text-anchor="middle" fill="#102a54">7QP W7N</text>
+      <text x="450" y="142" font-size="9" text-anchor="middle" fill="#555">~30 WPM</text>
+
+      <rect x="570" y="70" width="140" height="50" fill="#102a54" opacity="0.85"/>
+      <text x="640" y="65" font-size="11" text-anchor="middle" fill="#102a54">7QP W7N</text>
+      <text x="640" y="142" font-size="9" text-anchor="middle" fill="#555">~30 WPM</text>
+
+      <!-- Region brackets -->
+      <g stroke="#b21f1f" stroke-width="1.5" fill="none">
+        <path d="M55 165 L55 175 L145 175 L145 165"/>
+        <path d="M195 165 L195 175 L325 175 L325 165"/>
+        <path d="M375 165 L375 175 L525 175 L525 165"/>
+        <path d="M565 165 L565 175 L715 175 L715 165"/>
+      </g>
+      <text x="100" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;1</text>
+      <text x="260" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;2</text>
+      <text x="450" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;3</text>
+      <text x="640" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;4</text>
+    </svg>
+    <figcaption>
+      <strong>Figure 1.</strong> Schematic envelope of
+      <code>radio-20260502-105714.mp3</code>. Four CW bursts (dark
+      bars) at three distinct speeds are separated by background hiss
+      (gray band). Each burst becomes one decode region (red brackets);
+      the inter-burst static is never decoded.
+    </figcaption>
+  </figure>
+
+  <h3>3.1 Detection</h3>
+
+  <p>
+    Region detection is implemented in
+    <code>region_stream.rs</code>::<code>decode_region_stream</code>. The
+    function performs a coarse Goertzel pitch sweep over the entire
+    buffer, picks the dominant tone, and computes a frame-level energy
+    envelope at that pitch. From the envelope it derives two robust
+    floors via percentiles:
+  </p>
+
+  <pre><code>noise_floor  = quantile(env, 0.30)
+signal_floor = quantile(env, 0.95)
+threshold    = noise_floor
+             + threshold_factor &times; (signal_floor - noise_floor)</code></pre>
+
+  <p>
+    With <code>threshold_factor = 0.30</code>, the decision boundary
+    sits 30% of the way up the dynamic range &mdash; well clear of band
+    noise, well below saturation. Frames above threshold are marked
+    &ldquo;active&rdquo;. Active runs are merged across short gaps
+    (<code>merge_gap_s = 0.5 s</code> by default), and runs shorter
+    than <code>min_region_s = 0.3 s</code> are rejected as transient
+    static spikes. Each surviving run is padded symmetrically by
+    <code>pad_s = 0.15 s</code> so leading and trailing dits are not
+    clipped.
+  </p>
+
+  <h3>3.2 Per-region decode</h3>
+
+  <p>
+    For each detected region, the audio slice is handed to the
+    <code>ditdah</code> baseline decoder with no carry-over state. The
+    decoder estimates pitch and dot length fresh, runs its own k-means
+    classification, and emits a transcript fragment. Because each
+    region is short and homogeneous (one operator, one burst, one
+    speed), the baseline decoder &mdash; which was always strong on
+    short clean clips &mdash; performs near-perfectly.
+  </p>
+
+  <h3>3.3 The streaming wrapper</h3>
+
+  <p>
+    <code>region_streamer.rs</code> wraps the batch detector for true
+    streaming use. It maintains a rolling sample buffer; on every
+    <code>try_commit()</code> call it re-runs detection over the
+    current buffer and reports any region whose end time is followed
+    by at least <code>stable_latency_s = 0.6 s</code> of trailing
+    static. That trailing-static window is the commit gate &mdash; it
+    guarantees that no further morse from the same burst can still be
+    arriving when we lock in the region&rsquo;s text.
+  </p>
+
+  <pre><code>// Append-only commit, deduplicated across decode cycles.
+for region in detected:
+    if region.start &le; last_committed_end:
+        continue                    // already committed
+    if region.end &gt; head - stable_latency:
+        break                       // not stable yet
+    transcript.append(region.text)
+    last_committed_end = region.end</code></pre>
+
+  <p>
+    For long-running live capture, <code>trim_committed()</code> drops
+    the buffer back to a configurable lookback (default 6 s past the
+    last committed region), and <code>reset()</code> clears all state
+    in response to the operator&rsquo;s <code>Ctrl+Alt+W</code> relock
+    request, all without restarting the decoder process.
+  </p>
+
+  <h2>4. Integration with the V3 Visualizer</h2>
+
+  <p>
+    A key design constraint was that the visualizer must keep working.
+    Operators rely on the live waveform, the lock indicator, the
+    pitch readout, and the rolling WPM gauge to know whether the
+    decoder is healthy. The V3 envelope path produces all of those as a
+    side effect of its frame-level processing; the region streamer
+    produces none of them.
+  </p>
+
+  <p>
+    The integration therefore runs both decoders in parallel. The new
+    <code>--region-transcript</code> flag on
+    <code>stream-live-v3</code> instantiates a <code>RegionStreamer</code>
+    alongside the existing <code>LiveEnvelopeStreamer</code>. Audio
+    chunks are fed to both. The envelope streamer continues to emit
+    NDJSON <code>viz</code> frames on every decode cycle, exactly as
+    before. The region streamer&rsquo;s
+    <code>try_commit()</code> result overrides only one field on the
+    emitted <code>text</code> / <code>appended</code> / <code>end</code>
+    events: the cumulative <code>transcript</code> string.
+  </p>
+
+  <figure>
+    <svg viewBox="0 0 760 240" xmlns="http://www.w3.org/2000/svg">
+      <!-- Audio source -->
+      <rect x="20" y="100" width="120" height="40" fill="#fff" stroke="#102a54" stroke-width="1.5"/>
+      <text x="80" y="125" font-size="12" text-anchor="middle" fill="#102a54">Audio chunks</text>
+      <text x="80" y="155" font-size="10" text-anchor="middle" fill="#555">(mic / file replay)</text>
+
+      <!-- Fanout -->
+      <line x1="140" y1="120" x2="220" y2="60"  stroke="#102a54" stroke-width="1.5"/>
+      <line x1="140" y1="120" x2="220" y2="180" stroke="#102a54" stroke-width="1.5"/>
+
+      <!-- Envelope path -->
+      <rect x="220" y="40" width="200" height="60" fill="#fff" stroke="#102a54" stroke-width="1.5"/>
+      <text x="320" y="60" font-size="12" text-anchor="middle" fill="#102a54">LiveEnvelopeStreamer</text>
+      <text x="320" y="78" font-size="10" text-anchor="middle" fill="#555">Goertzel + hysteresis</text>
+      <text x="320" y="92" font-size="10" text-anchor="middle" fill="#555">k-means dot/dah, viz frames</text>
+
+      <!-- Region path -->
+      <rect x="220" y="160" width="200" height="60" fill="#fff" stroke="#b21f1f" stroke-width="1.5"/>
+      <text x="320" y="180" font-size="12" text-anchor="middle" fill="#b21f1f">RegionStreamer</text>
+      <text x="320" y="198" font-size="10" text-anchor="middle" fill="#555">burst detection +</text>
+      <text x="320" y="212" font-size="10" text-anchor="middle" fill="#555">per-region ditdah decode</text>
+
+      <!-- Merge -->
+      <line x1="420" y1="70"  x2="500" y2="120" stroke="#102a54" stroke-width="1.5"/>
+      <line x1="420" y1="190" x2="500" y2="120" stroke="#b21f1f" stroke-width="1.5"/>
+
+      <!-- Output -->
+      <rect x="500" y="80" width="240" height="80" fill="#fff" stroke="#102a54" stroke-width="1.5"/>
+      <text x="620" y="105" font-size="12" text-anchor="middle" fill="#102a54">NDJSON event stream</text>
+      <text x="620" y="125" font-size="10" text-anchor="middle" fill="#555">viz frames &larr; envelope</text>
+      <text x="620" y="142" font-size="10" text-anchor="middle" fill="#b21f1f">transcript &larr; region</text>
+    </svg>
+    <figcaption>
+      <strong>Figure 2.</strong> Dual-path integration. Audio is fanned
+      out to both decoders. The envelope path retains full ownership
+      of the visualizer&rsquo;s real-time frames; the region path owns
+      only the cumulative transcript field. Both UIs (production
+      logger F7 capture and the experimental visualizer) consume the
+      merged NDJSON stream unchanged.
+    </figcaption>
+  </figure>
+
+  <p>
+    Both UI surfaces &mdash; the production logger&rsquo;s
+    <code>CwDecoderProcessSampleSource</code> and the experimental
+    visualizer&rsquo;s <code>CwDecoderProcess</code> &mdash; spawn the
+    decoder with <code>--region-transcript</code> by default. Operators
+    do not see a new mode switch; they simply get a transcript that
+    matches what they actually heard.
+  </p>
+
+  <h2>5. Results</h2>
+
+  <p>
+    On the target reference recording, the architecture meets the
+    success criterion exactly:
+  </p>
+
+  <table>
+    <thead>
+      <tr><th>Path</th><th>Output transcript</th><th>vs. truth</th></tr>
+    </thead>
+    <tbody>
+      <tr class="match">
+        <td>truth.txt</td>
+        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
+        <td>&mdash;</td>
+      </tr>
+      <tr class="match">
+        <td><code>stream-region</code> (batch)</td>
+        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
+        <td>0 char diff</td>
+      </tr>
+      <tr class="match">
+        <td><code>stream-live-v3 --region-transcript</code></td>
+        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
+        <td>0 char diff</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>
+    A cross-validation run over additional samples confirms that the
+    streaming wrapper reproduces the batch reference on real CW audio:
+  </p>
+
+  <table>
+    <thead>
+      <tr><th>Sample</th><th>Description</th><th>Match</th></tr>
+    </thead>
+    <tbody>
+      <tr class="match">
+        <td><code>radio-20260502-105714.mp3</code></td>
+        <td>4 bursts, mixed WPM, real radio</td>
+        <td>yes</td>
+      </tr>
+      <tr class="match">
+        <td><code>cw_30wpm_abbrev_clean.wav</code></td>
+        <td>continuous, clean 30 WPM</td>
+        <td>yes</td>
+      </tr>
+      <tr class="match">
+        <td><code>cw_30wpm_abbrev_weak.wav</code></td>
+        <td>continuous, weak 30 WPM</td>
+        <td>yes</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>
+    On two extreme noise-only clips that contain no real CW content, the
+    incremental streaming and the batch reference produce different
+    sequences of garbage characters. This is an inherent property of
+    incremental versus batch noise-floor estimation and does not affect
+    real-CW operation. It is discussed in <a href="#future">Section&nbsp;7</a>.
+  </p>
+
+  <div class="callout">
+    <p><span class="label">Validation gates.</span>
+      The change clears <code>cargo&nbsp;fmt</code>,
+      <code>cargo&nbsp;clippy&nbsp;-D&nbsp;warnings</code>, the full
+      <code>cargo&nbsp;test</code> suite (129 passing, one pre-existing
+      environmental skip unrelated to this work),
+      <code>dotnet&nbsp;publish&nbsp;CwDecoderGui&nbsp;-c&nbsp;Release</code>,
+      and <code>dotnet&nbsp;build&nbsp;QsoRipper.Gui&nbsp;-c&nbsp;Release</code>.
+    </p>
+  </div>
+
+  <h2>6. Discussion</h2>
+
+  <h3>6.1 Latency</h3>
+
+  <p>
+    The trailing-static commit gate trades latency for correctness. With
+    <code>stable_latency_s = 0.6 s</code>, a region&rsquo;s text appears
+    in the transcript roughly 0.6 s after the operator releases the key
+    at the end of a burst. For logging and post-QSO copy this is
+    negligible. For real-time pile-up triage it would be perceptible;
+    the parameter is exposed as <code>--region-stable-latency-s</code>
+    and can be reduced at the cost of occasional re-decode churn.
+  </p>
+
+  <h3>6.2 Why batch and stream agree on real CW</h3>
+
+  <p>
+    The streaming wrapper and the batch reference call the same
+    <code>decode_region_stream</code> over the same audio. The only
+    difference is that the streaming wrapper invokes it incrementally
+    on a growing buffer. As long as the noise-floor percentiles are
+    stable across cycles &mdash; which they are once a real CW signal is
+    present &mdash; the detected regions are identical and the per-region
+    decoder is deterministic. On clips with no real signal, the
+    percentiles drift with the buffer length and incremental commits
+    can capture transient noise spikes that the batch reference
+    smooths out.
+  </p>
+
+  <h3>6.3 Relation to the append-only event-stream foundation</h3>
+
+  <p>
+    The append-only event-stream decoder in
+    <code>append_decode.rs</code> is not deprecated. It remains the
+    source of truth for the visualizer&rsquo;s bar painting and for
+    the time-weighted <code>cw_decode_rx_wpm</code> aggregator that
+    feeds ADIF. The region-isolated path supplements that foundation
+    for the transcript field; the two are now both &ldquo;line in the
+    sand&rdquo; baselines, each governing its own concern.
+  </p>
+
+  <h2 id="future">7. Future Directions</h2>
+
+  <p>
+    Several extensions are natural next steps:
+  </p>
+
+  <ul>
+    <li>
+      <span class="key">Content-stability gate.</span> Require a
+      candidate region to produce identical decoded text across
+      <i>N</i> consecutive <code>try_commit</code> cycles before
+      committing. This would converge the streaming and batch outputs
+      on noisy non-CW clips at the cost of one decode period of
+      additional latency. A prototype was implemented and reverted to
+      keep the current behavior surgical and faithful to the batch
+      reference; it is the obvious next iteration.
+    </li>
+    <li>
+      <span class="key">Adaptive trailing-static window.</span>
+      Slow CW (5&ndash;8 WPM) has intra-character gaps approaching the
+      current 0.6 s commit gate. An adaptive
+      <code>stable_latency_s = max(0.6, 4 &times; estimated_dot_period)</code>
+      would let the gate scale with the operator&rsquo;s speed without
+      manual tuning.
+    </li>
+    <li>
+      <span class="key">Multi-pitch region routing.</span> When two
+      stations share the passband at different pitches, the existing
+      <code>LiveMultiPitchStreamer</code> already separates them at the
+      envelope level. Routing per-pitch envelopes into per-pitch
+      <code>RegionStreamer</code> instances would let us produce two
+      simultaneous transcripts &mdash; useful for SO2R and contest
+      monitoring.
+    </li>
+    <li>
+      <span class="key">Confidence and provisional text.</span>
+      The current commit gate is binary: a region is either committed
+      or invisible. A provisional-text channel that surfaces in-flight
+      regions with a confidence band would let the GUI render copy as
+      it forms, without disturbing the committed transcript.
+    </li>
+    <li>
+      <span class="key">Integration into the engine-side
+      <code>CwDecodeService</code>.</span> The decoder presently runs
+      as a subprocess of each UI. Promoting it to a gRPC service in
+      <code>src/rust/qsoripper-server</code> would let multiple clients
+      (Avalonia GUI, web dashboard, future TUI) share a single decoder
+      instance and a single set of region commits.
+    </li>
+    <li>
+      <span class="key">Larger labeled corpus.</span> The strongest
+      protection against regression is a broad, real-world test set.
+      Expanding the existing <code>training-set-a</code> /
+      <code>training-set-b</code> with more multi-burst, mixed-speed,
+      mixed-conditions captures &mdash; each with an operator-supplied
+      truth file &mdash; is the cheapest way to keep raising the bar.
+    </li>
+  </ul>
+
+  <h2>8. Reproducing the Result</h2>
+
+  <p>
+    The complete cross-validation can be reproduced from a clean
+    checkout in a few minutes:
+  </p>
+
+  <pre><code>cd C:\Users\randy\Git\qsoripper
+cargo build --manifest-path experiments\cw-decoder\Cargo.toml --release
+
+$exe   = "experiments\cw-decoder\target\release\cw-decoder.exe"
+$base  = "C:\...\cw-samples\training-set-b"
+$f     = "$base\radio-20260502-105714.mp3"
+$truth = (Get-Content "$base\radio-20260502-105714.truth.txt" -Raw).Trim()
+
+# Batch reference.
+&amp; $exe stream-region --file $f --json --no-realtime `
+    --decode-every-ms 250 |
+    Select-String '"type":"end"' | Select-Object -Last 1
+
+# Live streaming path used by both UIs.
+&amp; $exe stream-live-v3 --file $f --json --region-transcript `
+    --decode-every-ms 250 |
+    Select-String '"type":"end"' | Select-Object -Last 1
+
+# Both transcript fields should equal $truth:
+#   IHU NVCHU 7QP W7N 7QP W7N</code></pre>
+
+  <h2>9. Conclusion</h2>
+
+  <p>
+    Multi-burst, mixed-speed off-air CW is a different problem from
+    long single-speed practice files, and it benefits from a different
+    decomposition. By detecting each operator burst as a region,
+    decoding each region independently, and committing only after a
+    trailing-static window, we achieve 100% character-exact transcripts
+    on real-world QSO audio that previously defeated our envelope-only
+    foundation. The architecture preserves the rich visualizer event
+    stream, integrates cleanly into both UI surfaces, and is now the
+    documented baseline against which future CW decoding experiments
+    will be measured. Future work will refine the commit gate, extend
+    to multi-pitch and provisional output, and grow the labeled corpus
+    that protects this baseline from regression.
+  </p>
+
+  <h2>Acknowledgments</h2>
+
+  <p>
+    Thanks to the upstream <code>ditdah</code> baseline decoder for the
+    short-clip Morse decoding that each region relies on, and to the
+    QsoRipper agent toolchain (Claude, GitHub Copilot CLI) for
+    rubber-ducking the architecture and helping cross-validate it
+    against the labeled corpus.
+  </p>
+
+  <h2 class="refs-h">References</h2>
+
+  <div class="refs">
+    <ol>
+      <li>
+        QsoRipper repository,
+        <code>experiments/cw-decoder/</code> &mdash; primary source for
+        the implementation discussed in this report.
+      </li>
+      <li>
+        QsoRipper PR&nbsp;#375, &ldquo;cw-decoder: region-based streaming
+        decoder (100% match on real-world QSO sample)&rdquo;, batch
+        path.
+      </li>
+      <li>
+        QsoRipper PR&nbsp;#376, &ldquo;cw-decoder: wire region-isolated
+        transcript into live streaming + GUIs&rdquo;.
+      </li>
+      <li>
+        ARRL, <i>The ARRL Handbook for Radio Communications</i>,
+        chapter on Morse code timing and PARIS-derived WPM.
+      </li>
+      <li>
+        Goertzel, G., &ldquo;An Algorithm for the Evaluation of Finite
+        Trigonometric Series&rdquo;, <i>American Mathematical Monthly</i>,
+        Vol.&nbsp;65, No.&nbsp;1, 1958, pp.&nbsp;34&ndash;35.
+      </li>
+      <li>
+        Lloyd, S. P., &ldquo;Least Squares Quantization in PCM&rdquo;,
+        <i>IEEE Transactions on Information Theory</i>,
+        Vol.&nbsp;28, No.&nbsp;2, 1982, pp.&nbsp;129&ndash;137 (the
+        k-means classifier underlying the dot/dah decision).
+      </li>
+    </ol>
+  </div>
+
+  </div><!-- /columns -->
+
+  <div class="footer">
+    QsoRipper Technical Report &middot; <i>Region-Isolated Streaming for
+    Real-World CW Copy</i> &middot; rev. May 2026.
+    Source: <code>experiments/cw-decoder/docs/cw-decoder-architecture.html</code>.
+  </div>
+
+</div>
+</body>
+</html>

--- a/experiments/cw-decoder/docs/cw-decoder-architecture.html
+++ b/experiments/cw-decoder/docs/cw-decoder-architecture.html
@@ -425,6 +425,18 @@ threshold    = noise_floor
     clipped.
   </p>
 
+  <p>
+    A later synthetic impairment sweep added one more guard that belongs
+    in the baseline: before a detected run is decoded, it must show
+    narrowband CW-like prominence. The implementation compares Goertzel
+    power at the selected pitch against the run&rsquo;s broadband frame
+    energy and rejects runs below
+    <code>min_tonal_prominence_ratio = 8.0</code>. This prevents pure
+    background static from being promoted into fake regions simply
+    because a percentile threshold can always split random noise into
+    &ldquo;above&rdquo; and &ldquo;below&rdquo; frames.
+  </p>
+
   <h3>3.2 Per-region decode</h3>
 
   <p>
@@ -602,12 +614,41 @@ for region in detected:
   </table>
 
   <p>
-    On two extreme noise-only clips that contain no real CW content, the
-    incremental streaming and the batch reference produce different
-    sequences of garbage characters. This is an inherent property of
-    incremental versus batch noise-floor estimation and does not affect
-    real-CW operation. It is discussed in <a href="#future">Section&nbsp;7</a>.
+    A synthetic impairment suite now exercises the baseline beyond the
+    reference MP3. It generates deterministic CW with quiet static gaps,
+    additive white noise, QSB amplitude fading, an offset continuous-tone
+    QRM carrier, and a combined noise/QSB/QRM exchange. The suite also
+    includes a noise-only stream that previously produced ghost text;
+    after the tonal-prominence guard, it remains empty.
   </p>
+
+  <table>
+    <thead>
+      <tr><th>Synthetic condition</th><th>Expected behavior</th><th>Result</th></tr>
+    </thead>
+    <tbody>
+      <tr class="match">
+        <td>clean four-burst reference shape</td>
+        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code>, four regions</td>
+        <td>pass</td>
+      </tr>
+      <tr class="match">
+        <td>quiet static between bursts</td>
+        <td>same exact copy, no extra regions</td>
+        <td>pass</td>
+      </tr>
+      <tr class="match">
+        <td>noise-only static stream</td>
+        <td>empty transcript</td>
+        <td>pass</td>
+      </tr>
+      <tr class="match">
+        <td>moderate white noise + QSB + offset QRM</td>
+        <td><code>CQ TEST KC7AVA 73</code></td>
+        <td>pass</td>
+      </tr>
+    </tbody>
+  </table>
 
   <div class="callout">
     <p><span class="label">Validation gates.</span>

--- a/experiments/cw-decoder/gui/Services/CwDecoderProcess.cs
+++ b/experiments/cw-decoder/gui/Services/CwDecoderProcess.cs
@@ -92,7 +92,12 @@ internal sealed class CwDecoderProcess : IDisposable
     {
         Stop();
         var ic = CultureInfo.InvariantCulture;
-        var args = $"stream-live-v3 --json --stdin-control --decode-every-ms {decodeEveryMs.ToString(ic)}";
+        // --region-transcript runs a RegionStreamer alongside the
+        // envelope decoder so the visualizer keeps its viz events but
+        // the transcript field is sourced from region-isolated decode.
+        // Handles real-world QSO audio with pauses between bursts at
+        // very different WPMs.
+        var args = $"stream-live-v3 --json --stdin-control --region-transcript --decode-every-ms {decodeEveryMs.ToString(ic)}";
         if (pinWpm > 0) args += $" --pin-wpm {pinWpm.ToString(ic)}";
         if (pinHz > 0) args += $" --pin-hz {pinHz.ToString(ic)}";
         if (!string.IsNullOrWhiteSpace(device)) args += $" --device \"{device}\"";
@@ -105,7 +110,8 @@ internal sealed class CwDecoderProcess : IDisposable
     {
         Stop();
         var ic = CultureInfo.InvariantCulture;
-        var args = $"stream-live-v3 --json --decode-every-ms {decodeEveryMs.ToString(ic)} --file \"{filePath}\"";
+        // See StartLiveV3 for --region-transcript rationale.
+        var args = $"stream-live-v3 --json --region-transcript --decode-every-ms {decodeEveryMs.ToString(ic)} --file \"{filePath}\"";
         if (playAudio) args += " --play";
         if (pinWpm > 0) args += $" --pin-wpm {pinWpm.ToString(ic)}";
         if (pinHz > 0) args += $" --pin-hz {pinHz.ToString(ic)}";

--- a/experiments/cw-decoder/src/envelope_decoder.rs
+++ b/experiments/cw-decoder/src/envelope_decoder.rs
@@ -2661,6 +2661,7 @@ mod tests {
                 pitch_step_hz: 10.0,
                 ..Default::default()
             },
+            peak_score: crate::region_stream::PeakScoreKind::Mean,
         };
         // Use the narrower bandpass for multi-pitch.
         let preprocess = PreprocessConfig {

--- a/experiments/cw-decoder/src/envelope_decoder.rs
+++ b/experiments/cw-decoder/src/envelope_decoder.rs
@@ -2071,12 +2071,7 @@ mod tests {
         let timed = timed_from_pattern(dot, ".--. .- .-. .. ...");
         let est = estimate_dot_period(&timed).expect("intra-element pairs present");
         // Period method should recover 40 ms within 5%.
-        assert!(
-            (est - dot).abs() < 0.05 * dot,
-            "expected ~{}, got {}",
-            dot,
-            est
-        );
+        assert!((est - dot).abs() < 0.05 * dot, "expected ~{dot}, got {est}");
     }
 
     #[test]

--- a/experiments/cw-decoder/src/lib.rs
+++ b/experiments/cw-decoder/src/lib.rs
@@ -14,6 +14,7 @@ pub mod log_capture;
 pub mod preprocess;
 pub mod preview;
 pub mod region_stream;
+pub mod region_streamer;
 pub mod streaming;
 pub mod streaming_v2;
 pub mod tui;

--- a/experiments/cw-decoder/src/lib.rs
+++ b/experiments/cw-decoder/src/lib.rs
@@ -17,4 +17,5 @@ pub mod region_stream;
 pub mod region_streamer;
 pub mod streaming;
 pub mod streaming_v2;
+pub mod synthetic_qso;
 pub mod tui;

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use cw_decoder_poc::{
     audio, bench_latency, decoder, ditdah_streaming, harvest, json, log_capture, preview,
-    streaming, streaming_v2, tui,
+    streaming, streaming_v2, synthetic_qso, tui,
 };
 
 #[derive(Parser, Debug)]
@@ -768,6 +768,35 @@ enum Cmd {
         #[arg(long, default_value_t = 1)]
         seed: u64,
     },
+
+    /// Generate deterministic ragchew and contest QSO CW samples, then
+    /// validate them through the region-isolated decoder baseline.
+    GenQsoSuite {
+        /// Directory for generated WAV, truth sidecar, and manifest files.
+        /// If omitted, samples are generated and validated in memory only.
+        #[arg(long)]
+        output: Option<PathBuf>,
+        /// Number of ragchew-style examples to generate.
+        #[arg(long, default_value_t = 6)]
+        ragchew: usize,
+        /// Number of contest-style examples to generate.
+        #[arg(long, default_value_t = 6)]
+        contest: usize,
+        /// Sample rate in Hz.
+        #[arg(long, default_value_t = 12000)]
+        sample_rate: u32,
+        /// RegionStreamer decode cadence used for validation.
+        /// Reserved for streaming parity; the current suite validates with
+        /// the same batch region core used by RegionStreamer commits.
+        #[arg(long, default_value_t = 500)]
+        decode_every_ms: u64,
+        /// Emit one NDJSON validation row per generated example.
+        #[arg(long)]
+        json: bool,
+        /// Exit non-zero if any generated example is not copied exactly.
+        #[arg(long)]
+        require_exact: bool,
+    },
 }
 
 const CLI_THREAD_STACK_BYTES: usize = 16 * 1024 * 1024;
@@ -1240,6 +1269,23 @@ fn run_cli() -> Result<()> {
             dit_weight,
             noise,
             seed,
+        ),
+        Cmd::GenQsoSuite {
+            output,
+            ragchew,
+            contest,
+            sample_rate,
+            decode_every_ms,
+            json,
+            require_exact,
+        } => run_gen_qso_suite(
+            output.as_deref(),
+            ragchew,
+            contest,
+            sample_rate,
+            decode_every_ms,
+            json,
+            require_exact,
         ),
     }
 }
@@ -3955,6 +4001,110 @@ fn run_gen_rough_fist(
     );
     println!("Truth: {}", truth_path.display());
     println!("Text:  {canonical_text}");
+    Ok(())
+}
+
+fn run_gen_qso_suite(
+    output: Option<&std::path::Path>,
+    ragchew_count: usize,
+    contest_count: usize,
+    sample_rate: u32,
+    decode_every_ms: u64,
+    json: bool,
+    require_exact: bool,
+) -> Result<()> {
+    let examples = synthetic_qso::generate_qso_suite(sample_rate, ragchew_count, contest_count);
+    let mut manifests = Vec::new();
+    let mut validations = Vec::with_capacity(examples.len());
+    for example in &examples {
+        let validation = synthetic_qso::validate_example(example, decode_every_ms);
+        let validation = if let Some(output) = output {
+            let manifest = synthetic_qso::write_example_files(example, &validation, output)?;
+            let written = manifest.validation.clone();
+            manifests.push(manifest);
+            written
+        } else {
+            validation
+        };
+        validations.push(validation);
+    }
+    let manifest_path = if let Some(output) = output {
+        Some(synthetic_qso::write_manifest(output, &manifests)?)
+    } else {
+        None
+    };
+
+    if json {
+        for validation in &validations {
+            println!(
+                "{}",
+                serde_json::to_string(validation).context("serializing validation")?
+            );
+        }
+        let failures = validations.iter().filter(|v| !v.exact_match).count();
+        if let Some(path) = manifest_path {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "type": "manifest",
+                    "path": path,
+                    "examples": validations.len(),
+                    "all_exact": validations.iter().all(|v| v.exact_match),
+                })
+            );
+        }
+        if require_exact && failures > 0 {
+            anyhow::bail!("{failures} synthetic QSO validation(s) failed exact-copy check");
+        }
+        return Ok(());
+    }
+
+    println!(
+        "Generated {} synthetic QSOs ({} ragchew, {} contest) @ {} Hz; decode_every={} ms",
+        validations.len(),
+        ragchew_count,
+        contest_count,
+        sample_rate,
+        decode_every_ms
+    );
+    if let Some(path) = manifest_path {
+        println!(
+            "Artifacts: {}",
+            path.parent().unwrap_or(path.as_path()).display()
+        );
+        println!("Manifest:  {}", path.display());
+    }
+    println!();
+    println!(
+        "{:<12} {:<8} {:>7} {:>7} {:<6} transcript",
+        "id", "kind", "sec", "regions", "match"
+    );
+    println!("{}", "-".repeat(96));
+    for validation in &validations {
+        println!(
+            "{:<12} {:<8} {:>7.2} {:>7} {:<6} {}",
+            validation.id,
+            validation.kind.as_str(),
+            validation.duration_s,
+            validation.region_count,
+            if validation.exact_match { "yes" } else { "NO" },
+            validation.transcript
+        );
+        if !validation.exact_match {
+            println!("  truth: {}", validation.truth);
+        }
+    }
+    let failures = validations.iter().filter(|v| !v.exact_match).count();
+    println!();
+    println!(
+        "Exact-copy summary: {}/{} passed, {} failed",
+        validations.len() - failures,
+        validations.len(),
+        failures
+    );
+    if require_exact && failures > 0 {
+        anyhow::bail!("{failures} synthetic QSO validation(s) failed exact-copy check");
+    }
     Ok(())
 }
 

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -559,6 +559,51 @@ enum Cmd {
         #[arg(long, alias = "multi", default_value_t = 0)]
         multi_pitch: usize,
     },
+    /// Region-based streaming decoder. Detects active morse bursts
+    /// (separated by background static), decodes each burst with the
+    /// ditdah baseline at its own auto-WPM, and emits append-only
+    /// transcript JSON events. Designed for real-world QSO audio with
+    /// pauses between transmissions and bursts at very different speeds.
+    ///
+    /// Currently file-only. Emits the same `transcript` event shape as
+    /// stream-live-v3 so the GUI's CwQsoTranscriptAggregator picks it up
+    /// transparently.
+    StreamRegion {
+        /// Decode an audio file (mp3/wav/m4a/...) at real-time pace.
+        #[arg(long)]
+        file: PathBuf,
+        /// Emit NDJSON events to stdout (one per line).
+        #[arg(long)]
+        json: bool,
+        /// Re-run region detection every N ms. Default 500 ms.
+        #[arg(long, default_value_t = 500)]
+        decode_every_ms: u64,
+        /// Trailing-static seconds required before a region is committed.
+        /// Higher values reduce mid-burst churn at the cost of latency.
+        #[arg(long, default_value_t = 0.6)]
+        stable_latency_s: f32,
+        /// Treat regions separated by less than this gap (seconds) as one
+        /// burst. Defaults are tuned for the common case where bursts are
+        /// separated by static of ~1 s or more.
+        #[arg(long, default_value_t = 0.5)]
+        merge_gap_s: f32,
+        /// Drop detected runs shorter than this many seconds (rejects
+        /// transient static spikes).
+        #[arg(long, default_value_t = 0.3)]
+        min_region_s: f32,
+        /// Threshold = noise_floor + factor * (signal_floor - noise_floor).
+        /// 0.30 works well across the test set; raise for noisier feeds.
+        #[arg(long, default_value_t = 0.30)]
+        threshold_factor: f32,
+        /// Symmetrical padding (seconds) added to each detected region
+        /// before decoding so leading/trailing dits aren't clipped.
+        #[arg(long, default_value_t = 0.15)]
+        pad_s: f32,
+        /// Replay the file as fast as possible instead of at real-time
+        /// pace. Useful for tests and one-shot batch decodes.
+        #[arg(long)]
+        no_realtime: bool,
+    },
     /// Diagnostic: scan candidate pitches across an audio file and print
     /// the trial-decode Fisher score per pitch. Use this to compare
     /// faint signals vs noise and tune lock thresholds.
@@ -1077,6 +1122,27 @@ fn run_cli() -> Result<()> {
             file.as_deref(),
             play,
             multi_pitch,
+        ),
+        Cmd::StreamRegion {
+            file,
+            json,
+            decode_every_ms,
+            stable_latency_s,
+            merge_gap_s,
+            min_region_s,
+            threshold_factor,
+            pad_s,
+            no_realtime,
+        } => run_stream_region_file(
+            &file,
+            json,
+            decode_every_ms,
+            stable_latency_s,
+            merge_gap_s,
+            min_region_s,
+            threshold_factor,
+            pad_s,
+            !no_realtime,
         ),
         Cmd::ProbeFisher {
             path,
@@ -4490,7 +4556,164 @@ fn run_stream_live_v3_file(
     Ok(())
 }
 
-/// Returns true when the per-cycle decoder snapshot is trustworthy
+/// Region-based streaming decoder (file mode).
+///
+/// Streams the file at real-time pace into a [`RegionStreamer`] that
+/// detects active morse bursts (separated by background static),
+/// decodes each burst at its own auto-WPM with the ditdah baseline,
+/// and emits append-only `transcript` JSON events to stdout.
+///
+/// Validated end-to-end on the `radio-20260502-105714.mp3` real-world
+/// sample (4 bursts at 13/8/39/29 WPM separated by ~1-7s of static)
+/// where it produces an exact match for the ground truth transcript.
+fn run_stream_region_file(
+    path: &std::path::Path,
+    json: bool,
+    decode_every_ms: u64,
+    stable_latency_s: f32,
+    merge_gap_s: f32,
+    min_region_s: f32,
+    threshold_factor: f32,
+    pad_s: f32,
+    realtime: bool,
+) -> Result<()> {
+    use cw_decoder_poc::region_stream::RegionStreamConfig;
+    use cw_decoder_poc::region_streamer::{RegionStreamer, RegionStreamerConfig};
+    use std::time::{Duration, Instant};
+
+    let decoded = audio::decode_file(path)?;
+    let sr = decoded.sample_rate;
+    let total_samples = decoded.samples.len();
+    let duration_s = total_samples as f32 / sr.max(1) as f32;
+
+    let region_cfg = RegionStreamConfig {
+        merge_gap_s,
+        min_region_s,
+        threshold_factor,
+        pad_s,
+        ..RegionStreamConfig::default()
+    };
+
+    let cfg = RegionStreamerConfig {
+        region: region_cfg,
+        stable_latency_s,
+    };
+    let mut streamer = RegionStreamer::with_config(sr, cfg);
+
+    let mut emitter = if json {
+        Some(json::JsonEmitter::new())
+    } else {
+        None
+    };
+    if let Some(em) = emitter.as_mut() {
+        em.emit(
+            0.0,
+            serde_json::json!({
+                "type": "ready",
+                "source": "stream-region-file",
+                "device": format!("file:{}", path.display()),
+                "rate": sr,
+                "decode_every_ms": decode_every_ms,
+                "duration_s": duration_s,
+                "stable_latency_s": stable_latency_s,
+                "merge_gap_s": merge_gap_s,
+                "min_region_s": min_region_s,
+                "threshold_factor": threshold_factor,
+                "pad_s": pad_s,
+            }),
+        );
+    } else {
+        println!(
+            "Streaming file (region-based): {} @ {} Hz ({:.2}s); decode every {} ms; stable_latency={:.2}s",
+            path.display(),
+            sr,
+            duration_s,
+            decode_every_ms,
+            stable_latency_s,
+        );
+    }
+
+    let chunk_period = Duration::from_millis(50);
+    let chunk_samples = ((sr as u64 * 50) / 1000).max(1) as usize;
+    let started = Instant::now();
+    let mut last_decode_at = Instant::now() - Duration::from_millis(decode_every_ms);
+    let decode_period = Duration::from_millis(decode_every_ms);
+    let mut cursor = 0usize;
+
+    while cursor < total_samples {
+        let end = (cursor + chunk_samples).min(total_samples);
+        let chunk = &decoded.samples[cursor..end];
+        cursor = end;
+        streamer.ingest(chunk);
+
+        if last_decode_at.elapsed() >= decode_period {
+            last_decode_at = Instant::now();
+            let committed = streamer.try_commit();
+            let t = started.elapsed().as_secs_f32();
+            emit_region_transcript(emitter.as_mut(), t, streamer.transcript(), &committed);
+        }
+
+        if realtime {
+            std::thread::sleep(chunk_period);
+        }
+    }
+
+    // Final commit: force-flush any in-flight regions.
+    let final_committed = streamer.flush();
+    let t = started.elapsed().as_secs_f32();
+    emit_region_transcript(emitter.as_mut(), t, streamer.transcript(), &final_committed);
+
+    if let Some(em) = emitter.as_mut() {
+        em.emit(
+            t,
+            serde_json::json!({
+                "type": "end",
+                "transcript": streamer.transcript(),
+                "committed": streamer.transcript(),
+            }),
+        );
+    } else {
+        println!();
+        println!("Final transcript (region-based):");
+        println!("{}", streamer.transcript());
+    }
+    Ok(())
+}
+
+fn emit_region_transcript(
+    emitter: Option<&mut json::JsonEmitter>,
+    t: f32,
+    transcript: &str,
+    just_committed: &[cw_decoder_poc::region_streamer::CommittedRegion],
+) {
+    if let Some(em) = emitter {
+        let appended: String = just_committed
+            .iter()
+            .map(|r| r.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        em.emit(
+            t,
+            serde_json::json!({
+                "type": "transcript",
+                "text": transcript,
+                "appended": appended,
+                "transcript": transcript,
+                "committed": transcript,
+                "provisional": "",
+                "wpm": 0.0,
+            }),
+        );
+    } else if !just_committed.is_empty() {
+        for r in just_committed {
+            println!(
+                "[t={:>6.2}s region {:.2}-{:.2}] {}",
+                t, r.start_s, r.end_s, r.text
+            );
+        }
+    }
+}
+
 /// enough to be stitched into the persistent session transcript.
 ///
 /// The streamer enters `LOCKED` (i.e. `viz.locked_wpm = Some(_)`) only

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -558,6 +558,30 @@ enum Cmd {
         /// alongside the single-track `transcript` event.
         #[arg(long, alias = "multi", default_value_t = 0)]
         multi_pitch: usize,
+
+        /// Use the region-based decoder for the transcript field.
+        /// When set, a RegionStreamer is run alongside the envelope
+        /// pipeline; viz events still come from the envelope decoder
+        /// (so the visualizer keeps working) but the `transcript` event
+        /// `text`/`appended` fields and the final `end` transcript come
+        /// from region-isolated ditdah decode. This is the
+        /// "human-level" path that handles real-world QSO audio with
+        /// pauses between bursts at different WPMs. Recommended for all
+        /// production live capture.
+        #[arg(long)]
+        region_transcript: bool,
+
+        /// Trailing-static seconds required before a region is committed
+        /// when `--region-transcript` is set. Higher = less mid-burst
+        /// churn at the cost of latency. Default 0.6 s.
+        #[arg(long, default_value_t = 0.6)]
+        region_stable_latency_s: f32,
+
+        /// During live capture, drop buffered audio that ends more than
+        /// this many seconds before the last committed region. Bounds
+        /// memory growth across long QSO sessions. Default 5 s.
+        #[arg(long, default_value_t = 5.0)]
+        region_keep_back_s: f32,
     },
     /// Region-based streaming decoder. Detects active morse bursts
     /// (separated by background static), decodes each burst with the
@@ -1108,6 +1132,9 @@ fn run_cli() -> Result<()> {
             file,
             play,
             multi_pitch,
+            region_transcript,
+            region_stable_latency_s,
+            region_keep_back_s,
         } => run_stream_live_v3(
             device.as_deref(),
             seconds,
@@ -1122,6 +1149,9 @@ fn run_cli() -> Result<()> {
             file.as_deref(),
             play,
             multi_pitch,
+            region_transcript,
+            region_stable_latency_s,
+            region_keep_back_s,
         ),
         Cmd::StreamRegion {
             file,
@@ -3942,6 +3972,9 @@ fn run_stream_live_v3(
     file: Option<&std::path::Path>,
     play_file_audio: bool,
     multi_pitch: usize,
+    region_transcript: bool,
+    region_stable_latency_s: f32,
+    region_keep_back_s: f32,
 ) -> Result<()> {
     if let Some(path) = file {
         return run_stream_live_v3_file(
@@ -3954,11 +3987,14 @@ fn run_stream_live_v3(
             min_snr_db,
             play_file_audio,
             multi_pitch,
+            region_transcript,
+            region_stable_latency_s,
         );
     }
     use cw_decoder_poc::envelope_decoder::{
         LiveEnvelopeStreamer, LiveMultiPitchStreamer, VizEventKind, MAX_VIZ_ENVELOPE_SAMPLES,
     };
+    use cw_decoder_poc::region_streamer::{RegionStreamer, RegionStreamerConfig};
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::sync::Arc;
     use std::time::{Duration, Instant};
@@ -3988,6 +4024,29 @@ fn run_stream_live_v3(
         }
     };
     let mut multi_streamer = new_multi();
+
+    let new_region = || {
+        if !region_transcript {
+            None
+        } else {
+            // Start from the streamer's TUNED defaults (merge_gap=0.5,
+            // min_region=0.3, pad=0.15, threshold=0.30) — the raw
+            // RegionStreamConfig::default() uses merge_gap=3.0 which
+            // glues real-world bursts that are <3s apart into one
+            // region and silently drops the trailing burst.
+            let defaults = RegionStreamerConfig::default();
+            let mut region = defaults.region;
+            if let Some(w) = pin_wpm {
+                region.pin_wpm = Some(w);
+            }
+            let cfg = RegionStreamerConfig {
+                region,
+                stable_latency_s: region_stable_latency_s.max(0.0),
+            };
+            Some(RegionStreamer::with_config(capture.sample_rate, cfg))
+        }
+    };
+    let mut region_streamer = new_region();
 
     let stop = Arc::new(AtomicBool::new(false));
     {
@@ -4065,6 +4124,7 @@ fn run_stream_live_v3(
                 if matches!(msg, StdinControlMessage::ResetLock) {
                     streamer = new_streamer();
                     multi_streamer = new_multi();
+                    region_streamer = new_region();
                     last_drain_at = capture.buffer.lock().written;
                     commit_cursor.reset_all();
                     append_decoder = cw_decoder_poc::append_decode::AppendEventDecoder::new();
@@ -4098,6 +4158,9 @@ fn run_stream_live_v3(
             if let Some(m) = multi_streamer.as_mut() {
                 let _ = m.feed(&chunk);
             }
+            if let Some(r) = region_streamer.as_mut() {
+                r.ingest(&chunk);
+            }
         }
 
         if last_decode_at.elapsed() < decode_period {
@@ -4108,6 +4171,27 @@ fn run_stream_live_v3(
         // Force a viz-producing decode now.
         let snap = streamer.flush_with_viz();
         let t = started.elapsed().as_secs_f32();
+        // When --region-transcript is set, drive the cumulative
+        // transcript field from the region-isolated decoder. This
+        // handles real-world QSO audio with pauses between bursts at
+        // very different WPMs (e.g. 8 vs 39 WPM) where a single-pass
+        // envelope decoder is structurally limited to one WPM lock.
+        let region_commits = region_streamer
+            .as_mut()
+            .map(|r| r.try_commit())
+            .unwrap_or_default();
+        let region_text_full = region_streamer
+            .as_ref()
+            .map(|r| r.transcript().to_string())
+            .unwrap_or_default();
+        let region_appended: String = region_commits
+            .iter()
+            .map(|r| r.text.as_str())
+            .collect::<Vec<_>>()
+            .join(" ");
+        if let Some(r) = region_streamer.as_mut() {
+            r.trim_committed(region_keep_back_s);
+        }
         // Approach A+: event-driven commit cursor (sample-indexed,
         // idempotent across re-decodes) replaces the old
         // string-stitching path that produced ghost-repeats like
@@ -4149,20 +4233,34 @@ fn run_stream_live_v3(
             );
         }
 
+        // Effective transcript-event payload. Region path overrides
+        // text/appended when active.
+        let use_region = region_streamer.is_some();
+        let eff_text = if use_region {
+            region_text_full.clone()
+        } else {
+            append.decoded_text.clone()
+        };
+        let eff_appended = if use_region {
+            region_appended.clone()
+        } else {
+            appended_session.clone()
+        };
         if let Some(em) = emitter.as_mut() {
             em.emit(
                 t,
                 serde_json::json!({
                     "type": "transcript",
-                    "text": append.decoded_text,
-                    "appended": appended_session,
-                    "transcript": append.decoded_text,
-                    "committed": commit.committed_text,
-                    "provisional": commit.provisional_tail,
+                    "text": eff_text,
+                    "appended": eff_appended,
+                    "transcript": eff_text,
+                    "committed": if use_region { region_text_full.clone() } else { commit.committed_text.clone() },
+                    "provisional": if use_region { String::new() } else { commit.provisional_tail.clone() },
                     "cursor_transcript": session_transcript.clone(),
                     "raw_morse": append.raw_stream,
                     "window_text": snap.transcript,
                     "wpm": snap.wpm,
+                    "region_mode": use_region,
                 }),
             );
             if let Some(viz) = snap.viz {
@@ -4259,20 +4357,36 @@ fn run_stream_live_v3(
     let recording_saved = capture
         .finalize_recording()
         .map(|p| p.display().to_string());
+    // Final flush for region streamer to commit any in-flight burst.
+    let final_region_text = if let Some(r) = region_streamer.as_mut() {
+        let _ = r.flush();
+        r.transcript().to_string()
+    } else {
+        String::new()
+    };
     if let Some(em) = emitter.as_mut() {
+        let final_text = if region_streamer.is_some() {
+            final_region_text
+        } else {
+            commit_cursor.committed_text().to_string()
+        };
         em.emit(
             started.elapsed().as_secs_f32(),
             serde_json::json!({
                 "type": "end",
-                "transcript": commit_cursor.committed_text(),
-                "committed": commit_cursor.committed_text(),
+                "transcript": final_text,
+                "committed": final_text,
                 "recording": recording_saved.or(recording_path),
             }),
         );
     } else {
         println!();
         println!("Final transcript (v3):");
-        println!("{}", commit_cursor.committed_text());
+        if region_streamer.is_some() {
+            println!("{final_region_text}");
+        } else {
+            println!("{}", commit_cursor.committed_text());
+        }
     }
     Ok(())
 }
@@ -4287,10 +4401,13 @@ fn run_stream_live_v3_file(
     min_snr_db: f32,
     play_file_audio: bool,
     multi_pitch: usize,
+    region_transcript: bool,
+    region_stable_latency_s: f32,
 ) -> Result<()> {
     use cw_decoder_poc::envelope_decoder::{
         LiveEnvelopeStreamer, LiveMultiPitchStreamer, VizEventKind, MAX_VIZ_ENVELOPE_SAMPLES,
     };
+    use cw_decoder_poc::region_streamer::{RegionStreamer, RegionStreamerConfig};
     use std::time::{Duration, Instant};
 
     let decoded = audio::decode_file(path)?;
@@ -4317,6 +4434,24 @@ fn run_stream_live_v3_file(
         s.set_pinned_wpm(pin_wpm);
         s.set_min_snr_db(min_snr_db);
         Some(s)
+    };
+
+    let mut region_streamer = if region_transcript {
+        // See run_stream_live_v3 for rationale on starting from the
+        // RegionStreamerConfig::default() tuned defaults rather than
+        // raw RegionStreamConfig::default().
+        let defaults = RegionStreamerConfig::default();
+        let mut region = defaults.region;
+        if let Some(w) = pin_wpm {
+            region.pin_wpm = Some(w);
+        }
+        let cfg = RegionStreamerConfig {
+            region,
+            stable_latency_s: region_stable_latency_s.max(0.0),
+        };
+        Some(RegionStreamer::with_config(sr, cfg))
+    } else {
+        None
     };
 
     let mut emitter = if json {
@@ -4382,6 +4517,9 @@ fn run_stream_live_v3_file(
             if let Some(m) = multi_streamer.as_mut() {
                 let _ = m.feed(&decoded.samples[cursor..end]);
             }
+            if let Some(r) = region_streamer.as_mut() {
+                r.ingest(&decoded.samples[cursor..end]);
+            }
             cursor = end;
         }
 
@@ -4392,6 +4530,16 @@ fn run_stream_live_v3_file(
 
         let snap = streamer.flush_with_viz();
         let t = started.elapsed().as_secs_f32();
+        // Region path runs alongside envelope to handle multi-burst
+        // real-world QSO audio with pauses + speed changes.
+        let _region_commits = region_streamer
+            .as_mut()
+            .map(|r| r.try_commit())
+            .unwrap_or_default();
+        let region_text_full = region_streamer
+            .as_ref()
+            .map(|r| r.transcript().to_string())
+            .unwrap_or_default();
         // Approach A+: drive the event-driven commit cursor instead of
         // string-stitching. The cursor is sample-indexed and idempotent
         // across re-decodes of the same audio region, so the
@@ -4434,20 +4582,27 @@ fn run_stream_live_v3_file(
             );
         }
 
+        let use_region = region_streamer.is_some();
+        let eff_text = if use_region {
+            region_text_full.clone()
+        } else {
+            append.decoded_text.clone()
+        };
         if let Some(em) = emitter.as_mut() {
             em.emit(
                 t,
                 serde_json::json!({
                     "type": "transcript",
-                    "text": append.decoded_text,
+                    "text": eff_text,
                     "appended": appended_session,
-                    "transcript": append.decoded_text,
-                    "committed": commit.committed_text,
-                    "provisional": commit.provisional_tail,
+                    "transcript": eff_text,
+                    "committed": if use_region { region_text_full.clone() } else { commit.committed_text.clone() },
+                    "provisional": if use_region { String::new() } else { commit.provisional_tail.clone() },
                     "cursor_transcript": session_transcript.clone(),
                     "raw_morse": append.raw_stream,
                     "window_text": snap.transcript,
                     "wpm": snap.wpm,
+                    "region_mode": use_region,
                 }),
             );
             if let Some(viz) = snap.viz {
@@ -4538,20 +4693,35 @@ fn run_stream_live_v3_file(
         }
     }
 
+    let final_region_text = if let Some(r) = region_streamer.as_mut() {
+        let _ = r.flush();
+        r.transcript().to_string()
+    } else {
+        String::new()
+    };
     if let Some(em) = emitter.as_mut() {
+        let final_text = if region_streamer.is_some() {
+            final_region_text
+        } else {
+            commit_cursor.committed_text().to_string()
+        };
         em.emit(
             started.elapsed().as_secs_f32(),
             serde_json::json!({
                 "type": "end",
-                "transcript": commit_cursor.committed_text(),
-                "committed": commit_cursor.committed_text(),
+                "transcript": final_text,
+                "committed": final_text,
                 "recording": serde_json::Value::Null,
             }),
         );
     } else {
         println!();
         println!("Final transcript (v3 file):");
-        println!("{}", commit_cursor.committed_text());
+        if region_streamer.is_some() {
+            println!("{final_region_text}");
+        } else {
+            println!("{}", commit_cursor.committed_text());
+        }
     }
     Ok(())
 }

--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -98,19 +98,7 @@ pub fn decode_region_stream(
     }
 
     let dominant_pitch_hz = estimate_dominant_pitch(samples, sample_rate, cfg);
-    let mut pitches = find_top_pitch_peaks(
-        samples,
-        sample_rate,
-        &MultiPitchConfig {
-            k: 6,
-            min_separation_hz: 40.0,
-            min_relative_power: 0.08,
-            sweep: cfg.clone(),
-        },
-    )
-    .into_iter()
-    .map(|peak| peak.pitch_hz)
-    .collect::<Vec<_>>();
+    let mut pitches = discover_burst_pitches(samples, sample_rate, cfg);
     if pitches.is_empty() {
         pitches.push(dominant_pitch_hz);
     }
@@ -392,6 +380,30 @@ pub struct PitchPeak {
     pub power: f32,
 }
 
+/// Strategy used to score a candidate pitch from per-frame Goertzel powers.
+///
+/// `Mean` (the historical default) reports the average power across the
+/// whole buffer — this is fine for short analysis windows where every
+/// pitch of interest is present for the full window. On long buffers
+/// (e.g. an end-to-end ragchew with 4 distinct turn pitches across 90 s)
+/// `Mean` smears the bursts together and produces a single artifact peak
+/// somewhere between the actual pitches.
+///
+/// `Percentile(q)` instead reports the q-quantile of per-frame powers.
+/// Each burst pitch will have a strong tail (high frame powers during
+/// its turn) so a high-percentile score (e.g. p90) lights up every
+/// pitch that hosts a real burst, regardless of how much of the buffer
+/// it occupies. This is what the region pipeline wants for long
+/// multi-station QSOs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PeakScoreKind {
+    Mean,
+    /// Quantile of per-frame Goertzel power (0.0..=1.0). 0.90 is a good
+    /// default for region routing — robust to single-frame outliers but
+    /// still surfaces bursts that are present for ~10% of the buffer.
+    Percentile(f32),
+}
+
 /// Configuration for [`find_top_pitch_peaks`]. Wraps a
 /// [`RegionStreamConfig`] (which controls the underlying Goertzel
 /// sweep) and adds NMS / dynamic-range knobs.
@@ -410,6 +422,13 @@ pub struct MultiPitchConfig {
     pub min_relative_power: f32,
     /// Underlying sweep configuration (pitch range, frame size, step).
     pub sweep: RegionStreamConfig,
+    /// How to score a pitch from its per-frame Goertzel power vector.
+    /// Defaults to `Mean` for backwards compatibility with the short
+    /// analysis window used by the multi-pitch envelope decoder. The
+    /// region pipeline overrides this to a high percentile so that long
+    /// buffers with multiple distinct burst pitches do not smear into
+    /// a single artifact peak.
+    pub peak_score: PeakScoreKind,
 }
 
 impl Default for MultiPitchConfig {
@@ -419,6 +438,7 @@ impl Default for MultiPitchConfig {
             min_separation_hz: 40.0,
             min_relative_power: 0.10,
             sweep: RegionStreamConfig::default(),
+            peak_score: PeakScoreKind::Mean,
         }
     }
 }
@@ -460,20 +480,34 @@ pub fn find_top_pitch_peaks(
     let stride = frame_step.saturating_mul(10).max(frame_step);
 
     let mut candidates: Vec<PitchPeak> = Vec::new();
+    let mut frame_powers: Vec<f32> = Vec::new();
     let mut pitch = sweep.pitch_lo_hz;
     while pitch <= sweep.pitch_hi_hz {
-        let mut sum = 0.0_f64;
-        let mut count = 0u32;
+        frame_powers.clear();
         let mut offset = 0usize;
         while offset + frame_len <= samples.len() {
-            sum += goertzel_power(&samples[offset..offset + frame_len], sample_rate, pitch) as f64;
-            count += 1;
+            let p = goertzel_power(&samples[offset..offset + frame_len], sample_rate, pitch);
+            frame_powers.push(p);
             offset += stride;
         }
-        let score = if count > 0 { sum / count as f64 } else { 0.0 };
+        let score = if frame_powers.is_empty() {
+            0.0
+        } else {
+            match cfg.peak_score {
+                PeakScoreKind::Mean => {
+                    let sum: f64 = frame_powers.iter().map(|p| *p as f64).sum();
+                    (sum / frame_powers.len() as f64) as f32
+                }
+                PeakScoreKind::Percentile(q) => {
+                    let mut sorted = frame_powers.clone();
+                    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                    percentile_sorted(&sorted, q)
+                }
+            }
+        };
         candidates.push(PitchPeak {
             pitch_hz: pitch,
-            power: score as f32,
+            power: score,
         });
         pitch += sweep.pitch_step_hz;
     }
@@ -536,6 +570,175 @@ pub fn find_top_pitch_peaks(
         }
     }
     chosen
+}
+
+/// Discover pitches likely to host CW bursts in a long buffer.
+///
+/// Two-source approach (union, then NMS):
+///
+/// 1. Per-window dominant pitches. Slide a window across the buffer and
+///    record the single dominant pitch in each window. Long-form
+///    ragchews — where each turn occupies a multi-second slice at a
+///    distinct pitch — produce a unique dominant pitch per turn.
+///
+/// 2. Whole-buffer mean-based top-K peaks. Dense clusters where bursts
+///    are short and similar in power (typical of contests) keep all of
+///    their pitches at the top of the mean-power ranking even when no
+///    single window is dominated by one of them.
+///
+/// The union is NMS-merged at a tight 25 Hz spacing — enough to
+/// suppress duplicates at the same sweep position but small enough that
+/// real adjacent stations spaced 30-50 Hz apart are kept separately.
+/// Final dedup of redundant decodes (when two close pitches generate
+/// overlapping regions) is left to `dedupe_region_candidates`, which
+/// scores by tonal prominence and useful character count.
+///
+/// Returns pitches sorted by descending power.
+pub fn discover_burst_pitches(
+    samples: &[f32],
+    sample_rate: u32,
+    cfg: &RegionStreamConfig,
+) -> Vec<f32> {
+    if samples.is_empty() || sample_rate == 0 {
+        return Vec::new();
+    }
+    // 25 Hz matches the sweep step. Tighter would just admit duplicate
+    // sweeps of the same sweep position; looser collapses real adjacent
+    // stations.
+    let nms_hz = (cfg.pitch_step_hz - 1.0).max(15.0);
+    let mut combined: Vec<PitchPeak> = Vec::new();
+
+    // Source 1: per-window dominants. Window is a balance — long enough
+    // for a single burst at a stable pitch to dominate (real ragchew
+    // turns are 15-30 s) and short enough that 4 turns produce 4
+    // distinct dominants. ~10 s with 5 s hop gives 2-3 windows per
+    // long-form turn.
+    let window_s = 10.0_f32;
+    let hop_s = 5.0_f32;
+    let total_s = samples.len() as f32 / sample_rate as f32;
+    // A window's dominant pitch is only contributed if the dominant
+    // sweep position has a clear advantage over the window's median
+    // sweep power. This keeps noise-only / QRM-only windows from
+    // polluting the candidate list with a noise-floor "dominant" that
+    // wastes downstream region-detection work.
+    let window_confidence_ratio = 2.5_f32;
+    let mut t0 = 0.0_f32;
+    while t0 < total_s {
+        let t1 = (t0 + window_s).min(total_s);
+        if t1 - t0 < 1.0 {
+            break;
+        }
+        let s = (t0 * sample_rate as f32) as usize;
+        let e = ((t1 * sample_rate as f32) as usize).min(samples.len());
+        if e > s {
+            let slice = &samples[s..e];
+            let dom = estimate_dominant_pitch(slice, sample_rate, cfg);
+            // Score the dominant by its absolute power within the window
+            // so the eventual ranking reflects burst strength.
+            let frame_len = ((cfg.frame_len_s * sample_rate as f32).round() as usize).max(64);
+            let frame_step = ((cfg.frame_step_s * sample_rate as f32).round() as usize).max(8);
+            let stride = frame_step.saturating_mul(10).max(frame_step);
+            let mut sum = 0.0_f64;
+            let mut count = 0u32;
+            let mut offset = 0usize;
+            while offset + frame_len <= slice.len() {
+                sum += goertzel_power(&slice[offset..offset + frame_len], sample_rate, dom) as f64;
+                count += 1;
+                offset += stride;
+            }
+            let power = if count > 0 {
+                (sum / count as f64) as f32
+            } else {
+                0.0
+            };
+            // Median sweep power across the same window — used to
+            // suppress noise-only windows whose "dominant" is just the
+            // luckiest noise bin.
+            let median_power = window_median_sweep_power(slice, sample_rate, cfg);
+            let confident = median_power > 0.0 && power >= median_power * window_confidence_ratio;
+            if confident {
+                combined.push(PitchPeak {
+                    pitch_hz: dom,
+                    power,
+                });
+            }
+        }
+        t0 += hop_s;
+    }
+
+    // Source 2: whole-buffer mean top-K. This preserves the historical
+    // multi-pitch behavior for short, dense clusters (contest bursts at
+    // closely-spaced pitches that none of which dominates a window).
+    // Use a tighter NMS here too so adjacent pitches aren't pre-merged.
+    let mean_peaks = find_top_pitch_peaks(
+        samples,
+        sample_rate,
+        &MultiPitchConfig {
+            k: 8,
+            min_separation_hz: nms_hz,
+            min_relative_power: 0.05,
+            sweep: cfg.clone(),
+            peak_score: PeakScoreKind::Mean,
+        },
+    );
+    combined.extend(mean_peaks);
+
+    if combined.is_empty() {
+        return Vec::new();
+    }
+
+    // Sort by power descending, then NMS-merge by pitch proximity.
+    combined.sort_by(|a, b| {
+        b.power
+            .partial_cmp(&a.power)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut chosen: Vec<f32> = Vec::new();
+    for cand in combined {
+        if chosen.iter().any(|&p| (p - cand.pitch_hz).abs() < nms_hz) {
+            continue;
+        }
+        chosen.push(cand.pitch_hz);
+    }
+    chosen
+}
+
+/// Median average-power across the Goertzel sweep used by region routing.
+/// Used as a noise-floor estimate to gate windowed dominant-pitch
+/// candidates: a real CW window has a dominant pitch many times above
+/// the median sweep power, while a noise-only window has a roughly flat
+/// sweep where the "dominant" is just the luckiest noise bin.
+fn window_median_sweep_power(samples: &[f32], sample_rate: u32, cfg: &RegionStreamConfig) -> f32 {
+    let frame_len = ((cfg.frame_len_s * sample_rate as f32).round() as usize).max(64);
+    let frame_step = ((cfg.frame_step_s * sample_rate as f32).round() as usize).max(8);
+    if samples.len() < frame_len || cfg.pitch_step_hz <= 0.0 {
+        return 0.0;
+    }
+    let stride = frame_step.saturating_mul(10).max(frame_step);
+    let mut scores: Vec<f32> = Vec::new();
+    let mut pitch = cfg.pitch_lo_hz;
+    while pitch <= cfg.pitch_hi_hz {
+        let mut sum = 0.0_f64;
+        let mut count = 0u32;
+        let mut offset = 0usize;
+        while offset + frame_len <= samples.len() {
+            sum += goertzel_power(&samples[offset..offset + frame_len], sample_rate, pitch) as f64;
+            count += 1;
+            offset += stride;
+        }
+        let s = if count > 0 {
+            (sum / count as f64) as f32
+        } else {
+            0.0
+        };
+        scores.push(s);
+        pitch += cfg.pitch_step_hz;
+    }
+    if scores.is_empty() {
+        return 0.0;
+    }
+    scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    percentile_sorted(&scores, 0.5)
 }
 
 pub fn estimate_dominant_pitch(samples: &[f32], sample_rate: u32, cfg: &RegionStreamConfig) -> f32 {
@@ -845,6 +1048,7 @@ mod tests {
                 pitch_step_hz: 10.0,
                 ..RegionStreamConfig::default()
             },
+            peak_score: PeakScoreKind::Mean,
         };
         let peaks = find_top_pitch_peaks(&buf, sr, &cfg);
         assert_eq!(peaks.len(), 2, "expected 2 peaks at 700/750, got {peaks:?}");
@@ -872,12 +1076,101 @@ mod tests {
                 pitch_step_hz: 10.0,
                 ..RegionStreamConfig::default()
             },
+            peak_score: PeakScoreKind::Mean,
         };
         let peaks = find_top_pitch_peaks(&buf, sr, &cfg);
         assert_eq!(
             peaks.len(),
             1,
             "60 Hz NMS should collapse 20-Hz-spaced peaks, got {peaks:?}"
+        );
+    }
+
+    #[test]
+    fn discover_burst_pitches_finds_long_form_turn_pitches() {
+        // Synthesize a 4-burst sequence at distinct pitches with silence
+        // between bursts. This mirrors the long-form ragchew failure
+        // pattern: each turn occupies ~5 s at a different pitch and the
+        // whole-buffer mean smears them into a single artifact peak.
+        let sr = 12_000u32;
+        let burst_s = 5.0_f32;
+        let gap_s = 1.0_f32;
+        let burst_pitches = [640.0_f32, 675.0, 710.0, 745.0];
+        let mut buf: Vec<f32> = Vec::new();
+        for (i, p) in burst_pitches.iter().enumerate() {
+            buf.extend(synth_tone(*p, burst_s, sr, 0.5));
+            if i + 1 < burst_pitches.len() {
+                buf.extend(vec![0.0_f32; (sr as f32 * gap_s) as usize]);
+            }
+        }
+        let cfg = RegionStreamConfig::default();
+        let pitches = discover_burst_pitches(&buf, sr, &cfg);
+        for &p in &burst_pitches {
+            let found = pitches.iter().any(|&q| (q - p).abs() <= cfg.pitch_step_hz);
+            assert!(
+                found,
+                "expected pitch ~{p} Hz to be discovered, got {pitches:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn discover_burst_pitches_handles_empty_buffer() {
+        let cfg = RegionStreamConfig::default();
+        let pitches = discover_burst_pitches(&[], 12_000, &cfg);
+        assert!(pitches.is_empty());
+    }
+
+    #[test]
+    fn decode_region_stream_returns_no_text_on_pure_noise() {
+        // Real-world dead-air should never yield ghost characters. The
+        // tonal_prominence_ratio guard plus the new windowed-confidence
+        // gate together must keep the pipeline silent.
+        let sr = 12_000u32;
+        let buf = noise_buf(sr, 30.0, 0xDEAD_BEEF, 0.05);
+        let cfg = RegionStreamConfig::default();
+        let result = decode_region_stream(&buf, sr, &cfg);
+        assert!(
+            result.text.trim().is_empty(),
+            "expected no text on pure noise, got: {:?}",
+            result.text
+        );
+    }
+
+    #[test]
+    fn discover_burst_pitches_ignores_continuous_carrier_when_cw_is_at_other_pitch() {
+        // Realistic failure mode: a strong continuous carrier at one
+        // pitch with intermittent CW bursts at a different pitch. The
+        // carrier dominates whole-buffer mean, but the windowed source
+        // should still surface the CW pitch where bursts occur.
+        let sr = 12_000u32;
+        let total_s = 30.0_f32;
+
+        // Continuous low-amplitude carrier at 900 Hz across the whole buffer
+        let mut buf = synth_tone(900.0, total_s, sr, 0.18);
+
+        // Intermittent CW-like bursts at 600 Hz: 4 bursts of ~3 s each
+        let burst_pitch = 600.0_f32;
+        let burst_amp = 0.50_f32;
+        let burst_pattern = [(2.0_f32, 3.0_f32), (8.0, 3.0), (16.0, 3.0), (24.0, 3.0)];
+        for (start, dur) in burst_pattern {
+            let s = (start * sr as f32) as usize;
+            let burst = synth_tone(burst_pitch, dur, sr, burst_amp);
+            for (i, sample) in burst.iter().enumerate() {
+                if s + i < buf.len() {
+                    buf[s + i] += *sample;
+                }
+            }
+        }
+
+        let cfg = RegionStreamConfig::default();
+        let pitches = discover_burst_pitches(&buf, sr, &cfg);
+        let cw_found = pitches
+            .iter()
+            .any(|&p| (p - burst_pitch).abs() <= cfg.pitch_step_hz);
+        assert!(
+            cw_found,
+            "expected CW pitch ~{burst_pitch} Hz to be discovered alongside the carrier, got {pitches:?}"
         );
     }
 }

--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -45,6 +45,10 @@ pub struct RegionStreamConfig {
     pub pad_s: f32,
     /// Optional pinned WPM for the per-region decode. None = ditdah auto.
     pub pin_wpm: Option<f32>,
+    /// Minimum Goertzel-vs-broadband energy ratio required before a detected
+    /// active run is decoded. White noise can still produce percentile-threshold
+    /// runs; this guard requires those runs to contain a narrowband CW tone.
+    pub min_tonal_prominence_ratio: f32,
 }
 
 impl Default for RegionStreamConfig {
@@ -60,6 +64,7 @@ impl Default for RegionStreamConfig {
             min_region_s: 0.6,
             pad_s: 0.10,
             pin_wpm: None,
+            min_tonal_prominence_ratio: 8.0,
         }
     }
 }
@@ -96,6 +101,16 @@ pub fn decode_region_stream(
     let regions_raw = detect_active_regions(samples, sample_rate, pitch_hz, cfg);
     let mut decoded = Vec::with_capacity(regions_raw.len());
     for (start_s, end_s) in regions_raw {
+        let region_s = (start_s.max(0.0) * sample_rate as f32) as usize;
+        let region_e = ((end_s * sample_rate as f32) as usize).min(samples.len());
+        if region_e <= region_s {
+            continue;
+        }
+        let prominence =
+            tonal_prominence_ratio(&samples[region_s..region_e], sample_rate, pitch_hz, cfg);
+        if prominence < cfg.min_tonal_prominence_ratio.max(0.0) {
+            continue;
+        }
         let pad = cfg.pad_s.max(0.0);
         let s = ((start_s - pad).max(0.0) * sample_rate as f32) as usize;
         let e = (((end_s + pad) * sample_rate as f32) as usize).min(samples.len());
@@ -127,6 +142,38 @@ pub fn decode_region_stream(
         regions: decoded,
         text,
     }
+}
+
+fn tonal_prominence_ratio(
+    samples: &[f32],
+    sample_rate: u32,
+    pitch_hz: f32,
+    cfg: &RegionStreamConfig,
+) -> f32 {
+    let frame_len = ((cfg.frame_len_s * sample_rate as f32).round() as usize).max(64);
+    let frame_step = ((cfg.frame_step_s * sample_rate as f32).round() as usize).max(8);
+    if samples.len() < frame_len {
+        return 0.0;
+    }
+
+    let mut power_sum = 0.0_f64;
+    let mut energy_sum = 0.0_f64;
+    let mut count = 0u32;
+    let mut offset = 0usize;
+    while offset + frame_len <= samples.len() {
+        let frame = &samples[offset..offset + frame_len];
+        power_sum += goertzel_power(frame, sample_rate, pitch_hz) as f64;
+        energy_sum += frame
+            .iter()
+            .map(|sample| (*sample as f64) * (*sample as f64))
+            .sum::<f64>();
+        count += 1;
+        offset += frame_step;
+    }
+    if count == 0 || energy_sum <= f64::EPSILON {
+        return 0.0;
+    }
+    (power_sum / energy_sum) as f32
 }
 
 /// One spectral peak from the goertzel sweep used by the multi-pitch

--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -97,9 +97,57 @@ pub fn decode_region_stream(
         };
     }
 
-    let pitch_hz = estimate_dominant_pitch(samples, sample_rate, cfg);
+    let dominant_pitch_hz = estimate_dominant_pitch(samples, sample_rate, cfg);
+    let mut pitches = find_top_pitch_peaks(
+        samples,
+        sample_rate,
+        &MultiPitchConfig {
+            k: 6,
+            min_separation_hz: 40.0,
+            min_relative_power: 0.08,
+            sweep: cfg.clone(),
+        },
+    )
+    .into_iter()
+    .map(|peak| peak.pitch_hz)
+    .collect::<Vec<_>>();
+    if pitches.is_empty() {
+        pitches.push(dominant_pitch_hz);
+    }
+
+    let mut candidates = Vec::new();
+    for pitch_hz in pitches {
+        collect_region_candidates(samples, sample_rate, cfg, pitch_hz, &mut candidates);
+    }
+    let decoded = dedupe_region_candidates(candidates);
+    let text = decoded
+        .iter()
+        .map(|r| r.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    RegionStreamResult {
+        pitch_hz: dominant_pitch_hz,
+        regions: decoded,
+        text,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RegionCandidate {
+    start_s: f32,
+    end_s: f32,
+    text: String,
+    score: f32,
+}
+
+fn collect_region_candidates(
+    samples: &[f32],
+    sample_rate: u32,
+    cfg: &RegionStreamConfig,
+    pitch_hz: f32,
+    candidates: &mut Vec<RegionCandidate>,
+) {
     let regions_raw = detect_active_regions(samples, sample_rate, pitch_hz, cfg);
-    let mut decoded = Vec::with_capacity(regions_raw.len());
     for (start_s, end_s) in regions_raw {
         let region_s = (start_s.max(0.0) * sample_rate as f32) as usize;
         let region_e = ((end_s * sample_rate as f32) as usize).min(samples.len());
@@ -126,22 +174,50 @@ pub fn decode_region_stream(
         if text.is_empty() {
             continue;
         }
-        decoded.push(DecodedRegion {
+        let useful_chars = text.chars().filter(|ch| ch.is_ascii_alphanumeric()).count() as f32;
+        candidates.push(RegionCandidate {
             start_s,
             end_s,
             text,
+            score: prominence * (1.0 + useful_chars * 0.05),
         });
     }
-    let text = decoded
-        .iter()
-        .map(|r| r.text.as_str())
-        .collect::<Vec<_>>()
-        .join(" ");
-    RegionStreamResult {
-        pitch_hz,
-        regions: decoded,
-        text,
+}
+
+fn dedupe_region_candidates(mut candidates: Vec<RegionCandidate>) -> Vec<DecodedRegion> {
+    candidates.sort_by(|a, b| {
+        a.start_s
+            .partial_cmp(&b.start_s)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    });
+    let mut chosen: Vec<RegionCandidate> = Vec::new();
+    for candidate in candidates {
+        if let Some(last) = chosen.last_mut() {
+            let overlap =
+                (last.end_s.min(candidate.end_s) - last.start_s.max(candidate.start_s)).max(0.0);
+            let min_len = (last.end_s - last.start_s).min(candidate.end_s - candidate.start_s);
+            if min_len > 0.0 && overlap / min_len >= 0.45 {
+                if candidate.score > last.score {
+                    *last = candidate;
+                }
+                continue;
+            }
+        }
+        chosen.push(candidate);
     }
+    chosen
+        .into_iter()
+        .map(|candidate| DecodedRegion {
+            start_s: candidate.start_s,
+            end_s: candidate.end_s,
+            text: candidate.text,
+        })
+        .collect()
 }
 
 fn tonal_prominence_ratio(

--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -166,10 +166,7 @@ fn collect_region_candidates(
             continue;
         }
         let slice = &samples[s..e];
-        let text = match cfg.pin_wpm {
-            Some(w) => decode_text_pinned(slice, sample_rate, w),
-            None => decode_text(slice, sample_rate),
-        };
+        let text = decode_region_slice(slice, sample_rate, pitch_hz, cfg);
         let text = text.trim().to_string();
         if text.is_empty() {
             continue;
@@ -182,6 +179,140 @@ fn collect_region_candidates(
             score: prominence * (1.0 + useful_chars * 0.05),
         });
     }
+}
+
+fn decode_region_slice(
+    samples: &[f32],
+    sample_rate: u32,
+    pitch_hz: f32,
+    cfg: &RegionStreamConfig,
+) -> String {
+    if let Some(w) = cfg.pin_wpm {
+        return decode_text_pinned(samples, sample_rate, w);
+    }
+
+    let auto = decode_text(samples, sample_rate);
+    let duration_s = samples.len() as f32 / sample_rate.max(1) as f32;
+    if duration_s > 1.5 {
+        return auto;
+    }
+
+    let Some(wpm) = estimate_short_region_wpm(samples, sample_rate, pitch_hz, cfg) else {
+        return auto;
+    };
+    let pinned = decode_text_pinned(samples, sample_rate, wpm);
+    if should_prefer_pinned_short_decode(&auto, &pinned) {
+        pinned
+    } else {
+        auto
+    }
+}
+
+fn should_prefer_pinned_short_decode(auto: &str, pinned: &str) -> bool {
+    let auto_norm = normalize_region_text(auto);
+    let pinned_norm = normalize_region_text(pinned);
+    if pinned_norm.is_empty() || auto_norm == pinned_norm {
+        return false;
+    }
+    let auto_chars = auto_norm
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .count();
+    let pinned_chars = pinned_norm
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .count();
+    auto_chars <= 2
+        && pinned_chars <= 2
+        && auto_norm
+            .chars()
+            .all(|ch| ch.is_whitespace() || matches!(ch, 'E' | 'I' | 'S' | 'H' | '5'))
+}
+
+fn normalize_region_text(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_uppercase()
+}
+
+fn estimate_short_region_wpm(
+    samples: &[f32],
+    sample_rate: u32,
+    pitch_hz: f32,
+    cfg: &RegionStreamConfig,
+) -> Option<f32> {
+    let frame_len = ((cfg.frame_len_s * sample_rate as f32).round() as usize).max(64);
+    let frame_step = ((cfg.frame_step_s * sample_rate as f32).round() as usize).max(8);
+    if samples.len() < frame_len {
+        return None;
+    }
+
+    let mut powers = Vec::new();
+    let mut offset = 0usize;
+    while offset + frame_len <= samples.len() {
+        powers.push(goertzel_power(
+            &samples[offset..offset + frame_len],
+            sample_rate,
+            pitch_hz,
+        ));
+        offset += frame_step;
+    }
+    if powers.len() < 4 {
+        return None;
+    }
+
+    let mut sorted = powers.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let noise_floor = percentile_sorted(&sorted, 0.35);
+    let signal_floor = percentile_sorted(&sorted, 0.85);
+    if !noise_floor.is_finite() || !signal_floor.is_finite() || signal_floor <= noise_floor {
+        return None;
+    }
+    let threshold = noise_floor + (signal_floor - noise_floor) * cfg.threshold_factor.max(0.0);
+
+    let step_s = frame_step as f32 / sample_rate as f32;
+    let frame_s = frame_len as f32 / sample_rate as f32;
+    let mut runs = Vec::new();
+    let mut cur_start: Option<usize> = None;
+    for (i, power) in powers.iter().enumerate() {
+        match (*power >= threshold, cur_start) {
+            (true, None) => cur_start = Some(i),
+            (false, Some(start)) => {
+                runs.push(active_run_duration_s(start, i - 1, step_s, frame_s));
+                cur_start = None;
+            }
+            _ => {}
+        }
+    }
+    if let Some(start) = cur_start {
+        runs.push(active_run_duration_s(
+            start,
+            powers.len() - 1,
+            step_s,
+            frame_s,
+        ));
+    }
+    if runs.is_empty() {
+        return None;
+    }
+
+    runs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let shortest = runs[0];
+    let longest = runs[runs.len() - 1];
+    let dot_s = if runs.len() == 1 && longest > 0.12 {
+        longest / 3.0
+    } else if longest >= shortest * 2.2 {
+        shortest
+    } else {
+        runs[runs.len() / 2]
+    };
+    let wpm = 1.2 / dot_s.max(0.001);
+    (5.0..=60.0).contains(&wpm).then_some(wpm)
+}
+
+fn active_run_duration_s(start_frame: usize, end_frame: usize, step_s: f32, frame_s: f32) -> f32 {
+    end_frame.saturating_sub(start_frame) as f32 * step_s + frame_s
 }
 
 fn dedupe_region_candidates(mut candidates: Vec<RegionCandidate>) -> Vec<DecodedRegion> {

--- a/experiments/cw-decoder/src/region_streamer.rs
+++ b/experiments/cw-decoder/src/region_streamer.rs
@@ -125,6 +125,44 @@ impl RegionStreamer {
         &self.committed_text
     }
 
+    /// Buffered audio length in seconds (relative to the current buffer
+    /// start, i.e. always >= 0 and bounded by the trim policy).
+    pub fn buffered_seconds(&self) -> f32 {
+        self.head_s
+    }
+
+    /// Reset all streaming state: drop the buffer, clear the committed
+    /// transcript, and reset the commit cursor. Used by the live mic
+    /// path's "ResetLock" stdin-control message so the operator can
+    /// start a new session without restarting the decoder process.
+    pub fn reset(&mut self) {
+        self.buffer.clear();
+        self.last_committed_end_s = 0.0;
+        self.head_s = 0.0;
+        self.committed_text.clear();
+    }
+
+    /// Drop everything in the buffer that ends more than `keep_back_s`
+    /// seconds before the last committed region. Bounds memory growth
+    /// during long-running live capture without losing any in-flight
+    /// (uncommitted) audio. Safe to call after `try_commit`. The
+    /// committed transcript is preserved.
+    pub fn trim_committed(&mut self, keep_back_s: f32) {
+        let cutoff = (self.last_committed_end_s - keep_back_s.max(0.0)).max(0.0);
+        if cutoff <= 0.0 {
+            return;
+        }
+        let sr = self.sample_rate.max(1) as f32;
+        let cut_samples = (cutoff * sr) as usize;
+        if cut_samples == 0 || cut_samples >= self.buffer.len() {
+            return;
+        }
+        self.buffer.drain(..cut_samples);
+        let shift = cut_samples as f32 / sr;
+        self.last_committed_end_s = (self.last_committed_end_s - shift).max(0.0);
+        self.head_s = self.buffer.len() as f32 / sr;
+    }
+
     fn commit_stable_regions(&mut self, force_all: bool) -> Vec<CommittedRegion> {
         if self.buffer.is_empty() {
             return Vec::new();
@@ -218,5 +256,28 @@ mod tests {
         let _ = s.flush();
         let _ = s.flush();
         assert_eq!(s.transcript(), "");
+    }
+
+    #[test]
+    fn streamer_reset_clears_all_state() {
+        let sr = 8_000;
+        let mut s = RegionStreamer::new(sr);
+        s.ingest(&synthesize_silence(sr, 0.5));
+        s.ingest(&morse_e(sr, 12.0));
+        assert!(s.buffered_seconds() > 0.0);
+        s.reset();
+        assert_eq!(s.transcript(), "");
+        assert_eq!(s.buffered_seconds(), 0.0);
+        assert!(s.try_commit().is_empty());
+    }
+
+    #[test]
+    fn streamer_trim_committed_is_no_op_when_nothing_committed() {
+        let sr = 8_000;
+        let mut s = RegionStreamer::new(sr);
+        s.ingest(&synthesize_silence(sr, 1.0));
+        let before = s.buffered_seconds();
+        s.trim_committed(0.5);
+        assert_eq!(s.buffered_seconds(), before);
     }
 }

--- a/experiments/cw-decoder/src/region_streamer.rs
+++ b/experiments/cw-decoder/src/region_streamer.rs
@@ -203,6 +203,7 @@ impl RegionStreamer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::f32::consts::TAU;
 
     fn synthesize_tone(sample_rate: u32, freq_hz: f32, duration_s: f32) -> Vec<f32> {
         let n = (duration_s * sample_rate as f32) as usize;
@@ -279,5 +280,256 @@ mod tests {
         let before = s.buffered_seconds();
         s.trim_committed(0.5);
         assert_eq!(s.buffered_seconds(), before);
+    }
+
+    fn morse_code(ch: char) -> Option<&'static str> {
+        match ch {
+            'A' => Some(".-"),
+            'B' => Some("-..."),
+            'C' => Some("-.-."),
+            'D' => Some("-.."),
+            'E' => Some("."),
+            'F' => Some("..-."),
+            'G' => Some("--."),
+            'H' => Some("...."),
+            'I' => Some(".."),
+            'J' => Some(".---"),
+            'K' => Some("-.-"),
+            'L' => Some(".-.."),
+            'M' => Some("--"),
+            'N' => Some("-."),
+            'O' => Some("---"),
+            'P' => Some(".--."),
+            'Q' => Some("--.-"),
+            'R' => Some(".-."),
+            'S' => Some("..."),
+            'T' => Some("-"),
+            'U' => Some("..-"),
+            'V' => Some("...-"),
+            'W' => Some(".--"),
+            'X' => Some("-..-"),
+            'Y' => Some("-.--"),
+            'Z' => Some("--.."),
+            '0' => Some("-----"),
+            '1' => Some(".----"),
+            '2' => Some("..---"),
+            '3' => Some("...--"),
+            '4' => Some("....-"),
+            '5' => Some("....."),
+            '6' => Some("-...."),
+            '7' => Some("--..."),
+            '8' => Some("---.."),
+            '9' => Some("----."),
+            _ => None,
+        }
+    }
+
+    fn push_silence(out: &mut Vec<f32>, sample_rate: u32, seconds: f32, phase_samples: &mut usize) {
+        let n = (seconds * sample_rate as f32).round() as usize;
+        out.resize(out.len() + n, 0.0);
+        *phase_samples += n;
+    }
+
+    fn push_tone(
+        out: &mut Vec<f32>,
+        sample_rate: u32,
+        pitch_hz: f32,
+        seconds: f32,
+        amp: f32,
+        phase_samples: &mut usize,
+    ) {
+        let n = (seconds * sample_rate as f32).round() as usize;
+        let ramp_n = ((sample_rate as f32) * 0.004).round() as usize;
+        for k in 0..n {
+            let rise = if ramp_n > 0 && k < ramp_n {
+                0.5 * (1.0 - ((std::f32::consts::PI * k as f32) / ramp_n as f32).cos())
+            } else {
+                1.0
+            };
+            let fall = if ramp_n > 0 && k + ramp_n > n {
+                let kk = (n - k) as f32;
+                0.5 * (1.0 - ((std::f32::consts::PI * kk) / ramp_n as f32).cos())
+            } else {
+                1.0
+            };
+            let t = *phase_samples as f32 / sample_rate as f32;
+            out.push((TAU * pitch_hz * t).sin() * amp * rise.min(fall));
+            *phase_samples += 1;
+        }
+    }
+
+    fn synth_morse(sample_rate: u32, pitch_hz: f32, wpm: f32, text: &str, amp: f32) -> Vec<f32> {
+        let dot_s = 1.2 / wpm;
+        let mut out = Vec::new();
+        let mut phase_samples = 0usize;
+        let chars: Vec<char> = text.to_uppercase().chars().collect();
+        for (idx, ch) in chars.iter().copied().enumerate() {
+            if ch.is_whitespace() {
+                push_silence(&mut out, sample_rate, dot_s * 7.0, &mut phase_samples);
+                continue;
+            }
+            let Some(code) = morse_code(ch) else {
+                continue;
+            };
+            for (element_idx, element) in code.chars().enumerate() {
+                let units = if element == '.' { 1.0 } else { 3.0 };
+                push_tone(
+                    &mut out,
+                    sample_rate,
+                    pitch_hz,
+                    dot_s * units,
+                    amp,
+                    &mut phase_samples,
+                );
+                if element_idx + 1 < code.len() {
+                    push_silence(&mut out, sample_rate, dot_s, &mut phase_samples);
+                }
+            }
+            if idx + 1 < chars.len() && !chars[idx + 1].is_whitespace() {
+                push_silence(&mut out, sample_rate, dot_s * 3.0, &mut phase_samples);
+            }
+        }
+        out
+    }
+
+    fn white_noise(len: usize, amp: f32, seed: u64) -> Vec<f32> {
+        let mut state = seed;
+        (0..len)
+            .map(|_| {
+                state = state
+                    .wrapping_mul(6364136223846793005)
+                    .wrapping_add(1442695040888963407);
+                let v = ((state >> 33) as u32) as f32 / u32::MAX as f32;
+                (v * 2.0 - 1.0) * amp
+            })
+            .collect()
+    }
+
+    fn add_white_noise(samples: &mut [f32], amp: f32, seed: u64) {
+        let noise = white_noise(samples.len(), amp, seed);
+        for (sample, noise) in samples.iter_mut().zip(noise) {
+            *sample += noise;
+        }
+    }
+
+    fn add_qsb(samples: &mut [f32], sample_rate: u32, depth: f32, rate_hz: f32, floor: f32) {
+        for (i, sample) in samples.iter_mut().enumerate() {
+            let t = i as f32 / sample_rate as f32;
+            let fade = floor + (1.0 - floor) * (0.5 + 0.5 * (TAU * rate_hz * t).sin());
+            *sample *= 1.0 - depth + depth * fade;
+        }
+    }
+
+    fn add_qrm_tone(samples: &mut [f32], sample_rate: u32, freq_hz: f32, amp: f32) {
+        for (i, sample) in samples.iter_mut().enumerate() {
+            let t = i as f32 / sample_rate as f32;
+            *sample += (TAU * freq_hz * t).sin() * amp;
+        }
+    }
+
+    fn normalize_for_assertion(text: &str) -> String {
+        text.split_whitespace().collect::<Vec<_>>().join(" ")
+    }
+
+    fn region_stream_transcript(
+        sample_rate: u32,
+        samples: &[f32],
+    ) -> (String, Vec<CommittedRegion>) {
+        let mut streamer = RegionStreamer::new(sample_rate);
+        let chunk = (sample_rate as f32 * 0.25).round() as usize;
+        let mut committed = Vec::new();
+        for frame in samples.chunks(chunk.max(1)) {
+            streamer.ingest(frame);
+            committed.extend(streamer.try_commit());
+        }
+        committed.extend(streamer.flush());
+        (
+            normalize_for_assertion(streamer.transcript()),
+            committed
+                .into_iter()
+                .filter(|region| !region.text.trim().is_empty())
+                .collect(),
+        )
+    }
+
+    fn build_multiburst(sample_rate: u32, gaps_are_static: bool) -> (Vec<f32>, String) {
+        let truth = "IHU NVCHU 7QP W7N 7QP W7N";
+        let bursts = [
+            ("IHU", 13.0_f32),
+            ("NVCHU", 8.0),
+            ("7QP W7N", 39.0),
+            ("7QP W7N", 29.0),
+        ];
+        let mut samples = synthesize_silence(sample_rate, 0.8);
+        for (idx, (text, wpm)) in bursts.iter().enumerate() {
+            samples.extend(synth_morse(sample_rate, 700.0, *wpm, text, 0.55));
+            if idx + 1 < bursts.len() {
+                let mut gap = synthesize_silence(sample_rate, 1.2 + idx as f32 * 0.35);
+                if gaps_are_static {
+                    add_white_noise(&mut gap, 0.025, 0xA11CE + idx as u64);
+                }
+                samples.extend(gap);
+            }
+        }
+        samples.extend(synthesize_silence(sample_rate, 1.0));
+        (samples, truth.to_string())
+    }
+
+    #[test]
+    fn synthetic_multiburst_clean_matches_reference_copy() {
+        let sr = 12_000;
+        let (samples, truth) = build_multiburst(sr, false);
+        let (transcript, regions) = region_stream_transcript(sr, &samples);
+        assert_eq!(transcript, truth);
+        assert_eq!(
+            regions.len(),
+            4,
+            "reference training-set-b shape should remain four committed bursts: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn synthetic_static_gaps_do_not_create_ghost_regions() {
+        let sr = 12_000;
+        let (samples, truth) = build_multiburst(sr, true);
+        let (transcript, regions) = region_stream_transcript(sr, &samples);
+        assert_eq!(transcript, truth);
+        assert_eq!(
+            regions.len(),
+            4,
+            "quiet background static between bursts must not create extra committed text: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn synthetic_noise_only_stream_stays_empty() {
+        let sr = 12_000;
+        let samples = white_noise((sr as f32 * 8.0) as usize, 0.035, 0x51A71C);
+        let (transcript, regions) = region_stream_transcript(sr, &samples);
+        assert_eq!(transcript, "");
+        assert!(
+            regions.is_empty(),
+            "noise-only stream must not produce ghost regions: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn synthetic_moderate_noise_qsb_and_qrm_still_exact_copy() {
+        let sr = 12_000;
+        let mut samples = synthesize_silence(sr, 0.8);
+        samples.extend(synth_morse(sr, 700.0, 18.0, "CQ TEST KC7AVA 73", 0.55));
+        samples.extend(synthesize_silence(sr, 1.0));
+
+        add_white_noise(&mut samples, 0.018, 0xC0DEC0DE);
+        add_qsb(&mut samples, sr, 0.65, 0.45, 0.35);
+        add_qrm_tone(&mut samples, sr, 830.0, 0.045);
+
+        let (transcript, regions) = region_stream_transcript(sr, &samples);
+        assert_eq!(transcript, "CQ TEST KC7AVA 73");
+        assert_eq!(
+            regions.len(),
+            1,
+            "single synthetic exchange should commit as one region: {regions:?}"
+        );
     }
 }

--- a/experiments/cw-decoder/src/region_streamer.rs
+++ b/experiments/cw-decoder/src/region_streamer.rs
@@ -1,0 +1,222 @@
+//! Region-based streaming CW decoder.
+//!
+//! On each decode cycle, runs [`decode_region_stream`] over the rolling audio
+//! buffer to find active morse bursts (separated by background static), and
+//! decodes each completed burst with the ditdah baseline.
+//!
+//! Unlike the v3 envelope streamer, regions are committed in append-only
+//! order: a region only enters the transcript once it has been "stable" for
+//! at least [`RegionStreamerConfig::stable_latency_s`] seconds (i.e. trailing
+//! static has been observed long enough that no further morse from that
+//! burst is expected). This eliminates the mid-region rewrites that occur
+//! when a single burst is still being received.
+//!
+//! Designed for the real-world case where an operator transmits, pauses
+//! during static, then transmits again at a different speed (e.g.
+//! `IHU NVCHU 7QP W7N 7QP W7N` with bursts at 13 / 8 / 39 / 29 WPM).
+
+use crate::region_stream::{decode_region_stream, RegionStreamConfig};
+
+/// Tunables for the region-based streamer.
+#[derive(Debug, Clone)]
+pub struct RegionStreamerConfig {
+    /// Underlying region detection / decode config.
+    pub region: RegionStreamConfig,
+    /// Trailing-static seconds required before a region is committed. Must
+    /// exceed the longest expected intra-burst gap. Default 0.6s, which is
+    /// larger than a word gap at 5 WPM (1.2s dot * 5 = 6.0s — actually for
+    /// 5 WPM the word gap is 1.2s, so bursts that include 5 WPM word gaps
+    /// would need a higher latency; default tuned for the common 8+ WPM case).
+    pub stable_latency_s: f32,
+}
+
+impl Default for RegionStreamerConfig {
+    fn default() -> Self {
+        // Defaults in [`RegionStreamConfig::default`] (merge_gap_s = 3.0,
+        // min_region_s = 0.6) are too eager for real-world bursts that
+        // are separated by ~0.5-2.5s of static and may be as short as a
+        // single trigraph. Tighten them so each burst stays its own
+        // region.
+        let region = RegionStreamConfig {
+            merge_gap_s: 0.5,
+            min_region_s: 0.3,
+            threshold_factor: 0.30,
+            pad_s: 0.15,
+            ..RegionStreamConfig::default()
+        };
+        Self {
+            region,
+            stable_latency_s: 0.6,
+        }
+    }
+}
+
+/// One region newly committed by [`RegionStreamer::ingest`].
+#[derive(Debug, Clone)]
+pub struct CommittedRegion {
+    pub start_s: f32,
+    pub end_s: f32,
+    pub text: String,
+}
+
+/// Stateful streaming wrapper around [`decode_region_stream`].
+///
+/// Buffers samples in absolute session time, runs region detection on every
+/// `ingest` call, and reports newly stable regions in append-only order.
+#[derive(Debug)]
+pub struct RegionStreamer {
+    sample_rate: u32,
+    cfg: RegionStreamerConfig,
+    buffer: Vec<f32>,
+    /// End time (seconds, relative to buffer start) of the last region that
+    /// has already been committed. Used to deduplicate emissions across
+    /// successive decode cycles.
+    last_committed_end_s: f32,
+    /// Append-only running transcript of all committed regions, joined by
+    /// single spaces.
+    committed_text: String,
+    /// Total seconds of audio that have been ingested so far. Equals
+    /// `buffer.len() / sample_rate` while no buffer trimming is performed.
+    head_s: f32,
+}
+
+impl RegionStreamer {
+    pub fn new(sample_rate: u32) -> Self {
+        Self::with_config(sample_rate, RegionStreamerConfig::default())
+    }
+
+    pub fn with_config(sample_rate: u32, cfg: RegionStreamerConfig) -> Self {
+        Self {
+            sample_rate,
+            cfg,
+            buffer: Vec::new(),
+            last_committed_end_s: 0.0,
+            committed_text: String::new(),
+            head_s: 0.0,
+        }
+    }
+
+    /// Append samples to the rolling buffer. Cheap; does no decoding.
+    /// Call [`Self::try_commit`] periodically on a decode cadence to
+    /// actually run region detection and emit committed regions.
+    pub fn ingest(&mut self, samples: &[f32]) {
+        self.buffer.extend_from_slice(samples);
+        self.head_s = self.buffer.len() as f32 / self.sample_rate.max(1) as f32;
+    }
+
+    /// Run region detection over the current buffer and return any
+    /// regions that have just become stable (committed). Should be
+    /// invoked on a fixed cadence (typically every 250-500 ms of
+    /// wallclock time) — not on every chunk feed, because region
+    /// detection scans the entire buffer.
+    pub fn try_commit(&mut self) -> Vec<CommittedRegion> {
+        self.commit_stable_regions(false)
+    }
+
+    /// Treat the current buffer as the final audio, committing any
+    /// remaining regions regardless of trailing-static latency. Call once
+    /// at end-of-stream.
+    pub fn flush(&mut self) -> Vec<CommittedRegion> {
+        self.commit_stable_regions(true)
+    }
+
+    /// Full append-only transcript so far.
+    pub fn transcript(&self) -> &str {
+        &self.committed_text
+    }
+
+    fn commit_stable_regions(&mut self, force_all: bool) -> Vec<CommittedRegion> {
+        if self.buffer.is_empty() {
+            return Vec::new();
+        }
+        let result = decode_region_stream(&self.buffer, self.sample_rate, &self.cfg.region);
+        let stability_threshold = if force_all {
+            self.head_s + 1.0 // commit everything
+        } else {
+            self.head_s - self.cfg.stable_latency_s
+        };
+
+        let mut newly = Vec::new();
+        for region in &result.regions {
+            if region.start_s <= self.last_committed_end_s {
+                continue; // already committed in an earlier cycle
+            }
+            if region.end_s > stability_threshold {
+                break; // region is still active; wait for more trailing static
+            }
+            newly.push(CommittedRegion {
+                start_s: region.start_s,
+                end_s: region.end_s,
+                text: region.text.clone(),
+            });
+            self.last_committed_end_s = region.end_s;
+        }
+
+        for region in &newly {
+            if !self.committed_text.is_empty() {
+                self.committed_text.push(' ');
+            }
+            self.committed_text.push_str(&region.text);
+        }
+        newly
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn synthesize_tone(sample_rate: u32, freq_hz: f32, duration_s: f32) -> Vec<f32> {
+        let n = (duration_s * sample_rate as f32) as usize;
+        (0..n)
+            .map(|i| {
+                let t = i as f32 / sample_rate as f32;
+                (2.0 * std::f32::consts::PI * freq_hz * t).sin() * 0.5
+            })
+            .collect()
+    }
+
+    fn synthesize_silence(sample_rate: u32, duration_s: f32) -> Vec<f32> {
+        vec![0.0; (duration_s * sample_rate as f32) as usize]
+    }
+
+    /// Build PARIS-style morse "E" (single dit) tone bursts at a known WPM.
+    fn morse_e(sample_rate: u32, wpm: f32) -> Vec<f32> {
+        let dot_s = 1.2 / wpm;
+        synthesize_tone(sample_rate, 700.0, dot_s)
+    }
+
+    #[test]
+    fn streamer_yields_no_regions_for_empty_buffer() {
+        let mut s = RegionStreamer::new(44_100);
+        s.ingest(&[]);
+        assert!(s.try_commit().is_empty());
+        assert_eq!(s.transcript(), "");
+    }
+
+    #[test]
+    fn streamer_holds_back_active_region_until_stable() {
+        let sr = 44_100;
+        let mut s = RegionStreamer::new(sr);
+        // 1s of leading silence + a single dit (~0.1s @ 12 WPM) — not yet
+        // stable because no trailing static observed.
+        let mut audio = synthesize_silence(sr, 1.0);
+        audio.extend(morse_e(sr, 12.0));
+        s.ingest(&audio);
+        let committed = s.try_commit();
+        assert!(
+            committed.is_empty(),
+            "active region must be held back until trailing static is seen"
+        );
+    }
+
+    #[test]
+    fn streamer_does_not_emit_duplicate_regions() {
+        let sr = 8_000;
+        let mut s = RegionStreamer::new(sr);
+        // Force-commit empty buffer — should not panic and yields nothing.
+        let _ = s.flush();
+        let _ = s.flush();
+        assert_eq!(s.transcript(), "");
+    }
+}

--- a/experiments/cw-decoder/src/synthetic_qso.rs
+++ b/experiments/cw-decoder/src/synthetic_qso.rs
@@ -1,0 +1,601 @@
+//! Synthetic QSO generator for decoder debugging.
+//!
+//! Produces deterministic ragchew and contest-style exchanges with realistic
+//! turn-taking, static gaps, QSB fades, and light in-band QRM. The generated
+//! audio is intentionally "radio-like" but controlled enough to use as a
+//! repeatable validation corpus for the region-isolated decoder baseline.
+
+use std::f32::consts::TAU;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::region_stream::decode_region_stream;
+use crate::region_streamer::RegionStreamerConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyntheticQsoKind {
+    Ragchew,
+    Contest,
+}
+
+impl SyntheticQsoKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ragchew => "ragchew",
+            Self::Contest => "contest",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SyntheticQsoExample {
+    pub id: String,
+    pub kind: SyntheticQsoKind,
+    pub sample_rate: u32,
+    pub samples: Vec<f32>,
+    pub truth: String,
+    pub bursts: Vec<SyntheticQsoBurst>,
+    pub impairments: SyntheticQsoImpairments,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SyntheticQsoBurst {
+    pub text: String,
+    pub wpm: f32,
+    pub pitch_hz: f32,
+    pub amp: f32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct SyntheticQsoImpairments {
+    pub static_amp: f32,
+    pub qsb_depth: f32,
+    pub qsb_rate_hz: f32,
+    pub qrm_hz: Option<f32>,
+    pub qrm_amp: f32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SyntheticQsoValidation {
+    pub id: String,
+    pub kind: SyntheticQsoKind,
+    pub duration_s: f32,
+    pub truth: String,
+    pub transcript: String,
+    pub exact_match: bool,
+    pub region_count: usize,
+    pub wav_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SyntheticQsoManifest {
+    pub id: String,
+    pub kind: SyntheticQsoKind,
+    pub sample_rate: u32,
+    pub duration_s: f32,
+    pub truth: String,
+    pub bursts: Vec<SyntheticQsoBurst>,
+    pub impairments: SyntheticQsoImpairments,
+    pub validation: SyntheticQsoValidation,
+    pub wav_path: Option<PathBuf>,
+    pub truth_path: Option<PathBuf>,
+}
+
+pub fn generate_qso_suite(
+    sample_rate: u32,
+    ragchew_count: usize,
+    contest_count: usize,
+) -> Vec<SyntheticQsoExample> {
+    let mut examples = Vec::with_capacity(ragchew_count + contest_count);
+    for i in 0..ragchew_count {
+        examples.push(generate_ragchew(i, sample_rate));
+    }
+    for i in 0..contest_count {
+        examples.push(generate_contest(i, sample_rate));
+    }
+    examples
+}
+
+pub fn validate_example(
+    example: &SyntheticQsoExample,
+    _decode_every_ms: u64,
+) -> SyntheticQsoValidation {
+    let cfg = RegionStreamerConfig::default();
+    let decoded = decode_region_stream(&example.samples, example.sample_rate, &cfg.region);
+    let transcript = normalize_transcript(&decoded.text);
+    let truth = normalize_transcript(&example.truth);
+    SyntheticQsoValidation {
+        id: example.id.clone(),
+        kind: example.kind,
+        duration_s: example.samples.len() as f32 / example.sample_rate as f32,
+        exact_match: transcript == truth,
+        region_count: decoded.regions.len(),
+        wav_path: None,
+        truth,
+        transcript,
+    }
+}
+
+pub fn write_example_files(
+    example: &SyntheticQsoExample,
+    validation: &SyntheticQsoValidation,
+    output_dir: &Path,
+) -> Result<SyntheticQsoManifest> {
+    std::fs::create_dir_all(output_dir)
+        .with_context(|| format!("creating output directory {}", output_dir.display()))?;
+    let wav_path = output_dir.join(format!("{}.wav", example.id));
+    let truth_path = output_dir.join(format!("{}.truth.txt", example.id));
+    write_wav(&wav_path, example.sample_rate, &example.samples)?;
+    std::fs::write(&truth_path, example.truth.as_bytes())
+        .with_context(|| format!("writing truth {}", truth_path.display()))?;
+
+    let mut validation = validation.clone();
+    validation.wav_path = Some(wav_path.clone());
+    Ok(SyntheticQsoManifest {
+        id: example.id.clone(),
+        kind: example.kind,
+        sample_rate: example.sample_rate,
+        duration_s: example.samples.len() as f32 / example.sample_rate as f32,
+        truth: example.truth.clone(),
+        bursts: example.bursts.clone(),
+        impairments: example.impairments,
+        validation,
+        wav_path: Some(wav_path),
+        truth_path: Some(truth_path),
+    })
+}
+
+pub fn write_manifest(output_dir: &Path, manifests: &[SyntheticQsoManifest]) -> Result<PathBuf> {
+    let path = output_dir.join("manifest.ndjson");
+    let mut lines = String::new();
+    for manifest in manifests {
+        lines.push_str(&serde_json::to_string(manifest).context("serializing manifest row")?);
+        lines.push('\n');
+    }
+    std::fs::write(&path, lines).with_context(|| format!("writing manifest {}", path.display()))?;
+    Ok(path)
+}
+
+fn generate_ragchew(index: usize, sample_rate: u32) -> SyntheticQsoExample {
+    let scripts: &[&[&str]] = &[
+        &[
+            "CQ CQ DE W7N W7N K",
+            "W7N DE KC7AVA GM RANDY WA RST 579 QTH SEATTLE K",
+            "KC7AVA DE W7N FB RANDY NAME LEE QTH PORTLAND RIG K3 ANT DIPOLE K",
+            "W7N DE KC7AVA FB LEE RIG TS590 ANT VERTICAL WX RAIN 73 SK",
+        ],
+        &[
+            "CQ CQ CQ DE K1ABC K1ABC K",
+            "K1ABC DE KC7AVA GA OM RST 589 NAME RANDY QTH WA K",
+            "KC7AVA DE K1ABC RR RANDY NAME TOM QTH MA POWER 100W K",
+            "K1ABC DE KC7AVA FB TOM SOLID COPY TNX QSO 73 SK",
+        ],
+        &[
+            "CQ DE N0CALL N0CALL K",
+            "N0CALL DE KC7AVA GE UR 569 IN WA NAME RANDY K",
+            "KC7AVA DE N0CALL RR RANDY NAME SUE QTH CO RIG IC7300 K",
+            "N0CALL DE KC7AVA FB SUE QSB BUT COPY OK 73 SK",
+        ],
+        &[
+            "CQ CQ DE VE3XYZ VE3XYZ K",
+            "VE3XYZ DE KC7AVA GM UR 599 WA NAME RANDY K",
+            "KC7AVA DE VE3XYZ TNX RANDY NAME AL QTH ON ANT LOOP K",
+            "VE3XYZ DE KC7AVA FB AL NICE SIG 73 SK",
+        ],
+        &[
+            "CQ CQ DE W5DX W5DX K",
+            "W5DX DE KC7AVA GA RST 579 NAME RANDY QTH WA K",
+            "KC7AVA DE W5DX RR NAME JO QTH TX TEMP 72 K",
+            "W5DX DE KC7AVA FB JO HR RAIN AND WIND TNX 73 SK",
+        ],
+        &[
+            "CQ DE K7RAD K7RAD K",
+            "K7RAD DE KC7AVA GM RST 589 NAME RANDY WA K",
+            "KC7AVA DE K7RAD RR RANDY NAME MIKE QTH AZ RIG 7300 K",
+            "K7RAD DE KC7AVA FB MIKE GREAT COPY 73 SK",
+        ],
+    ];
+    let script = scripts[index % scripts.len()];
+    let impairments = SyntheticQsoImpairments {
+        static_amp: 0.014 + (index % 3) as f32 * 0.004,
+        qsb_depth: 0.18 + (index % 4) as f32 * 0.06,
+        qsb_rate_hz: 0.18 + (index % 5) as f32 * 0.05,
+        qrm_hz: (index % 2 == 0).then_some(820.0 + index as f32 * 15.0),
+        qrm_amp: if index % 2 == 0 { 0.020 } else { 0.0 },
+    };
+    let bursts = script
+        .iter()
+        .enumerate()
+        .map(|(turn, text)| SyntheticQsoBurst {
+            text: (*text).to_string(),
+            wpm: 19.0 + ((index + turn) % 4) as f32,
+            pitch_hz: 640.0 + ((index + turn) % 5) as f32 * 35.0,
+            amp: 0.52 - (turn % 2) as f32 * 0.04,
+        })
+        .collect::<Vec<_>>();
+    build_example(
+        format!("ragchew-{:02}", index + 1),
+        SyntheticQsoKind::Ragchew,
+        sample_rate,
+        bursts,
+        impairments,
+        0xA11C_E000 + index as u64,
+    )
+}
+
+fn generate_contest(index: usize, sample_rate: u32) -> SyntheticQsoExample {
+    let scripts: &[&[&str]] = &[
+        &[
+            "CQ TEST W7N W7N",
+            "KC7AVA",
+            "KC7AVA 5NN WA",
+            "W7N 5NN OR TU",
+        ],
+        &[
+            "CQ FD K1ABC K1ABC",
+            "KC7AVA",
+            "KC7AVA 5NN 1D WA",
+            "K1ABC 5NN 2A EMA TU",
+        ],
+        &["TEST N0CALL", "KC7AVA", "KC7AVA 5NN CO", "N0CALL 5NN WA TU"],
+        &[
+            "CQ WPX VE3XYZ",
+            "KC7AVA",
+            "KC7AVA 5NN 104",
+            "VE3XYZ 5NN 052 TU",
+        ],
+        &[
+            "CQ NA W5DX W5DX",
+            "KC7AVA",
+            "KC7AVA 5NN TX",
+            "W5DX 5NN WA TU",
+        ],
+        &[
+            "CQ TEST K7RAD",
+            "KC7AVA",
+            "KC7AVA 5NN AZ",
+            "K7RAD 5NN WA TU",
+        ],
+    ];
+    let script = scripts[index % scripts.len()];
+    let impairments = SyntheticQsoImpairments {
+        static_amp: 0.018 + (index % 4) as f32 * 0.003,
+        qsb_depth: 0.12 + (index % 3) as f32 * 0.05,
+        qsb_rate_hz: 0.28 + (index % 4) as f32 * 0.07,
+        qrm_hz: (index % 3 != 1).then_some(560.0 + index as f32 * 40.0),
+        qrm_amp: if index % 3 != 1 { 0.018 } else { 0.0 },
+    };
+    let bursts = script
+        .iter()
+        .enumerate()
+        .map(|(turn, text)| SyntheticQsoBurst {
+            text: (*text).to_string(),
+            wpm: 24.0 + ((index + turn) % 5) as f32,
+            pitch_hz: 660.0 + ((index + turn) % 6) as f32 * 30.0,
+            amp: 0.54 - (turn % 2) as f32 * 0.03,
+        })
+        .collect::<Vec<_>>();
+    build_example(
+        format!("contest-{:02}", index + 1),
+        SyntheticQsoKind::Contest,
+        sample_rate,
+        bursts,
+        impairments,
+        0xC047_E570 + index as u64,
+    )
+}
+
+fn build_example(
+    id: String,
+    kind: SyntheticQsoKind,
+    sample_rate: u32,
+    bursts: Vec<SyntheticQsoBurst>,
+    impairments: SyntheticQsoImpairments,
+    seed: u64,
+) -> SyntheticQsoExample {
+    let mut rng = Lcg::new(seed);
+    let mut samples = static_noise(sample_rate, 0.65, impairments.static_amp, &mut rng);
+    let mut truth_parts = Vec::with_capacity(bursts.len());
+    for (idx, burst) in bursts.iter().enumerate() {
+        let mut audio = synth_morse(sample_rate, burst, &mut rng);
+        apply_qsb(
+            &mut audio,
+            sample_rate,
+            impairments.qsb_depth,
+            impairments.qsb_rate_hz,
+            0.42,
+            idx as f32 * 0.7,
+        );
+        samples.extend(audio);
+        truth_parts.push(canonical_text(&burst.text));
+        if idx + 1 < bursts.len() {
+            let gap_s = 0.82 + (idx % 3) as f32 * 0.18 + rng.next_unit() * 0.08;
+            samples.extend(static_noise(
+                sample_rate,
+                gap_s,
+                impairments.static_amp,
+                &mut rng,
+            ));
+        }
+    }
+    samples.extend(static_noise(
+        sample_rate,
+        0.8,
+        impairments.static_amp,
+        &mut rng,
+    ));
+    if let Some(qrm_hz) = impairments.qrm_hz {
+        add_qrm_tone(&mut samples, sample_rate, qrm_hz, impairments.qrm_amp);
+    }
+    clamp_samples(&mut samples);
+    SyntheticQsoExample {
+        id,
+        kind,
+        sample_rate,
+        samples,
+        truth: truth_parts.join(" "),
+        bursts,
+        impairments,
+    }
+}
+
+fn synth_morse(sample_rate: u32, burst: &SyntheticQsoBurst, rng: &mut Lcg) -> Vec<f32> {
+    let dot_s = 1.2 / burst.wpm;
+    let mut out = Vec::new();
+    let mut phase_sample = 0usize;
+    let canonical = canonical_text(&burst.text);
+    let mut words = canonical.split_whitespace().peekable();
+    while let Some(word) = words.next() {
+        let mut chars = word.chars().peekable();
+        while let Some(ch) = chars.next() {
+            let Some(code) = morse_for_char(ch) else {
+                continue;
+            };
+            let mut elements = code.chars().peekable();
+            while let Some(element) = elements.next() {
+                let units = if element == '.' { 1.0 } else { 3.0 };
+                let duration = dot_s * units * timing_jitter(rng, 0.035);
+                push_tone(
+                    &mut out,
+                    sample_rate,
+                    burst.pitch_hz,
+                    duration,
+                    burst.amp,
+                    &mut phase_sample,
+                );
+                if elements.peek().is_some() {
+                    push_silence(
+                        &mut out,
+                        sample_rate,
+                        dot_s * timing_jitter(rng, 0.03),
+                        &mut phase_sample,
+                    );
+                }
+            }
+            if chars.peek().is_some() {
+                push_silence(
+                    &mut out,
+                    sample_rate,
+                    dot_s * 3.0 * timing_jitter(rng, 0.03),
+                    &mut phase_sample,
+                );
+            }
+        }
+        if words.peek().is_some() {
+            push_silence(
+                &mut out,
+                sample_rate,
+                dot_s * 7.0 * timing_jitter(rng, 0.025),
+                &mut phase_sample,
+            );
+        }
+    }
+    out
+}
+
+fn push_tone(
+    out: &mut Vec<f32>,
+    sample_rate: u32,
+    pitch_hz: f32,
+    seconds: f32,
+    amp: f32,
+    phase_sample: &mut usize,
+) {
+    let n = (seconds * sample_rate as f32).round().max(1.0) as usize;
+    let ramp_n = ((sample_rate as f32) * 0.004).round() as usize;
+    for i in 0..n {
+        let rise = if ramp_n > 0 && i < ramp_n {
+            0.5 * (1.0 - ((std::f32::consts::PI * i as f32) / ramp_n as f32).cos())
+        } else {
+            1.0
+        };
+        let fall = if ramp_n > 0 && i + ramp_n > n {
+            let remaining = (n - i) as f32;
+            0.5 * (1.0 - ((std::f32::consts::PI * remaining) / ramp_n as f32).cos())
+        } else {
+            1.0
+        };
+        let t = *phase_sample as f32 / sample_rate as f32;
+        out.push((TAU * pitch_hz * t).sin() * amp * rise.min(fall));
+        *phase_sample += 1;
+    }
+}
+
+fn push_silence(out: &mut Vec<f32>, sample_rate: u32, seconds: f32, phase_sample: &mut usize) {
+    let n = (seconds * sample_rate as f32).round().max(0.0) as usize;
+    out.resize(out.len() + n, 0.0);
+    *phase_sample += n;
+}
+
+fn apply_qsb(
+    samples: &mut [f32],
+    sample_rate: u32,
+    depth: f32,
+    rate_hz: f32,
+    floor: f32,
+    phase: f32,
+) {
+    for (i, sample) in samples.iter_mut().enumerate() {
+        let t = i as f32 / sample_rate as f32;
+        let fade = floor + (1.0 - floor) * (0.5 + 0.5 * (TAU * rate_hz * t + phase).sin());
+        *sample *= 1.0 - depth + depth * fade;
+    }
+}
+
+fn add_qrm_tone(samples: &mut [f32], sample_rate: u32, freq_hz: f32, amp: f32) {
+    for (i, sample) in samples.iter_mut().enumerate() {
+        let t = i as f32 / sample_rate as f32;
+        *sample += (TAU * freq_hz * t).sin() * amp;
+    }
+}
+
+fn static_noise(sample_rate: u32, seconds: f32, amp: f32, rng: &mut Lcg) -> Vec<f32> {
+    let n = (seconds * sample_rate as f32).round() as usize;
+    (0..n).map(|_| rng.next_bipolar() * amp).collect()
+}
+
+fn timing_jitter(rng: &mut Lcg, width: f32) -> f32 {
+    (1.0 + rng.next_bipolar() * width).max(0.2)
+}
+
+fn clamp_samples(samples: &mut [f32]) {
+    for sample in samples {
+        *sample = sample.clamp(-0.98, 0.98);
+    }
+}
+
+fn write_wav(path: &Path, sample_rate: u32, samples: &[f32]) -> Result<()> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec)
+        .with_context(|| format!("creating WAV {}", path.display()))?;
+    for sample in samples {
+        writer
+            .write_sample((sample * i16::MAX as f32) as i16)
+            .context("writing sample")?;
+    }
+    writer.finalize().context("finalising WAV")?;
+    Ok(())
+}
+
+fn normalize_transcript(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn canonical_text(text: &str) -> String {
+    text.chars()
+        .map(|ch| ch.to_ascii_uppercase())
+        .filter(|ch| ch.is_ascii_alphanumeric() || ch.is_ascii_whitespace())
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn morse_for_char(c: char) -> Option<&'static str> {
+    match c.to_ascii_uppercase() {
+        'A' => Some(".-"),
+        'B' => Some("-..."),
+        'C' => Some("-.-."),
+        'D' => Some("-.."),
+        'E' => Some("."),
+        'F' => Some("..-."),
+        'G' => Some("--."),
+        'H' => Some("...."),
+        'I' => Some(".."),
+        'J' => Some(".---"),
+        'K' => Some("-.-"),
+        'L' => Some(".-.."),
+        'M' => Some("--"),
+        'N' => Some("-."),
+        'O' => Some("---"),
+        'P' => Some(".--."),
+        'Q' => Some("--.-"),
+        'R' => Some(".-."),
+        'S' => Some("..."),
+        'T' => Some("-"),
+        'U' => Some("..-"),
+        'V' => Some("...-"),
+        'W' => Some(".--"),
+        'X' => Some("-..-"),
+        'Y' => Some("-.--"),
+        'Z' => Some("--.."),
+        '0' => Some("-----"),
+        '1' => Some(".----"),
+        '2' => Some("..---"),
+        '3' => Some("...--"),
+        '4' => Some("....-"),
+        '5' => Some("....."),
+        '6' => Some("-...."),
+        '7' => Some("--..."),
+        '8' => Some("---.."),
+        '9' => Some("----."),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_unit(&mut self) -> f32 {
+        self.state = self
+            .state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((self.state >> 33) as u32) as f32 / u32::MAX as f32
+    }
+
+    fn next_bipolar(&mut self) -> f32 {
+        self.next_unit() * 2.0 - 1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suite_contains_requested_ragchew_and_contest_examples() {
+        let examples = generate_qso_suite(12_000, 6, 6);
+        assert_eq!(
+            examples
+                .iter()
+                .filter(|e| e.kind == SyntheticQsoKind::Ragchew)
+                .count(),
+            6
+        );
+        assert_eq!(
+            examples
+                .iter()
+                .filter(|e| e.kind == SyntheticQsoKind::Contest)
+                .count(),
+            6
+        );
+        assert!(examples.iter().all(|e| e.truth.contains("KC7AVA")));
+    }
+
+    #[test]
+    fn first_contest_example_validates_exact_copy() {
+        let example = generate_qso_suite(12_000, 0, 1).remove(0);
+        let validation = validate_example(&example, 500);
+        assert!(
+            validation.exact_match,
+            "expected exact copy for {}, truth={:?}, transcript={:?}",
+            example.id, validation.truth, validation.transcript
+        );
+    }
+}

--- a/experiments/cw-decoder/src/synthetic_qso.rs
+++ b/experiments/cw-decoder/src/synthetic_qso.rs
@@ -598,4 +598,72 @@ mod tests {
             example.id, validation.truth, validation.transcript
         );
     }
+
+    #[test]
+    fn final_over_k_after_cq_is_not_read_as_s() {
+        let sample_rate = 12_000;
+        let example = build_example(
+            "final-k-cq".to_string(),
+            SyntheticQsoKind::Contest,
+            sample_rate,
+            vec![SyntheticQsoBurst {
+                text: "CQ CQ DE W7N W7N K".to_string(),
+                wpm: 22.0,
+                pitch_hz: 700.0,
+                amp: 0.54,
+            }],
+            SyntheticQsoImpairments {
+                static_amp: 0.018,
+                qsb_depth: 0.22,
+                qsb_rate_hz: 0.33,
+                qrm_hz: Some(830.0),
+                qrm_amp: 0.018,
+            },
+            0xF1A1_0ACE,
+        );
+        let validation = validate_example(&example, 500);
+        assert_eq!(
+            validation.transcript, validation.truth,
+            "final over marker must remain K, truth={:?}, transcript={:?}",
+            validation.truth, validation.transcript
+        );
+    }
+
+    #[test]
+    fn isolated_final_over_k_region_is_not_read_as_s() {
+        let sample_rate = 12_000;
+        let example = build_example(
+            "isolated-final-k".to_string(),
+            SyntheticQsoKind::Contest,
+            sample_rate,
+            vec![
+                SyntheticQsoBurst {
+                    text: "CQ CQ DE W7N W7N".to_string(),
+                    wpm: 22.0,
+                    pitch_hz: 700.0,
+                    amp: 0.54,
+                },
+                SyntheticQsoBurst {
+                    text: "K".to_string(),
+                    wpm: 22.0,
+                    pitch_hz: 700.0,
+                    amp: 0.54,
+                },
+            ],
+            SyntheticQsoImpairments {
+                static_amp: 0.018,
+                qsb_depth: 0.22,
+                qsb_rate_hz: 0.33,
+                qrm_hz: Some(830.0),
+                qrm_amp: 0.018,
+            },
+            0xF1A1_0ACF,
+        );
+        let validation = validate_example(&example, 500);
+        assert_eq!(
+            validation.transcript, validation.truth,
+            "isolated final over marker must remain K, truth={:?}, transcript={:?}",
+            validation.truth, validation.transcript
+        );
+    }
 }

--- a/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/CwDecoderProcessSampleSource.cs
@@ -128,11 +128,18 @@ internal sealed class CwDecoderProcessSampleSource : ICwWpmSampleSource
             CreateNoWindow = true,
             WorkingDirectory = Path.GetDirectoryName(exe)!,
         };
-        psi.ArgumentList.Add("stream-live-v2");
+        psi.ArgumentList.Add("stream-live-v3");
         psi.ArgumentList.Add("--json");
         psi.ArgumentList.Add("--stdin-control");
+        // Region-isolated transcript: handles real-world QSO audio with
+        // pauses between bursts at very different WPMs (e.g. operator
+        // pauses, TX/RX cycles, ragchew vs contest mixes). The viz path
+        // still emits envelope/events so any future visualizer tab keeps
+        // working; only the cumulative transcript field is sourced from
+        // region-streamer.
+        psi.ArgumentList.Add("--region-transcript");
         psi.ArgumentList.Add("--decode-every-ms");
-        psi.ArgumentList.Add("5000");
+        psi.ArgumentList.Add("500");
         if (loopback)
         {
             // WASAPI loopback: capture from a system OUTPUT device so audio


### PR DESCRIPTION
Builds on PR #376 (region-isolated streaming, merged). Adds three iterative improvements that take the synthetic QSO debug suite from no coverage to 12/12 exact-copy.

1. Synthetic QSO debug generator (gen-qso-suite CLI). Deterministic ragchew and contest exchanges with realistic turn-taking, static gaps, QSB fades and light in-band QRM. Emits .wav, .truth.txt, manifest.ndjson, and validates each example through the region decoder. --require-exact for CI-style mismatch exit codes.

2. Isolated-K-as-S regression fix. Live-radio symptom: a final over marker K (-.-) at the end of a CQ was being decoded as S (...) when it landed in its own short region. Root cause: ditdah auto-WPM with too little context classifies dahs as dits. Fix: short regions (<1.5s) retry decode with a locally estimated WPM pinned, and pinned output is preferred only for tiny dit-heavy ambiguities (E/I/S/H/5). Added focused tests for both isolated K and final K after a CQ.

3. Hybrid windowed/mean burst pitch discovery. Long-form ragchews with 4 turns at distinct pitches (35-50 Hz apart) were dropping the first and last bursts because the whole-buffer mean Goertzel sweep smeared 4 burst pitches into one artifact peak. New region_stream::discover_burst_pitches unions per-window dominant pitches (10s window, 5s hop, with a dominant-vs-median confidence gate to suppress noise-only windows) with whole-buffer mean top-K (preserves dense contest clusters). NMS at pitch_step - 1 Hz; existing region-candidate dedupe handles overlapping decodes from neighboring pitches.

Validation:

- Synthetic suite: 6/12 -> 12/12 exact copy (5/6 -> 6/6 contest, 1/6 -> 6/6 ragchew)
- 24/24 at doubled suite size, 12/12 at 16 kHz and 48 kHz sample rates
- Training-set-b real-radio reference still exact: IHU NVCHU 7QP W7N 7QP W7N
- Both decode_region_stream (batch) and RegionStreamer (live) paths produce identical 12/12 result
- All 23 region_stream + 4 synthetic_qso + 9 region_streamer unit tests pass
- cargo fmt and cargo clippy -D warnings clean
- ~206x realtime in release mode

New tests added: per-pitch discovery on a 4-burst signal, empty-buffer handling, pure-noise no-ghost-text, continuous-carrier + intermittent CW (the realistic adversarial case raised by the rubber-duck critique), isolated final K decode, final K after CQ.

Note: PR #376 was already merged when these post-merge improvements were committed to this branch. This PR contains the seven post-#376 commits ahead of main.