### PR TITLE
experiment(cw-decoder): Kaggle morse-v2 baseline submission (LB 34.99 public / 34.18 private)

### DIFF
--- a/docs/experiments/kaggle-morse-v2-baseline-2026-05.md
+++ b/docs/experiments/kaggle-morse-v2-baseline-2026-05.md
@@ -1,0 +1,89 @@
+# Kaggle Morse Learning Machine Challenge v2 — Baseline (2026-05-09)
+
+First QsoRipper CW decoder submission to the public Kaggle leaderboard for the
+[Morse Learning Machine Challenge v2](https://www.kaggle.com/competitions/morse-learning-machine-challenge-v2).
+
+## Headline numbers
+
+| Metric | Score |
+|---|---|
+| Public leaderboard (mean Levenshtein) | **34.99** |
+| Private leaderboard (mean Levenshtein) | **34.18** |
+| Files predicted | 200 / 200 |
+| Files with non-empty prediction | 159 / 200 (79.5%) |
+| Files where decoder produced nothing | 41 / 200 (20.5%) |
+| Mean prediction length (chars) | 38.0 |
+| Submission ID | 52489975 |
+
+Lower mean Levenshtein distance is better. There is no published golden
+baseline for the v2 dataset yet; this number anchors all future improvements.
+
+## What was decoded
+
+The competition ships 200 unlabeled WAVs (`cw001.wav` … `cw200.wav`) and asks
+for one transcript per file. There is **no training set** with truth — scoring
+is leaderboard-only against the hidden ground truth.
+
+Decoder used: `experiments/cw-decoder/target/release/cw-decoder.exe stream-region --file <wav> --json --no-realtime`.
+Pipeline: download → manifest → decode-all → upload via Kaggle CLI.
+
+## Failure-mode shape (qualitative)
+
+Spot-checking the decoded outputs already shows the same failure classes the
+synthetic adversarial suite + bake-off identified:
+
+- **Empty transcripts (20.5%)**: decoder produced nothing. Either the file is
+  below the region detector's tonal-prominence floor, off the pitch search
+  band, or sub-region durations were rejected by `min_region_s`. Examples:
+  cw187, cw189, cw190.
+- **Ghost/noise expansions**: short bursts decoded as long noisy `E/T/I/M`
+  cascades (e.g. cw197 `'O1T 0MD9 94WWWO B6 Z'`).
+- **Leading-character drops** (the WA6MOW class from training-set-a): clean
+  callsigns recovered with one or two leading letters chopped, e.g. cw185
+  `'EUXILIARN'` (probably "AUXILIARY").
+- **Strong long-form CW recovered well**: cw194, cw195, cw196, cw198 each
+  produce 50+ char readable English, suggesting the steady-state portion of
+  the engine is healthy and the loss is concentrated at edges and weak files.
+
+The 20.5% "no transcript at all" rate is the single biggest concrete win
+available — every empty row is currently scoring `len(truth)` in Levenshtein.
+A naive "always emit something" lower-bound on those 41 files would meaningfully
+move the public score even without changing the engine.
+
+## How to reproduce
+
+```powershell
+# 1. KAGGLE_API_TOKEN in .env, plus competition rules accepted in browser
+python experiments\cw-decoder\scripts\kaggle_morse_v2\download.py
+python experiments\cw-decoder\scripts\kaggle_morse_v2\build_manifest.py
+python experiments\cw-decoder\scripts\kaggle_morse_v2\submit.py
+$env:KAGGLE_API_TOKEN = (Get-Content .env | Select-String '^KAGGLE_API_TOKEN=').ToString().Split('=',2)[1]
+& "$env:LOCALAPPDATA\Programs\Python\Python313\Scripts\kaggle.exe" `
+  competitions submit -c morse-learning-machine-challenge-v2 `
+  -f experiments\cw-decoder\scripts\kaggle_morse_v2\submission.csv `
+  -m "qsoripper baseline (region-stream, 200 files)"
+```
+
+## Next experiments to move this number
+
+In priority order (matching the bake-off direction in
+`docs/experiments/cw-decoder-bakeoff-2026-05.md`):
+
+1. **Reduce empty-transcript rate.** Lower
+   `RegionStreamConfig::min_tonal_prominence_ratio` and `min_region_s` for the
+   Kaggle bench specifically, OR add a "best guess from raw envelope" fallback
+   when the region pipeline produces nothing. Goal: <5% empty.
+2. **Hard-stack Viterbi + elem-gate** (the recommended next ensemble move from
+   PR #410's discussion). Should attack the ghost-cascade class directly.
+3. **Backward re-decode for warmup losses.** WA6MOW-class leading-character
+   drops dominate the partial-callsign failures here too.
+4. **Lower SNR / off-pitch sweep**. Several empty files appear to have
+   off-band pitch or weak signal. Widening the pitch search range or using a
+   coarser threshold on a second pass should rescue them.
+
+## Files in this baseline run
+
+- `experiments/cw-decoder/scripts/kaggle_morse_v2/submission.csv` — the actual
+  uploaded submission (200 rows, regenerable).
+- `experiments/cw-decoder/scripts/kaggle_morse_v2/manifest.jsonl` — file index.
+- Submission ID 52489975 on Kaggle ledger.

--- a/experiments/cw-decoder/scripts/kaggle_morse_v2/README.md
+++ b/experiments/cw-decoder/scripts/kaggle_morse_v2/README.md
@@ -44,17 +44,38 @@ The harness pattern matches `bench_adversarial.py` (PR #417) for consistency.
 
 ## Authentication
 
-The Kaggle CLI requires per-developer credentials.
+Two paths are supported.
+
+### Recommended: KAGGLE_API_TOKEN in .env (no kaggle.json needed)
 
 1. Visit <https://www.kaggle.com/settings/account> and click **Create New
-   Token**. This downloads `kaggle.json`.
-2. Place it at `%USERPROFILE%\.kaggle\kaggle.json` (Windows) or
-   `~/.kaggle/kaggle.json` (Linux/macOS).
-3. Restrict permissions on Linux/macOS: `chmod 600 ~/.kaggle/kaggle.json`.
-4. Accept the competition rules at
-   <https://www.kaggle.com/competitions/morse-learning-machine-challenge-v2/rules>.
+   Token** (the new "API Token" type that begins with `KGAT...`).
+2. Add to the repo's `.env` file:
 
-The Python `kaggle` package is required (`pip install kaggle`).
+   ```text
+   KAGGLE_API_TOKEN=KGAT...your-token...
+   ```
+
+3. **Accept the competition rules** (one-time, browser-only):
+   <https://www.kaggle.com/competitions/morse-learning-machine-challenge-v2/rules> →
+   click "I Understand and Accept". Without this step, every download endpoint
+   returns 403 Forbidden — Kaggle does not expose a programmatic
+   rules-acceptance API.
+
+`download.py` reads `.env` automatically (no `python-dotenv` dependency) and
+calls the Kaggle REST API directly. No `kaggle` CLI required.
+
+### Fallback: classic kaggle.json
+
+1. Same Create New Token page (download `kaggle.json`).
+2. Place at `%USERPROFILE%\.kaggle\kaggle.json` (Windows) or
+   `~/.kaggle/kaggle.json` (Linux/macOS).
+3. `chmod 600 ~/.kaggle/kaggle.json` on Linux/macOS.
+4. Accept the competition rules as above.
+5. `pip install kaggle`.
+
+`download.py` falls back to invoking `kaggle competitions download` when
+`KAGGLE_API_TOKEN` is not set.
 
 ## Usage
 

--- a/experiments/cw-decoder/scripts/kaggle_morse_v2/download.py
+++ b/experiments/cw-decoder/scripts/kaggle_morse_v2/download.py
@@ -1,7 +1,15 @@
 """Download the Kaggle Morse Learning Machine Challenge v2 dataset.
 
-Wraps `kaggle competitions download` so we have a single command + a stable
-local layout:
+Two auth paths are supported:
+
+1. Bearer token via env var (recommended, .env-friendly):
+       KAGGLE_API_TOKEN=KGAT....   (also reads .env at repo root)
+   Uses the public Kaggle REST API directly. No `kaggle` CLI required.
+
+2. Classic kaggle.json: ~/.kaggle/kaggle.json with username + key.
+   Falls back to invoking the `kaggle` CLI.
+
+Local layout:
 
     data/cw-samples/kaggle-morse-v2/
         archive.zip          (cached; safe to delete)
@@ -10,47 +18,174 @@ local layout:
             cw002.wav
             ...
         SampleSubmission.csv
-        train.csv            (if present)
-
-Authentication: ~/.kaggle/kaggle.json must exist. See README.md.
 
 Idempotent: re-running with the archive already extracted is a no-op.
+
+NOTE: Before files can be downloaded, the Kaggle account must accept the
+competition rules **once** at:
+  https://www.kaggle.com/competitions/morse-learning-machine-challenge-v2/rules
+This is a one-click step that cannot be done via the API.
 """
 
 from __future__ import annotations
 
 import argparse
+import io
 import os
 import shutil
 import subprocess
 import sys
+import urllib.request
 import zipfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[4]
 DEFAULT_DEST = REPO_ROOT / "data" / "cw-samples" / "kaggle-morse-v2"
 COMPETITION = "morse-learning-machine-challenge-v2"
+KAGGLE_API = "https://www.kaggle.com/api/v1"
 
 
-def _ensure_kaggle_cli() -> None:
+def _load_env_file(env_path: Path) -> None:
+    """Lightweight .env loader (no python-dotenv dep). Adds keys to os.environ
+    if they are not already set."""
+    if not env_path.exists():
+        return
+    for raw in env_path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, v = line.split("=", 1)
+        k, v = k.strip(), v.strip().strip('"').strip("'")
+        if k and k not in os.environ:
+            os.environ[k] = v
+
+
+def _get_bearer_token() -> str | None:
+    _load_env_file(REPO_ROOT / ".env")
+    return os.environ.get("KAGGLE_API_TOKEN")
+
+
+def _bearer_get(url: str, token: str, *, timeout: int = 600) -> bytes:
+    headers = {"Authorization": f"Bearer {token}"}
+    # Prefer `requests` (bundles certifi, avoids platform CA-bundle quirks).
     try:
-        import kaggle  # noqa: F401
+        import requests  # type: ignore
+        r = requests.get(url, headers=headers, timeout=timeout)
+        if r.status_code != 200:
+            err = urllib.error.HTTPError(url, r.status_code, r.reason, hdrs=None, fp=None)
+            raise err
+        return r.content
     except ImportError:
-        print("ERROR: 'kaggle' package not installed. Run: pip install kaggle", file=sys.stderr)
-        sys.exit(2)
-    cred_path = Path(os.environ.get("KAGGLE_CONFIG_DIR", str(Path.home() / ".kaggle"))) / "kaggle.json"
-    if not cred_path.exists():
-        print(f"ERROR: Kaggle credentials not found at {cred_path}.", file=sys.stderr)
-        print("See https://www.kaggle.com/settings/account to create a token.", file=sys.stderr)
-        sys.exit(2)
+        pass
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return resp.read()
+
+
+def _try_classic_cli() -> bool:
+    try:
+        import kaggle  # noqa: F401, PLC0415
+        return True
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def _already_extracted(dest: Path) -> bool:
     wavs = dest / "wavs"
     if not wavs.exists():
         return False
-    n = sum(1 for _ in wavs.glob("cw*.wav"))
-    return n >= 100
+    return sum(1 for _ in wavs.glob("cw*.wav")) >= 100
+
+
+def _extract_archive(archive: Path, dest: Path) -> int:
+    wavs_dir = dest / "wavs"
+    wavs_dir.mkdir(exist_ok=True)
+    with zipfile.ZipFile(archive) as z:
+        for name in z.namelist():
+            inner = Path(name)
+            if inner.suffix.lower() == ".wav":
+                target = wavs_dir / inner.name
+                with z.open(name) as src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+            elif inner.suffix.lower() in (".csv", ".txt", ".py", ".m"):
+                target = dest / inner.name
+                with z.open(name) as src, open(target, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+    return sum(1 for _ in wavs_dir.glob("*.wav"))
+
+
+def _download_via_bearer(dest: Path, token: str) -> None:
+    archive = dest / "archive.zip"
+    print(f"Downloading via Kaggle REST (Bearer token, {len(token)} chars) ...")
+    url = f"{KAGGLE_API}/competitions/data/download-all/{COMPETITION}"
+    try:
+        data = _bearer_get(url, token)
+    except urllib.error.HTTPError as e:  # type: ignore[attr-defined]
+        if e.code == 403:
+            print(
+                "\nERROR: Kaggle returned 403 Forbidden.\n"
+                "This means the account is authenticated but has not yet "
+                "accepted the competition rules.\n\n"
+                "FIX (one-time, browser-only):\n"
+                f"  1. Visit https://www.kaggle.com/competitions/{COMPETITION}/rules\n"
+                "  2. Click 'I Understand and Accept'.\n"
+                "  3. Re-run this script.\n",
+                file=sys.stderr,
+            )
+        else:
+            print(f"\nERROR: HTTP {e.code} {e.reason}", file=sys.stderr)
+        sys.exit(2)
+    archive.write_bytes(data)
+    print(f"  -> {archive} ({len(data) / 1024 / 1024:.1f} MB)")
+
+    # Some competitions wrap each file in its own .zip inside the outer zip
+    # (audio.zip nested inside the all-files archive). Extract recursively.
+    print("Extracting (with nested zip handling) ...")
+    n_wavs = _extract_archive(archive, dest)
+    # Look for nested zips that contain WAVs.
+    for inner_zip in list(dest.glob("*.zip")):
+        if inner_zip.name == "archive.zip":
+            continue
+        try:
+            n_wavs += _extract_archive(inner_zip, dest)
+        except zipfile.BadZipFile:
+            continue
+    # Also check inside the outer archive for nested ZIPs the first pass missed
+    # (some Kaggle bundles store audio.zip itself rather than the WAVs).
+    with zipfile.ZipFile(archive) as z:
+        for name in z.namelist():
+            if name.lower().endswith(".zip"):
+                with z.open(name) as src:
+                    buf = io.BytesIO(src.read())
+                with zipfile.ZipFile(buf) as inner:
+                    for member in inner.namelist():
+                        ip = Path(member)
+                        if ip.suffix.lower() == ".wav":
+                            target = (dest / "wavs") / ip.name
+                            target.parent.mkdir(exist_ok=True)
+                            with inner.open(member) as src2, open(target, "wb") as dst:
+                                shutil.copyfileobj(src2, dst)
+                                n_wavs += 1
+    print(f"OK: extracted {n_wavs} WAVs to {dest / 'wavs'}")
+
+
+def _download_via_classic_cli(dest: Path) -> None:
+    print(f"Downloading via kaggle CLI (kaggle.json auth) to {dest} ...")
+    cmd = ["kaggle", "competitions", "download", "-c", COMPETITION, "-p", str(dest)]
+    res = subprocess.run(cmd, check=False)
+    if res.returncode != 0:
+        print(
+            "ERROR: kaggle CLI failed. Either authenticate (~/.kaggle/kaggle.json), "
+            "set KAGGLE_API_TOKEN in .env, or accept the competition rules.",
+            file=sys.stderr,
+        )
+        sys.exit(res.returncode)
+    archives = sorted(dest.glob("*.zip"))
+    if not archives:
+        print(f"ERROR: no .zip archive found in {dest}", file=sys.stderr)
+        sys.exit(2)
+    n_wavs = _extract_archive(archives[-1], dest)
+    print(f"OK: extracted {n_wavs} WAVs to {dest / 'wavs'}")
 
 
 def main() -> None:
@@ -64,43 +199,24 @@ def main() -> None:
         print(f"Already extracted at {args.dest}. Use --force to re-download.")
         return
 
-    _ensure_kaggle_cli()
     args.dest.mkdir(parents=True, exist_ok=True)
-
-    print(f"Downloading competition '{COMPETITION}' to {args.dest} ...")
-    cmd = ["kaggle", "competitions", "download", "-c", COMPETITION, "-p", str(args.dest)]
-    res = subprocess.run(cmd, check=False)
-    if res.returncode != 0:
+    token = _get_bearer_token()
+    if token:
+        _download_via_bearer(args.dest, token)
+    elif _try_classic_cli():
+        _download_via_classic_cli(args.dest)
+    else:
         print(
-            "ERROR: kaggle CLI failed. Possible causes: not authenticated, did "
-            "not accept competition rules, or network failure.",
+            "ERROR: no Kaggle credentials found.\n"
+            "Either set KAGGLE_API_TOKEN in .env (recommended) or place "
+            "kaggle.json under ~/.kaggle/.",
             file=sys.stderr,
         )
-        sys.exit(res.returncode)
-
-    # Find the downloaded archive (kaggle CLI names it after the competition).
-    archives = sorted(args.dest.glob("*.zip"))
-    if not archives:
-        print(f"ERROR: no .zip archive found in {args.dest}", file=sys.stderr)
         sys.exit(2)
-    archive = archives[-1]
-    wavs_dir = args.dest / "wavs"
-    wavs_dir.mkdir(exist_ok=True)
-    print(f"Extracting {archive.name} ...")
-    with zipfile.ZipFile(archive) as z:
-        for name in z.namelist():
-            inner = Path(name)
-            if inner.suffix.lower() == ".wav":
-                target = wavs_dir / inner.name
-                with z.open(name) as src, open(target, "wb") as dst:
-                    shutil.copyfileobj(src, dst)
-            elif inner.suffix.lower() in (".csv", ".txt"):
-                target = args.dest / inner.name
-                with z.open(name) as src, open(target, "wb") as dst:
-                    shutil.copyfileobj(src, dst)
-    n_wavs = sum(1 for _ in wavs_dir.glob("*.wav"))
-    print(f"OK: extracted {n_wavs} WAVs to {wavs_dir}")
-    print(f"Companion files (.csv/.txt) under {args.dest}")
+
+
+if __name__ == "__main__":
+    main()
 
 
 if __name__ == "__main__":

--- a/experiments/cw-decoder/scripts/kaggle_morse_v2/submit.py
+++ b/experiments/cw-decoder/scripts/kaggle_morse_v2/submit.py
@@ -86,16 +86,23 @@ def main() -> None:
         preds.append((r["id"], hyp))
         print(f"  {r['id']:6s} -> {hyp[:60]!r}")
 
+    # morse-v2 expects header `ID,PREDICTION` with integer IDs (1..N).
+    # Map "cw001" -> 1, "cw042" -> 42, etc.
+    def _to_int_id(s: str) -> int:
+        digits = re.sub(r"\D", "", s)
+        return int(digits) if digits else 0
+
+    pred_map = {_to_int_id(cw_id): hyp for cw_id, hyp in preds}
     args.out.parent.mkdir(parents=True, exist_ok=True)
     with args.out.open("w", newline="", encoding="utf-8") as f:
         w = csv.writer(f)
-        w.writerow(["id", "Predicted"])
-        for cw_id, hyp in preds:
-            w.writerow([cw_id, hyp])
-    print(f"\nsubmission -> {args.out} ({len(preds)} rows)")
-    print("Upload via:")
-    print(f"  kaggle competitions submit -c morse-learning-machine-challenge-v2 "
-          f"-f {args.out} -m \"qsoripper baseline\"")
+        w.writerow(["ID", "PREDICTION"])
+        for i in sorted(pred_map):
+            w.writerow([i, pred_map[i]])
+    print(f"\nsubmission -> {args.out} ({len(pred_map)} rows)")
+    print("Upload via (KAGGLE_API_TOKEN must be set in the shell env first):")
+    print("  $env:KAGGLE_API_TOKEN = (Get-Content .env | Select-String '^KAGGLE_API_TOKEN=').ToString().Split('=',2)[1]")
+    print(f'  kaggle competitions submit -c morse-learning-machine-challenge-v2 -f "{args.out}" -m "qsoripper baseline"')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Wires up KAGGLE_API_TOKEN .env auth for the Kaggle morse-v2 download script AND ships the first QsoRipper submission to the public leaderboard.

Leaderboard:
- Public: 34.99 (mean Levenshtein per file, lower is better)
- Private: 34.18
- 200/200 files predicted, 159 non-empty (79.5%)
- Submission ID 52489975

Download script changes:
- Reads KAGGLE_API_TOKEN from repo .env (no python-dotenv dep, tiny inline parser)
- Calls Kaggle REST directly via requests; falls back to kaggle CLI / kaggle.json if no token present
- Handles nested zip layout (audio.zip inside the all-files archive)
- Clear 403 message pointing at the rules acceptance URL when needed

Submit script changes:
- Emits the exact ID,PREDICTION schema the grader expects (integer IDs, header casing matches SampleSubmission.csv)
- Print-out shows the env-var + kaggle-CLI one-liner for the upload step

Docs:
- docs/experiments/kaggle-morse-v2-baseline-2026-05.md captures headline numbers, failure-mode breakdown (20.5% empty transcripts, ghost cascades, leading-char drops), and reproduction steps
- README updated with both auth paths

The 41 empty-transcript rows are the single biggest concrete win available without engine changes; long-form decodes (cw194-cw198) confirm the steady-state pipeline is healthy. Follow-up to PR #426. Tracks #424.