### PR TITLE
build.ps1: instrument each step with timings + clean summary

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -68,11 +68,89 @@ function Get-CppcheckInstallHint {
 
 function Invoke-Build([string]$Step, [string]$Command, [string[]]$Arguments) {
     Write-Step $Step
-    & $Command @Arguments
-    if ($LASTEXITCODE -ne 0) {
-        Write-Host "FAILED: $Step" -ForegroundColor Red
-        exit $LASTEXITCODE
+    if (-not $script:BuildTimings) { $script:BuildTimings = [System.Collections.Generic.List[object]]::new() }
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $entry = [pscustomobject]@{ Step = $Step; Status = 'RUN'; Seconds = 0.0 }
+    $code = 0
+    try {
+        & $Command @Arguments
+        $code = $LASTEXITCODE
+    } finally {
+        $sw.Stop()
+        $entry.Seconds = [Math]::Round($sw.Elapsed.TotalSeconds, 2)
+        $script:BuildTimings.Add($entry) | Out-Null
     }
+    if ($code -ne 0) {
+        $entry.Status = 'FAIL'
+        Write-Host "FAILED: $Step" -ForegroundColor Red
+        exit $code
+    }
+    $entry.Status = 'OK'
+}
+
+function Measure-BuildStep([string]$Step, [scriptblock]$Body) {
+    Write-Step $Step
+    if (-not $script:BuildTimings) { $script:BuildTimings = [System.Collections.Generic.List[object]]::new() }
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    $entry = [pscustomobject]@{ Step = $Step; Status = 'RUN'; Seconds = 0.0 }
+    $code = 0
+    try {
+        & $Body
+        $code = $LASTEXITCODE
+    } finally {
+        $sw.Stop()
+        $entry.Seconds = [Math]::Round($sw.Elapsed.TotalSeconds, 2)
+        $script:BuildTimings.Add($entry) | Out-Null
+    }
+    if ($code -ne 0) {
+        $entry.Status = 'FAIL'
+        Write-Host "FAILED: $Step" -ForegroundColor Red
+        exit $code
+    }
+    $entry.Status = 'OK'
+}
+
+function Format-BuildSeconds([double]$Seconds) {
+    if ($Seconds -ge 60) {
+        $m = [Math]::Floor($Seconds / 60)
+        $s = $Seconds - ($m * 60)
+        return ('{0}m{1:N1}s' -f $m, $s)
+    }
+    return ('{0:N2}s' -f $Seconds)
+}
+
+function Write-BuildSummary {
+    if (-not $script:BuildTimings -or $script:BuildTimings.Count -eq 0) { return }
+    $total = ($script:BuildTimings | Measure-Object -Property Seconds -Sum).Sum
+    $maxLen = ($script:BuildTimings | ForEach-Object { $_.Step.Length } | Measure-Object -Maximum).Maximum
+    $maxLen = [Math]::Max([int]$maxLen, 4)
+    $bar = '=' * ($maxLen + 30)
+    Write-Host ''
+    Write-Host $bar -ForegroundColor Cyan
+    Write-Host (' BUILD TIMING SUMMARY ({0} steps)' -f $script:BuildTimings.Count) -ForegroundColor Cyan
+    Write-Host $bar -ForegroundColor Cyan
+    $headerFmt = '  {0,-6} {1,-' + $maxLen + '} {2,10}  {3,6}'
+    Write-Host ($headerFmt -f 'STATUS', 'STEP', 'TIME', 'SHARE') -ForegroundColor Gray
+    foreach ($e in $script:BuildTimings) {
+        $share = if ($total -gt 0) { ('{0,5:N1}%' -f (100.0 * $e.Seconds / $total)) } else { '    -' }
+        $color = if ($e.Status -eq 'OK') { 'Green' } elseif ($e.Status -eq 'FAIL') { 'Red' } else { 'Yellow' }
+        Write-Host ($headerFmt -f $e.Status, $e.Step, (Format-BuildSeconds $e.Seconds), $share) -ForegroundColor $color
+    }
+    Write-Host $bar -ForegroundColor Cyan
+    Write-Host (('  TOTAL  {0,-' + $maxLen + '} {1,10}') -f '', (Format-BuildSeconds $total)) -ForegroundColor Cyan
+    Write-Host $bar -ForegroundColor Cyan
+    $logDir = Join-Path $PSScriptRoot 'artifacts'
+    if (-not (Test-Path $logDir)) { New-Item -ItemType Directory -Path $logDir -Force | Out-Null }
+    $logFile = Join-Path $logDir 'build-timings.json'
+    $payload = [pscustomobject]@{
+        timestamp     = (Get-Date).ToString('o')
+        command       = $Command
+        configuration = $Configuration
+        total_seconds = [Math]::Round($total, 2)
+        steps         = $script:BuildTimings
+    }
+    $payload | ConvertTo-Json -Depth 5 | Set-Content -Path $logFile -Encoding utf8
+    Write-Host ('  log: {0}' -f $logFile) -ForegroundColor DarkGray
 }
 
 $Win32SourceDir = Join-Path $PSScriptRoot 'src' 'c' 'qsoripper-win32'
@@ -290,29 +368,26 @@ function Build-Win32 {
     }
 
     # cppcheck static analysis — fails the build on error-severity findings
-    Write-Step 'Win32 static analysis (cppcheck, optional)'
     $cppcheckExe = Get-Command cppcheck -ErrorAction SilentlyContinue
     if ($cppcheckExe) {
-        cppcheck --enable=warning,performance,portability `
-                 --error-exitcode=1 `
-                 --std=c11 `
-                 --suppress=missingIncludeSystem `
-                 --suppress=missingInclude `
-                 --inline-suppr `
-                 $Win32Source `
-                 $Win32JsonParserSource `
-                 $Win32FfiGateSource
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host 'FAILED: cppcheck found errors' -ForegroundColor Red
-            exit $LASTEXITCODE
+        Measure-BuildStep 'Win32 static analysis (cppcheck)' {
+            cppcheck --enable=warning,performance,portability `
+                     --error-exitcode=1 `
+                     --std=c11 `
+                     --suppress=missingIncludeSystem `
+                     --suppress=missingInclude `
+                     --inline-suppr `
+                     $Win32Source `
+                     $Win32JsonParserSource `
+                     $Win32FfiGateSource
         }
     }
     else {
+        Write-Step 'Win32 static analysis (cppcheck, optional)'
         $installHint = Get-CppcheckInstallHint
         Write-Host "cppcheck not found; continuing without optional Win32 static analysis. $installHint" -ForegroundColor Yellow
     }
 
-    Write-Step "Building qsoripper-win32 ($Configuration)"
     $null = New-Item -ItemType Directory -Force -Path $Win32PublishDir
     $optFlags = if ($IsReleaseBuild) { '/O2' } else { '/Od /Zi' }
     $exe = Join-Path $Win32PublishDir 'qsoripper-win32.exe'
@@ -328,16 +403,14 @@ if errorlevel 1 exit /b %errorlevel%
 cl /W4 /WX /analyze $optFlags /DUNICODE /D_UNICODE /I"$ffiInclude" /I"$Win32ResourcesDir" "$Win32Source" "$Win32JsonParserSource" "$Win32FfiGateSource" /Fe:"$exe" /link "$win32Res" user32.lib gdi32.lib shell32.lib comctl32.lib
 "@ | Set-Content -LiteralPath $buildScript -Encoding ASCII
 
-    Push-Location $Win32PublishDir
-    try {
-        cmd /c $buildScript
-        if ($LASTEXITCODE -ne 0) {
-            Write-Host "FAILED: Building qsoripper-win32 ($Configuration)" -ForegroundColor Red
-            exit $LASTEXITCODE
+    Measure-BuildStep "Building qsoripper-win32 ($Configuration)" {
+        Push-Location $Win32PublishDir
+        try {
+            cmd /c $buildScript
         }
-    }
-    finally {
-        Pop-Location
+        finally {
+            Pop-Location
+        }
     }
 
     # Copy FFI DLL alongside the win32 executable
@@ -560,17 +633,21 @@ Examples:
 "@
 }
 
-switch ($Command) {
-    'build'        { Build-All }
-    'check'        { Check-All }
-    'rust'         { Build-Rust }
-    'cw-decoder'   { Build-CwDecoderRust }
-    'dotnet'       { Build-Dotnet }
-    'win32'        { Build-Win32 }
-    'check-rust'   { Check-Rust }
-    'check-dotnet' { Check-Dotnet }
-    'proto'        { Check-Proto }
-    'help'         { Show-Help }
+try {
+    switch ($Command) {
+        'build'        { Build-All }
+        'check'        { Check-All }
+        'rust'         { Build-Rust }
+        'cw-decoder'   { Build-CwDecoderRust }
+        'dotnet'       { Build-Dotnet }
+        'win32'        { Build-Win32 }
+        'check-rust'   { Check-Rust }
+        'check-dotnet' { Check-Dotnet }
+        'proto'        { Check-Proto }
+        'help'         { Show-Help }
+    }
+} finally {
+    Write-BuildSummary
 }
 
 Write-Host "`nDone." -ForegroundColor Green


### PR DESCRIPTION
Wraps each step in build.ps1 with a stopwatch and emits a clean per-step + total summary at the end of every run, even on failure. Two paths instrumented: the common Invoke-Build helper (cargo + dotnet publish steps) and a new Measure-BuildStep helper for the inline Win32 cppcheck/cl invocations that bypass Invoke-Build.

Sample summary on a full clean Release build (9 steps, 3m35.5s total):

```
===========================================================================
 BUILD TIMING SUMMARY (9 steps)
===========================================================================
  STATUS STEP                                                TIME   SHARE
  OK     Building Rust (Release)                           1m6.2s   30.7%
  OK     Building CW decoder Rust binaries (Release)       1m2.5s   29.0%
  OK     Publishing QsoRipper.Cli Native AOT (Release)     21.02s    9.8%
  OK     Publishing QsoRipper.Gui (Release)                23.93s   11.1%
  OK     Publishing QsoRipper.Engine.DotNet (Release)      14.72s    6.8%
  OK     Publishing QsoRipper.DebugHost (Release)          12.97s    6.0%
  OK     Publishing CwDecoderGui (Release)                  4.44s    2.1%
  OK     Win32 static analysis (cppcheck)                   5.48s    2.5%
  OK     Building qsoripper-win32 (Release)                 4.20s    1.9%
===========================================================================
  TOTAL                                                   3m35.5s
===========================================================================
```

Useful observations the summary makes obvious:

- The two Rust builds (workspace + cw-decoder vendor) eat ~60% of total wall time. Biggest inner-loop win is leaving `target/` intact between runs.
- The seven .NET publish steps total ~95s; CwDecoderGui is the smallest.
- Win32 cppcheck + cl add ~10s when MSVC + cppcheck are installed.

Also writes a machine-readable `artifacts/build-timings.json` each run (timestamp, command, configuration, per-step seconds, total) so trends are trackable over time without scraping console output. `artifacts/` is already gitignored.

The wrapping uses try/finally so the summary still prints when a step fails — that step gets marked FAIL in red and the script exits with the original non-zero code, matching prior behavior. Verified on a build with a still-locked DLL: summary printed correctly and the failure was visible in the table.