### PR TITLE
Fix QRZ sync for local corrections

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -1129,20 +1129,27 @@ Every logged QSO must carry station identity data. The station context system wo
 
 ### 7.3 Sync Lifecycle
 
-The QRZ logbook sync is a three-phase operation:
+The QRZ logbook sync is a multi-phase operation:
+
+#### Phase 0.5: Push local corrections before download
+
+Before fetching remote QSOs, engines MUST resolve the QRZ logbook owner callsign (via `STATUS`, falling back to cached metadata on transient failure) and push local rows with `sync_status = MODIFIED` and a non-empty `qrz_logid` when the effective conflict policy is `CONFLICT_POLICY_FLAG_FOR_REVIEW` or `CONFLICT_POLICY_UNSPECIFIED`. This uses the documented replace form `ACTION=INSERT&OPTION=REPLACE,LOGID:<logid>`.
+
+This pre-download upload prevents a stale QRZ copy from being downloaded first and converting a normal local correction into `CONFLICT` before the upload phase can update QRZ. Engines MUST remember the `qrz_logid` values successfully uploaded during this phase and ignore matching remote rows returned by the same sync's subsequent `FETCH`, because QRZ may briefly return the stale pre-replace copy.
 
 #### Phase 1: Download
 
 1. Call QRZ logbook API `FETCH` with `OPTION=ALL` (full sync) or `OPTION=ALL,MODSINCE:YYYY-MM-DD` (incremental).
 2. Parse the ADIF response into QSO records. Engines MUST recognise QRZ-specific ADIF application fields and map them onto dedicated domain fields (see §7.5 Import).
 3. For each remote QSO:
-   a. Prefer a direct match on `qrz_logid` if one was returned for that record.
-   b. Otherwise, fuzzy-match against local records: callsign (case-insensitive) + UTC timestamp (within a tolerance window, typically ±60s) + band + mode.
-   c. If matched, apply the configured `ConflictPolicy`:
-      - `CONFLICT_POLICY_LAST_WRITE_WINS` — treat the remote record as authoritative and overwrite local fields; mark the merged row as `SYNCED`.
-      - `CONFLICT_POLICY_FLAG_FOR_REVIEW` — when the local row was locally edited (`sync_status = MODIFIED`), preserve the local fields, set `sync_status = CONFLICT`, and increment the sync result's conflict counter so operators can reconcile manually. When the local row is already `SYNCED`, remote wins (no conflict).
-      - `CONFLICT_POLICY_UNSPECIFIED` — engines MUST treat the zero value as `FLAG_FOR_REVIEW` (the safe, non-destructive default) per §6.3.
-   d. If unmatched, insert as a new local record with `sync_status = SYNCED` and populate `qrz_logid` from the remote record.
+    a. Prefer a direct match on `qrz_logid` if one was returned for that record.
+    b. Otherwise, fuzzy-match against local records: callsign (case-insensitive) + UTC timestamp (within a tolerance window, typically ±60s) + band + mode.
+    c. If the remote `qrz_logid` was successfully uploaded during Phase 0.5 of this same sync, skip it rather than overwriting the corrected local row with a stale remote response.
+    d. If matched, apply the configured `ConflictPolicy`:
+       - `CONFLICT_POLICY_LAST_WRITE_WINS` — treat the remote record as authoritative and overwrite local fields; mark the merged row as `SYNCED`.
+       - `CONFLICT_POLICY_FLAG_FOR_REVIEW` — when the local row was locally edited (`sync_status = MODIFIED`), preserve the local fields, set `sync_status = CONFLICT`, and increment the sync result's conflict counter so operators can reconcile manually. When the local row is already `SYNCED`, remote wins (no conflict).
+       - `CONFLICT_POLICY_UNSPECIFIED` — engines MUST treat the zero value as `FLAG_FOR_REVIEW` (the safe, non-destructive default) per §6.3.
+    e. If unmatched, insert as a new local record with `sync_status = SYNCED` and populate `qrz_logid` from the remote record.
 4. Filter ghost records: remote QSOs missing required fields (callsign, timestamp) are skipped without incrementing any counter.
 5. **Soft-delete suppression:** before matching, engines MUST load the full local record set including soft-deleted rows (see §7.8) and build the set of `qrz_logid` values associated with locally soft-deleted QSOs. Any remote QSO whose `qrz_logid` is in that set MUST be skipped (no insert, no merge), and the engine MUST increment the `deletes_skipped_remote` counter on the sync result. This prevents resurrection of QSOs the operator has trashed locally before the queued remote-delete (Phase 2.5) has propagated.
 

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzSyncEngineTests.cs
@@ -110,7 +110,11 @@ public sealed class QrzSyncEngineTests
         var remote = MakeRemoteQso("W1AW", BaseTime, Band._20M, Mode.Ft8, "500");
         remote.Notes = "Updated from QRZ";
 
-        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var api = new FakeQrzLogbookApi
+        {
+            FetchResult = [remote],
+            UpdateFunc = qso => qso.QrzLogid,
+        };
         var engine = new QrzSyncEngine(api);
 
         var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
@@ -135,7 +139,11 @@ public sealed class QrzSyncEngineTests
         // Remote has same callsign/band/mode, timestamp 30s off, but no logid.
         var remote = MakeRemoteQso("W1AW", BaseTime.AddSeconds(30), Band._20M, Mode.Ft8, null);
 
-        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var api = new FakeQrzLogbookApi
+        {
+            FetchResult = [remote],
+            UpdateFunc = qso => qso.QrzLogid,
+        };
         var engine = new QrzSyncEngine(api);
 
         var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
@@ -156,7 +164,11 @@ public sealed class QrzSyncEngineTests
         // Remote has same callsign/band/mode, but timestamp 90s off — too far.
         var remote = MakeRemoteQso("W1AW", BaseTime.AddSeconds(90), Band._20M, Mode.Ft8, null);
 
-        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var api = new FakeQrzLogbookApi
+        {
+            FetchResult = [remote],
+            UpdateFunc = qso => qso.QrzLogid,
+        };
         var engine = new QrzSyncEngine(api);
 
         var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
@@ -176,7 +188,11 @@ public sealed class QrzSyncEngineTests
         // Same callsign and timestamp, but different band.
         var remote = MakeRemoteQso("W1AW", BaseTime, Band._40M, Mode.Ft8, null);
 
-        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var api = new FakeQrzLogbookApi
+        {
+            FetchResult = [remote],
+            UpdateFunc = qso => qso.QrzLogid,
+        };
         var engine = new QrzSyncEngine(api);
 
         await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
@@ -512,7 +528,11 @@ public sealed class QrzSyncEngineTests
         var remote = MakeRemoteQso("W1AW", BaseTime, Band._20M, Mode.Ft8, "700");
         remote.Notes = "Remote copy";
 
-        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var api = new FakeQrzLogbookApi
+        {
+            FetchResult = [remote],
+            UpdateFunc = qso => qso.QrzLogid,
+        };
         var engine = new QrzSyncEngine(api);
 
         var result = await engine.ExecuteSyncAsync(
@@ -542,7 +562,11 @@ public sealed class QrzSyncEngineTests
         var remote = MakeRemoteQso("W1AW", BaseTime, Band._20M, Mode.Ft8, "LOG-REMOTE-NEW");
         remote.Notes = "remote authoritative";
 
-        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var api = new FakeQrzLogbookApi
+        {
+            FetchResult = [remote],
+            UpdateFunc = qso => qso.QrzLogid,
+        };
         var engine = new QrzSyncEngine(api);
 
         var result = await engine.ExecuteSyncAsync(
@@ -557,7 +581,7 @@ public sealed class QrzSyncEngineTests
     }
 
     [Fact]
-    public async Task Merge_flag_for_review_preserves_local_and_marks_conflict()
+    public async Task Merge_flag_for_review_pushes_qrz_linked_local_edit_before_remote_can_conflict()
     {
         var store = CreateStore();
         var local = MakeLocalQso("W1AW", BaseTime, Band._20M, Mode.Ft8, SyncStatus.Modified);
@@ -568,7 +592,11 @@ public sealed class QrzSyncEngineTests
         var remote = MakeRemoteQso("W1AW", BaseTime, Band._20M, Mode.Ft8, "800");
         remote.Notes = "Remote that should NOT win";
 
-        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var api = new FakeQrzLogbookApi
+        {
+            FetchResult = [remote],
+            UpdateFunc = qso => qso.QrzLogid,
+        };
         var engine = new QrzSyncEngine(api);
 
         var result = await engine.ExecuteSyncAsync(
@@ -576,16 +604,18 @@ public sealed class QrzSyncEngineTests
             fullSync: true,
             ConflictPolicy.FlagForReview);
 
-        Assert.Equal(1u, result.ConflictCount);
+        Assert.Equal(0u, result.ConflictCount);
+        Assert.Equal(1u, result.UploadedCount);
+        Assert.Single(api.UpdatedQsos);
         var all = await store.Logbook.ListQsosAsync(new QsoListQuery());
         Assert.Single(all);
         Assert.Equal("Local operator edit", all[0].Notes);
-        Assert.Equal(SyncStatus.Conflict, all[0].SyncStatus);
+        Assert.Equal(SyncStatus.Synced, all[0].SyncStatus);
         Assert.Equal("800", all[0].QrzLogid);
     }
 
     [Fact]
-    public async Task Merge_unspecified_policy_defaults_to_flag_for_review()
+    public async Task Merge_unspecified_policy_pushes_qrz_linked_local_edit_before_remote_can_conflict()
     {
         var store = CreateStore();
         var local = MakeLocalQso("W1AW", BaseTime, Band._20M, Mode.Ft8, SyncStatus.Modified);
@@ -596,7 +626,11 @@ public sealed class QrzSyncEngineTests
         var remote = MakeRemoteQso("W1AW", BaseTime, Band._20M, Mode.Ft8, "900");
         remote.Notes = "Remote copy";
 
-        var api = new FakeQrzLogbookApi { FetchResult = [remote] };
+        var api = new FakeQrzLogbookApi
+        {
+            FetchResult = [remote],
+            UpdateFunc = qso => qso.QrzLogid,
+        };
         var engine = new QrzSyncEngine(api);
 
         // Unspecified must act like FlagForReview per engine spec §6.3.
@@ -605,10 +639,11 @@ public sealed class QrzSyncEngineTests
             fullSync: true,
             ConflictPolicy.Unspecified);
 
-        Assert.Equal(1u, result.ConflictCount);
+        Assert.Equal(0u, result.ConflictCount);
+        Assert.Equal(1u, result.UploadedCount);
         var all = await store.Logbook.ListQsosAsync(new QsoListQuery());
         Assert.Equal("Local edit", all[0].Notes);
-        Assert.Equal(SyncStatus.Conflict, all[0].SyncStatus);
+        Assert.Equal(SyncStatus.Synced, all[0].SyncStatus);
     }
 
     [Fact]
@@ -905,6 +940,73 @@ public sealed class QrzSyncEngineTests
         Assert.Empty(api.UploadReplacedQsos);
     }
 
+    [Fact]
+    public async Task FullSync_pushes_modified_qrz_linked_local_correction_before_stale_remote_can_conflict()
+    {
+        var store = CreateStore();
+        var local = MakeLocalQso("W1AW/0", BaseTime, Band._20M, Mode.Ft8, SyncStatus.Modified);
+        local.QrzLogid = "stale-qrz-logid";
+        await store.Logbook.InsertQsoAsync(local);
+
+        var staleRemote = MakeRemoteQso("W1AW/1", BaseTime, Band._20M, Mode.Ft8, "stale-qrz-logid");
+        var api = new FakeQrzLogbookApi
+        {
+            FetchResult = [staleRemote],
+            UpdateLogid = "stale-qrz-logid",
+        };
+
+        var engine = new QrzSyncEngine(api);
+        var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
+
+        Assert.Null(result.ErrorSummary);
+        Assert.Equal(1u, result.UploadedCount);
+        Assert.Equal(0u, result.ConflictCount);
+        Assert.Single(api.UpdatedQsos);
+        Assert.Equal("W1AW/0", api.UpdatedQsos[0].WorkedCallsign);
+
+        var all = await store.Logbook.ListQsosAsync(new QsoListQuery());
+        var saved = Assert.Single(all);
+        Assert.Equal("W1AW/0", saved.WorkedCallsign);
+        Assert.Equal(SyncStatus.Synced, saved.SyncStatus);
+        Assert.Equal("stale-qrz-logid", saved.QrzLogid);
+    }
+
+    [Fact]
+    public async Task FullSync_pushes_all_modified_qrz_linked_rows_so_stale_qrz_entries_are_resolved()
+    {
+        var store = CreateStore();
+        var first = MakeLocalQso("W1AW/0", BaseTime, Band._20M, Mode.Ft8, SyncStatus.Modified);
+        first.QrzLogid = "qrz-1";
+        var second = MakeLocalQso("K7ABC", BaseTime.AddMinutes(1), Band._40M, Mode.Cw, SyncStatus.Modified);
+        second.QrzLogid = "qrz-2";
+        await store.Logbook.InsertQsoAsync(first);
+        await store.Logbook.InsertQsoAsync(second);
+
+        var staleFirst = MakeRemoteQso("W1AW/1", BaseTime, Band._20M, Mode.Ft8, "qrz-1");
+        var staleSecond = MakeRemoteQso("K7OLD", BaseTime.AddMinutes(1), Band._40M, Mode.Cw, "qrz-2");
+        var api = new FakeQrzLogbookApi
+        {
+            FetchResult = [staleFirst, staleSecond],
+            UpdateFunc = qso => qso.QrzLogid,
+        };
+
+        var engine = new QrzSyncEngine(api);
+        var result = await engine.ExecuteSyncAsync(store.Logbook, fullSync: true);
+
+        Assert.Null(result.ErrorSummary);
+        Assert.Equal(2u, result.UploadedCount);
+        Assert.Equal(0u, result.ConflictCount);
+        Assert.Equal(2, api.UpdatedQsos.Count);
+        Assert.Contains(api.UpdatedQsos, qso => qso.WorkedCallsign == "W1AW/0");
+        Assert.Contains(api.UpdatedQsos, qso => qso.WorkedCallsign == "K7ABC");
+
+        var all = await store.Logbook.ListQsosAsync(new QsoListQuery());
+        Assert.All(all, qso => Assert.Equal(SyncStatus.Synced, qso.SyncStatus));
+        Assert.Contains(all, qso => qso.WorkedCallsign == "W1AW/0");
+        Assert.Contains(all, qso => qso.WorkedCallsign == "K7ABC");
+        Assert.DoesNotContain(all, qso => qso.WorkedCallsign is "W1AW/1" or "K7OLD");
+    }
+
     private static MemoryStorage CreateStore() => new();
 
     private static QsoRecord MakeRemoteQso(string callsign, DateTimeOffset timestamp, Band band, Mode mode, string? logid)
@@ -948,6 +1050,7 @@ public sealed class QrzSyncEngineTests
         public string UploadLogid { get; set; } = "12345";
         public string UpdateLogid { get; set; } = "12345";
         public Func<QsoRecord, Task<string>>? UploadFunc { get; set; }
+        public Func<QsoRecord, string>? UpdateFunc { get; set; }
         public List<QsoRecord> UploadedQsos { get; } = [];
         public List<QsoRecord> UpdatedQsos { get; } = [];
         public string? LastSinceDate { get; private set; }
@@ -987,7 +1090,7 @@ public sealed class QrzSyncEngineTests
         {
             UpdatedQsos.Add(qso);
             LastUpdateBookOwner = bookOwner;
-            return Task.FromResult(UpdateLogid);
+            return Task.FromResult(UpdateFunc?.Invoke(qso) ?? UpdateLogid);
         }
 
         /// <summary>Configurable STATUS owner. Empty string mimics QRZ omitting the field.</summary>

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzSyncEngine.cs
@@ -68,10 +68,6 @@ public sealed class QrzSyncEngine
         uint deletesSkippedRemote = 0;
         uint duplicateReplaces = 0;
 
-        // ---------------------------------------------------------------
-        // Phase 1 — Download from QRZ
-        // ---------------------------------------------------------------
-
         SyncMetadata metadata;
         try
         {
@@ -82,6 +78,54 @@ public sealed class QrzSyncEngine
             metadata = new SyncMetadata();
             errors.Add($"Failed to read sync metadata: {ex.Message}");
         }
+
+        // ---------------------------------------------------------------
+        // Phase 0.5 — Resolve owner and push local corrections first
+        // ---------------------------------------------------------------
+        // Under the default safe conflict policy, a stale QRZ copy of a locally
+        // modified row would otherwise be downloaded first and mark the row
+        // Conflict before Phase 2 can upload it. Push QRZ-linked local edits
+        // before download so F6 sync updates the existing QRZ row.
+
+        QrzLogbookStatus? statusResult = null;
+        Exception? statusException = null;
+        try
+        {
+            statusResult = await _client.GetStatusAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            statusException = ex;
+        }
+
+        string? bookOwner = null;
+        if (statusResult is { } sr && !string.IsNullOrWhiteSpace(sr.Owner))
+        {
+            bookOwner = sr.Owner.Trim();
+        }
+        else if (!string.IsNullOrWhiteSpace(metadata.QrzLogbookOwner))
+        {
+            // STATUS failed or returned no owner — fall back to the cached
+            // owner so QSOs can still upload after a transient API hiccup.
+            bookOwner = metadata.QrzLogbookOwner;
+        }
+
+        var freshlyUploadedLogids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (effectivePolicy != ConflictPolicy.LastWriteWins)
+        {
+            var preUpload = await UploadPendingQsosAsync(
+                store,
+                bookOwner,
+                q => q.SyncStatus == SyncStatus.Modified && !string.IsNullOrWhiteSpace(q.QrzLogid),
+                errors).ConfigureAwait(false);
+            uploaded += preUpload.Uploaded;
+            duplicateReplaces += preUpload.DuplicateReplaces;
+            freshlyUploadedLogids.UnionWith(preUpload.UploadedLogids);
+        }
+
+        // ---------------------------------------------------------------
+        // Phase 1 — Download from QRZ
+        // ---------------------------------------------------------------
 
         IReadOnlyList<QsoRecord> localQsosAll;
         try
@@ -150,6 +194,15 @@ public sealed class QrzSyncEngine
             }
 
             var remoteLogid = ExtractQrzLogid(remote);
+
+            // If this sync just pushed the local correction to QRZ, ignore a
+            // stale remote copy returned by the same FETCH response. QRZ may
+            // lag briefly after REPLACE; local storage already reflects the
+            // operator's corrected record.
+            if (remoteLogid is not null && freshlyUploadedLogids.Contains(remoteLogid))
+            {
+                continue;
+            }
 
             // Phase 1 skip: don't resurrect soft-deleted local rows.
             if (remoteLogid is not null && deletedLogids.Contains(remoteLogid))
@@ -228,100 +281,16 @@ public sealed class QrzSyncEngine
         }
 
         // ---------------------------------------------------------------
-        // Phase 1.5 — Resolve the QRZ logbook owner callsign
-        // ---------------------------------------------------------------
-        // Fetch STATUS once, before upload, so we can rewrite the
-        // STATION_CALLSIGN of QSOs logged under a previous callsign
-        // (issue #337). The same result is reused in Phase 3 for metadata
-        // refresh, avoiding a second STATUS round-trip per sync.
-
-        QrzLogbookStatus? statusResult = null;
-        Exception? statusException = null;
-        try
-        {
-            statusResult = await _client.GetStatusAsync().ConfigureAwait(false);
-        }
-        catch (Exception ex)
-        {
-            statusException = ex;
-        }
-
-        string? bookOwner = null;
-        if (statusResult is { } sr && !string.IsNullOrWhiteSpace(sr.Owner))
-        {
-            bookOwner = sr.Owner.Trim();
-        }
-        else if (!string.IsNullOrWhiteSpace(metadata.QrzLogbookOwner))
-        {
-            // STATUS failed or returned no owner — fall back to the cached
-            // owner so QSOs can still upload after a transient API hiccup.
-            bookOwner = metadata.QrzLogbookOwner;
-        }
-
-        // ---------------------------------------------------------------
         // Phase 2 — Upload pending local QSOs
         // ---------------------------------------------------------------
 
-        IReadOnlyList<QsoRecord> pendingQsos;
-        try
-        {
-            var allQsos = await store.ListQsosAsync(new QsoListQuery { Sort = QsoSortOrder.OldestFirst }).ConfigureAwait(false);
-            pendingQsos = allQsos
-                .Where(q => q.SyncStatus is SyncStatus.LocalOnly or SyncStatus.Modified)
-                .ToList();
-        }
-        catch (Exception ex)
-        {
-            errors.Add($"Failed to list pending QSOs for upload: {ex.Message}");
-            pendingQsos = [];
-        }
-
-        foreach (var qso in pendingQsos)
-        {
-            try
-            {
-                string logid;
-                var hasExistingLogid = !string.IsNullOrWhiteSpace(qso.QrzLogid);
-
-                if (qso.SyncStatus == SyncStatus.Modified && hasExistingLogid)
-                {
-                    logid = await _client.UpdateQsoAsync(qso, bookOwner).ConfigureAwait(false);
-                }
-                else
-                {
-                    try
-                    {
-                        logid = await _client.UploadQsoAsync(qso, bookOwner).ConfigureAwait(false);
-                    }
-                    catch (QrzLogbookException ex) when (!hasExistingLogid && IsDuplicateError(ex.Message))
-                    {
-                        // QSO already exists on QRZ (e.g. uploaded via web UI) but we
-                        // don't have the logid locally. Retry with OPTION=REPLACE to
-                        // auto-match and adopt the remote logid.
-                        logid = await _client.UploadQsoWithReplaceAsync(qso, bookOwner).ConfigureAwait(false);
-                        duplicateReplaces++;
-                    }
-                }
-
-                var synced = qso.Clone();
-                synced.QrzLogid = logid;
-                synced.SyncStatus = SyncStatus.Synced;
-                try
-                {
-                    await store.UpdateQsoAsync(synced).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    errors.Add($"Upload succeeded for {qso.WorkedCallsign} but local update failed: {ex.Message}");
-                }
-
-                uploaded++;
-            }
-            catch (Exception ex)
-            {
-                errors.Add($"Upload failed for {qso.WorkedCallsign}: {ex.Message}");
-            }
-        }
+        var pendingUpload = await UploadPendingQsosAsync(
+            store,
+            bookOwner,
+            q => q.SyncStatus is SyncStatus.LocalOnly or SyncStatus.Modified,
+            errors).ConfigureAwait(false);
+        uploaded += pendingUpload.Uploaded;
+        duplicateReplaces += pendingUpload.DuplicateReplaces;
 
         // ---------------------------------------------------------------
         // Phase 2.5 — Push queued remote deletes to QRZ
@@ -442,6 +411,84 @@ public sealed class QrzSyncEngine
             DeletesSkippedRemote = deletesSkippedRemote,
             DuplicateReplaceCount = duplicateReplaces,
         };
+    }
+
+    private sealed record UploadPassResult(
+        uint Uploaded,
+        uint DuplicateReplaces,
+        HashSet<string> UploadedLogids);
+
+    private async Task<UploadPassResult> UploadPendingQsosAsync(
+        ILogbookStore store,
+        string? bookOwner,
+        Func<QsoRecord, bool> shouldUpload,
+        List<string> errors)
+    {
+        IReadOnlyList<QsoRecord> pendingQsos;
+        try
+        {
+            var allQsos = await store.ListQsosAsync(new QsoListQuery { Sort = QsoSortOrder.OldestFirst }).ConfigureAwait(false);
+            pendingQsos = allQsos.Where(shouldUpload).ToList();
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"Failed to list pending QSOs for upload: {ex.Message}");
+            pendingQsos = [];
+        }
+
+        uint uploaded = 0;
+        uint duplicateReplaces = 0;
+        var uploadedLogids = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var qso in pendingQsos)
+        {
+            try
+            {
+                string logid;
+                var hasExistingLogid = !string.IsNullOrWhiteSpace(qso.QrzLogid);
+
+                if (qso.SyncStatus == SyncStatus.Modified && hasExistingLogid)
+                {
+                    logid = await _client.UpdateQsoAsync(qso, bookOwner).ConfigureAwait(false);
+                }
+                else
+                {
+                    try
+                    {
+                        logid = await _client.UploadQsoAsync(qso, bookOwner).ConfigureAwait(false);
+                    }
+                    catch (QrzLogbookException ex) when (!hasExistingLogid && IsDuplicateError(ex.Message))
+                    {
+                        // QSO already exists on QRZ (e.g. uploaded via web UI) but we
+                        // don't have the logid locally. Retry with OPTION=REPLACE to
+                        // auto-match and adopt the remote logid.
+                        logid = await _client.UploadQsoWithReplaceAsync(qso, bookOwner).ConfigureAwait(false);
+                        duplicateReplaces++;
+                    }
+                }
+
+                var synced = qso.Clone();
+                synced.QrzLogid = logid;
+                synced.SyncStatus = SyncStatus.Synced;
+                try
+                {
+                    await store.UpdateQsoAsync(synced).ConfigureAwait(false);
+                    uploadedLogids.Add(logid);
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"Upload succeeded for {qso.WorkedCallsign} but local update failed: {ex.Message}");
+                }
+
+                uploaded++;
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"Upload failed for {qso.WorkedCallsign}: {ex.Message}");
+            }
+        }
+
+        return new UploadPassResult(uploaded, duplicateReplaces, uploadedLogids);
     }
 
     // -- Matching helpers ---------------------------------------------------

--- a/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
@@ -79,6 +79,47 @@ public sealed class MainWindowViewModelTests
         Assert.Contains("Last sync", viewModel.SyncStatusText, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task SyncNowShowsConflictCountWhenQrzDiffersFromLocal()
+    {
+        var engine = new FakeEngineClient
+        {
+            SyncResponse = new SyncWithQrzResponse
+            {
+                Complete = true,
+                UploadedRecords = 0,
+                DownloadedRecords = 0,
+                ConflictRecords = 1,
+            },
+        };
+        using var viewModel = new MainWindowViewModel(engine);
+
+        await viewModel.SyncNowCommand.ExecuteAsync(null);
+
+        Assert.Contains("conflict", viewModel.SyncStatusText, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("1", viewModel.SyncStatusText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task SyncNowShowsResolvedMismatchCountWhenQrzWasUpdated()
+    {
+        var engine = new FakeEngineClient
+        {
+            SyncResponse = new SyncWithQrzResponse
+            {
+                Complete = true,
+                UploadedRecords = 2,
+                DownloadedRecords = 0,
+                ConflictRecords = 0,
+            },
+        };
+        using var viewModel = new MainWindowViewModel(engine);
+
+        await viewModel.SyncNowCommand.ExecuteAsync(null);
+
+        Assert.Contains("↑2", viewModel.SyncStatusText, StringComparison.Ordinal);
+    }
+
     private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
@@ -125,6 +166,8 @@ public sealed class MainWindowViewModelTests
 
         public Task<GetSyncStatusResponse> SyncStatusTask { get; init; } = Task.FromResult(new GetSyncStatusResponse());
 
+        public SyncWithQrzResponse SyncResponse { get; init; } = new();
+
         public Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default) =>
             Task.FromResult(new GetSetupWizardStateResponse { Status = SetupStatus.Status ?? new SetupStatus() });
 
@@ -150,7 +193,7 @@ public sealed class MainWindowViewModelTests
             throw new NotImplementedException();
 
         public Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default) =>
-            Task.FromResult(new SyncWithQrzResponse());
+            Task.FromResult(SyncResponse);
 
         public Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default) =>
             SyncStatusTask;

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -369,7 +369,10 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 
             var up = response.UploadedRecords;
             var down = response.DownloadedRecords;
-            SyncStatusText = $"Synced: \u2191{up} \u2193{down}";
+            var conflicts = response.ConflictRecords;
+            SyncStatusText = conflicts > 0
+                ? $"Sync needs review: {conflicts} conflict{(conflicts == 1 ? string.Empty : "s")} (\u2191{up} \u2193{down})"
+                : $"Synced: \u2191{up} \u2193{down}";
             await RecentQsos.RefreshAsync();
             MarkEngineReachable();
         }

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -224,13 +224,15 @@ pub(crate) async fn execute_sync(
     };
 
     let Some(metadata) = download_phase(
-        client,
-        store,
-        &metadata,
-        full_sync,
-        conflict_policy,
-        &freshly_uploaded_logids,
-        progress_tx,
+        DownloadPhaseInput {
+            client,
+            store,
+            metadata: &metadata,
+            full_sync,
+            conflict_policy,
+            freshly_uploaded_logids: &freshly_uploaded_logids,
+            progress_tx,
+        },
         &mut counters,
     )
     .await
@@ -276,16 +278,30 @@ pub(crate) async fn execute_sync(
 // Phase 1 — Download from QRZ
 // ---------------------------------------------------------------------------
 
-async fn download_phase(
-    client: &dyn QrzLogbookApi,
-    store: &dyn LogbookStore,
-    metadata: &SyncMetadata,
+struct DownloadPhaseInput<'a> {
+    client: &'a dyn QrzLogbookApi,
+    store: &'a dyn LogbookStore,
+    metadata: &'a SyncMetadata,
     full_sync: bool,
     conflict_policy: ConflictPolicy,
-    freshly_uploaded_logids: &HashSet<String>,
-    progress_tx: &mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
+    freshly_uploaded_logids: &'a HashSet<String>,
+    progress_tx: &'a mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
+}
+
+async fn download_phase(
+    input: DownloadPhaseInput<'_>,
     counters: &mut SyncCounters,
 ) -> Option<SyncMetadata> {
+    let DownloadPhaseInput {
+        client,
+        store,
+        metadata,
+        full_sync,
+        conflict_policy,
+        freshly_uploaded_logids,
+        progress_tx,
+    } = input;
+
     send_progress(progress_tx, "Fetching QSOs from QRZ…", 0, 0, 0).await;
 
     // Load all local QSOs (including soft-deleted) so we can both match

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -184,17 +184,15 @@ pub(crate) async fn execute_sync(
 ) {
     let mut counters = SyncCounters::new();
 
-    let Some(metadata) = download_phase(
-        client,
-        store,
-        full_sync,
-        conflict_policy,
-        progress_tx,
-        &mut counters,
-    )
-    .await
-    else {
-        return;
+    let metadata = match store.get_sync_metadata().await {
+        Ok(m) => m,
+        Err(err) => {
+            eprintln!("[sync] Failed to read sync metadata: {err}");
+            counters
+                .errors
+                .push(format!("Failed to read sync metadata: {err}"));
+            SyncMetadata::default()
+        }
     };
 
     let status_result = client.fetch_status().await;
@@ -211,10 +209,40 @@ pub(crate) async fn execute_sync(
     .map(|s| s.trim().to_owned())
     .filter(|s| !s.is_empty());
 
+    let freshly_uploaded_logids = if conflict_policy == ConflictPolicy::LastWriteWins {
+        HashSet::new()
+    } else {
+        upload_phase(
+            client,
+            store,
+            book_owner.as_deref(),
+            UploadSelection::ModifiedWithLogid,
+            progress_tx,
+            &mut counters,
+        )
+        .await
+    };
+
+    let Some(metadata) = download_phase(
+        client,
+        store,
+        &metadata,
+        full_sync,
+        conflict_policy,
+        &freshly_uploaded_logids,
+        progress_tx,
+        &mut counters,
+    )
+    .await
+    else {
+        return;
+    };
+
     upload_phase(
         client,
         store,
         book_owner.as_deref(),
+        UploadSelection::Pending,
         progress_tx,
         &mut counters,
     )
@@ -251,20 +279,14 @@ pub(crate) async fn execute_sync(
 async fn download_phase(
     client: &dyn QrzLogbookApi,
     store: &dyn LogbookStore,
+    metadata: &SyncMetadata,
     full_sync: bool,
     conflict_policy: ConflictPolicy,
+    freshly_uploaded_logids: &HashSet<String>,
     progress_tx: &mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
     counters: &mut SyncCounters,
 ) -> Option<SyncMetadata> {
     send_progress(progress_tx, "Fetching QSOs from QRZ…", 0, 0, 0).await;
-
-    let metadata = match store.get_sync_metadata().await {
-        Ok(m) => m,
-        Err(err) => {
-            eprintln!("[sync] Failed to read sync metadata: {err}");
-            SyncMetadata::default()
-        }
-    };
 
     // Load all local QSOs (including soft-deleted) so we can both match
     // against active rows AND honor user intent: any remote row whose
@@ -341,6 +363,7 @@ async fn download_phase(
     process_remote_qsos(
         &remote_qsos,
         &deleted_logids,
+        freshly_uploaded_logids,
         by_qrz_logid,
         by_key,
         store,
@@ -349,7 +372,7 @@ async fn download_phase(
     )
     .await;
 
-    Some(metadata)
+    Some(metadata.clone())
 }
 
 /// Iterate downloaded remote QSOs, applying the soft-delete skip set, then
@@ -358,6 +381,7 @@ async fn download_phase(
 async fn process_remote_qsos(
     remote_qsos: &[QsoRecord],
     deleted_logids: &HashSet<String>,
+    freshly_uploaded_logids: &HashSet<String>,
     mut by_qrz_logid: LogidIndex,
     mut by_key: FuzzyIndex,
     store: &dyn LogbookStore,
@@ -373,6 +397,17 @@ async fn process_remote_qsos(
         }
 
         let remote_logid = extract_qrz_logid(remote);
+
+        // If this sync just pushed the local correction to QRZ, ignore a
+        // stale remote copy returned by the same FETCH response. QRZ may lag
+        // briefly after REPLACE; local storage already reflects the operator's
+        // corrected record.
+        if remote_logid
+            .as_deref()
+            .is_some_and(|logid| freshly_uploaded_logids.contains(logid))
+        {
+            continue;
+        }
 
         // Skip remote rows that match a soft-deleted local row. The user
         // intentionally trashed it; download must not resurrect it.
@@ -463,13 +498,23 @@ async fn insert_new_remote_qso(
 // Phase 2 — Upload pending local QSOs to QRZ
 // ---------------------------------------------------------------------------
 
+#[derive(Clone, Copy)]
+enum UploadSelection {
+    /// Local edits with QRZ identity that must be pushed before remote download
+    /// can classify the stale QRZ row as a conflict.
+    ModifiedWithLogid,
+    /// Normal pending upload pass after download/linking.
+    Pending,
+}
+
 async fn upload_phase(
     client: &dyn QrzLogbookApi,
     store: &dyn LogbookStore,
     book_owner: Option<&str>,
+    selection: UploadSelection,
     progress_tx: &mpsc::Sender<Result<SyncWithQrzResponse, Status>>,
     counters: &mut SyncCounters,
-) {
+) -> HashSet<String> {
     send_progress(
         progress_tx,
         "Uploading local QSOs to QRZ…",
@@ -482,10 +527,7 @@ async fn upload_phase(
     let pending_qsos: Vec<QsoRecord> = match store.list_qsos(&QsoListQuery::default()).await {
         Ok(qsos) => qsos
             .into_iter()
-            .filter(|q| {
-                q.sync_status == SyncStatus::LocalOnly as i32
-                    || q.sync_status == SyncStatus::Modified as i32
-            })
+            .filter(|q| should_upload_qso(q, selection))
             .collect(),
         Err(err) => {
             eprintln!("[sync] Failed to list pending QSOs for upload: {err}");
@@ -501,9 +543,15 @@ async fn upload_phase(
         pending_qsos.len()
     );
 
+    let mut uploaded_logids = HashSet::new();
     for qso in &pending_qsos {
         match sync_single_qso(client, store, qso, book_owner).await {
             Ok(outcome) => {
+                if let Some(logid) = outcome.qso.qrz_logid.as_deref() {
+                    if !logid.is_empty() {
+                        uploaded_logids.insert(logid.to_string());
+                    }
+                }
                 counters.uploaded += 1;
                 if outcome.was_duplicate_replace {
                     counters.duplicate_replaces += 1;
@@ -518,6 +566,24 @@ async fn upload_phase(
                     .errors
                     .push(format!("Upload failed for {}: {err}", qso.worked_callsign));
             }
+        }
+    }
+
+    uploaded_logids
+}
+
+fn should_upload_qso(qso: &QsoRecord, selection: UploadSelection) -> bool {
+    match selection {
+        UploadSelection::ModifiedWithLogid => {
+            qso.sync_status == SyncStatus::Modified as i32
+                && qso
+                    .qrz_logid
+                    .as_deref()
+                    .is_some_and(|logid| !logid.is_empty())
+        }
+        UploadSelection::Pending => {
+            qso.sync_status == SyncStatus::LocalOnly as i32
+                || qso.sync_status == SyncStatus::Modified as i32
         }
     }
 }
@@ -1548,6 +1614,82 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn full_sync_pushes_modified_qrz_linked_local_correction_before_stale_remote_can_conflict(
+    ) {
+        let store = MemoryStorage::new();
+        let mut local = make_qso("K7TEST", "W1AW/0", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        local.sync_status = SyncStatus::Modified as i32;
+        local.qrz_logid = Some("stale-qrz-logid".to_string());
+        store.insert_qso(&local).await.expect("insert local qso");
+
+        let mut stale_remote =
+            make_qso("K7TEST", "W1AW/1", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        stale_remote.qrz_logid = Some("stale-qrz-logid".to_string());
+        let api = MockQrzApi::new(Ok(vec![stale_remote]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::FlagForReview, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.uploaded_records, 1);
+        assert_eq!(final_msg.conflict_records, 0);
+        assert_eq!(api.replace_calls.lock().unwrap().len(), 1);
+
+        let saved = store
+            .list_qsos(&QsoListQuery::default())
+            .await
+            .expect("list qsos");
+        assert_eq!(saved.len(), 1);
+        assert_eq!(saved[0].worked_callsign, "W1AW/0");
+        assert_eq!(saved[0].sync_status, SyncStatus::Synced as i32);
+        assert_eq!(saved[0].qrz_logid.as_deref(), Some("stale-qrz-logid"));
+    }
+
+    #[tokio::test]
+    async fn full_sync_pushes_all_modified_qrz_linked_rows_so_stale_qrz_entries_are_resolved() {
+        let store = MemoryStorage::new();
+        let mut first = make_qso("K7TEST", "W1AW/0", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        first.sync_status = SyncStatus::Modified as i32;
+        first.qrz_logid = Some("qrz-1".to_string());
+        let mut second = make_qso("K7TEST", "K7ABC", Band::Band40m, Mode::Cw, 1_700_000_060);
+        second.sync_status = SyncStatus::Modified as i32;
+        second.qrz_logid = Some("qrz-2".to_string());
+        store.insert_qso(&first).await.expect("insert first qso");
+        store.insert_qso(&second).await.expect("insert second qso");
+
+        let mut stale_first = make_qso("K7TEST", "W1AW/1", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        stale_first.qrz_logid = Some("qrz-1".to_string());
+        let mut stale_second = make_qso("K7TEST", "K7OLD", Band::Band40m, Mode::Cw, 1_700_000_060);
+        stale_second.qrz_logid = Some("qrz-2".to_string());
+        let api = MockQrzApi::new(Ok(vec![stale_first, stale_second]), vec![]);
+
+        let (tx, rx) = mpsc::channel(16);
+        execute_sync(&api, &store, true, ConflictPolicy::FlagForReview, &tx).await;
+        drop(tx);
+
+        let final_msg = collect_final(rx).await;
+        assert!(final_msg.complete);
+        assert_eq!(final_msg.uploaded_records, 2);
+        assert_eq!(final_msg.conflict_records, 0);
+        assert_eq!(api.replace_calls.lock().unwrap().len(), 2);
+
+        let saved = store
+            .list_qsos(&QsoListQuery::default())
+            .await
+            .expect("list qsos");
+        assert_eq!(saved.len(), 2);
+        assert!(saved.iter().any(|qso| qso.worked_callsign == "W1AW/0"));
+        assert!(saved.iter().any(|qso| qso.worked_callsign == "K7ABC"));
+        assert!(saved
+            .iter()
+            .all(|qso| qso.sync_status == SyncStatus::Synced as i32));
+        assert!(!saved.iter().any(|qso| qso.worked_callsign == "W1AW/1"));
+        assert!(!saved.iter().any(|qso| qso.worked_callsign == "K7OLD"));
+    }
+
+    #[tokio::test]
     async fn execute_sync_falls_back_to_cached_owner_when_status_fails() {
         let store = MemoryStorage::new();
         store
@@ -1869,7 +2011,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn modified_local_marked_as_conflict_on_remote_match() {
+    async fn modified_local_with_qrz_logid_uploaded_before_remote_can_conflict() {
         let store = MemoryStorage::new();
 
         // Local QSO with MODIFIED status.
@@ -1893,12 +2035,12 @@ mod tests {
 
         let final_msg = collect_final(rx).await;
         assert!(final_msg.complete);
-        assert_eq!(final_msg.conflict_records, 1);
-        assert_eq!(final_msg.uploaded_records, 0);
+        assert_eq!(final_msg.conflict_records, 0);
+        assert_eq!(final_msg.uploaded_records, 1);
 
         let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
         assert_eq!(all.len(), 1);
-        assert_eq!(all[0].sync_status, SyncStatus::Conflict as i32);
+        assert_eq!(all[0].sync_status, SyncStatus::Synced as i32);
     }
 
     #[tokio::test]
@@ -2304,7 +2446,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn flag_for_review_does_not_overwrite_and_skips_upload() {
+    async fn flag_for_review_pushes_qrz_linked_local_edit_before_remote_can_conflict() {
         let store = MemoryStorage::new();
 
         // Local QSO: MODIFIED.
@@ -2330,7 +2472,6 @@ mod tests {
             q
         };
 
-        // No upload results — CONFLICT QSOs should not be uploaded.
         let api = MockQrzApi::new(Ok(vec![remote]), vec![]);
 
         let (tx, rx) = mpsc::channel(16);
@@ -2339,13 +2480,13 @@ mod tests {
 
         let final_msg = collect_final(rx).await;
         assert!(final_msg.complete);
-        assert_eq!(final_msg.conflict_records, 1);
+        assert_eq!(final_msg.conflict_records, 0);
         assert_eq!(final_msg.downloaded_records, 0);
-        assert_eq!(final_msg.uploaded_records, 0);
+        assert_eq!(final_msg.uploaded_records, 1);
 
         let all = store.list_qsos(&QsoListQuery::default()).await.unwrap();
         assert_eq!(all.len(), 1);
-        assert_eq!(all[0].sync_status, SyncStatus::Conflict as i32);
+        assert_eq!(all[0].sync_status, SyncStatus::Synced as i32);
         // Local data preserved, not overwritten by remote.
         assert_eq!(all[0].notes.as_deref(), Some("local version"));
     }


### PR DESCRIPTION
Fixes QRZ sync when a previously uploaded QSO is corrected locally.

The sync engines now push QRZ-linked modified rows before downloading remote rows, so a stale QRZ copy cannot turn a normal local correction into a conflict before upload. The same sync also ignores stale remote rows for log IDs it just replaced, which lets a full sync bring QRZ back in line with local records.

The GUI F6 status now reports conflict counts so users get a visible clue when QRZ/local differences require review.

Tests added for the stale local-correction path in both .NET and Rust, plus GUI sync status feedback. Updated the engine specification with the new pre-download correction phase.

Closes #386