### PR TITLE
Promote region transcript across CW Scope

### DIFF
--- a/experiments/cw-decoder/gui/Services/CwBenchRunner.cs
+++ b/experiments/cw-decoder/gui/Services/CwBenchRunner.cs
@@ -38,6 +38,7 @@ internal static class CwBenchRunner
         public bool DisableAutoThreshold { get; set; }
         public float? ForcePitchHz { get; set; }
         public bool Foundation { get; set; }
+        public bool Region { get; set; }
     }
 
     public sealed class RunResult
@@ -109,7 +110,11 @@ internal static class CwBenchRunner
             psi.ArgumentList.Add("--force-pitch-hz");
             psi.ArgumentList.Add(fp.ToString(CultureInfo.InvariantCulture));
         }
-        if (opts.Foundation)
+        if (opts.Region)
+        {
+            psi.ArgumentList.Add("--region");
+        }
+        else if (opts.Foundation)
         {
             psi.ArgumentList.Add("--foundation");
         }

--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Bench.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Bench.cs
@@ -170,10 +170,10 @@ public sealed partial class MainWindowViewModel
         }
     }
 
-    // V3 foundation = stable baseline (envelope_decoder + append_decode).
+    // Region = production transcript path (RegionStreamer + per-region ditdah).
     // V2 streaming = legacy ConfidenceState path, kept for A/B comparison.
-    // Foundation is the default; the legacy V2 knobs (purity / wide-bins
-    // / auto-threshold) are ignored when foundation is selected.
+    // Region is the default; the legacy V2 knobs (purity / wide-bins
+    // / auto-threshold) are ignored when region is selected.
     private bool _benchUseFoundation = true;
     public bool BenchUseFoundation
     {
@@ -322,7 +322,7 @@ public sealed partial class MainWindowViewModel
             WideBins = (int)Math.Max(0, _benchWideBins),
             DisableAutoThreshold = !_benchAutoThreshold,
             ForcePitchHz = _benchForcePitchHz > 0 ? (float)_benchForcePitchHz : (float?)null,
-            Foundation = _benchUseFoundation,
+            Region = _benchUseFoundation,
         };
 
         _benchCts?.Dispose();

--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.cs
@@ -30,7 +30,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
     private SweepTopResult? _topSweepResult;
 
     private const string CustomDecoderModeLabel = "Custom streaming";
-    private const string FoundationDecoderModeLabel = "Append event stream (foundation)";
+    private const string FoundationDecoderModeLabel = "Region-isolated stream";
     private const string BaselineDecoderModeLabel = "Baseline ditdah (rolling window)";
     private const string V2DecoderModeLabel = "Whole-buffer ditdah (v2)";
 
@@ -1568,7 +1568,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         {
             var useBaseline = IsBaselineDecoderMode;
             var cfg = CurrentConfig();
-            ReplayDecoderLabel = IsFoundationDecoderMode ? "OFFLINE REPLAY (FOUNDATION)" : useBaseline ? "OFFLINE REPLAY (BASELINE)" : "OFFLINE REPLAY (CUSTOM)";
+            ReplayDecoderLabel = IsFoundationDecoderMode ? "OFFLINE REPLAY (REGION)" : useBaseline ? "OFFLINE REPLAY (BASELINE)" : "OFFLINE REPLAY (CUSTOM)";
             var transcript = await Task.Run(() => RunOfflineReplay(path, useBaseline, IsFoundationDecoderMode, cfg)).ConfigureAwait(false);
             await Dispatcher.UIThread.InvokeAsync(() =>
             {
@@ -1752,6 +1752,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         {
             psi.ArgumentList.Add("stream-live-v3");
             psi.ArgumentList.Add("--json");
+            psi.ArgumentList.Add("--region-transcript");
             psi.ArgumentList.Add("--decode-every-ms");
             psi.ArgumentList.Add("250");
             psi.ArgumentList.Add("--file");
@@ -2604,7 +2605,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         }
     }
 
-    private string _strategySweepWpms = "foundation,auto,28,region28,env,env28,live-env";
+    private string _strategySweepWpms = "region,foundation,auto,28,env,env28,live-env";
     /// <summary>Comma-separated list of strategy tokens. Retained for
     /// backwards compatibility (some tests/bindings still reference it),
     /// but no longer the source of truth for the TUNING tab — the picker
@@ -2618,17 +2619,17 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
 
     /// <summary>Predefined strategy checkboxes shown in the TUNING tab picker.
     /// Tokens are forwarded verbatim to the Rust eval binary's
-    /// parse_strategy_list (foundation, auto, region, region&lt;N&gt;,
+    /// parse_strategy_list (region, foundation, auto, region&lt;N&gt;,
     /// env, env&lt;N&gt;, live-env, bare numbers).</summary>
     public ObservableCollection<StrategyOption> StrategyOptions { get; } = new()
     {
-        new StrategyOption("foundation", "foundation", true,  "Append-only event-stream decoder used by DECODE/VISUALIZER"),
-        new StrategyOption("auto",     "auto",     true,  "Whole-buffer ditdah, auto-detect WPM (DECODE tab default)"),
+        new StrategyOption("region",   "region",   true,  "Region-isolated stream transcript used by DECODE/LABELING/VISUALIZER"),
+        new StrategyOption("foundation", "foundation", false, "Append-only event-stream foundation, kept for baseline comparison"),
+        new StrategyOption("auto",     "auto",     true,  "Whole-buffer ditdah, auto-detect WPM"),
         new StrategyOption("22",       "22 wpm",   false, "Whole-buffer ditdah, pinned to 22 wpm"),
         new StrategyOption("25",       "25 wpm",   false, "Whole-buffer ditdah, pinned to 25 wpm"),
         new StrategyOption("28",       "28 wpm",   true,  "Whole-buffer ditdah, pinned to 28 wpm"),
         new StrategyOption("30",       "30 wpm",   false, "Whole-buffer ditdah, pinned to 30 wpm"),
-        new StrategyOption("region",   "region",   false, "Region-stream pipeline, auto-detect WPM"),
         new StrategyOption("region28", "region28", true,  "Region-stream pipeline, pinned to 28 wpm"),
         new StrategyOption("env",      "env",      true,  "Offline envelope decoder, auto-detect WPM"),
         new StrategyOption("env28",    "env28",    true,  "Offline envelope decoder, pinned to 28 wpm"),
@@ -2673,12 +2674,12 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
     }
 
     /// <summary>Resolve the ordered, deduped (case-insensitive) token list to send
-    /// to the eval binary: always "auto" first, then checked picker tokens in
+    /// to the eval binary: always "region" first, then checked picker tokens in
     /// declaration order, then comma-split custom tokens.</summary>
     private List<string> BuildStrategyTokens()
     {
-        var tokens = new List<string> { "foundation" };
-        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "foundation" };
+        var tokens = new List<string> { "region" };
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "region" };
         foreach (var opt in StrategyOptions)
         {
             if (!opt.IsChecked) continue;
@@ -2787,7 +2788,7 @@ public sealed partial class MainWindowViewModel : INotifyPropertyChanged, IDispo
         // auto, region, region<N>, region:<N>, env, envelope, env<N>,
         // envelope<N>, env:<N>, envelope:<N>, live-env, liveenv, and bare
         // numbers (ExactPin). BuildStrategyTokens always includes
-        // "foundation" first and dedupes case-insensitively across picker
+        // "region" first and dedupes case-insensitively across picker
         // + custom tokens.
         var strategies = BuildStrategyTokens();
 

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml
@@ -1096,8 +1096,8 @@
               <StackPanel Grid.Column="1" Spacing="2">
                 <TextBlock Text="DECODER" Classes="label" />
                 <StackPanel Orientation="Horizontal" Spacing="8">
-                  <RadioButton GroupName="BenchDecoder" Content="FOUNDATION" IsChecked="{Binding BenchUseFoundation, Mode=TwoWay}"
-                               ToolTip.Tip="V3 envelope_decoder + append_decode (stable baseline used everywhere else in CW SCOPE)" />
+                  <RadioButton GroupName="BenchDecoder" Content="REGION" IsChecked="{Binding BenchUseFoundation, Mode=TwoWay}"
+                               ToolTip.Tip="Region-isolated stream transcript (production CW SCOPE path)" />
                   <RadioButton GroupName="BenchDecoder" Content="STREAMING (V2)" IsChecked="{Binding BenchUseStreamingV2, Mode=TwoWay}"
                                ToolTip.Tip="Legacy ConfidenceState path. Kept for A/B comparison only." />
                 </StackPanel>

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -726,6 +726,11 @@ enum Cmd {
         /// quality against truth; latency-specific fields are left empty.
         #[arg(long, default_value_t = false)]
         foundation: bool,
+        /// Use the region-isolated streaming transcript path. This is the
+        /// production CW Scope architecture: detect active bursts, decode
+        /// each region independently, and commit only stable region text.
+        #[arg(long, default_value_t = false)]
+        region: bool,
         /// Emit one NDJSON record per scenario in addition to the table
         /// (handy for collecting comparison runs into a file).
         #[arg(long, default_value_t = false)]
@@ -1227,6 +1232,7 @@ fn run_cli() -> Result<()> {
             min_pulse_dot_fraction,
             cfar_keying,
             foundation,
+            region,
             json,
         } => run_bench_latency(
             from_file.as_deref(),
@@ -1245,6 +1251,7 @@ fn run_cli() -> Result<()> {
             min_pulse_dot_fraction,
             cfar_keying,
             foundation,
+            region,
             json,
         ),
         Cmd::GenRoughFist {
@@ -1343,6 +1350,7 @@ fn run_bench_latency(
     min_pulse_dot_fraction: f32,
     cfar_keying: bool,
     foundation: bool,
+    region: bool,
     json: bool,
 ) -> Result<()> {
     let mut cfg = streaming::DecoderConfig::defaults();
@@ -1408,7 +1416,9 @@ fn run_bench_latency(
 
     let mut results = Vec::with_capacity(scenarios.len());
     for scen in &scenarios {
-        let r = if foundation {
+        let r = if region {
+            run_region_bench_scenario(scen, chunk_ms, stable_n, label)
+        } else if foundation {
             // V3 foundation: envelope_decoder + append_decode, with
             // commit-time char timestamps and quality-gate timeline.
             // BENCH knob `force_pitch_hz` maps to V3 `pin_hz`; V2-only
@@ -1534,6 +1544,98 @@ fn run_bench_latency(
     let agg = bench_latency::aggregate(&results);
     bench_latency::print_aggregate(label, &agg);
     Ok(())
+}
+
+fn run_region_bench_scenario(
+    scen: &bench_latency::Scenario,
+    chunk_ms: u32,
+    stable_n: usize,
+    label: &str,
+) -> bench_latency::BenchResult {
+    let sr = scen.audio.sample_rate;
+    let chunk_samples = ((sr as u64 * chunk_ms as u64) / 1000).max(1) as usize;
+    let truth_upper = scen.truth.to_uppercase();
+    let mut streamer = cw_decoder_poc::region_streamer::RegionStreamer::new(sr);
+    let mut transcript = String::new();
+    let mut char_times = Vec::new();
+
+    let mut consumed = 0usize;
+    while consumed < scen.audio.samples.len() {
+        let end = (consumed + chunk_samples).min(scen.audio.samples.len());
+        streamer.ingest(&scen.audio.samples[consumed..end]);
+        let t_ms = ((end as u64 * 1000) / sr as u64) as u32;
+        append_region_commits(
+            streamer.try_commit(),
+            t_ms,
+            &mut transcript,
+            &mut char_times,
+        );
+        consumed = end;
+    }
+
+    let t_end = ((scen.audio.samples.len() as u64 * 1000) / sr as u64) as u32;
+    append_region_commits(streamer.flush(), t_end, &mut transcript, &mut char_times);
+
+    let mut result = bench_latency::BenchResult {
+        scenario: scen.name.clone(),
+        config_label: label.to_string(),
+        cw_onset_ms: scen.cw_onset_ms,
+        truth: truth_upper.clone(),
+        transcript: transcript.trim().to_string(),
+        stable_n,
+        decoder_path: "region".to_string(),
+        ..Default::default()
+    };
+
+    let trimmed = trim_char_times_to_transcript(&transcript, &char_times);
+    result.t_first_char_ms = result
+        .transcript
+        .chars()
+        .zip(trimmed.iter().copied())
+        .find_map(|(ch, t)| (!ch.is_whitespace()).then_some(t));
+    let transcript_owned = result.transcript.clone();
+    bench_latency::update_truth_metrics(
+        &transcript_owned,
+        &truth_upper,
+        &trimmed,
+        stable_n,
+        &mut result,
+    );
+    result.cer_vs_truth = bench_latency::character_error_rate(&result.transcript, &truth_upper);
+    result
+}
+
+fn append_region_commits(
+    commits: Vec<cw_decoder_poc::region_streamer::CommittedRegion>,
+    t_ms: u32,
+    transcript: &mut String,
+    char_times: &mut Vec<u32>,
+) {
+    for commit in commits {
+        let text = commit.text.trim();
+        if text.is_empty() {
+            continue;
+        }
+        if !transcript.is_empty() {
+            transcript.push(' ');
+            char_times.push(t_ms);
+        }
+        transcript.push_str(text);
+        char_times.extend(std::iter::repeat_n(t_ms, text.chars().count()));
+    }
+}
+
+fn trim_char_times_to_transcript(raw: &str, raw_times: &[u32]) -> Vec<u32> {
+    let chars: Vec<char> = raw.chars().collect();
+    let leading_ws = chars.iter().take_while(|c| c.is_whitespace()).count();
+    let trailing_ws = chars.iter().rev().take_while(|c| c.is_whitespace()).count();
+    let trimmed_len = chars.len().saturating_sub(leading_ws + trailing_ws);
+    raw_times
+        .iter()
+        .copied()
+        .skip(leading_ws)
+        .take(trimmed_len)
+        .collect()
 }
 
 fn run_file(

--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -156,7 +156,7 @@ fn collect_region_candidates(
         let slice = &samples[s..e];
         let text = decode_region_slice(slice, sample_rate, pitch_hz, cfg);
         let text = text.trim().to_string();
-        if text.is_empty() {
+        if text.is_empty() || is_low_confidence_region_text(&text) {
             continue;
         }
         let useful_chars = text.chars().filter(|ch| ch.is_ascii_alphanumeric()).count() as f32;
@@ -167,6 +167,10 @@ fn collect_region_candidates(
             score: prominence * (1.0 + useful_chars * 0.05),
         });
     }
+}
+
+fn is_low_confidence_region_text(text: &str) -> bool {
+    text.contains('?')
 }
 
 fn decode_region_slice(
@@ -938,6 +942,12 @@ mod tests {
         let r = decode_region_stream(&[], 12_000, &cfg);
         assert!(r.text.is_empty());
         assert!(r.regions.is_empty());
+    }
+
+    #[test]
+    fn unknown_region_text_is_low_confidence() {
+        assert!(is_low_confidence_region_text("E?R"));
+        assert!(!is_low_confidence_region_text("7QP W7N"));
     }
 
     fn noise_buf(rate: u32, seconds: f32, seed: u64, amplitude: f32) -> Vec<f32> {


### PR DESCRIPTION
Promotes the region-isolated transcript path as the default CW Scope architecture. Decode, Labeling, Visualizer, offline replay, Tuning defaults, and Bench now route through the region transcript path or the matching region evaluation/bench mode, while the older append foundation remains available as a comparison strategy.

This also filters low-confidence region candidates containing ditdah unknowns before they can be committed, restoring the training-set-b real-radio reference transcript after the hybrid multi-pitch regression.

Validation: .\runall.ps1 completed successfully.