### PR TITLE
Add CW visualizer truth workflow

### DIFF
--- a/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Visualizer.cs
+++ b/experiments/cw-decoder/gui/ViewModels/MainWindowViewModel.Visualizer.cs
@@ -76,12 +76,62 @@ public sealed partial class MainWindowViewModel
     private readonly CwDecoderProcess _vizProcess = new();
     private readonly AudioPlaybackProcess _vizPlayback = new();
     private bool _vizWired;
+    private string? _vizCapturePath;
 
     private VizFrameVm _vizFrame = VizFrameVm.Empty;
     public VizFrameVm VizFrame { get => _vizFrame; set => Set(ref _vizFrame, value); }
 
     private string _vizTranscript = "";
-    public string VizTranscript { get => _vizTranscript; set => Set(ref _vizTranscript, value); }
+    public string VizTranscript
+    {
+        get => _vizTranscript;
+        set
+        {
+            if (Set(ref _vizTranscript, value))
+            {
+                OnPropertyChanged(nameof(VizCopyText));
+            }
+        }
+    }
+
+    private string _vizTruthText = "";
+    public string VizTruthText
+    {
+        get => _vizTruthText;
+        set
+        {
+            if (Set(ref _vizTruthText, (value ?? string.Empty).ToUpperInvariant()))
+            {
+                OnPropertyChanged(nameof(CanSaveVizTruth));
+                OnPropertyChanged(nameof(VizCopyText));
+            }
+        }
+    }
+
+    private bool _vizEditMode;
+    public bool VizEditMode
+    {
+        get => _vizEditMode;
+        set
+        {
+            if (Set(ref _vizEditMode, value))
+            {
+                if (value && string.IsNullOrWhiteSpace(VizTruthText))
+                {
+                    VizTruthText = VizTranscript;
+                }
+                OnPropertyChanged(nameof(VizEditModeLabel));
+                OnPropertyChanged(nameof(IsVizTranscriptReadOnly));
+            }
+        }
+    }
+
+    public string VizEditModeLabel => VizEditMode ? "LOCK TEXT" : "EDIT TRUTH";
+    public bool IsVizTranscriptReadOnly => !VizEditMode;
+    public bool HasVizCapture => !string.IsNullOrWhiteSpace(_vizCapturePath) && System.IO.File.Exists(_vizCapturePath);
+    public string VizCaptureDisplay => string.IsNullOrWhiteSpace(_vizCapturePath) ? "(none)" : System.IO.Path.GetFileName(_vizCapturePath);
+    public bool CanSaveVizTruth => HasVizCapture && !VizRunning && !string.IsNullOrWhiteSpace(VizTruthText);
+    public bool CanUseVizCaptureInLabeling => HasVizCapture && !VizRunning;
 
     private double _vizWindowSeconds = 10.0;
     public double VizWindowSeconds { get => _vizWindowSeconds; set => Set(ref _vizWindowSeconds, value); }
@@ -98,6 +148,8 @@ public sealed partial class MainWindowViewModel
             if (Set(ref _vizRunning, value))
             {
                 OnPropertyChanged(nameof(VizStartStopLabel));
+                OnPropertyChanged(nameof(CanSaveVizTruth));
+                OnPropertyChanged(nameof(CanUseVizCaptureInLabeling));
             }
         }
     }
@@ -158,6 +210,8 @@ public sealed partial class MainWindowViewModel
 
     public string VizStartStopLabel => VizRunning ? "STOP" : "START LIVE";
 
+    public string VizCopyText => string.IsNullOrWhiteSpace(VizTruthText) ? VizTranscript : VizTruthText;
+
     /// <summary>Resolves the persistent capture directory and ensures it exists.</summary>
     private static string ResolveVizCaptureDir()
     {
@@ -193,6 +247,8 @@ public sealed partial class MainWindowViewModel
         try
         {
             VizTranscript = "";
+            VizTruthText = "";
+            VizEditMode = false;
             VizFrame = VizFrameVm.Empty;
             VizCurrentWpm = 0;
             VizStatus = "starting…";
@@ -201,6 +257,7 @@ public sealed partial class MainWindowViewModel
             var stamp = DateTime.Now.ToString("yyyyMMdd-HHmmss-fff");
             var captureDir = ResolveVizCaptureDir();
             var recordPath = System.IO.Path.Combine(captureDir, $"viz-{stamp}.wav");
+            SetVizCapturePath(recordPath);
             _vizProcess.StartLiveV3(SelectedDevice, decodeEveryMs: 250,
                 recordPath: recordPath, loopback: VizUseLoopback,
                 pinWpm: VizPinWpm, pinHz: VizPinHz);
@@ -220,9 +277,15 @@ public sealed partial class MainWindowViewModel
         try { _vizProcess.Stop(); } catch { /* best effort */ }
         try { _vizPlayback.Stop(); } catch { /* best effort */ }
         VizRunning = false;
-        VizStatus = "stopped";
+        if (!VizEditMode)
+        {
+            VizTruthText = VizTranscript;
+        }
+        VizStatus = HasVizCapture
+            ? $"stopped → {VizCaptureDisplay}"
+            : "stopped";
         var flushed = VizBarMonitor.Flush();
-        if (flushed is not null) VizStatus = $"stopped → {System.IO.Path.GetFileName(flushed)}";
+        if (flushed is not null) VizStatus += $" / bars {System.IO.Path.GetFileName(flushed)}";
     }
 
     public void StartVizFile(string filePath)
@@ -231,6 +294,9 @@ public sealed partial class MainWindowViewModel
         try
         {
             VizTranscript = "";
+            VizTruthText = "";
+            VizEditMode = false;
+            SetVizCapturePath(null);
             VizFrame = VizFrameVm.Empty;
             VizCurrentWpm = 0;
             VizStatus = $"file: {System.IO.Path.GetFileName(filePath)}";
@@ -274,6 +340,10 @@ public sealed partial class MainWindowViewModel
             {
                 case "ready":
                     VizStatus = $"ready @ {ev.Rate ?? 0} Hz";
+                    if (!string.IsNullOrWhiteSpace(ev.Recording))
+                    {
+                        SetVizCapturePath(ev.Recording);
+                    }
                     break;
                 case "transcript":
                     // PR #370 (Approach A+): the Rust side now emits a
@@ -291,7 +361,14 @@ public sealed partial class MainWindowViewModel
                     // only — empty until the streamer locks is
                     // expected and accurate.
                     var sess = ev.Transcript;
-                    if (sess is not null) VizTranscript = sess;
+                    if (sess is not null)
+                    {
+                        VizTranscript = sess;
+                        if (!VizEditMode)
+                        {
+                            VizTruthText = sess;
+                        }
+                    }
                     if (ev.Wpm.HasValue) _lastVizWpmPeriod = ev.Wpm.Value;
                     if (ev.WpmKmeans.HasValue) _lastVizWpmKmeans = ev.WpmKmeans.Value;
                     if (ev.Wpm.HasValue || ev.WpmKmeans.HasValue)
@@ -314,13 +391,110 @@ public sealed partial class MainWindowViewModel
                     }
                     break;
                 case "end":
-                    if (ev.Transcript is not null) VizTranscript = ev.Transcript;
+                    if (ev.Transcript is not null)
+                    {
+                        VizTranscript = ev.Transcript;
+                        if (!VizEditMode)
+                        {
+                            VizTruthText = ev.Transcript;
+                        }
+                    }
+                    if (!string.IsNullOrWhiteSpace(ev.Recording))
+                    {
+                        SetVizCapturePath(ev.Recording);
+                    }
                     VizRunning = false;
-                    VizStatus = "ended";
+                    VizStatus = HasVizCapture
+                        ? $"ended → {VizCaptureDisplay}"
+                        : "ended";
                     var flushed = VizBarMonitor.Flush();
-                    if (flushed is not null) VizStatus = $"ended → {System.IO.Path.GetFileName(flushed)}";
+                    if (flushed is not null) VizStatus += $" / bars {System.IO.Path.GetFileName(flushed)}";
                     break;
             }
         });
+    }
+
+    public void ToggleVizEditMode()
+    {
+        VizEditMode = !VizEditMode;
+    }
+
+    public bool SendVizCaptureToLabeling()
+    {
+        if (!CanUseVizCaptureInLabeling || string.IsNullOrWhiteSpace(_vizCapturePath))
+        {
+            VizStatus = VizRunning
+                ? "stop the visualizer before loading the capture into Labeling"
+                : "no visualizer capture to label yet";
+            return false;
+        }
+
+        SetHarvestFile(_vizCapturePath);
+        CorrectCopy = VizTruthText;
+        AdvancedStatusText = $"Loaded visualizer capture {VizCaptureDisplay}. Harvest candidates or save labels from Labeling.";
+        VizStatus = $"loaded {VizCaptureDisplay} into Labeling";
+        return true;
+    }
+
+    public void SaveVizTruth()
+    {
+        if (!CanSaveVizTruth || string.IsNullOrWhiteSpace(_vizCapturePath))
+        {
+            VizStatus = "record live audio and enter corrected text before saving truth";
+            return;
+        }
+
+        try
+        {
+            var truth = VizTruthText.Trim();
+            var truthPath = System.IO.Path.ChangeExtension(_vizCapturePath, ".truth.txt");
+            System.IO.File.WriteAllText(truthPath, truth);
+
+            var duration = Math.Max(0, TryProbeFileDurationSeconds(_vizCapturePath));
+            var label = new CandidateLabel
+            {
+                Source = System.IO.Path.GetFileName(_vizCapturePath),
+                StartSeconds = 0,
+                EndSeconds = duration,
+                HarvestStartSeconds = 0,
+                HarvestEndSeconds = duration,
+                LabelScope = CandidateLabel.ExactWindowScope,
+                CorrectCopy = truth,
+                ClipStart = false,
+                ClipEnd = false,
+                Needles = Array.Empty<string>(),
+                OfflineText = VizTranscript,
+                StreamText = VizTranscript,
+                SavedAtUtc = DateTime.UtcNow.ToString("O"),
+            };
+
+            var labelPath = System.IO.Path.ChangeExtension(_vizCapturePath, ".labels.jsonl");
+            var lines = System.IO.File.Exists(labelPath)
+                ? System.IO.File.ReadAllLines(labelPath).Where(line => !MatchesSameWindow(line, label)).ToList()
+                : new List<string>();
+            lines.Add(System.Text.Json.JsonSerializer.Serialize(label));
+            System.IO.File.WriteAllLines(labelPath, lines);
+
+            VizEditMode = false;
+            VizStatus = $"saved {System.IO.Path.GetFileName(truthPath)} + {System.IO.Path.GetFileName(labelPath)}";
+        }
+        catch (Exception ex)
+        {
+            VizStatus = $"truth save failed: {ex.Message}";
+        }
+    }
+
+    private void SetVizCapturePath(string? path)
+    {
+        if (string.Equals(_vizCapturePath, path, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        _vizCapturePath = path;
+        OnPropertyChanged(nameof(HasVizCapture));
+        OnPropertyChanged(nameof(VizCaptureDisplay));
+        OnPropertyChanged(nameof(CanSaveVizTruth));
+        OnPropertyChanged(nameof(CanUseVizCaptureInLabeling));
     }
 }

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml
@@ -130,7 +130,7 @@
     </Border>
 
 
-    <TabControl Grid.Row="2" Margin="14,12,14,4">
+    <TabControl x:Name="MainTabs" Grid.Row="2" Margin="14,12,14,4">
       <TabItem Header="DECODE">
         <Border Classes="panel">
           <Grid RowDefinitions="Auto,Auto,Auto,Auto,*,Auto">
@@ -1263,22 +1263,55 @@
                                   MinHeight="320" />
             </Border>
 
-            <!-- Live transcript -->
+            <!-- Live transcript / truth capture -->
             <Border Grid.Row="3" Background="{StaticResource BgDeep}" CornerRadius="4"
                     BorderBrush="{StaticResource EdgeGlow}" BorderThickness="1"
                     Padding="10,8" Margin="0,8,0,0">
-              <ScrollViewer Name="VizTranscriptScroll"
-                            HorizontalScrollBarVisibility="Disabled"
-                            VerticalScrollBarVisibility="Auto"
-                            MinHeight="120"
-                            MaxHeight="240">
-                <TextBlock Text="{Binding VizTranscript}"
+              <Grid RowDefinitions="Auto,*" RowSpacing="6">
+                <Grid ColumnDefinitions="Auto,Auto,Auto,Auto,Auto,*" ColumnSpacing="8">
+                  <TextBlock Text="DECODED / TRUTH"
+                             FontFamily="Consolas"
+                             FontSize="11"
+                             Foreground="{StaticResource TextDim}"
+                             VerticalAlignment="Center" />
+                  <Button Grid.Column="1" Content="COPY TEXT" Click="OnCopyVizTranscriptClick"
+                          FontSize="11" Padding="10,3"
+                          ToolTip.Tip="Copy the decoded/corrected text. Ctrl+C also works when the text box is focused." />
+                  <Button Grid.Column="2" Content="{Binding VizEditModeLabel}" Click="OnToggleVizEditClick"
+                          FontSize="11" Padding="10,3"
+                          ToolTip.Tip="Toggle edit mode so you can correct the decoded text before saving truth." />
+                  <Button Grid.Column="3" Content="SAVE TRUTH" Click="OnSaveVizTruthClick"
+                          IsEnabled="{Binding CanSaveVizTruth}"
+                          FontSize="11" Padding="10,3"
+                          ToolTip.Tip="Save .truth.txt and .labels.jsonl next to the captured visualizer WAV." />
+                  <Button Grid.Column="4" Content="USE IN LABELING" Click="OnUseVizCaptureInLabelingClick"
+                          IsEnabled="{Binding CanUseVizCaptureInLabeling}"
+                          FontSize="11" Padding="10,3"
+                          ToolTip.Tip="Load the captured WAV into the Labeling tab for harvest, preview, and corpus export." />
+                  <TextBlock Grid.Column="5" Text="{Binding VizCaptureDisplay}"
+                             FontFamily="Consolas"
+                             FontSize="11"
+                             Foreground="{StaticResource TextDim}"
+                             HorizontalAlignment="Right"
+                             VerticalAlignment="Center" />
+                </Grid>
+                <ScrollViewer Name="VizTranscriptScroll"
+                              Grid.Row="1"
+                              HorizontalScrollBarVisibility="Disabled"
+                              VerticalScrollBarVisibility="Auto"
+                              MinHeight="120"
+                              MaxHeight="240">
+                  <TextBox Text="{Binding VizTruthText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                           IsReadOnly="{Binding IsVizTranscriptReadOnly}"
+                           AcceptsReturn="True"
+                           TextWrapping="Wrap"
+                           BorderThickness="0"
+                           Background="Transparent"
                            FontFamily="Consolas"
                            FontSize="16"
-                           LineHeight="22"
-                           TextWrapping="Wrap"
                            Foreground="{StaticResource TextHi}" />
-              </ScrollViewer>
+                </ScrollViewer>
+              </Grid>
             </Border>
           </Grid>
         </Border>

--- a/experiments/cw-decoder/gui/Views/MainWindow.axaml.cs
+++ b/experiments/cw-decoder/gui/Views/MainWindow.axaml.cs
@@ -73,6 +73,30 @@ public partial class MainWindow : Window
             Vm.StartVizFile(path);
     }
 
+    private async void OnCopyVizTranscriptClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (Vm is null || string.IsNullOrWhiteSpace(Vm.VizCopyText)) return;
+        if (Clipboard is { } clip)
+        {
+            await clip.SetTextAsync(Vm.VizCopyText);
+        }
+    }
+
+    private void OnToggleVizEditClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => Vm?.ToggleVizEditMode();
+
+    private void OnSaveVizTruthClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+        => Vm?.SaveVizTruth();
+
+    private void OnUseVizCaptureInLabelingClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+    {
+        if (Vm?.SendVizCaptureToLabeling() == true
+            && this.FindControl<TabControl>("MainTabs") is { } tabs)
+        {
+            tabs.SelectedIndex = 1;
+        }
+    }
+
     private void OnRefreshClick(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
         => Vm?.RefreshDevices();
 


### PR DESCRIPTION
This makes the CW Scope Visualizer tab a direct entry point for labeling live SDR/on-air captures. The transcript area is now a selectable/copyable text box, can be toggled into edit mode for correcting decoded copy, and can save corrected text next to the auto-captured WAV as .truth.txt and .labels.jsonl sidecars. The Visualizer also exposes the active capture file and can load the stopped capture directly into the Labeling tab so it can be harvested, previewed, and exported to the corpus without manually finding the file. The workflow is gated so save/load actions are available after stopping the live capture, avoiding incomplete WAVs.