### PR TITLE
Improve CW live region transcript copy

### DIFF
--- a/experiments/cw-decoder/src/harvest.rs
+++ b/experiments/cw-decoder/src/harvest.rs
@@ -883,7 +883,7 @@ fn append_stream_events(transcript: &mut String, events: Vec<StreamEvent>) {
         match ev {
             StreamEvent::Char { ch, .. } => transcript.push(ch),
             StreamEvent::Word => transcript.push(' '),
-            StreamEvent::Garbled { .. } => transcript.push('?'),
+            StreamEvent::Garbled { .. } => transcript.push('*'),
             StreamEvent::PitchUpdate { .. }
             | StreamEvent::PitchLost { .. }
             | StreamEvent::WpmUpdate { .. }

--- a/experiments/cw-decoder/src/main.rs
+++ b/experiments/cw-decoder/src/main.rs
@@ -11,6 +11,8 @@ use cw_decoder_poc::{
     preview, streaming, streaming_v2, synthetic_qso, tui,
 };
 
+const BAD_COPY_MARKER: char = '*';
+
 #[derive(Parser, Debug)]
 #[command(
     name = "cw-decoder",
@@ -1600,29 +1602,43 @@ fn run_region_bench_scenario(
     stable_n: usize,
     label: &str,
 ) -> bench_latency::BenchResult {
+    const REGION_BENCH_DECODE_EVERY_MS: u64 = 2000;
+
     let sr = scen.audio.sample_rate;
     let chunk_samples = ((sr as u64 * chunk_ms as u64) / 1000).max(1) as usize;
+    let decode_every_samples = ((sr as u64 * REGION_BENCH_DECODE_EVERY_MS) / 1000).max(1) as usize;
     let truth_upper = scen.truth.to_uppercase();
     let mut streamer = cw_decoder_poc::region_streamer::RegionStreamer::new(sr);
     let mut transcript = String::new();
     let mut char_times = Vec::new();
 
     let mut consumed = 0usize;
+    let mut last_decode_consumed = 0usize;
     while consumed < scen.audio.samples.len() {
         let end = (consumed + chunk_samples).min(scen.audio.samples.len());
         streamer.ingest(&scen.audio.samples[consumed..end]);
-        let t_ms = ((end as u64 * 1000) / sr as u64) as u32;
-        append_region_commits(
-            streamer.try_commit(),
-            t_ms,
-            &mut transcript,
-            &mut char_times,
-        );
+        if end.saturating_sub(last_decode_consumed) >= decode_every_samples {
+            last_decode_consumed = end;
+            let t_ms = ((end as u64 * 1000) / sr as u64) as u32;
+            let _ = streamer.try_commit();
+            sync_region_visible_snapshot(
+                &streamer.transcript_with_provisional(),
+                t_ms,
+                &mut transcript,
+                &mut char_times,
+            );
+        }
         consumed = end;
     }
 
     let t_end = ((scen.audio.samples.len() as u64 * 1000) / sr as u64) as u32;
-    append_region_commits(streamer.flush(), t_end, &mut transcript, &mut char_times);
+    let _ = streamer.flush();
+    sync_region_visible_snapshot(
+        streamer.transcript(),
+        t_end,
+        &mut transcript,
+        &mut char_times,
+    );
 
     let mut result = bench_latency::BenchResult {
         scenario: scen.name.clone(),
@@ -1653,24 +1669,29 @@ fn run_region_bench_scenario(
     result
 }
 
-fn append_region_commits(
-    commits: Vec<cw_decoder_poc::region_streamer::CommittedRegion>,
+fn sync_region_visible_snapshot(
+    snapshot: &str,
     t_ms: u32,
     transcript: &mut String,
     char_times: &mut Vec<u32>,
 ) {
-    for commit in commits {
-        let text = commit.text.trim();
-        if text.is_empty() {
-            continue;
-        }
-        if !transcript.is_empty() {
-            transcript.push(' ');
-            char_times.push(t_ms);
-        }
-        transcript.push_str(text);
-        char_times.extend(std::iter::repeat_n(t_ms, text.chars().count()));
+    let snapshot = snapshot.trim();
+    if snapshot.is_empty() {
+        return;
     }
+
+    let common_prefix = transcript
+        .chars()
+        .zip(snapshot.chars())
+        .take_while(|(old, new)| old == new)
+        .count();
+    let new_len = snapshot.chars().count();
+    char_times.truncate(common_prefix);
+    char_times.extend(std::iter::repeat_n(
+        t_ms,
+        new_len.saturating_sub(common_prefix),
+    ));
+    *transcript = snapshot.to_string();
 }
 
 fn select_region_effective_text(region_text: &str, append_text: &str) -> String {
@@ -2555,7 +2576,7 @@ fn emit_decoder_events(
         match &ev {
             streaming::StreamEvent::Char { ch, .. } => transcript.push(*ch),
             streaming::StreamEvent::Word => transcript.push(' '),
-            streaming::StreamEvent::Garbled { .. } => transcript.push('?'),
+            streaming::StreamEvent::Garbled { .. } => transcript.push(BAD_COPY_MARKER),
             _ => {}
         }
         if let Some(em) = emitter.as_deref_mut() {
@@ -2729,7 +2750,7 @@ fn run_stream_file(
                 match &ev {
                     streaming::StreamEvent::Char { ch, .. } => transcript.push(*ch),
                     streaming::StreamEvent::Word => transcript.push(' '),
-                    streaming::StreamEvent::Garbled { .. } => transcript.push('?'),
+                    streaming::StreamEvent::Garbled { .. } => transcript.push(BAD_COPY_MARKER),
                     _ => {}
                 }
                 continue;
@@ -2783,7 +2804,7 @@ fn run_stream_file(
                 streaming::StreamEvent::Garbled {
                     morse, pitch_hz, ..
                 } => {
-                    transcript.push('?');
+                    transcript.push(BAD_COPY_MARKER);
                     if !quiet {
                         let pitch_suffix = pitch_hz
                             .map(|hz| format!("  @{hz:>6.1} Hz"))
@@ -2818,7 +2839,7 @@ fn run_stream_file(
         }
         match ev {
             streaming::StreamEvent::Char { ch, .. } => transcript.push(ch),
-            streaming::StreamEvent::Garbled { .. } => transcript.push('?'),
+            streaming::StreamEvent::Garbled { .. } => transcript.push(BAD_COPY_MARKER),
             _ => {}
         }
     }
@@ -3589,7 +3610,7 @@ fn run_stream_live(
                 match &ev {
                     streaming::StreamEvent::Char { ch, .. } => transcript.push(*ch),
                     streaming::StreamEvent::Word => transcript.push(' '),
-                    streaming::StreamEvent::Garbled { .. } => transcript.push('?'),
+                    streaming::StreamEvent::Garbled { .. } => transcript.push(BAD_COPY_MARKER),
                     _ => {}
                 }
                 continue;
@@ -3629,7 +3650,7 @@ fn run_stream_live(
                 streaming::StreamEvent::Garbled {
                     morse, pitch_hz, ..
                 } => {
-                    transcript.push('?');
+                    transcript.push(BAD_COPY_MARKER);
                     let pitch_suffix = pitch_hz
                         .map(|hz| format!("  @{hz:>6.1} Hz"))
                         .unwrap_or_default();
@@ -4726,16 +4747,16 @@ fn run_stream_live_v3(
         let mut region_text_full = String::new();
         if let Some(r) = region_streamer.as_mut() {
             if continuous_append_mode_active(&best_region_effective_text) {
-                region_text_full = r.transcript().to_string();
+                region_text_full = r.transcript_with_provisional();
             } else if last_drain_at.saturating_sub(last_region_decode_written)
                 >= region_decode_every_samples
             {
                 last_region_decode_written = last_drain_at;
                 region_commits = r.try_commit();
                 r.trim_committed(region_keep_back_s);
-                region_text_full = r.transcript().to_string();
+                region_text_full = r.transcript_with_provisional();
             } else {
-                region_text_full = r.transcript().to_string();
+                region_text_full = r.transcript_with_provisional();
             }
         }
         let region_appended: String = region_commits
@@ -4793,6 +4814,9 @@ fn run_stream_live_v3(
         } else {
             append.decoded_text.clone()
         };
+        if use_region && eff_text.is_empty() {
+            eff_text = snap.transcript.clone();
+        }
         if use_region && !best_region_effective_text.is_empty() {
             eff_text = select_region_effective_text(&eff_text, &best_region_effective_text);
         }
@@ -5107,15 +5131,15 @@ fn run_stream_live_v3_file(
         let mut region_text_full = String::new();
         if let Some(r) = region_streamer.as_mut() {
             if continuous_append_mode_active(&best_region_effective_text) {
-                region_text_full = r.transcript().to_string();
+                region_text_full = r.transcript_with_provisional();
             } else if cursor.saturating_sub(last_region_decode_cursor)
                 >= region_decode_every_samples
             {
                 last_region_decode_cursor = cursor;
                 let _ = r.try_commit();
-                region_text_full = r.transcript().to_string();
+                region_text_full = r.transcript_with_provisional();
             } else {
-                region_text_full = r.transcript().to_string();
+                region_text_full = r.transcript_with_provisional();
             }
         }
         // Approach A+: drive the event-driven commit cursor instead of
@@ -5167,6 +5191,9 @@ fn run_stream_live_v3_file(
         } else {
             append.decoded_text.clone()
         };
+        if use_region && eff_text.is_empty() {
+            eff_text = snap.transcript.clone();
+        }
         if use_region && !best_region_effective_text.is_empty() {
             eff_text = select_region_effective_text(&eff_text, &best_region_effective_text);
         }
@@ -5408,7 +5435,8 @@ fn run_stream_region_file(
             last_decode_cursor = cursor;
             let committed = streamer.try_commit();
             let t = started.elapsed().as_secs_f32();
-            emit_region_transcript(emitter.as_mut(), t, streamer.transcript(), &committed);
+            let transcript = streamer.transcript_with_provisional();
+            emit_region_transcript(emitter.as_mut(), t, &transcript, &committed);
         }
 
         if realtime {
@@ -5717,6 +5745,31 @@ mod v3_session_transcript_tests {
             select_region_effective_text("IHU NVCHU", "IHU"),
             "IHU NVCHU"
         );
+    }
+
+    #[test]
+    fn region_visible_snapshot_preserves_early_prefix_times() {
+        let mut transcript = String::new();
+        let mut times = Vec::new();
+        sync_region_visible_snapshot("FF ? BK DE A", 2_000, &mut transcript, &mut times);
+        sync_region_visible_snapshot("FF ? BK DE @7", 4_000, &mut transcript, &mut times);
+
+        assert_eq!(transcript, "FF ? BK DE @7");
+        let prefix_len = "FF ? BK DE ".chars().count();
+        assert!(times.iter().take(prefix_len).all(|t| *t == 2_000));
+        assert!(times.iter().skip(prefix_len).all(|t| *t == 4_000));
+    }
+
+    #[test]
+    fn region_visible_snapshot_truncates_revised_shorter_copy() {
+        let mut transcript = String::new();
+        let mut times = Vec::new();
+        sync_region_visible_snapshot("FF ? BK DE AC7", 2_000, &mut transcript, &mut times);
+        sync_region_visible_snapshot("FF ? BK", 4_000, &mut transcript, &mut times);
+
+        assert_eq!(transcript, "FF ? BK");
+        assert_eq!(times.len(), transcript.chars().count());
+        assert!(times.iter().all(|t| *t == 2_000));
     }
 
     fn make_snapshot(

--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -16,6 +16,7 @@
 //! buffer.
 
 use crate::decoder::{decode_text, decode_text_pinned};
+use crate::preprocess::bandpass_in_place;
 
 const BAD_COPY_MARKER: char = '*';
 const DIT_DAH_BOUNDARY: f32 = 2.0;
@@ -139,6 +140,7 @@ pub fn decode_region_stream(
 struct RegionCandidate {
     start_s: f32,
     end_s: f32,
+    pitch_hz: f32,
     text: String,
     score: f32,
 }
@@ -186,22 +188,124 @@ fn collect_region_candidates(
             continue;
         }
         let slice = &samples[s..e];
-        let text = decode_region_slice(slice, sample_rate, pitch_hz, cfg);
+        let interval = decode_region_slice_from_intervals(slice, sample_rate, pitch_hz, cfg);
+        let text =
+            decode_region_slice_with_interval(slice, sample_rate, pitch_hz, cfg, interval.as_ref());
         let text = trim_leading_voice_like_prefix(text.trim());
-        if text.is_empty() || is_low_confidence_region_text(&text) {
-            continue;
+        maybe_push_region_candidate(
+            candidates,
+            RegionCandidateInput {
+                start_s,
+                end_s,
+                pitch_hz,
+                text: text.clone(),
+                prominence,
+                evidence,
+                cfg,
+            },
+        );
+
+        if let Some(interval) = interval {
+            let interval_text = trim_leading_voice_like_prefix(interval.text.trim());
+            if should_keep_pitch_isolated_candidate(&text, &interval_text) {
+                maybe_push_region_candidate(
+                    candidates,
+                    RegionCandidateInput {
+                        start_s,
+                        end_s,
+                        pitch_hz,
+                        text: interval_text,
+                        prominence,
+                        evidence,
+                        cfg,
+                    },
+                );
+            }
         }
-        if !evidence.passes(cfg) && !is_short_distinctive_cw_text(&text) {
-            continue;
+
+        let focused_text = trim_leading_voice_like_prefix(
+            pitch_focused_decode_text(slice, sample_rate, pitch_hz).trim(),
+        );
+        if should_keep_pitch_isolated_candidate(&text, &focused_text) {
+            maybe_push_region_candidate(
+                candidates,
+                RegionCandidateInput {
+                    start_s,
+                    end_s,
+                    pitch_hz,
+                    text: focused_text,
+                    prominence,
+                    evidence,
+                    cfg,
+                },
+            );
         }
-        let useful_chars = text.chars().filter(|ch| ch.is_ascii_alphanumeric()).count() as f32;
-        candidates.push(RegionCandidate {
-            start_s,
-            end_s,
-            text,
-            score: prominence * (1.0 + useful_chars * 0.05),
-        });
     }
+}
+
+struct RegionCandidateInput<'a> {
+    start_s: f32,
+    end_s: f32,
+    pitch_hz: f32,
+    text: String,
+    prominence: f32,
+    evidence: CwWaveformEvidence,
+    cfg: &'a RegionStreamConfig,
+}
+
+fn maybe_push_region_candidate(
+    candidates: &mut Vec<RegionCandidate>,
+    input: RegionCandidateInput<'_>,
+) {
+    if input.text.is_empty() || is_low_confidence_region_text(&input.text) {
+        return;
+    }
+    if !input.evidence.passes(input.cfg) && !is_short_distinctive_cw_text(&input.text) {
+        return;
+    }
+    candidates.push(RegionCandidate {
+        start_s: input.start_s,
+        end_s: input.end_s,
+        pitch_hz: input.pitch_hz,
+        score: region_candidate_score(input.prominence, &input.text),
+        text: input.text,
+    });
+}
+
+fn should_keep_pitch_isolated_candidate(primary: &str, isolated: &str) -> bool {
+    let primary = normalize_region_text(primary);
+    let isolated = normalize_region_text(isolated);
+    if isolated.is_empty() || isolated == primary {
+        return false;
+    }
+
+    let isolated_chars = useful_copy_chars(&isolated);
+    if isolated_chars < 3 {
+        return false;
+    }
+
+    let primary_score = transcript_quality_score(&primary);
+    let isolated_score = transcript_quality_score(&isolated);
+    let isolated_has_strong_anchor = !has_no_strong_qso_anchor(&isolated);
+    isolated_has_strong_anchor
+        && (isolated_score > primary_score + 1.0
+            || (primary.contains(BAD_COPY_MARKER) && !isolated.contains(BAD_COPY_MARKER))
+            || (!has_transcript_start_anchor(&primary) && isolated_score >= primary_score - 0.5))
+}
+
+fn pitch_focused_decode_text(samples: &[f32], sample_rate: u32, pitch_hz: f32) -> String {
+    if samples.is_empty() || sample_rate == 0 || !pitch_hz.is_finite() || pitch_hz <= 0.0 {
+        return String::new();
+    }
+
+    let mut focused = samples.to_vec();
+    bandpass_in_place(&mut focused, sample_rate, pitch_hz, 100.0);
+    decode_text(&focused, sample_rate)
+}
+
+fn region_candidate_score(prominence: f32, text: &str) -> f32 {
+    let useful_chars = text.chars().filter(|ch| ch.is_ascii_alphanumeric()).count() as f32;
+    prominence * (1.0 + useful_chars * 0.05)
 }
 
 fn is_low_confidence_region_text(text: &str) -> bool {
@@ -280,32 +384,46 @@ pub(crate) fn has_transcript_start_anchor(text: &str) -> bool {
         matches!(token, "CQ" | "DE" | "K" | "BK" | "AR" | "+")
             || token.chars().any(|ch| ch.is_ascii_digit())
             || is_callsign_token(token)
+            || token == "IHU"
             || (token.len() >= 3
                 && token
                     .chars()
-                    .any(|ch| ch.is_ascii_alphabetic() && !"ETIANMOSH".contains(ch)))
+                    .filter(|ch| ch.is_ascii_alphabetic() && !"ETIANMOSH".contains(*ch))
+                    .count()
+                    >= 2)
     })
 }
 
+#[cfg(test)]
 fn decode_region_slice(
     samples: &[f32],
     sample_rate: u32,
     pitch_hz: f32,
     cfg: &RegionStreamConfig,
 ) -> String {
+    let interval = decode_region_slice_from_intervals(samples, sample_rate, pitch_hz, cfg);
+    decode_region_slice_with_interval(samples, sample_rate, pitch_hz, cfg, interval.as_ref())
+}
+
+fn decode_region_slice_with_interval(
+    samples: &[f32],
+    sample_rate: u32,
+    pitch_hz: f32,
+    cfg: &RegionStreamConfig,
+    interval: Option<&IntervalDecode>,
+) -> String {
     if let Some(w) = cfg.pin_wpm {
         return decode_text_pinned(samples, sample_rate, w);
     }
 
     let auto = decode_text(samples, sample_rate);
-    if let Some(interval) = decode_region_slice_from_intervals(samples, sample_rate, pitch_hz, cfg)
-    {
+    if let Some(interval) = interval {
         if let Some(spaced) = best_timing_spacing_overlay(&auto, samples, sample_rate, interval.wpm)
         {
             return spaced;
         }
         if should_prefer_interval_decode(&auto, &interval.text) {
-            return interval.text;
+            return interval.text.clone();
         }
     }
 
@@ -1187,6 +1305,11 @@ fn dedupe_region_candidates(mut candidates: Vec<RegionCandidate>) -> Vec<Decoded
             .partial_cmp(&b.start_s)
             .unwrap_or(std::cmp::Ordering::Equal)
             .then_with(|| {
+                a.pitch_hz
+                    .partial_cmp(&b.pitch_hz)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .then_with(|| {
                 b.score
                     .partial_cmp(&a.score)
                     .unwrap_or(std::cmp::Ordering::Equal)
@@ -1194,19 +1317,33 @@ fn dedupe_region_candidates(mut candidates: Vec<RegionCandidate>) -> Vec<Decoded
     });
     let mut chosen: Vec<RegionCandidate> = Vec::new();
     for candidate in candidates {
-        if let Some(last) = chosen.last_mut() {
-            let overlap =
-                (last.end_s.min(candidate.end_s) - last.start_s.max(candidate.start_s)).max(0.0);
-            let min_len = (last.end_s - last.start_s).min(candidate.end_s - candidate.start_s);
-            if min_len > 0.0 && overlap / min_len >= 0.45 {
-                if candidate.score > last.score {
-                    *last = candidate;
-                }
-                continue;
+        let mut redundant_idx = None;
+        for (idx, existing) in chosen.iter().enumerate() {
+            if overlapping_region_ratio(existing, &candidate) >= 0.45
+                && redundant_region_candidate(existing, &candidate)
+            {
+                redundant_idx = Some(idx);
+                break;
             }
         }
-        chosen.push(candidate);
+        if let Some(idx) = redundant_idx {
+            if candidate.score > chosen[idx].score {
+                chosen[idx] = candidate;
+            }
+        } else {
+            chosen.push(candidate);
+        }
     }
+    chosen.sort_by(|a, b| {
+        a.start_s
+            .partial_cmp(&b.start_s)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| {
+                a.pitch_hz
+                    .partial_cmp(&b.pitch_hz)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+    });
     chosen
         .into_iter()
         .map(|candidate| DecodedRegion {
@@ -1215,6 +1352,52 @@ fn dedupe_region_candidates(mut candidates: Vec<RegionCandidate>) -> Vec<Decoded
             text: candidate.text,
         })
         .collect()
+}
+
+fn overlapping_region_ratio(a: &RegionCandidate, b: &RegionCandidate) -> f32 {
+    let overlap = (a.end_s.min(b.end_s) - a.start_s.max(b.start_s)).max(0.0);
+    let min_len = (a.end_s - a.start_s).min(b.end_s - b.start_s);
+    if min_len <= 0.0 {
+        0.0
+    } else {
+        overlap / min_len
+    }
+}
+
+fn redundant_region_candidate(a: &RegionCandidate, b: &RegionCandidate) -> bool {
+    (a.pitch_hz - b.pitch_hz).abs() < 35.0 || compact_text_similarity(&a.text, &b.text) >= 0.80
+}
+
+fn compact_text_similarity(a: &str, b: &str) -> f32 {
+    let a: Vec<char> = a
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '?' | '@'))
+        .collect();
+    let b: Vec<char> = b
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '?' | '@'))
+        .collect();
+    if a.is_empty() || b.is_empty() {
+        return 0.0;
+    }
+    lcs_len(&a, &b) as f32 / a.len().min(b.len()) as f32
+}
+
+fn lcs_len(a: &[char], b: &[char]) -> usize {
+    let mut prev = vec![0usize; b.len() + 1];
+    let mut cur = vec![0usize; b.len() + 1];
+    for a_ch in a {
+        for (j, b_ch) in b.iter().enumerate() {
+            cur[j + 1] = if a_ch == b_ch {
+                prev[j] + 1
+            } else {
+                prev[j + 1].max(cur[j])
+            };
+        }
+        std::mem::swap(&mut prev, &mut cur);
+        cur.fill(0);
+    }
+    prev[b.len()]
 }
 
 fn tonal_prominence_ratio(
@@ -2080,6 +2263,13 @@ mod tests {
         out
     }
 
+    fn mix(a: &[f32], b: &[f32]) -> Vec<f32> {
+        let n = a.len().max(b.len());
+        (0..n)
+            .map(|i| a.get(i).copied().unwrap_or(0.0) + b.get(i).copied().unwrap_or(0.0))
+            .collect()
+    }
+
     fn irregular_tonal_syllables(sample_rate: u32, pitch_hz: f32) -> Vec<f32> {
         let on_s = [0.035_f32, 0.22, 0.06, 0.40, 0.11, 0.27];
         let off_s = [0.16_f32, 0.045, 0.29, 0.08, 0.22];
@@ -2254,6 +2444,36 @@ mod tests {
         assert!(
             result.text.contains("CQ"),
             "expected the CW portion to still decode, got {:?}",
+            result.text
+        );
+    }
+
+    #[test]
+    fn decode_region_stream_preserves_overlapping_distinct_pitch_regions() {
+        let sr = 12_000u32;
+        let low = synth_morse(sr, 600.0, 24.0, "CQ CQ", 0.45);
+        let high = synth_morse(sr, 850.0, 24.0, "DE W1AW", 0.45);
+        let mut buf = synth_silence(0.5, sr);
+        buf.extend(mix(&low, &high));
+        buf.extend(synth_silence(0.7, sr));
+
+        let cfg = RegionStreamConfig {
+            pitch_step_hz: 10.0,
+            merge_gap_s: 0.5,
+            min_region_s: 0.3,
+            pad_s: 0.15,
+            ..RegionStreamConfig::default()
+        };
+        let result = decode_region_stream(&buf, sr, &cfg);
+
+        assert!(
+            result.regions.len() >= 2,
+            "expected separate pitch regions, got {:?}",
+            result.regions
+        );
+        assert!(
+            result.text.contains("CQ") && result.text.contains("W1AW"),
+            "expected copy from both pitch-separated stations, got {:?}",
             result.text
         );
     }

--- a/experiments/cw-decoder/src/region_stream.rs
+++ b/experiments/cw-decoder/src/region_stream.rs
@@ -17,6 +17,7 @@
 
 use crate::decoder::{decode_text, decode_text_pinned};
 
+const BAD_COPY_MARKER: char = '*';
 const DIT_DAH_BOUNDARY: f32 = 2.0;
 const LETTER_SPACE_BOUNDARY: f32 = 2.0;
 const WORD_SPACE_BOUNDARY: f32 = 5.0;
@@ -204,7 +205,28 @@ fn collect_region_candidates(
 }
 
 fn is_low_confidence_region_text(text: &str) -> bool {
-    text.contains('?') || useful_copy_chars(text) == 0
+    let normalized = normalize_region_text(text);
+    let useful_chars = useful_copy_chars(&normalized);
+    if useful_chars == 0 {
+        return true;
+    }
+
+    if !normalized.contains(BAD_COPY_MARKER) {
+        return false;
+    }
+
+    // `?` is valid CW (`..--..`). Bad element clusters use a separate
+    // marker, and are only kept when the region has enough QSO context.
+    has_no_strong_qso_anchor(&normalized) || useful_chars < 6
+}
+
+fn has_no_strong_qso_anchor(text: &str) -> bool {
+    !text.split_whitespace().any(|token| {
+        matches!(
+            token,
+            "CQ" | "DE" | "K" | "BK" | "AR" | "+" | "QSL" | "TU" | "73"
+        ) || is_callsign_token(token)
+    })
 }
 
 fn trim_leading_voice_like_prefix(text: &str) -> String {
@@ -276,9 +298,15 @@ fn decode_region_slice(
     }
 
     let auto = decode_text(samples, sample_rate);
-    let interval = decode_region_slice_from_intervals(samples, sample_rate, pitch_hz, cfg);
-    if should_prefer_interval_decode(&auto, &interval) {
-        return interval;
+    if let Some(interval) = decode_region_slice_from_intervals(samples, sample_rate, pitch_hz, cfg)
+    {
+        if let Some(spaced) = best_timing_spacing_overlay(&auto, samples, sample_rate, interval.wpm)
+        {
+            return spaced;
+        }
+        if should_prefer_interval_decode(&auto, &interval.text) {
+            return interval.text;
+        }
     }
 
     let duration_s = samples.len() as f32 / sample_rate.max(1) as f32;
@@ -297,10 +325,211 @@ fn decode_region_slice(
     }
 }
 
+fn best_timing_spacing_overlay(
+    auto: &str,
+    samples: &[f32],
+    sample_rate: u32,
+    interval_wpm: f32,
+) -> Option<String> {
+    let auto_norm = normalize_region_text(auto);
+    if !looks_run_together(&auto_norm) {
+        return None;
+    }
+
+    let mut wpms = Vec::new();
+    let rounded = (interval_wpm / 2.0).round() * 2.0;
+    for wpm in [
+        rounded - 4.0,
+        rounded - 2.0,
+        rounded,
+        rounded + 2.0,
+        rounded + 4.0,
+    ] {
+        if (5.0..=60.0).contains(&wpm) {
+            wpms.push(wpm);
+        }
+    }
+    for wpm in [18.0, 20.0, 22.0, 24.0, 26.0, 28.0, 30.0] {
+        wpms.push(wpm);
+    }
+    wpms.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+    wpms.dedup_by(|a, b| (*a - *b).abs() < 0.1);
+
+    let auto_chars = useful_copy_chars(&auto_norm);
+    let auto_spaces = space_count(&auto_norm);
+    let mut best: Option<(f32, String)> = None;
+    for wpm in wpms {
+        let source = normalize_region_text(&decode_text_pinned(samples, sample_rate, wpm));
+        if source.is_empty()
+            || useful_copy_chars(&source) < auto_chars.saturating_mul(3) / 4
+            || !has_transcript_start_anchor(&source)
+            || singleton_token_count(&source) > 4
+        {
+            continue;
+        }
+        let Some(spaced) = transfer_timing_spaces(&auto_norm, &source) else {
+            continue;
+        };
+        let spaced = smooth_spurious_timing_splits(&normalize_region_text(&spaced));
+        let gained_spaces = space_count(&spaced).saturating_sub(auto_spaces);
+        if gained_spaces < 2 || longest_token_len(&spaced) >= longest_token_len(&auto_norm) {
+            continue;
+        }
+        let score = timing_spacing_source_score(&source) + gained_spaces as f32 * 0.2;
+        if best
+            .as_ref()
+            .is_none_or(|(best_score, _)| score > *best_score)
+        {
+            best = Some((score, spaced));
+        }
+    }
+
+    best.map(|(_, spaced)| spaced)
+}
+
+fn smooth_spurious_timing_splits(text: &str) -> String {
+    let mut out: Vec<String> = Vec::new();
+    for token in text.split_whitespace() {
+        if let Some(prev) = out.last_mut() {
+            if should_merge_spurious_timing_split(prev, token) {
+                prev.push_str(token);
+                continue;
+            }
+        }
+        out.push(token.to_string());
+    }
+    out.join(" ")
+}
+
+fn should_merge_spurious_timing_split(left: &str, right: &str) -> bool {
+    let left_useful = useful_copy_chars(left);
+    let right_useful = useful_copy_chars(right);
+    let left_alnum = left.chars().all(|ch| ch.is_ascii_alphanumeric());
+    let right_alnum = right.chars().all(|ch| ch.is_ascii_alphanumeric());
+    if !left_alnum || !right_alnum {
+        return false;
+    }
+    (left_useful == 1 && right_useful == 1)
+        || (left_useful == 2
+            && left.chars().all(|ch| ch.is_ascii_alphabetic())
+            && !matches!(left, "DE" | "BK" | "TU")
+            && right.chars().any(|ch| ch.is_ascii_digit()))
+}
+
+fn looks_run_together(text: &str) -> bool {
+    longest_token_len(text) >= 10
+}
+
+fn longest_token_len(text: &str) -> usize {
+    text.split_whitespace()
+        .map(useful_copy_chars)
+        .max()
+        .unwrap_or(0)
+}
+
+fn space_count(text: &str) -> usize {
+    text.split_whitespace().count().saturating_sub(1)
+}
+
+fn timing_spacing_source_score(text: &str) -> f32 {
+    let bad = text.chars().filter(|ch| *ch == BAD_COPY_MARKER).count() as f32;
+    let singletons = singleton_token_count(text) as f32;
+    transcript_quality_score(text) + space_count(text) as f32 * 0.2 - bad * 3.0 - singletons * 2.0
+}
+
+fn singleton_token_count(text: &str) -> usize {
+    text.split_whitespace()
+        .filter(|token| useful_copy_chars(token) == 1)
+        .count()
+}
+
+fn transfer_timing_spaces(primary: &str, spacing_source: &str) -> Option<String> {
+    let primary_chars: Vec<char> = primary.chars().filter(|ch| !ch.is_whitespace()).collect();
+    let source_chars: Vec<char> = spacing_source
+        .chars()
+        .filter(|ch| !ch.is_whitespace())
+        .collect();
+    if primary_chars.is_empty() || source_chars.is_empty() {
+        return None;
+    }
+
+    let mapping = lcs_source_to_primary_mapping(&primary_chars, &source_chars);
+    let mut insert_space_after = vec![false; primary_chars.len()];
+    let mut source_seen = 0usize;
+    for token in spacing_source.split_whitespace() {
+        let token_len = token.chars().count();
+        if token_len == 0 {
+            continue;
+        }
+        source_seen += token_len;
+        if source_seen >= source_chars.len() {
+            break;
+        }
+        if let Some(primary_idx) = nearest_primary_mapping(&mapping, source_seen - 1, source_seen) {
+            if primary_idx + 1 < insert_space_after.len() {
+                insert_space_after[primary_idx] = true;
+            }
+        }
+    }
+
+    let mut out = String::new();
+    for (idx, ch) in primary_chars.iter().copied().enumerate() {
+        out.push(ch);
+        if insert_space_after[idx] && !out.ends_with(' ') {
+            out.push(' ');
+        }
+    }
+    Some(out)
+}
+
+fn nearest_primary_mapping(
+    mapping: &[Option<usize>],
+    prev_source_idx: usize,
+    next_source_idx: usize,
+) -> Option<usize> {
+    mapping.get(prev_source_idx).copied().flatten().or_else(|| {
+        mapping
+            .get(next_source_idx)
+            .copied()
+            .flatten()
+            .map(|idx| idx.saturating_sub(1))
+    })
+}
+
+fn lcs_source_to_primary_mapping(primary: &[char], source: &[char]) -> Vec<Option<usize>> {
+    let n = primary.len();
+    let m = source.len();
+    let mut dp = vec![vec![0usize; m + 1]; n + 1];
+    for i in (0..n).rev() {
+        for j in (0..m).rev() {
+            dp[i][j] = if primary[i] == source[j] {
+                dp[i + 1][j + 1] + 1
+            } else {
+                dp[i + 1][j].max(dp[i][j + 1])
+            };
+        }
+    }
+
+    let mut mapping = vec![None; m];
+    let (mut i, mut j) = (0usize, 0usize);
+    while i < n && j < m {
+        if primary[i] == source[j] {
+            mapping[j] = Some(i);
+            i += 1;
+            j += 1;
+        } else if dp[i + 1][j] >= dp[i][j + 1] {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+    mapping
+}
+
 fn should_prefer_interval_decode(auto: &str, interval: &str) -> bool {
     let auto_norm = normalize_region_text(auto);
     let interval_norm = normalize_region_text(interval);
-    if interval_norm.is_empty() || auto_norm == interval_norm || interval_norm.contains('?') {
+    if interval_norm.is_empty() || auto_norm == interval_norm {
         return false;
     }
 
@@ -320,14 +549,16 @@ fn should_prefer_interval_decode(auto: &str, interval: &str) -> bool {
         || interval_norm.contains('/');
 
     interval_score > auto_score + 2.0
-        || (auto_norm.contains('?') && interval_score >= auto_score)
+        || (auto_norm.contains(BAD_COPY_MARKER) && interval_score >= auto_score)
         || (auto_has_garbage_tail && interval_score >= auto_score - 6.0)
         || (interval_has_callsign_shape && interval_score >= auto_score - 0.5)
 }
 
 fn useful_copy_chars(text: &str) -> usize {
     text.chars()
-        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '/' | '+' | '=' | '.' | ','))
+        .filter(|ch| {
+            ch.is_ascii_alphanumeric() || matches!(ch, '/' | '+' | '=' | '.' | ',' | '?' | '@')
+        })
         .count()
 }
 
@@ -340,9 +571,9 @@ fn transcript_quality_score(text: &str) -> f32 {
     for ch in text.chars() {
         if ch.is_ascii_alphanumeric() {
             score += 1.0;
-        } else if matches!(ch, '/' | '+' | '=' | '.' | ',') {
+        } else if matches!(ch, '/' | '+' | '=' | '.' | ',' | '?' | '@') {
             score += 0.6;
-        } else if ch == '?' {
+        } else if ch == BAD_COPY_MARKER {
             score -= 3.0;
         }
     }
@@ -478,16 +709,22 @@ fn average_score(scores: &[f32]) -> f32 {
     scores.iter().sum::<f32>() / scores.len() as f32
 }
 
+#[derive(Debug, Clone)]
+struct IntervalDecode {
+    text: String,
+    wpm: f32,
+}
+
 fn decode_region_slice_from_intervals(
     samples: &[f32],
     sample_rate: u32,
     pitch_hz: f32,
     cfg: &RegionStreamConfig,
-) -> String {
+) -> Option<IntervalDecode> {
     let frame_len = ((cfg.frame_len_s * sample_rate as f32).round() as usize).max(64);
     let frame_step = ((cfg.frame_step_s * sample_rate as f32).round() as usize).max(8);
     if samples.len() < frame_len {
-        return String::new();
+        return None;
     }
 
     let mut log_powers = Vec::new();
@@ -498,23 +735,23 @@ fn decode_region_slice_from_intervals(
         offset += frame_step;
     }
     if log_powers.len() < 4 {
-        return String::new();
+        return None;
     }
 
-    let Some(threshold) = otsu_log_power_threshold(&log_powers) else {
-        return String::new();
-    };
+    let threshold = otsu_log_power_threshold(&log_powers)?;
     let mut active: Vec<bool> = log_powers.iter().map(|power| *power >= threshold).collect();
     clean_interval_mask(&mut active);
 
     let runs = collect_frame_runs(&active);
     let step_s = frame_step as f32 / sample_rate as f32;
     let frame_s = frame_len as f32 / sample_rate as f32;
-    let Some(dot_s) = estimate_dot_from_runs(&runs, step_s, frame_s) else {
-        return String::new();
-    };
+    let dot_s = estimate_dot_from_runs(&runs, step_s, frame_s)?;
 
-    decode_runs_to_text(&runs, step_s, frame_s, dot_s)
+    let wpm = 1.2 / dot_s.max(0.001);
+    Some(IntervalDecode {
+        text: decode_runs_to_text(&runs, step_s, frame_s, dot_s),
+        wpm,
+    })
 }
 
 fn otsu_log_power_threshold(log_powers: &[f32]) -> Option<f32> {
@@ -662,7 +899,7 @@ fn push_morse_letter(out: &mut String, current: &mut String) {
     if let Some(ch) = morse_to_char(current) {
         out.push(ch);
     } else {
-        out.push('?');
+        out.push(BAD_COPY_MARKER);
     }
     current.clear();
 }
@@ -758,8 +995,40 @@ fn normalize_region_text(text: &str) -> String {
 
 pub(crate) fn normalize_region_transcript(text: &str) -> String {
     let normalized = normalize_region_text(text);
-    let repaired = repair_repeated_callsign_portable_suffix(&normalized);
+    let repaired = repair_embedded_at_sign_callsign(&normalized);
+    let repaired = repair_repeated_callsign_portable_suffix(&repaired);
     replace_final_ar_prosign(&repaired)
+}
+
+fn repair_embedded_at_sign_callsign(text: &str) -> String {
+    text.split_whitespace()
+        .flat_map(|token| {
+            let Some(at_idx) = token.find('@') else {
+                return vec![token.to_string()];
+            };
+            if token[at_idx + 1..].contains('@') {
+                return vec![token.to_string()];
+            }
+
+            let prefix = &token[..at_idx];
+            let suffix = &token[at_idx + 1..];
+            let suffix_looks_like_callsign_tail = !suffix.is_empty()
+                && suffix.chars().all(|ch| ch.is_ascii_alphanumeric())
+                && suffix.chars().any(|ch| ch.is_ascii_digit());
+            let prefix_is_alnum = prefix.chars().all(|ch| ch.is_ascii_alphanumeric());
+            if !prefix_is_alnum || !suffix_looks_like_callsign_tail {
+                return vec![token.to_string()];
+            }
+
+            let expanded = format!("AC{suffix}");
+            if prefix.is_empty() {
+                vec![expanded]
+            } else {
+                vec![prefix.to_string(), expanded]
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 fn replace_final_ar_prosign(text: &str) -> String {
@@ -1896,9 +2165,20 @@ mod tests {
     }
 
     #[test]
-    fn unknown_region_text_is_low_confidence() {
-        assert!(is_low_confidence_region_text("E?R"));
+    fn bad_copy_marker_fragment_is_low_confidence() {
+        assert!(is_low_confidence_region_text("E*R"));
+        assert!(!is_low_confidence_region_text("E?R"));
+        assert!(!is_low_confidence_region_text("BK ? DE W1AW"));
         assert!(!is_low_confidence_region_text("7QP W7N"));
+    }
+
+    #[test]
+    fn anchored_partial_copy_with_question_marks_is_not_low_confidence() {
+        assert!(!is_low_confidence_region_text(
+            "FF ? BK DE @7FFU*5FB*KQSL AC7FFTUDAVE 73DEK5OHYTU EEEE"
+        ));
+        assert!(is_low_confidence_region_text("* EEN EKTTE T0N"));
+        assert!(is_low_confidence_region_text("BK *"));
     }
 
     #[test]
@@ -1984,12 +2264,41 @@ mod tests {
     }
 
     #[test]
+    fn timing_spacing_overlay_transfers_spaces_without_qso_tokens() {
+        let primary = "FF ? BK DE @7FFU*5FB*KQSL AC7FFTUDAVE 73DEK5OHYTU EEEE";
+        let timing = "FF ? BK LE **KIE*IEIEEH4ETIEEEIEEHEB4BKQSL AC7FF TU DAVE 73 DE K5OHY TU EE E";
+        let spaced = transfer_timing_spaces(primary, timing).expect("spacing overlay");
+        assert!(
+            spaced.contains("AC7FF TU DAVE") && spaced.contains("73 DE K5OHY TU"),
+            "expected timing-derived spaces in {spaced:?}"
+        );
+    }
+
+    #[test]
+    fn timing_spacing_smoothing_removes_single_character_splits() {
+        assert_eq!(
+            smooth_spurious_timing_splits("F F ? BK A C 7FF T U DAVE 73 D E K5OHY"),
+            "FF ? BK AC7FF TU DAVE 73 DE K5OHY"
+        );
+    }
+
+    #[test]
     fn transcript_normalization_repairs_repeated_callsign_portable_tail() {
         let raw = "IQ CQ CQ DE WA2IAC WA2IAC WA2 AD /1 +";
         assert_eq!(
             normalize_region_transcript(raw),
             "IQ CQ CQ DE WA2IAC WA2IAC WA2IAC/1 AR"
         );
+    }
+
+    #[test]
+    fn transcript_normalization_expands_embedded_at_in_callsign_like_copy() {
+        assert_eq!(
+            normalize_region_transcript("FF ? BK DE@7FFA"),
+            "FF ? BK DE AC7FFA"
+        );
+        assert_eq!(normalize_region_transcript("@7FFA"), "AC7FFA");
+        assert_eq!(normalize_region_transcript("CQ @ TEST"), "CQ @ TEST");
     }
 
     fn noise_buf(rate: u32, seconds: f32, seed: u64, amplitude: f32) -> Vec<f32> {
@@ -2209,21 +2518,21 @@ mod tests {
         // Regression guard for the PR #378 -> PR #379 cycle: my windowed
         // pitch discovery (PR #378) re-promoted noise-window pitches that
         // produced low-quality region decodes. PR #379 patched the
-        // operator-visible symptom with `is_low_confidence_region_text`
-        // (any region text containing `?` is dropped at candidate
-        // collection time).
+        // operator-visible symptom with `is_low_confidence_region_text`,
+        // which drops short bad-copy fragments that have no strong QSO
+        // anchor.
         //
-        // Probing reveals the `?`-text filter is load-bearing here:
-        // `decode_region_slice` happily returns `"? EEN EKTTE T0N…"` for
+        // Probing reveals the ambiguous-fragment filter is load-bearing here:
+        // `decode_region_slice` happily returns `"* EEN EKTTE T0N…"` for
         // colored hiss at 700 Hz. The end-to-end empty result depends on
         // that filter doing its job.
         //
         // We lock both layers in:
-        //   1. `decode_region_slice` produces text containing `?` — the
+        //   1. `decode_region_slice` produces text containing `*` — the
         //      explicit precondition that `is_low_confidence_region_text`
-        //      relies on. If a future change scrubs `?` from raw region
-        //      text without strengthening the deeper rejection, this
-        //      assertion fires and forces a conscious update.
+        //      relies on. If a future change resolves unknown clusters
+        //      without strengthening the deeper rejection, this assertion
+        //      fires and forces a conscious update.
         //   2. `decode_region_stream` returns empty text end-to-end — the
         //      operator-facing contract: no ghost characters reach the UI.
         let sr = 12_000u32;
@@ -2231,8 +2540,8 @@ mod tests {
         let cfg = RegionStreamConfig::default();
         let slice_text = decode_region_slice(&buf, sr, 700.0, &cfg);
         assert!(
-            slice_text.contains('?'),
-            "expected raw region slice on colored hiss to contain `?` (so the low-confidence filter has something to drop); got {slice_text:?}"
+            slice_text.contains('*'),
+            "expected raw region slice on colored hiss to contain `*` (so the low-confidence filter has something to drop); got {slice_text:?}"
         );
         let result = decode_region_stream(&buf, sr, &cfg);
         assert!(

--- a/experiments/cw-decoder/src/region_streamer.rs
+++ b/experiments/cw-decoder/src/region_streamer.rs
@@ -128,6 +128,22 @@ impl RegionStreamer {
         &self.committed_text
     }
 
+    /// Transcript plus the current uncommitted active region, for live UI
+    /// preview. The committed transcript remains append-only; this view may
+    /// change as more audio arrives.
+    pub fn transcript_with_provisional(&self) -> String {
+        let Some(provisional) = self.first_uncommitted_region_text() else {
+            return self.committed_text.clone();
+        };
+
+        let mut text = self.committed_text.clone();
+        if !text.is_empty() {
+            text.push(' ');
+        }
+        text.push_str(&provisional);
+        normalize_region_transcript(&text)
+    }
+
     /// Buffered audio length in seconds (relative to the current buffer
     /// start, i.e. always >= 0 and bounded by the trim policy).
     pub fn buffered_seconds(&self) -> f32 {
@@ -166,6 +182,22 @@ impl RegionStreamer {
         self.head_s = self.buffer.len() as f32 / sr;
     }
 
+    fn first_uncommitted_region_text(&self) -> Option<String> {
+        if self.buffer.is_empty() {
+            return None;
+        }
+        let result = decode_region_stream(&self.buffer, self.sample_rate, &self.cfg.region);
+        result.regions.into_iter().find_map(|region| {
+            if region.end_s <= self.last_committed_end_s {
+                return None;
+            }
+            if self.committed_text.is_empty() && !has_transcript_start_anchor(&region.text) {
+                return None;
+            }
+            (!region.text.trim().is_empty()).then_some(region.text)
+        })
+    }
+
     fn commit_stable_regions(&mut self, force_all: bool) -> Vec<CommittedRegion> {
         if self.buffer.is_empty() {
             return Vec::new();
@@ -179,7 +211,7 @@ impl RegionStreamer {
 
         let mut newly = Vec::new();
         for region in &result.regions {
-            if region.start_s <= self.last_committed_end_s {
+            if region.end_s <= self.last_committed_end_s {
                 continue; // already committed in an earlier cycle
             }
             if region.end_s > stability_threshold {
@@ -255,6 +287,26 @@ mod tests {
             committed.is_empty(),
             "active region must be held back until trailing static is seen"
         );
+    }
+
+    #[test]
+    fn streamer_exposes_uncommitted_region_as_provisional_transcript() {
+        let sr = 12_000;
+        let mut s = RegionStreamer::new(sr);
+        let mut audio = synthesize_silence(sr, 0.6);
+        audio.extend(synth_morse(sr, 700.0, 24.0, "BK DE W1AW", 0.55));
+        s.ingest(&audio);
+
+        assert!(
+            s.try_commit().is_empty(),
+            "active region should not be committed before trailing static"
+        );
+        let provisional = s.transcript_with_provisional();
+        assert!(
+            provisional.contains("BK") && provisional.contains("DE"),
+            "active region should be visible as provisional copy, got {provisional:?}"
+        );
+        assert_eq!(s.transcript(), "");
     }
 
     #[test]

--- a/experiments/cw-decoder/vendor/ditdah/src/decoder.rs
+++ b/experiments/cw-decoder/vendor/ditdah/src/decoder.rs
@@ -14,6 +14,7 @@ const RESAMPLER_CHUNK_SIZE: usize = 1024;
 const DIT_DAH_BOUNDARY: f32 = 2.0;
 const LETTER_SPACE_BOUNDARY: f32 = 2.0; // Gaps > 2x dot length end the current letter
 const WORD_SPACE_BOUNDARY: f32 = 5.0; // Gaps > 5x dot length add word space
+const BAD_COPY_MARKER: char = '*';
 
 // --- BiquadFilter (Unchanged) ---
 #[derive(Debug, Clone, Copy)]
@@ -550,7 +551,7 @@ impl MorseDecoder {
                                 if let Some(c) = morse_to_char(&current_letter) {
                                     result.push(c);
                                 } else {
-                                    result.push('?');
+                                    result.push(BAD_COPY_MARKER);
                                 }
                                 current_letter.clear();
                             }
@@ -572,7 +573,7 @@ impl MorseDecoder {
             if let Some(c) = morse_to_char(&current_letter) {
                 result.push(c);
             } else {
-                result.push('?');
+                result.push(BAD_COPY_MARKER);
             }
         }
 


### PR DESCRIPTION
This PR improves the CW live region transcript path after the live Visualizer regression.

It preserves question mark as valid ITU CW copy and uses a distinct asterisk marker for bad or unknown copy. It also exposes provisional region transcript text during live playback instead of waiting for a region to commit at end of stream, and updates the region bench path to timestamp visible provisional copy.

On the reported training-set-a clip, the region bench path now produces copy at about 4 seconds with CER around 0.159 instead of empty/EOF-only copy. Full CW decoder tests, clippy with warnings denied, fmt check, and diff whitespace check passed locally.

The early blended two-station section is still imperfect; true parallel per-pitch station separation will be handled in a separate follow-up PR so this baseline remains easy to fall back to.