### PR TITLE
cw-decoder: synthetic QSO suite + isolated-K fix + hybrid burst pitch discovery (12/12 exact copy)

### DIFF
--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -67,7 +67,10 @@ The current breakthrough is that the best live behavior did **not** come from ro
 > The baseline now also includes deterministic synthetic impairment
 > coverage in `region_streamer.rs`: clean four-burst copy, quiet static
 > gaps, noise-only no-ghost-text, and a moderate white-noise + QSB +
-> offset-QRM exchange (`CQ TEST KC7AVA 73`).
+> offset-QRM exchange (`CQ TEST KC7AVA 73`). `synthetic_qso.rs` also
+> carries regression coverage for the live-CQ failure mode where an
+> isolated final over marker `K` (`-.-`) was auto-calibrated as `S`
+> (`...`) when it was decoded as its own short region.
 >
 > For broader QSO-debug traffic, use the synthetic suite generator:
 >

--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -69,6 +69,19 @@ The current breakthrough is that the best live behavior did **not** come from ro
 > gaps, noise-only no-ghost-text, and a moderate white-noise + QSB +
 > offset-QRM exchange (`CQ TEST KC7AVA 73`).
 >
+> For broader QSO-debug traffic, use the synthetic suite generator:
+>
+> ```powershell
+> cargo run --manifest-path experiments\cw-decoder\Cargo.toml --bin cw-decoder -- `
+>   gen-qso-suite --output .artifacts\cw-qso-suite --ragchew 6 --contest 6
+> ```
+>
+> The generator emits deterministic ragchew and contest WAVs, `.truth.txt`
+> sidecars, and `manifest.ndjson`, then validates each sample through the
+> region decoder. Use `--require-exact` when you want CI-style non-zero
+> exit on any transcript mismatch; leave it off for exploratory debugging
+> runs where failures are the point.
+>
 > **Future experiments must not regress this baseline.** Before merging
 > any change that touches `region_streamer.rs`, `region_stream.rs`,
 > `stream-live-v3`, the GUI launchers, or the underlying decoder

--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -85,6 +85,18 @@ The current breakthrough is that the best live behavior did **not** come from ro
 > exit on any transcript mismatch; leave it off for exploratory debugging
 > runs where failures are the point.
 >
+> **Multi-pitch burst discovery (June 2026).** The pitch-routing front
+> end of `decode_region_stream` was upgraded from a whole-buffer mean-
+> Goertzel sweep to a hybrid windowed/mean approach in
+> `region_stream::discover_burst_pitches`. The whole-buffer mean smears
+> long-form ragchew turns at distinct pitches into one artifact peak;
+> the windowed source (10 s window, 5 s hop, with a noise-floor
+> confidence gate) surfaces each turn's pitch independently. The mean
+> source still runs alongside to preserve dense-cluster contest cases.
+> The combined synthetic suite now scores 12/12 exact copy (was 6/12);
+> validated through both `decode_region_stream` (batch) and
+> `RegionStreamer` (live streaming) paths at 12/16/48 kHz sample rates.
+>
 > **Future experiments must not regress this baseline.** Before merging
 > any change that touches `region_streamer.rs`, `region_stream.rs`,
 > `stream-live-v3`, the GUI launchers, or the underlying decoder

--- a/experiments/cw-decoder/src/envelope_decoder.rs
+++ b/experiments/cw-decoder/src/envelope_decoder.rs
@@ -2661,6 +2661,7 @@ mod tests {
                 pitch_step_hz: 10.0,
                 ..Default::default()
             },
+            peak_score: crate::region_stream::PeakScoreKind::Mean,
         };
         // Use the narrower bandpass for multi-pitch.
         let preprocess = PreprocessConfig {

--- a/experiments/cw-decoder/src/lib.rs
+++ b/experiments/cw-decoder/src/lib.rs
@@ -17,4 +17,5 @@ pub mod region_stream;
 pub mod region_streamer;
 pub mod streaming;
 pub mod streaming_v2;
+pub mod synthetic_qso;
 pub mod tui;

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use cw_decoder_poc::{
     audio, bench_latency, decoder, ditdah_streaming, harvest, json, log_capture, preview,
-    streaming, streaming_v2, tui,
+    streaming, streaming_v2, synthetic_qso, tui,
 };
 
 #[derive(Parser, Debug)]
@@ -768,6 +768,35 @@ enum Cmd {
         #[arg(long, default_value_t = 1)]
         seed: u64,
     },
+
+    /// Generate deterministic ragchew and contest QSO CW samples, then
+    /// validate them through the region-isolated decoder baseline.
+    GenQsoSuite {
+        /// Directory for generated WAV, truth sidecar, and manifest files.
+        /// If omitted, samples are generated and validated in memory only.
+        #[arg(long)]
+        output: Option<PathBuf>,
+        /// Number of ragchew-style examples to generate.
+        #[arg(long, default_value_t = 6)]
+        ragchew: usize,
+        /// Number of contest-style examples to generate.
+        #[arg(long, default_value_t = 6)]
+        contest: usize,
+        /// Sample rate in Hz.
+        #[arg(long, default_value_t = 12000)]
+        sample_rate: u32,
+        /// RegionStreamer decode cadence used for validation.
+        /// Reserved for streaming parity; the current suite validates with
+        /// the same batch region core used by RegionStreamer commits.
+        #[arg(long, default_value_t = 500)]
+        decode_every_ms: u64,
+        /// Emit one NDJSON validation row per generated example.
+        #[arg(long)]
+        json: bool,
+        /// Exit non-zero if any generated example is not copied exactly.
+        #[arg(long)]
+        require_exact: bool,
+    },
 }
 
 const CLI_THREAD_STACK_BYTES: usize = 16 * 1024 * 1024;
@@ -1240,6 +1269,23 @@ fn run_cli() -> Result<()> {
             dit_weight,
             noise,
             seed,
+        ),
+        Cmd::GenQsoSuite {
+            output,
+            ragchew,
+            contest,
+            sample_rate,
+            decode_every_ms,
+            json,
+            require_exact,
+        } => run_gen_qso_suite(
+            output.as_deref(),
+            ragchew,
+            contest,
+            sample_rate,
+            decode_every_ms,
+            json,
+            require_exact,
         ),
     }
 }
@@ -3955,6 +4001,110 @@ fn run_gen_rough_fist(
     );
     println!("Truth: {}", truth_path.display());
     println!("Text:  {canonical_text}");
+    Ok(())
+}
+
+fn run_gen_qso_suite(
+    output: Option<&std::path::Path>,
+    ragchew_count: usize,
+    contest_count: usize,
+    sample_rate: u32,
+    decode_every_ms: u64,
+    json: bool,
+    require_exact: bool,
+) -> Result<()> {
+    let examples = synthetic_qso::generate_qso_suite(sample_rate, ragchew_count, contest_count);
+    let mut manifests = Vec::new();
+    let mut validations = Vec::with_capacity(examples.len());
+    for example in &examples {
+        let validation = synthetic_qso::validate_example(example, decode_every_ms);
+        let validation = if let Some(output) = output {
+            let manifest = synthetic_qso::write_example_files(example, &validation, output)?;
+            let written = manifest.validation.clone();
+            manifests.push(manifest);
+            written
+        } else {
+            validation
+        };
+        validations.push(validation);
+    }
+    let manifest_path = if let Some(output) = output {
+        Some(synthetic_qso::write_manifest(output, &manifests)?)
+    } else {
+        None
+    };
+
+    if json {
+        for validation in &validations {
+            println!(
+                "{}",
+                serde_json::to_string(validation).context("serializing validation")?
+            );
+        }
+        let failures = validations.iter().filter(|v| !v.exact_match).count();
+        if let Some(path) = manifest_path {
+            println!(
+                "{}",
+                serde_json::json!({
+                    "type": "manifest",
+                    "path": path,
+                    "examples": validations.len(),
+                    "all_exact": validations.iter().all(|v| v.exact_match),
+                })
+            );
+        }
+        if require_exact && failures > 0 {
+            anyhow::bail!("{failures} synthetic QSO validation(s) failed exact-copy check");
+        }
+        return Ok(());
+    }
+
+    println!(
+        "Generated {} synthetic QSOs ({} ragchew, {} contest) @ {} Hz; decode_every={} ms",
+        validations.len(),
+        ragchew_count,
+        contest_count,
+        sample_rate,
+        decode_every_ms
+    );
+    if let Some(path) = manifest_path {
+        println!(
+            "Artifacts: {}",
+            path.parent().unwrap_or(path.as_path()).display()
+        );
+        println!("Manifest:  {}", path.display());
+    }
+    println!();
+    println!(
+        "{:<12} {:<8} {:>7} {:>7} {:<6} transcript",
+        "id", "kind", "sec", "regions", "match"
+    );
+    println!("{}", "-".repeat(96));
+    for validation in &validations {
+        println!(
+            "{:<12} {:<8} {:>7.2} {:>7} {:<6} {}",
+            validation.id,
+            validation.kind.as_str(),
+            validation.duration_s,
+            validation.region_count,
+            if validation.exact_match { "yes" } else { "NO" },
+            validation.transcript
+        );
+        if !validation.exact_match {
+            println!("  truth: {}", validation.truth);
+        }
+    }
+    let failures = validations.iter().filter(|v| !v.exact_match).count();
+    println!();
+    println!(
+        "Exact-copy summary: {}/{} passed, {} failed",
+        validations.len() - failures,
+        validations.len(),
+        failures
+    );
+    if require_exact && failures > 0 {
+        anyhow::bail!("{failures} synthetic QSO validation(s) failed exact-copy check");
+    }
     Ok(())
 }
 

--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -98,19 +98,7 @@ pub fn decode_region_stream(
     }
 
     let dominant_pitch_hz = estimate_dominant_pitch(samples, sample_rate, cfg);
-    let mut pitches = find_top_pitch_peaks(
-        samples,
-        sample_rate,
-        &MultiPitchConfig {
-            k: 6,
-            min_separation_hz: 40.0,
-            min_relative_power: 0.08,
-            sweep: cfg.clone(),
-        },
-    )
-    .into_iter()
-    .map(|peak| peak.pitch_hz)
-    .collect::<Vec<_>>();
+    let mut pitches = discover_burst_pitches(samples, sample_rate, cfg);
     if pitches.is_empty() {
         pitches.push(dominant_pitch_hz);
     }
@@ -392,6 +380,30 @@ pub struct PitchPeak {
     pub power: f32,
 }
 
+/// Strategy used to score a candidate pitch from per-frame Goertzel powers.
+///
+/// `Mean` (the historical default) reports the average power across the
+/// whole buffer — this is fine for short analysis windows where every
+/// pitch of interest is present for the full window. On long buffers
+/// (e.g. an end-to-end ragchew with 4 distinct turn pitches across 90 s)
+/// `Mean` smears the bursts together and produces a single artifact peak
+/// somewhere between the actual pitches.
+///
+/// `Percentile(q)` instead reports the q-quantile of per-frame powers.
+/// Each burst pitch will have a strong tail (high frame powers during
+/// its turn) so a high-percentile score (e.g. p90) lights up every
+/// pitch that hosts a real burst, regardless of how much of the buffer
+/// it occupies. This is what the region pipeline wants for long
+/// multi-station QSOs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum PeakScoreKind {
+    Mean,
+    /// Quantile of per-frame Goertzel power (0.0..=1.0). 0.90 is a good
+    /// default for region routing — robust to single-frame outliers but
+    /// still surfaces bursts that are present for ~10% of the buffer.
+    Percentile(f32),
+}
+
 /// Configuration for [`find_top_pitch_peaks`]. Wraps a
 /// [`RegionStreamConfig`] (which controls the underlying Goertzel
 /// sweep) and adds NMS / dynamic-range knobs.
@@ -410,6 +422,13 @@ pub struct MultiPitchConfig {
     pub min_relative_power: f32,
     /// Underlying sweep configuration (pitch range, frame size, step).
     pub sweep: RegionStreamConfig,
+    /// How to score a pitch from its per-frame Goertzel power vector.
+    /// Defaults to `Mean` for backwards compatibility with the short
+    /// analysis window used by the multi-pitch envelope decoder. The
+    /// region pipeline overrides this to a high percentile so that long
+    /// buffers with multiple distinct burst pitches do not smear into
+    /// a single artifact peak.
+    pub peak_score: PeakScoreKind,
 }
 
 impl Default for MultiPitchConfig {
@@ -419,6 +438,7 @@ impl Default for MultiPitchConfig {
             min_separation_hz: 40.0,
             min_relative_power: 0.10,
             sweep: RegionStreamConfig::default(),
+            peak_score: PeakScoreKind::Mean,
         }
     }
 }
@@ -460,20 +480,34 @@ pub fn find_top_pitch_peaks(
     let stride = frame_step.saturating_mul(10).max(frame_step);
 
     let mut candidates: Vec<PitchPeak> = Vec::new();
+    let mut frame_powers: Vec<f32> = Vec::new();
     let mut pitch = sweep.pitch_lo_hz;
     while pitch <= sweep.pitch_hi_hz {
-        let mut sum = 0.0_f64;
-        let mut count = 0u32;
+        frame_powers.clear();
         let mut offset = 0usize;
         while offset + frame_len <= samples.len() {
-            sum += goertzel_power(&samples[offset..offset + frame_len], sample_rate, pitch) as f64;
-            count += 1;
+            let p = goertzel_power(&samples[offset..offset + frame_len], sample_rate, pitch);
+            frame_powers.push(p);
             offset += stride;
         }
-        let score = if count > 0 { sum / count as f64 } else { 0.0 };
+        let score = if frame_powers.is_empty() {
+            0.0
+        } else {
+            match cfg.peak_score {
+                PeakScoreKind::Mean => {
+                    let sum: f64 = frame_powers.iter().map(|p| *p as f64).sum();
+                    (sum / frame_powers.len() as f64) as f32
+                }
+                PeakScoreKind::Percentile(q) => {
+                    let mut sorted = frame_powers.clone();
+                    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+                    percentile_sorted(&sorted, q)
+                }
+            }
+        };
         candidates.push(PitchPeak {
             pitch_hz: pitch,
-            power: score as f32,
+            power: score,
         });
         pitch += sweep.pitch_step_hz;
     }
@@ -536,6 +570,175 @@ pub fn find_top_pitch_peaks(
         }
     }
     chosen
+}
+
+/// Discover pitches likely to host CW bursts in a long buffer.
+///
+/// Two-source approach (union, then NMS):
+///
+/// 1. Per-window dominant pitches. Slide a window across the buffer and
+///    record the single dominant pitch in each window. Long-form
+///    ragchews — where each turn occupies a multi-second slice at a
+///    distinct pitch — produce a unique dominant pitch per turn.
+///
+/// 2. Whole-buffer mean-based top-K peaks. Dense clusters where bursts
+///    are short and similar in power (typical of contests) keep all of
+///    their pitches at the top of the mean-power ranking even when no
+///    single window is dominated by one of them.
+///
+/// The union is NMS-merged at a tight 25 Hz spacing — enough to
+/// suppress duplicates at the same sweep position but small enough that
+/// real adjacent stations spaced 30-50 Hz apart are kept separately.
+/// Final dedup of redundant decodes (when two close pitches generate
+/// overlapping regions) is left to `dedupe_region_candidates`, which
+/// scores by tonal prominence and useful character count.
+///
+/// Returns pitches sorted by descending power.
+pub fn discover_burst_pitches(
+    samples: &[f32],
+    sample_rate: u32,
+    cfg: &RegionStreamConfig,
+) -> Vec<f32> {
+    if samples.is_empty() || sample_rate == 0 {
+        return Vec::new();
+    }
+    // 25 Hz matches the sweep step. Tighter would just admit duplicate
+    // sweeps of the same sweep position; looser collapses real adjacent
+    // stations.
+    let nms_hz = (cfg.pitch_step_hz - 1.0).max(15.0);
+    let mut combined: Vec<PitchPeak> = Vec::new();
+
+    // Source 1: per-window dominants. Window is a balance — long enough
+    // for a single burst at a stable pitch to dominate (real ragchew
+    // turns are 15-30 s) and short enough that 4 turns produce 4
+    // distinct dominants. ~10 s with 5 s hop gives 2-3 windows per
+    // long-form turn.
+    let window_s = 10.0_f32;
+    let hop_s = 5.0_f32;
+    let total_s = samples.len() as f32 / sample_rate as f32;
+    // A window's dominant pitch is only contributed if the dominant
+    // sweep position has a clear advantage over the window's median
+    // sweep power. This keeps noise-only / QRM-only windows from
+    // polluting the candidate list with a noise-floor "dominant" that
+    // wastes downstream region-detection work.
+    let window_confidence_ratio = 2.5_f32;
+    let mut t0 = 0.0_f32;
+    while t0 < total_s {
+        let t1 = (t0 + window_s).min(total_s);
+        if t1 - t0 < 1.0 {
+            break;
+        }
+        let s = (t0 * sample_rate as f32) as usize;
+        let e = ((t1 * sample_rate as f32) as usize).min(samples.len());
+        if e > s {
+            let slice = &samples[s..e];
+            let dom = estimate_dominant_pitch(slice, sample_rate, cfg);
+            // Score the dominant by its absolute power within the window
+            // so the eventual ranking reflects burst strength.
+            let frame_len = ((cfg.frame_len_s * sample_rate as f32).round() as usize).max(64);
+            let frame_step = ((cfg.frame_step_s * sample_rate as f32).round() as usize).max(8);
+            let stride = frame_step.saturating_mul(10).max(frame_step);
+            let mut sum = 0.0_f64;
+            let mut count = 0u32;
+            let mut offset = 0usize;
+            while offset + frame_len <= slice.len() {
+                sum += goertzel_power(&slice[offset..offset + frame_len], sample_rate, dom) as f64;
+                count += 1;
+                offset += stride;
+            }
+            let power = if count > 0 {
+                (sum / count as f64) as f32
+            } else {
+                0.0
+            };
+            // Median sweep power across the same window — used to
+            // suppress noise-only windows whose "dominant" is just the
+            // luckiest noise bin.
+            let median_power = window_median_sweep_power(slice, sample_rate, cfg);
+            let confident = median_power > 0.0 && power >= median_power * window_confidence_ratio;
+            if confident {
+                combined.push(PitchPeak {
+                    pitch_hz: dom,
+                    power,
+                });
+            }
+        }
+        t0 += hop_s;
+    }
+
+    // Source 2: whole-buffer mean top-K. This preserves the historical
+    // multi-pitch behavior for short, dense clusters (contest bursts at
+    // closely-spaced pitches that none of which dominates a window).
+    // Use a tighter NMS here too so adjacent pitches aren't pre-merged.
+    let mean_peaks = find_top_pitch_peaks(
+        samples,
+        sample_rate,
+        &MultiPitchConfig {
+            k: 8,
+            min_separation_hz: nms_hz,
+            min_relative_power: 0.05,
+            sweep: cfg.clone(),
+            peak_score: PeakScoreKind::Mean,
+        },
+    );
+    combined.extend(mean_peaks);
+
+    if combined.is_empty() {
+        return Vec::new();
+    }
+
+    // Sort by power descending, then NMS-merge by pitch proximity.
+    combined.sort_by(|a, b| {
+        b.power
+            .partial_cmp(&a.power)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    let mut chosen: Vec<f32> = Vec::new();
+    for cand in combined {
+        if chosen.iter().any(|&p| (p - cand.pitch_hz).abs() < nms_hz) {
+            continue;
+        }
+        chosen.push(cand.pitch_hz);
+    }
+    chosen
+}
+
+/// Median average-power across the Goertzel sweep used by region routing.
+/// Used as a noise-floor estimate to gate windowed dominant-pitch
+/// candidates: a real CW window has a dominant pitch many times above
+/// the median sweep power, while a noise-only window has a roughly flat
+/// sweep where the "dominant" is just the luckiest noise bin.
+fn window_median_sweep_power(samples: &[f32], sample_rate: u32, cfg: &RegionStreamConfig) -> f32 {
+    let frame_len = ((cfg.frame_len_s * sample_rate as f32).round() as usize).max(64);
+    let frame_step = ((cfg.frame_step_s * sample_rate as f32).round() as usize).max(8);
+    if samples.len() < frame_len || cfg.pitch_step_hz <= 0.0 {
+        return 0.0;
+    }
+    let stride = frame_step.saturating_mul(10).max(frame_step);
+    let mut scores: Vec<f32> = Vec::new();
+    let mut pitch = cfg.pitch_lo_hz;
+    while pitch <= cfg.pitch_hi_hz {
+        let mut sum = 0.0_f64;
+        let mut count = 0u32;
+        let mut offset = 0usize;
+        while offset + frame_len <= samples.len() {
+            sum += goertzel_power(&samples[offset..offset + frame_len], sample_rate, pitch) as f64;
+            count += 1;
+            offset += stride;
+        }
+        let s = if count > 0 {
+            (sum / count as f64) as f32
+        } else {
+            0.0
+        };
+        scores.push(s);
+        pitch += cfg.pitch_step_hz;
+    }
+    if scores.is_empty() {
+        return 0.0;
+    }
+    scores.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    percentile_sorted(&scores, 0.5)
 }
 
 pub fn estimate_dominant_pitch(samples: &[f32], sample_rate: u32, cfg: &RegionStreamConfig) -> f32 {
@@ -845,6 +1048,7 @@ mod tests {
                 pitch_step_hz: 10.0,
                 ..RegionStreamConfig::default()
             },
+            peak_score: PeakScoreKind::Mean,
         };
         let peaks = find_top_pitch_peaks(&buf, sr, &cfg);
         assert_eq!(peaks.len(), 2, "expected 2 peaks at 700/750, got {peaks:?}");
@@ -872,12 +1076,101 @@ mod tests {
                 pitch_step_hz: 10.0,
                 ..RegionStreamConfig::default()
             },
+            peak_score: PeakScoreKind::Mean,
         };
         let peaks = find_top_pitch_peaks(&buf, sr, &cfg);
         assert_eq!(
             peaks.len(),
             1,
             "60 Hz NMS should collapse 20-Hz-spaced peaks, got {peaks:?}"
+        );
+    }
+
+    #[test]
+    fn discover_burst_pitches_finds_long_form_turn_pitches() {
+        // Synthesize a 4-burst sequence at distinct pitches with silence
+        // between bursts. This mirrors the long-form ragchew failure
+        // pattern: each turn occupies ~5 s at a different pitch and the
+        // whole-buffer mean smears them into a single artifact peak.
+        let sr = 12_000u32;
+        let burst_s = 5.0_f32;
+        let gap_s = 1.0_f32;
+        let burst_pitches = [640.0_f32, 675.0, 710.0, 745.0];
+        let mut buf: Vec<f32> = Vec::new();
+        for (i, p) in burst_pitches.iter().enumerate() {
+            buf.extend(synth_tone(*p, burst_s, sr, 0.5));
+            if i + 1 < burst_pitches.len() {
+                buf.extend(vec![0.0_f32; (sr as f32 * gap_s) as usize]);
+            }
+        }
+        let cfg = RegionStreamConfig::default();
+        let pitches = discover_burst_pitches(&buf, sr, &cfg);
+        for &p in &burst_pitches {
+            let found = pitches.iter().any(|&q| (q - p).abs() <= cfg.pitch_step_hz);
+            assert!(
+                found,
+                "expected pitch ~{p} Hz to be discovered, got {pitches:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn discover_burst_pitches_handles_empty_buffer() {
+        let cfg = RegionStreamConfig::default();
+        let pitches = discover_burst_pitches(&[], 12_000, &cfg);
+        assert!(pitches.is_empty());
+    }
+
+    #[test]
+    fn decode_region_stream_returns_no_text_on_pure_noise() {
+        // Real-world dead-air should never yield ghost characters. The
+        // tonal_prominence_ratio guard plus the new windowed-confidence
+        // gate together must keep the pipeline silent.
+        let sr = 12_000u32;
+        let buf = noise_buf(sr, 30.0, 0xDEAD_BEEF, 0.05);
+        let cfg = RegionStreamConfig::default();
+        let result = decode_region_stream(&buf, sr, &cfg);
+        assert!(
+            result.text.trim().is_empty(),
+            "expected no text on pure noise, got: {:?}",
+            result.text
+        );
+    }
+
+    #[test]
+    fn discover_burst_pitches_ignores_continuous_carrier_when_cw_is_at_other_pitch() {
+        // Realistic failure mode: a strong continuous carrier at one
+        // pitch with intermittent CW bursts at a different pitch. The
+        // carrier dominates whole-buffer mean, but the windowed source
+        // should still surface the CW pitch where bursts occur.
+        let sr = 12_000u32;
+        let total_s = 30.0_f32;
+
+        // Continuous low-amplitude carrier at 900 Hz across the whole buffer
+        let mut buf = synth_tone(900.0, total_s, sr, 0.18);
+
+        // Intermittent CW-like bursts at 600 Hz: 4 bursts of ~3 s each
+        let burst_pitch = 600.0_f32;
+        let burst_amp = 0.50_f32;
+        let burst_pattern = [(2.0_f32, 3.0_f32), (8.0, 3.0), (16.0, 3.0), (24.0, 3.0)];
+        for (start, dur) in burst_pattern {
+            let s = (start * sr as f32) as usize;
+            let burst = synth_tone(burst_pitch, dur, sr, burst_amp);
+            for (i, sample) in burst.iter().enumerate() {
+                if s + i < buf.len() {
+                    buf[s + i] += *sample;
+                }
+            }
+        }
+
+        let cfg = RegionStreamConfig::default();
+        let pitches = discover_burst_pitches(&buf, sr, &cfg);
+        let cw_found = pitches
+            .iter()
+            .any(|&p| (p - burst_pitch).abs() <= cfg.pitch_step_hz);
+        assert!(
+            cw_found,
+            "expected CW pitch ~{burst_pitch} Hz to be discovered alongside the carrier, got {pitches:?}"
         );
     }
 }

--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -97,9 +97,57 @@ pub fn decode_region_stream(
         };
     }
 
-    let pitch_hz = estimate_dominant_pitch(samples, sample_rate, cfg);
+    let dominant_pitch_hz = estimate_dominant_pitch(samples, sample_rate, cfg);
+    let mut pitches = find_top_pitch_peaks(
+        samples,
+        sample_rate,
+        &MultiPitchConfig {
+            k: 6,
+            min_separation_hz: 40.0,
+            min_relative_power: 0.08,
+            sweep: cfg.clone(),
+        },
+    )
+    .into_iter()
+    .map(|peak| peak.pitch_hz)
+    .collect::<Vec<_>>();
+    if pitches.is_empty() {
+        pitches.push(dominant_pitch_hz);
+    }
+
+    let mut candidates = Vec::new();
+    for pitch_hz in pitches {
+        collect_region_candidates(samples, sample_rate, cfg, pitch_hz, &mut candidates);
+    }
+    let decoded = dedupe_region_candidates(candidates);
+    let text = decoded
+        .iter()
+        .map(|r| r.text.as_str())
+        .collect::<Vec<_>>()
+        .join(" ");
+    RegionStreamResult {
+        pitch_hz: dominant_pitch_hz,
+        regions: decoded,
+        text,
+    }
+}
+
+#[derive(Debug, Clone)]
+struct RegionCandidate {
+    start_s: f32,
+    end_s: f32,
+    text: String,
+    score: f32,
+}
+
+fn collect_region_candidates(
+    samples: &[f32],
+    sample_rate: u32,
+    cfg: &RegionStreamConfig,
+    pitch_hz: f32,
+    candidates: &mut Vec<RegionCandidate>,
+) {
     let regions_raw = detect_active_regions(samples, sample_rate, pitch_hz, cfg);
-    let mut decoded = Vec::with_capacity(regions_raw.len());
     for (start_s, end_s) in regions_raw {
         let region_s = (start_s.max(0.0) * sample_rate as f32) as usize;
         let region_e = ((end_s * sample_rate as f32) as usize).min(samples.len());
@@ -126,22 +174,50 @@ pub fn decode_region_stream(
         if text.is_empty() {
             continue;
         }
-        decoded.push(DecodedRegion {
+        let useful_chars = text.chars().filter(|ch| ch.is_ascii_alphanumeric()).count() as f32;
+        candidates.push(RegionCandidate {
             start_s,
             end_s,
             text,
+            score: prominence * (1.0 + useful_chars * 0.05),
         });
     }
-    let text = decoded
-        .iter()
-        .map(|r| r.text.as_str())
-        .collect::<Vec<_>>()
-        .join(" ");
-    RegionStreamResult {
-        pitch_hz,
-        regions: decoded,
-        text,
+}
+
+fn dedupe_region_candidates(mut candidates: Vec<RegionCandidate>) -> Vec<DecodedRegion> {
+    candidates.sort_by(|a, b| {
+        a.start_s
+            .partial_cmp(&b.start_s)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                b.score
+                    .partial_cmp(&a.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    });
+    let mut chosen: Vec<RegionCandidate> = Vec::new();
+    for candidate in candidates {
+        if let Some(last) = chosen.last_mut() {
+            let overlap =
+                (last.end_s.min(candidate.end_s) - last.start_s.max(candidate.start_s)).max(0.0);
+            let min_len = (last.end_s - last.start_s).min(candidate.end_s - candidate.start_s);
+            if min_len > 0.0 && overlap / min_len >= 0.45 {
+                if candidate.score > last.score {
+                    *last = candidate;
+                }
+                continue;
+            }
+        }
+        chosen.push(candidate);
     }
+    chosen
+        .into_iter()
+        .map(|candidate| DecodedRegion {
+            start_s: candidate.start_s,
+            end_s: candidate.end_s,
+            text: candidate.text,
+        })
+        .collect()
 }
 
 fn tonal_prominence_ratio(

--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -166,10 +166,7 @@ fn collect_region_candidates(
             continue;
         }
         let slice = &samples[s..e];
-        let text = match cfg.pin_wpm {
-            Some(w) => decode_text_pinned(slice, sample_rate, w),
-            None => decode_text(slice, sample_rate),
-        };
+        let text = decode_region_slice(slice, sample_rate, pitch_hz, cfg);
         let text = text.trim().to_string();
         if text.is_empty() {
             continue;
@@ -182,6 +179,140 @@ fn collect_region_candidates(
             score: prominence * (1.0 + useful_chars * 0.05),
         });
     }
+}
+
+fn decode_region_slice(
+    samples: &[f32],
+    sample_rate: u32,
+    pitch_hz: f32,
+    cfg: &RegionStreamConfig,
+) -> String {
+    if let Some(w) = cfg.pin_wpm {
+        return decode_text_pinned(samples, sample_rate, w);
+    }
+
+    let auto = decode_text(samples, sample_rate);
+    let duration_s = samples.len() as f32 / sample_rate.max(1) as f32;
+    if duration_s > 1.5 {
+        return auto;
+    }
+
+    let Some(wpm) = estimate_short_region_wpm(samples, sample_rate, pitch_hz, cfg) else {
+        return auto;
+    };
+    let pinned = decode_text_pinned(samples, sample_rate, wpm);
+    if should_prefer_pinned_short_decode(&auto, &pinned) {
+        pinned
+    } else {
+        auto
+    }
+}
+
+fn should_prefer_pinned_short_decode(auto: &str, pinned: &str) -> bool {
+    let auto_norm = normalize_region_text(auto);
+    let pinned_norm = normalize_region_text(pinned);
+    if pinned_norm.is_empty() || auto_norm == pinned_norm {
+        return false;
+    }
+    let auto_chars = auto_norm
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .count();
+    let pinned_chars = pinned_norm
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .count();
+    auto_chars <= 2
+        && pinned_chars <= 2
+        && auto_norm
+            .chars()
+            .all(|ch| ch.is_whitespace() || matches!(ch, 'E' | 'I' | 'S' | 'H' | '5'))
+}
+
+fn normalize_region_text(text: &str) -> String {
+    text.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_ascii_uppercase()
+}
+
+fn estimate_short_region_wpm(
+    samples: &[f32],
+    sample_rate: u32,
+    pitch_hz: f32,
+    cfg: &RegionStreamConfig,
+) -> Option<f32> {
+    let frame_len = ((cfg.frame_len_s * sample_rate as f32).round() as usize).max(64);
+    let frame_step = ((cfg.frame_step_s * sample_rate as f32).round() as usize).max(8);
+    if samples.len() < frame_len {
+        return None;
+    }
+
+    let mut powers = Vec::new();
+    let mut offset = 0usize;
+    while offset + frame_len <= samples.len() {
+        powers.push(goertzel_power(
+            &samples[offset..offset + frame_len],
+            sample_rate,
+            pitch_hz,
+        ));
+        offset += frame_step;
+    }
+    if powers.len() < 4 {
+        return None;
+    }
+
+    let mut sorted = powers.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let noise_floor = percentile_sorted(&sorted, 0.35);
+    let signal_floor = percentile_sorted(&sorted, 0.85);
+    if !noise_floor.is_finite() || !signal_floor.is_finite() || signal_floor <= noise_floor {
+        return None;
+    }
+    let threshold = noise_floor + (signal_floor - noise_floor) * cfg.threshold_factor.max(0.0);
+
+    let step_s = frame_step as f32 / sample_rate as f32;
+    let frame_s = frame_len as f32 / sample_rate as f32;
+    let mut runs = Vec::new();
+    let mut cur_start: Option<usize> = None;
+    for (i, power) in powers.iter().enumerate() {
+        match (*power >= threshold, cur_start) {
+            (true, None) => cur_start = Some(i),
+            (false, Some(start)) => {
+                runs.push(active_run_duration_s(start, i - 1, step_s, frame_s));
+                cur_start = None;
+            }
+            _ => {}
+        }
+    }
+    if let Some(start) = cur_start {
+        runs.push(active_run_duration_s(
+            start,
+            powers.len() - 1,
+            step_s,
+            frame_s,
+        ));
+    }
+    if runs.is_empty() {
+        return None;
+    }
+
+    runs.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    let shortest = runs[0];
+    let longest = runs[runs.len() - 1];
+    let dot_s = if runs.len() == 1 && longest > 0.12 {
+        longest / 3.0
+    } else if longest >= shortest * 2.2 {
+        shortest
+    } else {
+        runs[runs.len() / 2]
+    };
+    let wpm = 1.2 / dot_s.max(0.001);
+    (5.0..=60.0).contains(&wpm).then_some(wpm)
+}
+
+fn active_run_duration_s(start_frame: usize, end_frame: usize, step_s: f32, frame_s: f32) -> f32 {
+    end_frame.saturating_sub(start_frame) as f32 * step_s + frame_s
 }
 
 fn dedupe_region_candidates(mut candidates: Vec<RegionCandidate>) -> Vec<DecodedRegion> {

--- a/experiments/cw-decoder/src/synthetic_qso.rs
+++ b/experiments/cw-decoder/src/synthetic_qso.rs
@@ -1,0 +1,601 @@
+//! Synthetic QSO generator for decoder debugging.
+//!
+//! Produces deterministic ragchew and contest-style exchanges with realistic
+//! turn-taking, static gaps, QSB fades, and light in-band QRM. The generated
+//! audio is intentionally "radio-like" but controlled enough to use as a
+//! repeatable validation corpus for the region-isolated decoder baseline.
+
+use std::f32::consts::TAU;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::Serialize;
+
+use crate::region_stream::decode_region_stream;
+use crate::region_streamer::RegionStreamerConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyntheticQsoKind {
+    Ragchew,
+    Contest,
+}
+
+impl SyntheticQsoKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ragchew => "ragchew",
+            Self::Contest => "contest",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SyntheticQsoExample {
+    pub id: String,
+    pub kind: SyntheticQsoKind,
+    pub sample_rate: u32,
+    pub samples: Vec<f32>,
+    pub truth: String,
+    pub bursts: Vec<SyntheticQsoBurst>,
+    pub impairments: SyntheticQsoImpairments,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SyntheticQsoBurst {
+    pub text: String,
+    pub wpm: f32,
+    pub pitch_hz: f32,
+    pub amp: f32,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+pub struct SyntheticQsoImpairments {
+    pub static_amp: f32,
+    pub qsb_depth: f32,
+    pub qsb_rate_hz: f32,
+    pub qrm_hz: Option<f32>,
+    pub qrm_amp: f32,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SyntheticQsoValidation {
+    pub id: String,
+    pub kind: SyntheticQsoKind,
+    pub duration_s: f32,
+    pub truth: String,
+    pub transcript: String,
+    pub exact_match: bool,
+    pub region_count: usize,
+    pub wav_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SyntheticQsoManifest {
+    pub id: String,
+    pub kind: SyntheticQsoKind,
+    pub sample_rate: u32,
+    pub duration_s: f32,
+    pub truth: String,
+    pub bursts: Vec<SyntheticQsoBurst>,
+    pub impairments: SyntheticQsoImpairments,
+    pub validation: SyntheticQsoValidation,
+    pub wav_path: Option<PathBuf>,
+    pub truth_path: Option<PathBuf>,
+}
+
+pub fn generate_qso_suite(
+    sample_rate: u32,
+    ragchew_count: usize,
+    contest_count: usize,
+) -> Vec<SyntheticQsoExample> {
+    let mut examples = Vec::with_capacity(ragchew_count + contest_count);
+    for i in 0..ragchew_count {
+        examples.push(generate_ragchew(i, sample_rate));
+    }
+    for i in 0..contest_count {
+        examples.push(generate_contest(i, sample_rate));
+    }
+    examples
+}
+
+pub fn validate_example(
+    example: &SyntheticQsoExample,
+    _decode_every_ms: u64,
+) -> SyntheticQsoValidation {
+    let cfg = RegionStreamerConfig::default();
+    let decoded = decode_region_stream(&example.samples, example.sample_rate, &cfg.region);
+    let transcript = normalize_transcript(&decoded.text);
+    let truth = normalize_transcript(&example.truth);
+    SyntheticQsoValidation {
+        id: example.id.clone(),
+        kind: example.kind,
+        duration_s: example.samples.len() as f32 / example.sample_rate as f32,
+        exact_match: transcript == truth,
+        region_count: decoded.regions.len(),
+        wav_path: None,
+        truth,
+        transcript,
+    }
+}
+
+pub fn write_example_files(
+    example: &SyntheticQsoExample,
+    validation: &SyntheticQsoValidation,
+    output_dir: &Path,
+) -> Result<SyntheticQsoManifest> {
+    std::fs::create_dir_all(output_dir)
+        .with_context(|| format!("creating output directory {}", output_dir.display()))?;
+    let wav_path = output_dir.join(format!("{}.wav", example.id));
+    let truth_path = output_dir.join(format!("{}.truth.txt", example.id));
+    write_wav(&wav_path, example.sample_rate, &example.samples)?;
+    std::fs::write(&truth_path, example.truth.as_bytes())
+        .with_context(|| format!("writing truth {}", truth_path.display()))?;
+
+    let mut validation = validation.clone();
+    validation.wav_path = Some(wav_path.clone());
+    Ok(SyntheticQsoManifest {
+        id: example.id.clone(),
+        kind: example.kind,
+        sample_rate: example.sample_rate,
+        duration_s: example.samples.len() as f32 / example.sample_rate as f32,
+        truth: example.truth.clone(),
+        bursts: example.bursts.clone(),
+        impairments: example.impairments,
+        validation,
+        wav_path: Some(wav_path),
+        truth_path: Some(truth_path),
+    })
+}
+
+pub fn write_manifest(output_dir: &Path, manifests: &[SyntheticQsoManifest]) -> Result<PathBuf> {
+    let path = output_dir.join("manifest.ndjson");
+    let mut lines = String::new();
+    for manifest in manifests {
+        lines.push_str(&serde_json::to_string(manifest).context("serializing manifest row")?);
+        lines.push('\n');
+    }
+    std::fs::write(&path, lines).with_context(|| format!("writing manifest {}", path.display()))?;
+    Ok(path)
+}
+
+fn generate_ragchew(index: usize, sample_rate: u32) -> SyntheticQsoExample {
+    let scripts: &[&[&str]] = &[
+        &[
+            "CQ CQ DE W7N W7N K",
+            "W7N DE KC7AVA GM RANDY WA RST 579 QTH SEATTLE K",
+            "KC7AVA DE W7N FB RANDY NAME LEE QTH PORTLAND RIG K3 ANT DIPOLE K",
+            "W7N DE KC7AVA FB LEE RIG TS590 ANT VERTICAL WX RAIN 73 SK",
+        ],
+        &[
+            "CQ CQ CQ DE K1ABC K1ABC K",
+            "K1ABC DE KC7AVA GA OM RST 589 NAME RANDY QTH WA K",
+            "KC7AVA DE K1ABC RR RANDY NAME TOM QTH MA POWER 100W K",
+            "K1ABC DE KC7AVA FB TOM SOLID COPY TNX QSO 73 SK",
+        ],
+        &[
+            "CQ DE N0CALL N0CALL K",
+            "N0CALL DE KC7AVA GE UR 569 IN WA NAME RANDY K",
+            "KC7AVA DE N0CALL RR RANDY NAME SUE QTH CO RIG IC7300 K",
+            "N0CALL DE KC7AVA FB SUE QSB BUT COPY OK 73 SK",
+        ],
+        &[
+            "CQ CQ DE VE3XYZ VE3XYZ K",
+            "VE3XYZ DE KC7AVA GM UR 599 WA NAME RANDY K",
+            "KC7AVA DE VE3XYZ TNX RANDY NAME AL QTH ON ANT LOOP K",
+            "VE3XYZ DE KC7AVA FB AL NICE SIG 73 SK",
+        ],
+        &[
+            "CQ CQ DE W5DX W5DX K",
+            "W5DX DE KC7AVA GA RST 579 NAME RANDY QTH WA K",
+            "KC7AVA DE W5DX RR NAME JO QTH TX TEMP 72 K",
+            "W5DX DE KC7AVA FB JO HR RAIN AND WIND TNX 73 SK",
+        ],
+        &[
+            "CQ DE K7RAD K7RAD K",
+            "K7RAD DE KC7AVA GM RST 589 NAME RANDY WA K",
+            "KC7AVA DE K7RAD RR RANDY NAME MIKE QTH AZ RIG 7300 K",
+            "K7RAD DE KC7AVA FB MIKE GREAT COPY 73 SK",
+        ],
+    ];
+    let script = scripts[index % scripts.len()];
+    let impairments = SyntheticQsoImpairments {
+        static_amp: 0.014 + (index % 3) as f32 * 0.004,
+        qsb_depth: 0.18 + (index % 4) as f32 * 0.06,
+        qsb_rate_hz: 0.18 + (index % 5) as f32 * 0.05,
+        qrm_hz: (index % 2 == 0).then_some(820.0 + index as f32 * 15.0),
+        qrm_amp: if index % 2 == 0 { 0.020 } else { 0.0 },
+    };
+    let bursts = script
+        .iter()
+        .enumerate()
+        .map(|(turn, text)| SyntheticQsoBurst {
+            text: (*text).to_string(),
+            wpm: 19.0 + ((index + turn) % 4) as f32,
+            pitch_hz: 640.0 + ((index + turn) % 5) as f32 * 35.0,
+            amp: 0.52 - (turn % 2) as f32 * 0.04,
+        })
+        .collect::<Vec<_>>();
+    build_example(
+        format!("ragchew-{:02}", index + 1),
+        SyntheticQsoKind::Ragchew,
+        sample_rate,
+        bursts,
+        impairments,
+        0xA11C_E000 + index as u64,
+    )
+}
+
+fn generate_contest(index: usize, sample_rate: u32) -> SyntheticQsoExample {
+    let scripts: &[&[&str]] = &[
+        &[
+            "CQ TEST W7N W7N",
+            "KC7AVA",
+            "KC7AVA 5NN WA",
+            "W7N 5NN OR TU",
+        ],
+        &[
+            "CQ FD K1ABC K1ABC",
+            "KC7AVA",
+            "KC7AVA 5NN 1D WA",
+            "K1ABC 5NN 2A EMA TU",
+        ],
+        &["TEST N0CALL", "KC7AVA", "KC7AVA 5NN CO", "N0CALL 5NN WA TU"],
+        &[
+            "CQ WPX VE3XYZ",
+            "KC7AVA",
+            "KC7AVA 5NN 104",
+            "VE3XYZ 5NN 052 TU",
+        ],
+        &[
+            "CQ NA W5DX W5DX",
+            "KC7AVA",
+            "KC7AVA 5NN TX",
+            "W5DX 5NN WA TU",
+        ],
+        &[
+            "CQ TEST K7RAD",
+            "KC7AVA",
+            "KC7AVA 5NN AZ",
+            "K7RAD 5NN WA TU",
+        ],
+    ];
+    let script = scripts[index % scripts.len()];
+    let impairments = SyntheticQsoImpairments {
+        static_amp: 0.018 + (index % 4) as f32 * 0.003,
+        qsb_depth: 0.12 + (index % 3) as f32 * 0.05,
+        qsb_rate_hz: 0.28 + (index % 4) as f32 * 0.07,
+        qrm_hz: (index % 3 != 1).then_some(560.0 + index as f32 * 40.0),
+        qrm_amp: if index % 3 != 1 { 0.018 } else { 0.0 },
+    };
+    let bursts = script
+        .iter()
+        .enumerate()
+        .map(|(turn, text)| SyntheticQsoBurst {
+            text: (*text).to_string(),
+            wpm: 24.0 + ((index + turn) % 5) as f32,
+            pitch_hz: 660.0 + ((index + turn) % 6) as f32 * 30.0,
+            amp: 0.54 - (turn % 2) as f32 * 0.03,
+        })
+        .collect::<Vec<_>>();
+    build_example(
+        format!("contest-{:02}", index + 1),
+        SyntheticQsoKind::Contest,
+        sample_rate,
+        bursts,
+        impairments,
+        0xC047_E570 + index as u64,
+    )
+}
+
+fn build_example(
+    id: String,
+    kind: SyntheticQsoKind,
+    sample_rate: u32,
+    bursts: Vec<SyntheticQsoBurst>,
+    impairments: SyntheticQsoImpairments,
+    seed: u64,
+) -> SyntheticQsoExample {
+    let mut rng = Lcg::new(seed);
+    let mut samples = static_noise(sample_rate, 0.65, impairments.static_amp, &mut rng);
+    let mut truth_parts = Vec::with_capacity(bursts.len());
+    for (idx, burst) in bursts.iter().enumerate() {
+        let mut audio = synth_morse(sample_rate, burst, &mut rng);
+        apply_qsb(
+            &mut audio,
+            sample_rate,
+            impairments.qsb_depth,
+            impairments.qsb_rate_hz,
+            0.42,
+            idx as f32 * 0.7,
+        );
+        samples.extend(audio);
+        truth_parts.push(canonical_text(&burst.text));
+        if idx + 1 < bursts.len() {
+            let gap_s = 0.82 + (idx % 3) as f32 * 0.18 + rng.next_unit() * 0.08;
+            samples.extend(static_noise(
+                sample_rate,
+                gap_s,
+                impairments.static_amp,
+                &mut rng,
+            ));
+        }
+    }
+    samples.extend(static_noise(
+        sample_rate,
+        0.8,
+        impairments.static_amp,
+        &mut rng,
+    ));
+    if let Some(qrm_hz) = impairments.qrm_hz {
+        add_qrm_tone(&mut samples, sample_rate, qrm_hz, impairments.qrm_amp);
+    }
+    clamp_samples(&mut samples);
+    SyntheticQsoExample {
+        id,
+        kind,
+        sample_rate,
+        samples,
+        truth: truth_parts.join(" "),
+        bursts,
+        impairments,
+    }
+}
+
+fn synth_morse(sample_rate: u32, burst: &SyntheticQsoBurst, rng: &mut Lcg) -> Vec<f32> {
+    let dot_s = 1.2 / burst.wpm;
+    let mut out = Vec::new();
+    let mut phase_sample = 0usize;
+    let canonical = canonical_text(&burst.text);
+    let mut words = canonical.split_whitespace().peekable();
+    while let Some(word) = words.next() {
+        let mut chars = word.chars().peekable();
+        while let Some(ch) = chars.next() {
+            let Some(code) = morse_for_char(ch) else {
+                continue;
+            };
+            let mut elements = code.chars().peekable();
+            while let Some(element) = elements.next() {
+                let units = if element == '.' { 1.0 } else { 3.0 };
+                let duration = dot_s * units * timing_jitter(rng, 0.035);
+                push_tone(
+                    &mut out,
+                    sample_rate,
+                    burst.pitch_hz,
+                    duration,
+                    burst.amp,
+                    &mut phase_sample,
+                );
+                if elements.peek().is_some() {
+                    push_silence(
+                        &mut out,
+                        sample_rate,
+                        dot_s * timing_jitter(rng, 0.03),
+                        &mut phase_sample,
+                    );
+                }
+            }
+            if chars.peek().is_some() {
+                push_silence(
+                    &mut out,
+                    sample_rate,
+                    dot_s * 3.0 * timing_jitter(rng, 0.03),
+                    &mut phase_sample,
+                );
+            }
+        }
+        if words.peek().is_some() {
+            push_silence(
+                &mut out,
+                sample_rate,
+                dot_s * 7.0 * timing_jitter(rng, 0.025),
+                &mut phase_sample,
+            );
+        }
+    }
+    out
+}
+
+fn push_tone(
+    out: &mut Vec<f32>,
+    sample_rate: u32,
+    pitch_hz: f32,
+    seconds: f32,
+    amp: f32,
+    phase_sample: &mut usize,
+) {
+    let n = (seconds * sample_rate as f32).round().max(1.0) as usize;
+    let ramp_n = ((sample_rate as f32) * 0.004).round() as usize;
+    for i in 0..n {
+        let rise = if ramp_n > 0 && i < ramp_n {
+            0.5 * (1.0 - ((std::f32::consts::PI * i as f32) / ramp_n as f32).cos())
+        } else {
+            1.0
+        };
+        let fall = if ramp_n > 0 && i + ramp_n > n {
+            let remaining = (n - i) as f32;
+            0.5 * (1.0 - ((std::f32::consts::PI * remaining) / ramp_n as f32).cos())
+        } else {
+            1.0
+        };
+        let t = *phase_sample as f32 / sample_rate as f32;
+        out.push((TAU * pitch_hz * t).sin() * amp * rise.min(fall));
+        *phase_sample += 1;
+    }
+}
+
+fn push_silence(out: &mut Vec<f32>, sample_rate: u32, seconds: f32, phase_sample: &mut usize) {
+    let n = (seconds * sample_rate as f32).round().max(0.0) as usize;
+    out.resize(out.len() + n, 0.0);
+    *phase_sample += n;
+}
+
+fn apply_qsb(
+    samples: &mut [f32],
+    sample_rate: u32,
+    depth: f32,
+    rate_hz: f32,
+    floor: f32,
+    phase: f32,
+) {
+    for (i, sample) in samples.iter_mut().enumerate() {
+        let t = i as f32 / sample_rate as f32;
+        let fade = floor + (1.0 - floor) * (0.5 + 0.5 * (TAU * rate_hz * t + phase).sin());
+        *sample *= 1.0 - depth + depth * fade;
+    }
+}
+
+fn add_qrm_tone(samples: &mut [f32], sample_rate: u32, freq_hz: f32, amp: f32) {
+    for (i, sample) in samples.iter_mut().enumerate() {
+        let t = i as f32 / sample_rate as f32;
+        *sample += (TAU * freq_hz * t).sin() * amp;
+    }
+}
+
+fn static_noise(sample_rate: u32, seconds: f32, amp: f32, rng: &mut Lcg) -> Vec<f32> {
+    let n = (seconds * sample_rate as f32).round() as usize;
+    (0..n).map(|_| rng.next_bipolar() * amp).collect()
+}
+
+fn timing_jitter(rng: &mut Lcg, width: f32) -> f32 {
+    (1.0 + rng.next_bipolar() * width).max(0.2)
+}
+
+fn clamp_samples(samples: &mut [f32]) {
+    for sample in samples {
+        *sample = sample.clamp(-0.98, 0.98);
+    }
+}
+
+fn write_wav(path: &Path, sample_rate: u32, samples: &[f32]) -> Result<()> {
+    let spec = hound::WavSpec {
+        channels: 1,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+    let mut writer = hound::WavWriter::create(path, spec)
+        .with_context(|| format!("creating WAV {}", path.display()))?;
+    for sample in samples {
+        writer
+            .write_sample((sample * i16::MAX as f32) as i16)
+            .context("writing sample")?;
+    }
+    writer.finalize().context("finalising WAV")?;
+    Ok(())
+}
+
+fn normalize_transcript(text: &str) -> String {
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn canonical_text(text: &str) -> String {
+    text.chars()
+        .map(|ch| ch.to_ascii_uppercase())
+        .filter(|ch| ch.is_ascii_alphanumeric() || ch.is_ascii_whitespace())
+        .collect::<String>()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn morse_for_char(c: char) -> Option<&'static str> {
+    match c.to_ascii_uppercase() {
+        'A' => Some(".-"),
+        'B' => Some("-..."),
+        'C' => Some("-.-."),
+        'D' => Some("-.."),
+        'E' => Some("."),
+        'F' => Some("..-."),
+        'G' => Some("--."),
+        'H' => Some("...."),
+        'I' => Some(".."),
+        'J' => Some(".---"),
+        'K' => Some("-.-"),
+        'L' => Some(".-.."),
+        'M' => Some("--"),
+        'N' => Some("-."),
+        'O' => Some("---"),
+        'P' => Some(".--."),
+        'Q' => Some("--.-"),
+        'R' => Some(".-."),
+        'S' => Some("..."),
+        'T' => Some("-"),
+        'U' => Some("..-"),
+        'V' => Some("...-"),
+        'W' => Some(".--"),
+        'X' => Some("-..-"),
+        'Y' => Some("-.--"),
+        'Z' => Some("--.."),
+        '0' => Some("-----"),
+        '1' => Some(".----"),
+        '2' => Some("..---"),
+        '3' => Some("...--"),
+        '4' => Some("....-"),
+        '5' => Some("....."),
+        '6' => Some("-...."),
+        '7' => Some("--..."),
+        '8' => Some("---.."),
+        '9' => Some("----."),
+        _ => None,
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Lcg {
+    state: u64,
+}
+
+impl Lcg {
+    fn new(seed: u64) -> Self {
+        Self { state: seed }
+    }
+
+    fn next_unit(&mut self) -> f32 {
+        self.state = self
+            .state
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        ((self.state >> 33) as u32) as f32 / u32::MAX as f32
+    }
+
+    fn next_bipolar(&mut self) -> f32 {
+        self.next_unit() * 2.0 - 1.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn suite_contains_requested_ragchew_and_contest_examples() {
+        let examples = generate_qso_suite(12_000, 6, 6);
+        assert_eq!(
+            examples
+                .iter()
+                .filter(|e| e.kind == SyntheticQsoKind::Ragchew)
+                .count(),
+            6
+        );
+        assert_eq!(
+            examples
+                .iter()
+                .filter(|e| e.kind == SyntheticQsoKind::Contest)
+                .count(),
+            6
+        );
+        assert!(examples.iter().all(|e| e.truth.contains("KC7AVA")));
+    }
+
+    #[test]
+    fn first_contest_example_validates_exact_copy() {
+        let example = generate_qso_suite(12_000, 0, 1).remove(0);
+        let validation = validate_example(&example, 500);
+        assert!(
+            validation.exact_match,
+            "expected exact copy for {}, truth={:?}, transcript={:?}",
+            example.id, validation.truth, validation.transcript
+        );
+    }
+}

--- a/experiments/cw-decoder/src/synthetic_qso.rs
+++ b/experiments/cw-decoder/src/synthetic_qso.rs
@@ -598,4 +598,72 @@ mod tests {
             example.id, validation.truth, validation.transcript
         );
     }
+
+    #[test]
+    fn final_over_k_after_cq_is_not_read_as_s() {
+        let sample_rate = 12_000;
+        let example = build_example(
+            "final-k-cq".to_string(),
+            SyntheticQsoKind::Contest,
+            sample_rate,
+            vec![SyntheticQsoBurst {
+                text: "CQ CQ DE W7N W7N K".to_string(),
+                wpm: 22.0,
+                pitch_hz: 700.0,
+                amp: 0.54,
+            }],
+            SyntheticQsoImpairments {
+                static_amp: 0.018,
+                qsb_depth: 0.22,
+                qsb_rate_hz: 0.33,
+                qrm_hz: Some(830.0),
+                qrm_amp: 0.018,
+            },
+            0xF1A1_0ACE,
+        );
+        let validation = validate_example(&example, 500);
+        assert_eq!(
+            validation.transcript, validation.truth,
+            "final over marker must remain K, truth={:?}, transcript={:?}",
+            validation.truth, validation.transcript
+        );
+    }
+
+    #[test]
+    fn isolated_final_over_k_region_is_not_read_as_s() {
+        let sample_rate = 12_000;
+        let example = build_example(
+            "isolated-final-k".to_string(),
+            SyntheticQsoKind::Contest,
+            sample_rate,
+            vec![
+                SyntheticQsoBurst {
+                    text: "CQ CQ DE W7N W7N".to_string(),
+                    wpm: 22.0,
+                    pitch_hz: 700.0,
+                    amp: 0.54,
+                },
+                SyntheticQsoBurst {
+                    text: "K".to_string(),
+                    wpm: 22.0,
+                    pitch_hz: 700.0,
+                    amp: 0.54,
+                },
+            ],
+            SyntheticQsoImpairments {
+                static_amp: 0.018,
+                qsb_depth: 0.22,
+                qsb_rate_hz: 0.33,
+                qrm_hz: Some(830.0),
+                qrm_amp: 0.018,
+            },
+            0xF1A1_0ACF,
+        );
+        let validation = validate_example(&example, 500);
+        assert_eq!(
+            validation.transcript, validation.truth,
+            "isolated final over marker must remain K, truth={:?}, transcript={:?}",
+            validation.truth, validation.transcript
+        );
+    }
 }


### PR DESCRIPTION
Builds on PR #376 (region-isolated streaming, merged) with three iterative improvements that take the synthetic QSO debug suite from no coverage to 12/12 exact-copy. Replaces #377 with a clean rebase onto current main.

Three commits, each independently reviewable:

1. cw-decoder: add synthetic QSO suite generator
   gen-qso-suite CLI command. Deterministic ragchew and contest exchanges with realistic turn-taking, static gaps, QSB fades, and light in-band QRM. Emits .wav, .truth.txt, manifest.ndjson, and validates each example through the region decoder. --require-exact for CI-style mismatch exit codes.

2. cw-decoder: preserve isolated final K over markers
   Live-radio symptom: a final over marker K (-.-) at the end of a CQ was being decoded as S (...) when it landed in its own short region. Root cause: ditdah auto-WPM with too little context classifies dahs as dits. Fix: short regions (<1.5 s) retry decode with a locally estimated WPM pinned, and pinned output is preferred only for tiny dit-heavy ambiguities (E/I/S/H/5). Adds focused tests for both isolated K and final K after a CQ.

3. cw-decoder: hybrid windowed/mean burst pitch discovery
   Long-form ragchews with 4 turns at distinct pitches (35-50 Hz apart) were dropping the first and last bursts because the whole-buffer mean Goertzel sweep smeared 4 burst pitches into one artifact peak. New region_stream::discover_burst_pitches unions per-window dominant pitches (10 s window, 5 s hop, with a dominant-vs-median confidence gate to suppress noise-only windows) with whole-buffer mean top-K (preserves dense contest clusters). NMS at pitch_step - 1 Hz; existing region-candidate dedupe handles overlapping decodes from neighboring pitches.

Validation:

- Synthetic suite: 6/12 -> 12/12 exact copy (5/6 -> 6/6 contest, 1/6 -> 6/6 ragchew)
- 24/24 at doubled suite size, 12/12 at 16 kHz and 48 kHz sample rates
- Training-set-b real-radio reference still exact: IHU NVCHU 7QP W7N 7QP W7N
- Both decode_region_stream (batch) and RegionStreamer (live) paths produce identical 12/12 result
- 141/142 lib tests pass (only pre-existing environmental W1AW MP3 missing-file test fails)
- cargo fmt and cargo clippy -D warnings clean
- ~206x realtime in release mode

New tests added: per-pitch discovery on a 4-burst signal, empty-buffer handling, pure-noise no-ghost-text, continuous-carrier + intermittent CW (the realistic adversarial case raised by the rubber-duck critique), isolated final K decode, final K after CQ.