### PR TITLE
Add dirs.proj for full dotnet tree traversal build

### DIFF
--- a/src/dotnet/dirs.proj
+++ b/src/dotnet/dirs.proj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.Build.Traversal/4.1.82">
+
+  <ItemGroup>
+    <ProjectReference Include="**\*.*proj" Exclude="$(MSBuildProjectFile)" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Adds a Microsoft.Build.Traversal-based dirs.proj (SDK v4.1.82) that globs all *.*proj files under src/dotnet, so the entire tree can be built with a single command:

dotnet build src\dotnet\dirs.proj

This picks up all 25 projects including stress-client which is not in the slnx. No separate traversal targets file is needed since the SDK handles everything. Verified: full restore + build succeeds with 0 warnings, 0 errors.