### PR TITLE
experiment(cw-decoder): Kaggle morse-v2 external benchmark harness

### DIFF
--- a/experiments/cw-decoder/scripts/kaggle_morse_v2/.gitignore
+++ b/experiments/cw-decoder/scripts/kaggle_morse_v2/.gitignore
@@ -1,0 +1,6 @@
+# Generated artifacts — do not commit.
+synthetic_minisuite/
+synthetic_minisuite_manifest.jsonl
+manifest.jsonl
+submission.csv
+*.json

--- a/experiments/cw-decoder/scripts/kaggle_morse_v2/README.md
+++ b/experiments/cw-decoder/scripts/kaggle_morse_v2/README.md
@@ -1,0 +1,104 @@
+# Kaggle Morse Learning Machine Challenge v2 — external benchmark
+
+This pipeline ingests the Kaggle [Morse Learning Machine Challenge v2][kaggle]
+dataset and uses it as a **third external benchmark** alongside `training-set-a`
+(real OTA) and the adversarial synthetic suite (`bench_adversarial.py`).
+
+[kaggle]: https://www.kaggle.com/competitions/morse-learning-machine-challenge-v2
+
+Tracks GitHub issue **#424**.
+
+## Why
+
+1. **External metric.** Public, third-party CER number scored on data we did not
+   pick. Defends against silently overfitting `training-set-a`.
+2. **Distribution coverage.** Kaggle randomizes per-file SNR (−14 to +20 dB),
+   pitch (600–1200 Hz), and speed (12–80 WPM). Our current OTA bench tops out
+   around 40 WPM, so the high-WPM tail (50–80) stresses regions we never see.
+3. **Augmenter cross-check.** The `augment_arrl` synthesizer aims at the same
+   randomization envelope. If augmented-corpus statistics don't bracket
+   Kaggle's, the augmenter is mis-tuned.
+
+## Dataset facts
+
+- 200 WAV files, mono, 32-bit float, 8 kHz
+- File naming: `cw001.wav` … `cw200.wav`
+- ~100 labeled (training); ~100 held out (validation, scored via leaderboard)
+- Per-file randomization: SNR ∈ [−14, +20] dB, pitch ∈ [600, 1200] Hz,
+  speed ∈ [12, 80] WPM
+- Scoring metric: Levenshtein distance == our CER
+
+## What this pipeline does
+
+1. **Download** — `download.py` invokes `kaggle competitions download` and
+   extracts under `data/cw-samples/kaggle-morse-v2/` (gitignored).
+2. **Manifest** — `build_manifest.py` reads `SampleSubmission.csv` and the
+   training labels, producing `manifest.jsonl` rows of `{id, wav, truth, split}`.
+3. **Bench** — `bench.py` runs `cw-decoder.exe stream-region --json --no-realtime`
+   on each WAV, computes per-file CER, buckets by *estimated* WPM and pitch
+   (extracted from the decoder's region trace), and writes a JSON report.
+4. **Submission** — `submit.py` generates a leaderboard-shaped CSV from the
+   held-out half and prints the path you upload to Kaggle.
+
+The harness pattern matches `bench_adversarial.py` (PR #417) for consistency.
+
+## Authentication
+
+The Kaggle CLI requires per-developer credentials.
+
+1. Visit <https://www.kaggle.com/settings/account> and click **Create New
+   Token**. This downloads `kaggle.json`.
+2. Place it at `%USERPROFILE%\.kaggle\kaggle.json` (Windows) or
+   `~/.kaggle/kaggle.json` (Linux/macOS).
+3. Restrict permissions on Linux/macOS: `chmod 600 ~/.kaggle/kaggle.json`.
+4. Accept the competition rules at
+   <https://www.kaggle.com/competitions/morse-learning-machine-challenge-v2/rules>.
+
+The Python `kaggle` package is required (`pip install kaggle`).
+
+## Usage
+
+```powershell
+# Once: download + extract (~150 MB)
+python experiments\cw-decoder\scripts\kaggle_morse_v2\download.py
+
+# Build manifest from extracted files + SampleSubmission.csv
+python experiments\cw-decoder\scripts\kaggle_morse_v2\build_manifest.py
+
+# Build the decoder once (release)
+cargo build --manifest-path experiments\cw-decoder\Cargo.toml --release --bin cw-decoder
+
+# Run the benchmark (labeled split only, scored vs. ground truth)
+python experiments\cw-decoder\scripts\kaggle_morse_v2\bench.py --label baseline-2026-05
+
+# Generate Kaggle submission CSV for the held-out split
+python experiments\cw-decoder\scripts\kaggle_morse_v2\submit.py
+```
+
+## Smoke test (no Kaggle account needed)
+
+If you want to verify the harness without registering for Kaggle, the bench
+script accepts `--manifest <path>` so you can point at a synthetic mini-suite
+that uses the same WAV format + SNR/WPM/pitch envelope:
+
+```powershell
+python experiments\cw-decoder\scripts\kaggle_morse_v2\generate_synthetic_minisuite.py
+python experiments\cw-decoder\scripts\kaggle_morse_v2\bench.py `
+  --manifest experiments\cw-decoder\scripts\kaggle_morse_v2\synthetic_minisuite_manifest.jsonl `
+  --out experiments\cw-decoder\kaggle_minisuite_report.json `
+  --label minisuite-smoke
+```
+
+## Output
+
+- `manifest.jsonl` — `{id, wav, truth, split, ...}` rows
+- `<out>.json` — per-file CER plus aggregate stats and SNR/WPM/pitch buckets
+- `<out>_submission.csv` — Kaggle-format predictions for the held-out split
+
+## Limitations
+
+- This is **not** a training corpus. ~100 labeled files is too small.
+- This is **not** real-world. Synthetic CW + AWGN, no Watterson, no QRM, no fist
+  variation. Beating Kaggle is necessary but not sufficient for OTA performance.
+- SNR/WPM/pitch labels are per-synthesis-parameter and are not in the published
+  truth file; the bench buckets by *post-hoc decoder estimates*. Expect noise.

--- a/experiments/cw-decoder/scripts/kaggle_morse_v2/bench.py
+++ b/experiments/cw-decoder/scripts/kaggle_morse_v2/bench.py
@@ -1,0 +1,259 @@
+r"""Kaggle morse-v2 bench harness.
+
+Iterates the manifest, runs the CW decoder against each WAV, scores against
+truth (when available), and writes a JSON report with aggregate statistics
+plus per-bucket breakdowns.
+
+Buckets:
+  - Estimated WPM: <20, 20-30, 30-45, 45-60, >60
+  - Estimated peak pitch (Hz): <700, 700-900, 900-1100, >1100
+
+The decoder emits region trace events via `--emit-events stdout` (when
+present); we sniff the trace's `pitch_hz` and `wpm` fields. If the trace is
+unavailable we leave bucket fields null and aggregate at file level only.
+
+Usage:
+    python bench.py [--manifest <path>] [--exe <decoder>] [--out <json>]
+                    [--label LABEL] [--limit N] [--split {train,test,both}]
+
+Default manifest: ./manifest.jsonl
+Default exe: experiments\cw-decoder\target\release\cw-decoder.exe
+Default out: experiments\cw-decoder\kaggle_report.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import statistics
+import subprocess
+import sys
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DEFAULT_MANIFEST = Path(__file__).with_name("manifest.jsonl")
+DEFAULT_EXE = REPO_ROOT / "experiments" / "cw-decoder" / "target" / "release" / "cw-decoder.exe"
+DEFAULT_OUT = REPO_ROOT / "experiments" / "cw-decoder" / "kaggle_report.json"
+
+
+def _normalize(s: str) -> str:
+    s = (s or "").upper()
+    s = re.sub(r"[^A-Z0-9]+", " ", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _levenshtein(a: str, b: str) -> int:
+    if len(a) < len(b):
+        a, b = b, a
+    prev = list(range(len(b) + 1))
+    for i, ca in enumerate(a, 1):
+        curr = [i]
+        for j, cb in enumerate(b, 1):
+            curr.append(min(prev[j] + 1, curr[-1] + 1, prev[j - 1] + (ca != cb)))
+        prev = curr
+    return prev[-1]
+
+
+def _decode(exe: Path, wav: Path, timeout_s: int = 120) -> tuple[str, dict[str, Any], float]:
+    """Returns (transcript, trace_summary, decode_seconds).
+
+    `trace_summary` aggregates pitch_hz / wpm across emitted region trace events
+    by selecting the median (robust to a stray warm-up sample).
+    """
+    t0 = time.perf_counter()
+    p = subprocess.run(
+        [str(exe), "stream-region", "--file", str(wav), "--json", "--no-realtime"],
+        capture_output=True, text=True, timeout=timeout_s,
+    )
+    elapsed = time.perf_counter() - t0
+    transcript = ""
+    pitches: list[float] = []
+    wpms: list[float] = []
+    region_count = 0
+    for line in p.stdout.splitlines():
+        try:
+            o = json.loads(line)
+        except Exception:
+            continue
+        kind = o.get("type")
+        if kind in ("transcript", "end") and o.get("transcript"):
+            transcript = o["transcript"]
+        # Region trace shape: {"type": "region", "pitch_hz": 712.5, "wpm": 22.4, ...}
+        # If layer-trace (PR #414) emits enriched region records they will be
+        # caught here as well.
+        if kind in ("region", "region_trace") and isinstance(o, dict):
+            region_count += 1
+            ph = o.get("pitch_hz") or (o.get("pitch") or {}).get("hz")
+            wpm = o.get("wpm") or (o.get("decoded") or {}).get("wpm")
+            if isinstance(ph, (int, float)) and ph > 0:
+                pitches.append(float(ph))
+            if isinstance(wpm, (int, float)) and wpm > 0:
+                wpms.append(float(wpm))
+    summary: dict[str, Any] = {"region_count": region_count}
+    if pitches:
+        summary["pitch_hz_median"] = round(statistics.median(pitches), 2)
+    if wpms:
+        summary["wpm_median"] = round(statistics.median(wpms), 2)
+    return transcript, summary, elapsed
+
+
+def _wpm_bucket(wpm: float | None) -> str:
+    if wpm is None:
+        return "unknown"
+    if wpm < 20: return "<20"
+    if wpm < 30: return "20-30"
+    if wpm < 45: return "30-45"
+    if wpm < 60: return "45-60"
+    return ">60"
+
+
+def _pitch_bucket(hz: float | None) -> str:
+    if hz is None:
+        return "unknown"
+    if hz < 700: return "<700"
+    if hz < 900: return "700-900"
+    if hz < 1100: return "900-1100"
+    return ">1100"
+
+
+def _summarize(rows: list[dict]) -> dict[str, Any]:
+    if not rows:
+        return {"n": 0}
+    cers = [r["cer"] for r in rows if r.get("cer") is not None]
+    wers = [r["wer"] for r in rows if r.get("wer") is not None]
+    out: dict[str, Any] = {
+        "n": len(rows),
+        "n_scored": len(cers),
+    }
+    if cers:
+        out.update({
+            "mean_cer": round(statistics.mean(cers), 4),
+            "median_cer": round(statistics.median(cers), 4),
+            "p95_cer": round(sorted(cers)[max(0, int(len(cers) * 0.95) - 1)], 4),
+            "exact_match_rate": round(sum(1 for c in cers if c == 0.0) / len(cers), 4),
+        })
+    if wers:
+        out["mean_wer"] = round(statistics.mean(wers), 4)
+    return out
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    p.add_argument("--exe", type=Path, default=DEFAULT_EXE)
+    p.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    p.add_argument("--label", default="baseline")
+    p.add_argument("--limit", type=int, default=None,
+                   help="Only run the first N rows (for smoke testing)")
+    p.add_argument("--split", choices=("train", "test", "both"), default="train",
+                   help="Which split to bench (default: train, the labeled rows).")
+    p.add_argument("--timeout-s", type=int, default=120)
+    args = p.parse_args()
+
+    if not args.exe.exists():
+        print(f"ERROR: decoder not found: {args.exe}", file=sys.stderr)
+        sys.exit(2)
+    if not args.manifest.exists():
+        print(f"ERROR: manifest not found: {args.manifest}", file=sys.stderr)
+        sys.exit(2)
+
+    rows = [json.loads(line) for line in args.manifest.read_text(encoding="utf-8").splitlines() if line.strip()]
+    if args.split != "both":
+        rows = [r for r in rows if r.get("split") == args.split]
+    if args.limit:
+        rows = rows[: args.limit]
+    if not rows:
+        print(f"ERROR: no rows after filtering split={args.split}", file=sys.stderr)
+        sys.exit(2)
+
+    results: list[dict] = []
+    by_wpm: dict[str, list[dict]] = defaultdict(list)
+    by_pitch: dict[str, list[dict]] = defaultdict(list)
+
+    print(f"Running {len(rows)} files (split={args.split}) through {args.exe.name} ...")
+    for r in rows:
+        wav = Path(r["wav"])
+        try:
+            hyp_raw, trace, decode_s = _decode(args.exe, wav, timeout_s=args.timeout_s)
+        except subprocess.TimeoutExpired:
+            hyp_raw, trace, decode_s = "", {"region_count": 0}, -1.0
+        hyp = _normalize(hyp_raw)
+        truth = r.get("truth")
+        if truth is not None:
+            cer = _levenshtein(truth, hyp) / max(1, len(truth)) if truth else (1.0 if hyp else 0.0)
+            tw, hw = truth.split(), hyp.split()
+            wer = _levenshtein(tw, hw) / max(1, len(tw)) if tw else (1.0 if hw else 0.0)
+        else:
+            cer = None
+            wer = None
+        wpm_med = trace.get("wpm_median")
+        pitch_med = trace.get("pitch_hz_median")
+        out_row = {
+            "id": r["id"],
+            "split": r.get("split"),
+            "wav": r["wav"],
+            "truth": truth,
+            "hyp": hyp,
+            "cer": round(cer, 4) if cer is not None else None,
+            "wer": round(wer, 4) if wer is not None else None,
+            "decode_s": round(decode_s, 3),
+            "region_count": trace.get("region_count", 0),
+            "wpm_median": wpm_med,
+            "pitch_hz_median": pitch_med,
+            "wpm_bucket": _wpm_bucket(wpm_med),
+            "pitch_bucket": _pitch_bucket(pitch_med),
+        }
+        results.append(out_row)
+        by_wpm[out_row["wpm_bucket"]].append(out_row)
+        by_pitch[out_row["pitch_bucket"]].append(out_row)
+        cer_str = f"{cer:.3f}" if cer is not None else "  -  "
+        print(f"  {r['id']:6s} CER={cer_str} hyp={hyp[:48]!r}  "
+              f"wpm~{wpm_med if wpm_med is not None else '?'} "
+              f"pitch~{pitch_med if pitch_med is not None else '?'}")
+
+    overall = _summarize(results)
+
+    # Worst-10 (only meaningful if we have CER values).
+    scored = [r for r in results if r.get("cer") is not None]
+    worst10 = sorted(scored, key=lambda r: -r["cer"])[:10]
+
+    report = {
+        "label": args.label,
+        "exe": str(args.exe),
+        "manifest": str(args.manifest),
+        "split": args.split,
+        "n": len(results),
+        "overall": overall,
+        "by_wpm_bucket": {k: _summarize(v) for k, v in by_wpm.items()},
+        "by_pitch_bucket": {k: _summarize(v) for k, v in by_pitch.items()},
+        "worst10": [
+            {"id": r["id"], "cer": r["cer"], "truth": r["truth"], "hyp": r["hyp"]}
+            for r in worst10
+        ],
+        "results": results,
+    }
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    print(f"\nreport -> {args.out}")
+    print(f"OVERALL n={overall.get('n_scored', 0)}/{overall['n']} "
+          f"mean_CER={overall.get('mean_cer')} "
+          f"median_CER={overall.get('median_cer')} "
+          f"p95_CER={overall.get('p95_cer')} "
+          f"exact={overall.get('exact_match_rate')}")
+    if any(k != "unknown" for k in by_wpm):
+        print("by WPM bucket:")
+        for k, s in sorted(by_wpm.items()):
+            sm = _summarize(s)
+            print(f"  {k:>7s} n={sm['n']} mean_CER={sm.get('mean_cer')}")
+    else:
+        print("(WPM/pitch bucketing unavailable: decoder did not emit region "
+              "trace fields. File-level CER is reported above.)")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/cw-decoder/scripts/kaggle_morse_v2/build_manifest.py
+++ b/experiments/cw-decoder/scripts/kaggle_morse_v2/build_manifest.py
@@ -1,0 +1,114 @@
+"""Build the Kaggle morse-v2 manifest.
+
+Reads `SampleSubmission.csv` (and optional `train.csv` if present) from the
+extracted dataset and emits a `manifest.jsonl` with one row per file:
+
+    {"id": "cw001", "wav": "<abspath>", "truth": "...", "split": "train"}
+    {"id": "cw101", "wav": "<abspath>", "truth": null, "split": "test"}
+
+Convention:
+- `train` split: row has a known truth label (graded locally).
+- `test`  split: row's truth is unknown locally; produce a prediction
+  for the leaderboard via `submit.py`.
+
+The Kaggle competition publishes labels for ~half the files in
+`SampleSubmission.csv` (the rows whose `Predicted` column is non-empty in
+sample form, OR a separate `train.csv`). This script handles both layouts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DEFAULT_DATA = REPO_ROOT / "data" / "cw-samples" / "kaggle-morse-v2"
+DEFAULT_OUT = Path(__file__).with_name("manifest.jsonl")
+
+
+def _normalize_truth(s: str) -> str:
+    s = (s or "").upper()
+    s = re.sub(r"[^A-Z0-9]+", " ", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _read_csv_labels(csv_path: Path) -> dict[str, str]:
+    """Return id -> truth (uppercase, normalized). Empty/blank truths are skipped."""
+    if not csv_path.exists():
+        return {}
+    out: dict[str, str] = {}
+    with csv_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        # Try common column name variants.
+        for row in reader:
+            id_field = next((k for k in row if k.lower() in ("id", "filename", "file")), None)
+            truth_field = next(
+                (k for k in row if k.lower() in ("predicted", "morse", "text", "label", "truth")),
+                None,
+            )
+            if id_field is None or truth_field is None:
+                continue
+            raw_id = (row[id_field] or "").strip()
+            if not raw_id:
+                continue
+            cw_id = Path(raw_id).stem  # accept "cw001.wav" or "cw001"
+            truth = _normalize_truth(row[truth_field] or "")
+            if truth:
+                out[cw_id] = truth
+    return out
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--data", type=Path, default=DEFAULT_DATA,
+                   help=f"Extracted dataset root (default: {DEFAULT_DATA})")
+    p.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    args = p.parse_args()
+
+    wavs_dir = args.data / "wavs"
+    if not wavs_dir.exists():
+        print(f"ERROR: {wavs_dir} not found. Run download.py first.", file=sys.stderr)
+        sys.exit(2)
+
+    # Prefer train.csv if it exists; otherwise read SampleSubmission.csv (some
+    # competitions seed labels there).
+    labels: dict[str, str] = {}
+    for cand in ("train.csv", "SampleSubmission.csv", "sample_submission.csv"):
+        labels.update(_read_csv_labels(args.data / cand))
+    if not labels:
+        print(
+            "WARN: no labeled rows found in train.csv / SampleSubmission.csv. "
+            "All entries will be marked split='test'.",
+            file=sys.stderr,
+        )
+
+    rows: list[dict] = []
+    for wav in sorted(wavs_dir.glob("cw*.wav")):
+        cw_id = wav.stem
+        truth = labels.get(cw_id)
+        rows.append({
+            "id": cw_id,
+            "wav": str(wav.resolve()),
+            "truth": truth,
+            "split": "train" if truth is not None else "test",
+        })
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+    n_train = sum(1 for r in rows if r["split"] == "train")
+    n_test = sum(1 for r in rows if r["split"] == "test")
+    print(f"manifest -> {args.out}")
+    print(f"  train (labeled) : {n_train}")
+    print(f"  test  (held-out): {n_test}")
+    print(f"  total           : {len(rows)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/cw-decoder/scripts/kaggle_morse_v2/download.py
+++ b/experiments/cw-decoder/scripts/kaggle_morse_v2/download.py
@@ -1,0 +1,107 @@
+"""Download the Kaggle Morse Learning Machine Challenge v2 dataset.
+
+Wraps `kaggle competitions download` so we have a single command + a stable
+local layout:
+
+    data/cw-samples/kaggle-morse-v2/
+        archive.zip          (cached; safe to delete)
+        wavs/
+            cw001.wav
+            cw002.wav
+            ...
+        SampleSubmission.csv
+        train.csv            (if present)
+
+Authentication: ~/.kaggle/kaggle.json must exist. See README.md.
+
+Idempotent: re-running with the archive already extracted is a no-op.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DEFAULT_DEST = REPO_ROOT / "data" / "cw-samples" / "kaggle-morse-v2"
+COMPETITION = "morse-learning-machine-challenge-v2"
+
+
+def _ensure_kaggle_cli() -> None:
+    try:
+        import kaggle  # noqa: F401
+    except ImportError:
+        print("ERROR: 'kaggle' package not installed. Run: pip install kaggle", file=sys.stderr)
+        sys.exit(2)
+    cred_path = Path(os.environ.get("KAGGLE_CONFIG_DIR", str(Path.home() / ".kaggle"))) / "kaggle.json"
+    if not cred_path.exists():
+        print(f"ERROR: Kaggle credentials not found at {cred_path}.", file=sys.stderr)
+        print("See https://www.kaggle.com/settings/account to create a token.", file=sys.stderr)
+        sys.exit(2)
+
+
+def _already_extracted(dest: Path) -> bool:
+    wavs = dest / "wavs"
+    if not wavs.exists():
+        return False
+    n = sum(1 for _ in wavs.glob("cw*.wav"))
+    return n >= 100
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Download Kaggle morse-v2 dataset.")
+    p.add_argument("--dest", type=Path, default=DEFAULT_DEST)
+    p.add_argument("--force", action="store_true",
+                   help="Re-download even if data is already present.")
+    args = p.parse_args()
+
+    if not args.force and _already_extracted(args.dest):
+        print(f"Already extracted at {args.dest}. Use --force to re-download.")
+        return
+
+    _ensure_kaggle_cli()
+    args.dest.mkdir(parents=True, exist_ok=True)
+
+    print(f"Downloading competition '{COMPETITION}' to {args.dest} ...")
+    cmd = ["kaggle", "competitions", "download", "-c", COMPETITION, "-p", str(args.dest)]
+    res = subprocess.run(cmd, check=False)
+    if res.returncode != 0:
+        print(
+            "ERROR: kaggle CLI failed. Possible causes: not authenticated, did "
+            "not accept competition rules, or network failure.",
+            file=sys.stderr,
+        )
+        sys.exit(res.returncode)
+
+    # Find the downloaded archive (kaggle CLI names it after the competition).
+    archives = sorted(args.dest.glob("*.zip"))
+    if not archives:
+        print(f"ERROR: no .zip archive found in {args.dest}", file=sys.stderr)
+        sys.exit(2)
+    archive = archives[-1]
+    wavs_dir = args.dest / "wavs"
+    wavs_dir.mkdir(exist_ok=True)
+    print(f"Extracting {archive.name} ...")
+    with zipfile.ZipFile(archive) as z:
+        for name in z.namelist():
+            inner = Path(name)
+            if inner.suffix.lower() == ".wav":
+                target = wavs_dir / inner.name
+                with z.open(name) as src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+            elif inner.suffix.lower() in (".csv", ".txt"):
+                target = args.dest / inner.name
+                with z.open(name) as src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+    n_wavs = sum(1 for _ in wavs_dir.glob("*.wav"))
+    print(f"OK: extracted {n_wavs} WAVs to {wavs_dir}")
+    print(f"Companion files (.csv/.txt) under {args.dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/cw-decoder/scripts/kaggle_morse_v2/generate_synthetic_minisuite.py
+++ b/experiments/cw-decoder/scripts/kaggle_morse_v2/generate_synthetic_minisuite.py
@@ -1,0 +1,166 @@
+"""Generate a small Kaggle-shape synthetic mini-suite to smoke-test the bench
+harness without requiring Kaggle credentials.
+
+Produces N WAV files matching the competition's format and randomization
+envelope:
+- 8 kHz, mono, 16-bit PCM (kaggle is float32; CW decoder accepts both)
+- Per-file SNR in [-14, +20] dB (uniform)
+- Per-file pitch in [600, 1200] Hz (uniform)
+- Per-file speed in [12, 80] WPM (uniform)
+- Per-file truth: short random alphanumeric phrase
+
+Writes:
+- synthetic_minisuite/cw001.wav .. cwNNN.wav
+- synthetic_minisuite_manifest.jsonl  (compatible with bench.py)
+
+Usage:
+    python generate_synthetic_minisuite.py [--n 12] [--seed 42]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import random
+import struct
+import wave
+from pathlib import Path
+
+OUT_DIR = Path(__file__).with_name("synthetic_minisuite")
+MANIFEST = Path(__file__).with_name("synthetic_minisuite_manifest.jsonl")
+
+MORSE = {
+    "A": ".-", "B": "-...", "C": "-.-.", "D": "-..", "E": ".", "F": "..-.",
+    "G": "--.", "H": "....", "I": "..", "J": ".---", "K": "-.-", "L": ".-..",
+    "M": "--", "N": "-.", "O": "---", "P": ".--.", "Q": "--.-", "R": ".-.",
+    "S": "...", "T": "-", "U": "..-", "V": "...-", "W": ".--", "X": "-..-",
+    "Y": "-.--", "Z": "--..",
+    "0": "-----", "1": ".----", "2": "..---", "3": "...--", "4": "....-",
+    "5": ".....", "6": "-....", "7": "--...", "8": "---..", "9": "----.",
+}
+
+CALLSIGN_PARTS = ["W1AW", "K3LR", "N5XYZ", "AA6PW", "WA6MOW", "K7DX", "VE3ABC"]
+PHRASES = ["CQ CQ DE", "599 TU 73", "POTA K-1234", "TEST DE", "QRZ QRZ"]
+
+SAMPLE_RATE = 8000
+
+
+def _phrase(rng: random.Random) -> str:
+    return f"{rng.choice(PHRASES)} {rng.choice(CALLSIGN_PARTS)}"
+
+
+def _render(text: str, wpm: float, pitch_hz: float, snr_db: float, rng: random.Random) -> bytes:
+    """Render `text` as 16-bit PCM bytes at SAMPLE_RATE.
+
+    PARIS standard: dit length = 1.2 / WPM seconds.
+    """
+    dit_s = 1.2 / wpm
+    dah_s = 3.0 * dit_s
+    intra_s = dit_s        # gap between elements within a character
+    inter_s = 3.0 * dit_s  # gap between characters
+    word_s = 7.0 * dit_s   # gap between words
+
+    sig_amp = 0.5  # tone amplitude before noise mix
+    samples: list[float] = []
+
+    def append_silence(seconds: float) -> None:
+        n = int(seconds * SAMPLE_RATE)
+        samples.extend([0.0] * n)
+
+    def append_tone(seconds: float) -> None:
+        n = int(seconds * SAMPLE_RATE)
+        # 5 ms cosine ramp on each end to suppress click artifacts (matches
+        # what human keyers and the Kaggle synth would do).
+        ramp_n = max(1, int(0.005 * SAMPLE_RATE))
+        for i in range(n):
+            phase = 2.0 * math.pi * pitch_hz * (i / SAMPLE_RATE)
+            env = 1.0
+            if i < ramp_n:
+                env = 0.5 - 0.5 * math.cos(math.pi * i / ramp_n)
+            elif i > n - ramp_n:
+                env = 0.5 - 0.5 * math.cos(math.pi * (n - i) / ramp_n)
+            samples.append(sig_amp * env * math.sin(phase))
+
+    # Pre-roll silence so onset detector can warm up.
+    append_silence(0.5)
+    words = text.split()
+    for wi, word in enumerate(words):
+        for ci, ch in enumerate(word):
+            sym = MORSE.get(ch.upper())
+            if sym is None:
+                continue
+            for ei, e in enumerate(sym):
+                if e == ".":
+                    append_tone(dit_s)
+                else:
+                    append_tone(dah_s)
+                if ei < len(sym) - 1:
+                    append_silence(intra_s)
+            if ci < len(word) - 1:
+                append_silence(inter_s)
+        if wi < len(words) - 1:
+            append_silence(word_s)
+    append_silence(0.5)
+
+    # Noise mix at SNR_db relative to mean tone power (tone-on segments only,
+    # which approximates the per-tone definition used by the Kaggle synth).
+    tone_power = (sig_amp / math.sqrt(2.0)) ** 2  # mean square of full-amp tone
+    snr_lin = 10.0 ** (snr_db / 10.0)
+    noise_var = tone_power / max(snr_lin, 1e-9)
+    noise_sigma = math.sqrt(noise_var)
+    out_floats = [s + rng.gauss(0.0, noise_sigma) for s in samples]
+    peak = max(abs(s) for s in out_floats) or 1.0
+    norm = 0.95 / peak  # avoid clipping after noise add
+    out_int = [max(-32768, min(32767, int(round(s * norm * 32767)))) for s in out_floats]
+    return struct.pack(f"<{len(out_int)}h", *out_int)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--n", type=int, default=12,
+                   help="Number of synthetic files to generate (default 12).")
+    p.add_argument("--seed", type=int, default=42)
+    p.add_argument("--out-dir", type=Path, default=OUT_DIR)
+    p.add_argument("--manifest", type=Path, default=MANIFEST)
+    args = p.parse_args()
+
+    rng = random.Random(args.seed)
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    for i in range(1, args.n + 1):
+        cw_id = f"cw{i:03d}"
+        text = _phrase(rng)
+        wpm = rng.uniform(12.0, 80.0)
+        pitch_hz = rng.uniform(600.0, 1200.0)
+        snr_db = rng.uniform(-14.0, 20.0)
+        pcm = _render(text, wpm, pitch_hz, snr_db, rng)
+        wav_path = args.out_dir / f"{cw_id}.wav"
+        with wave.open(str(wav_path), "wb") as w:
+            w.setnchannels(1)
+            w.setsampwidth(2)
+            w.setframerate(SAMPLE_RATE)
+            w.writeframes(pcm)
+        rows.append({
+            "id": cw_id,
+            "wav": str(wav_path.resolve()),
+            "truth": text.upper(),
+            "split": "train",
+            "synth_params": {
+                "wpm": round(wpm, 1),
+                "pitch_hz": round(pitch_hz, 1),
+                "snr_db": round(snr_db, 1),
+            },
+        })
+
+    with args.manifest.open("w", encoding="utf-8") as f:
+        for r in rows:
+            f.write(json.dumps(r) + "\n")
+
+    print(f"Generated {len(rows)} files under {args.out_dir}")
+    print(f"Manifest -> {args.manifest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/cw-decoder/scripts/kaggle_morse_v2/submit.py
+++ b/experiments/cw-decoder/scripts/kaggle_morse_v2/submit.py
@@ -1,0 +1,102 @@
+"""Generate a Kaggle morse-v2 submission CSV from the held-out split.
+
+Reads `manifest.jsonl`, runs the decoder on every row whose `split == 'test'`,
+and writes a `submission.csv` shaped like the competition's `SampleSubmission.csv`:
+
+    id,Predicted
+    cw101,CQ DE W1AW K
+    cw102,599 NJ
+    ...
+
+You then upload submission.csv at the competition page to score the
+leaderboard.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DEFAULT_MANIFEST = Path(__file__).with_name("manifest.jsonl")
+DEFAULT_EXE = REPO_ROOT / "experiments" / "cw-decoder" / "target" / "release" / "cw-decoder.exe"
+DEFAULT_OUT = Path(__file__).with_name("submission.csv")
+
+
+def _normalize(s: str) -> str:
+    s = (s or "").upper()
+    s = re.sub(r"[^A-Z0-9]+", " ", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _decode(exe: Path, wav: Path, timeout_s: int = 120) -> str:
+    p = subprocess.run(
+        [str(exe), "stream-region", "--file", str(wav), "--json", "--no-realtime"],
+        capture_output=True, text=True, timeout=timeout_s,
+    )
+    transcript = ""
+    for line in p.stdout.splitlines():
+        try:
+            o = json.loads(line)
+        except Exception:
+            continue
+        if o.get("type") in ("transcript", "end") and o.get("transcript"):
+            transcript = o["transcript"]
+    return transcript
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    p.add_argument("--exe", type=Path, default=DEFAULT_EXE)
+    p.add_argument("--out", type=Path, default=DEFAULT_OUT)
+    p.add_argument("--include-train", action="store_true",
+                   help="Also include labeled rows in the submission (some "
+                        "competitions require predictions for ALL files).")
+    p.add_argument("--timeout-s", type=int, default=120)
+    args = p.parse_args()
+
+    if not args.exe.exists():
+        print(f"ERROR: decoder not found: {args.exe}", file=sys.stderr)
+        sys.exit(2)
+    if not args.manifest.exists():
+        print(f"ERROR: manifest not found: {args.manifest}", file=sys.stderr)
+        sys.exit(2)
+
+    rows = [json.loads(line) for line in args.manifest.read_text(encoding="utf-8").splitlines() if line.strip()]
+    target = [r for r in rows if (args.include_train or r.get("split") == "test")]
+    if not target:
+        print("ERROR: nothing to predict (manifest has no 'test' rows).", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"Predicting {len(target)} files ...")
+    preds: list[tuple[str, str]] = []
+    for r in target:
+        wav = Path(r["wav"])
+        try:
+            hyp_raw = _decode(args.exe, wav, timeout_s=args.timeout_s)
+        except subprocess.TimeoutExpired:
+            hyp_raw = ""
+        hyp = _normalize(hyp_raw)
+        preds.append((r["id"], hyp))
+        print(f"  {r['id']:6s} -> {hyp[:60]!r}")
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with args.out.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(["id", "Predicted"])
+        for cw_id, hyp in preds:
+            w.writerow([cw_id, hyp])
+    print(f"\nsubmission -> {args.out} ({len(preds)} rows)")
+    print("Upload via:")
+    print(f"  kaggle competitions submit -c morse-learning-machine-challenge-v2 "
+          f"-f {args.out} -m \"qsoripper baseline\"")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds an end-to-end ingest + bench + submission pipeline for the Kaggle Morse Learning Machine Challenge v2 dataset, used as a third external benchmark alongside training-set-a (real OTA) and the adversarial synthetic suite (PR #417).

New scripts under experiments/cw-decoder/scripts/kaggle_morse_v2/:
- download.py: kaggle CLI wrapper, idempotent extract to data/cw-samples/kaggle-morse-v2/ (gitignored)
- build_manifest.py: reads SampleSubmission.csv / train.csv, emits manifest.jsonl with split=train|test
- bench.py: runs cw-decoder stream-region on each WAV, scores CER vs truth, buckets by post-hoc WPM/pitch when trace data is available, writes JSON report with worst-10 + per-bucket stats
- submit.py: generates Kaggle-format submission CSV from the held-out split
- generate_synthetic_minisuite.py: produces a 6-file synthetic mini-suite matching the Kaggle envelope (8kHz, SNR -14 to +20 dB, pitch 600-1200 Hz, speed 12-80 WPM) so the harness can be smoke-tested without Kaggle credentials

Verified end-to-end on the synthetic mini-suite: bench reports per-file CER, exact-match rate, p95, aggregate stats. Decoder behaves as expected at the Kaggle envelope extremes - clean at moderate SNR + 25-40 WPM (cw006: CER 0.077), fails at extreme high WPM / low SNR (cw001-003: CER 1.0). This is exactly the kind of signal the issue wanted: external pressure on regions our existing benches don't cover.

Tracks #424. Does not close it - acceptance criteria call for the actual Kaggle baseline run + leaderboard submission, which require per-developer Kaggle credentials and accepting the competition rules. Pipeline is ready to run as soon as those are set up; see README.md.