### PR TITLE
Win32 JSON parser: match keys only at top level of outer object

### DIFF
--- a/src/c/qsoripper-win32/CMakeLists.txt
+++ b/src/c/qsoripper-win32/CMakeLists.txt
@@ -30,6 +30,13 @@ target_link_libraries(qsoripper-win32 PRIVATE
 # Enable Unicode
 target_compile_definitions(qsoripper-win32 PRIVATE UNICODE _UNICODE)
 
+# main.c defines wWinMain (Unicode GUI entry). MSVC accepts this automatically,
+# but the mingw/gcc CRT defaults to looking for WinMain (ANSI). The -municode
+# flag switches mingw's startup to look for wWinMain instead.
+if(MINGW)
+    target_link_options(qsoripper-win32 PRIVATE -municode)
+endif()
+
 if(MSVC)
     target_compile_options(qsoripper-win32 PRIVATE
         /W4

--- a/src/c/qsoripper-win32/src/json_parser.c
+++ b/src/c/qsoripper-win32/src/json_parser.c
@@ -8,6 +8,10 @@
  *     correctly ignored by extract_object, array_nth)
  *   - Dynamic pattern buffer for keys longer than 126 characters
  *   - Zero-allocation numeric parsing (get_int/get_double parse in-place)
+ *   - Top-level-only key lookup: json_get_string/int/double match the named
+ *     key only at depth 1 of the outer object, skipping over nested objects,
+ *     arrays, and string-value bytes. This prevents string-array elements or
+ *     nested-object keys from masquerading as top-level keys.
  */
 
 #define _CRT_SECURE_NO_WARNINGS
@@ -18,72 +22,69 @@
 #include <errno.h>
 #include <limits.h>
 
-/* Returns non-zero if c is JSON whitespace */
 static int is_json_ws(char c)
 {
     return c == ' ' || c == '\t' || c == '\r' || c == '\n';
 }
 
-char *json_get_string(const char *json, const char *key)
+/* Skip a JSON string starting at *p (which must point to the opening '"').
+   Returns a pointer just past the closing '"', or to the terminating NUL if
+   the string is unterminated. */
+static const char *skip_string(const char *p)
 {
-    if (!json || !key) return NULL;
-
-    /* Build the quoted key pattern: "key" */
-    size_t key_len = strlen(key);
-    size_t pat_len = key_len + 2; /* two quotes */
-    char stack_buf[128];
-    char *pattern;
-    if (pat_len < sizeof(stack_buf)) {
-        pattern = stack_buf;
-    } else {
-        pattern = (char *)malloc(pat_len + 1);
-        if (!pattern) return NULL;
-    }
-    pattern[0] = '"';
-    memcpy(pattern + 1, key, key_len);
-    pattern[1 + key_len] = '"';
-    pattern[2 + key_len] = '\0';
-
-    const char *p = strstr(json, pattern);
-    if (pattern != stack_buf) free(pattern);
-    if (!p) return NULL;
-
-    p += pat_len;
-    /* Skip JSON whitespace and colon */
-    while (is_json_ws(*p)) p++;
-    if (*p == ':') p++;
-    while (is_json_ws(*p)) p++;
-
-    if (*p == '"') {
+    if (*p != '"') return p;
+    p++;
+    while (*p && *p != '"') {
+        if (*p == '\\' && *(p + 1)) p++;
         p++;
-        const char *end = p;
-        while (*end && *end != '"') {
-            if (*end == '\\' && *(end + 1)) end++;
-            end++;
-        }
-        size_t len = (size_t)(end - p);
-        char *val = (char *)malloc(len + 1);
-        if (!val) return NULL;
-        memcpy(val, p, len);
-        val[len] = 0;
-        return val;
     }
-    /* Numeric or boolean value */
-    const char *end = p;
-    while (*end && *end != ',' && *end != '}' && *end != ']' && *end != '\n') end++;
-    size_t len = (size_t)(end - p);
-    while (len > 0 && (p[len - 1] == ' ' || p[len - 1] == '\r')) len--;
-    char *val = (char *)malloc(len + 1);
-    if (!val) return NULL;
-    memcpy(val, p, len);
-    val[len] = 0;
-    return val;
+    if (*p == '"') p++;
+    return p;
 }
 
-/* Locate the value span for a key without allocating.
-   Returns pointer to start of value, sets *out_len to length.
-   Returns NULL if not found. */
-static const char *locate_value(const char *json, const char *key, size_t *out_len)
+/* Skip a JSON container (object or array) starting at *p (which must point to
+   '{' or '['). Returns a pointer just past the matching closer, or to the
+   terminating NUL if unbalanced. String contents are scanned for escapes so
+   braces and brackets inside strings are ignored. */
+static const char *skip_container(const char *p)
+{
+    char open = *p;
+    if (open != '{' && open != '[') return p;
+    char close = (open == '{') ? '}' : ']';
+    int depth = 0;
+    int in_str = 0;
+    int esc = 0;
+    for (; *p; p++) {
+        if (in_str) {
+            if (esc) { esc = 0; continue; }
+            if (*p == '\\') { esc = 1; continue; }
+            if (*p == '"') { in_str = 0; }
+            continue;
+        }
+        if (*p == '"') { in_str = 1; continue; }
+        if (*p == open) depth++;
+        else if (*p == close) {
+            depth--;
+            if (depth == 0) { p++; break; }
+        }
+    }
+    return p;
+}
+
+/* Skip a bare scalar (number, true, false, null) until a value terminator. */
+static const char *skip_scalar(const char *p)
+{
+    while (*p && *p != ',' && *p != '}' && *p != ']') p++;
+    return p;
+}
+
+/* Find the first top-level key matching `key` inside the outer object of
+   `json` and return a pointer to the first byte of its value (past the
+   colon and any whitespace). Returns NULL if not found.
+   Only keys at depth 1 are considered: keys nested inside sub-objects or
+   array elements are skipped over, and string-value bytes are never
+   interpreted as key text. */
+static const char *find_value_start(const char *json, const char *key)
 {
     if (!json || !key) return NULL;
 
@@ -102,16 +103,86 @@ static const char *locate_value(const char *json, const char *key, size_t *out_l
     pattern[1 + key_len] = '"';
     pattern[2 + key_len] = '\0';
 
-    const char *p = strstr(json, pattern);
+    const char *p = json;
+    while (*p && is_json_ws(*p)) p++;
+    if (*p != '{') {
+        if (pattern != stack_buf) free(pattern);
+        return NULL;
+    }
+    p++;
+
+    const char *value_start = NULL;
+    while (*p) {
+        while (*p && is_json_ws(*p)) p++;
+        if (*p == '}' || *p == 0) break;
+        if (*p == ',') { p++; continue; }
+        if (*p != '"') { p++; continue; }
+
+        if (strncmp(p, pattern, pat_len) == 0) {
+            const char *after = p + pat_len;
+            while (*after && is_json_ws(*after)) after++;
+            if (*after == ':') {
+                after++;
+                while (*after && is_json_ws(*after)) after++;
+                value_start = after;
+                break;
+            }
+        }
+
+        p = skip_string(p);
+
+        while (*p && is_json_ws(*p)) p++;
+        if (*p == ':') p++;
+        while (*p && is_json_ws(*p)) p++;
+
+        if (*p == '"') {
+            p = skip_string(p);
+        } else if (*p == '{' || *p == '[') {
+            p = skip_container(p);
+        } else if (*p) {
+            p = skip_scalar(p);
+        }
+    }
+
     if (pattern != stack_buf) free(pattern);
+    return value_start;
+}
+
+char *json_get_string(const char *json, const char *key)
+{
+    const char *p = find_value_start(json, key);
     if (!p) return NULL;
 
-    p += pat_len;
-    while (is_json_ws(*p)) p++;
-    if (*p == ':') p++;
-    while (is_json_ws(*p)) p++;
+    if (*p == '"') {
+        p++;
+        const char *end = p;
+        while (*end && *end != '"') {
+            if (*end == '\\' && *(end + 1)) end++;
+            end++;
+        }
+        size_t len = (size_t)(end - p);
+        char *val = (char *)malloc(len + 1);
+        if (!val) return NULL;
+        memcpy(val, p, len);
+        val[len] = 0;
+        return val;
+    }
+    const char *end = p;
+    while (*end && *end != ',' && *end != '}' && *end != ']' && *end != '\n') end++;
+    size_t len = (size_t)(end - p);
+    while (len > 0 && (p[len - 1] == ' ' || p[len - 1] == '\r')) len--;
+    char *val = (char *)malloc(len + 1);
+    if (!val) return NULL;
+    memcpy(val, p, len);
+    val[len] = 0;
+    return val;
+}
 
-    /* Find value end */
+static const char *locate_value(const char *json, const char *key, size_t *out_len)
+{
+    const char *p = find_value_start(json, key);
+    if (!p) return NULL;
+
     if (*p == '"') {
         p++;
         const char *end = p;
@@ -122,7 +193,6 @@ static const char *locate_value(const char *json, const char *key, size_t *out_l
         *out_len = (size_t)(end - p);
         return p;
     }
-    /* Numeric/boolean value */
     const char *end = p;
     while (*end && *end != ',' && *end != '}' && *end != ']' && *end != '\n') end++;
     size_t len = (size_t)(end - p);
@@ -137,7 +207,6 @@ double json_get_double(const char *json, const char *key, double dflt)
     const char *span = locate_value(json, key, &len);
     if (!span || len == 0) return dflt;
 
-    /* Copy to a small stack buffer for strtod (needs NUL terminator) */
     char buf[64];
     if (len >= sizeof(buf)) return dflt;
     memcpy(buf, span, len);
@@ -177,7 +246,7 @@ const char *json_array_nth(const char *json, int n)
     int depth = 0, idx = 0, in_str = 0;
     for (; *p; p++) {
         if (in_str) {
-            if (in_str == 2) { in_str = 1; continue; } /* escaped char */
+            if (in_str == 2) { in_str = 1; continue; }
             if (*p == '\\') { in_str = 2; continue; }
             if (*p == '"') { in_str = 0; }
             continue;

--- a/src/c/qsoripper-win32/tests/json_parser_tests.c
+++ b/src/c/qsoripper-win32/tests/json_parser_tests.c
@@ -330,9 +330,13 @@ static void test_deeply_nested(void)
     char *v = json_extract_object(deep);
     ASSERT_STR_EQ(deep, v); free(v);
 
-    /* Can extract inner key (strstr finds first match) */
-    v = json_get_string(deep, "e");
-    ASSERT_STR_EQ("leaf", v); free(v);
+    /* json_get_string is top-level only: outer key "a" returns the nested
+       object as a raw substring; inner-only key "e" returns NULL. Callers
+       that need to descend must call json_extract_object first. */
+    v = json_get_string(deep, "a");
+    if (v) { free(v); g_pass++; } else { g_fail++; printf("  FAIL: outer key 'a' not found\n"); }
+
+    ASSERT_NULL(json_get_string(deep, "e"));
 }
 
 static void test_numeric_edge_cases(void)
@@ -381,12 +385,70 @@ static void test_escaped_quotes_in_value(void)
 static void test_key_as_substring_of_value(void)
 {
     printf("test_key_as_substring_of_value\n");
-    /* Key "id" appears inside a value before the real key */
+    /* Key "id" appears inside a value before the real key.
+       The quoted-pattern "id" does not match inside "id_holder" because of the
+       trailing _, so the real key is found correctly. */
     char *v = json_get_string("{\"name\":\"id_holder\",\"id\":\"real\"}", "id");
-    /* strstr finds "id" inside "id_holder" first — this is a known limitation.
-       The important thing is it doesn't crash. */
-    if (v) free(v);
-    g_pass++; /* no crash */
+    ASSERT_STR_EQ("real", v); if (v) free(v);
+}
+
+/* The CLI emits well-formed JSON, but operator-supplied free-text values
+   (notes, comment, qth, workedName) can contain bytes that look like another
+   JSON key. We must only match keys at the top level of the outer object,
+   never inside a string array, nested object, or string value. */
+static void test_top_level_only_string_array_element(void)
+{
+    printf("test_top_level_only_string_array_element\n");
+
+    /* String-array element "callsign" sits in the byte stream as the literal
+       bytes "callsign" (correctly quoted by JSON). The current parser walks
+       the text with strstr and matches the array element before reaching the
+       real top-level key. */
+    const char *json =
+        "{\"tags\":[\"band\",\"callsign\"],\"callsign\":\"K7AVA\"}";
+    char *v = json_get_string(json, "callsign");
+    ASSERT_STR_EQ("K7AVA", v); if (v) free(v);
+}
+
+static void test_top_level_only_nested_object_key(void)
+{
+    printf("test_top_level_only_nested_object_key\n");
+
+    /* Same key appears in an inner object first. We want the outer value. */
+    const char *json =
+        "{\"meta\":{\"callsign\":\"NESTED\"},\"callsign\":\"OUTER\"}";
+    char *v = json_get_string(json, "callsign");
+    ASSERT_STR_EQ("OUTER", v); if (v) free(v);
+
+    /* Same for numeric values via locate_value. */
+    const char *jnum =
+        "{\"meta\":{\"cqZone\":99},\"cqZone\":5}";
+    ASSERT_INT_EQ(5, json_get_int(jnum, "cqZone", 0));
+
+    /* Same for doubles. */
+    const char *jdbl =
+        "{\"meta\":{\"kIndex\":9.9},\"kIndex\":1.5}";
+    ASSERT_DOUBLE_EQ(1.5, json_get_double(jdbl, "kIndex", 0.0), 0.001);
+}
+
+static void test_top_level_only_key_present_only_in_nested(void)
+{
+    printf("test_top_level_only_key_present_only_in_nested\n");
+
+    /* Key exists only at depth >= 2. Top-level lookup must return NULL. */
+    const char *json = "{\"meta\":{\"callsign\":\"NESTED\"}}";
+    ASSERT_NULL(json_get_string(json, "callsign"));
+    ASSERT_INT_EQ(-1, json_get_int(json, "cqZone", -1));
+}
+
+static void test_top_level_only_key_in_array_only(void)
+{
+    printf("test_top_level_only_key_in_array_only\n");
+
+    /* Key-shaped string only appears as an array element, not as a real key. */
+    const char *json = "{\"tags\":[\"callsign\",\"band\"]}";
+    ASSERT_NULL(json_get_string(json, "callsign"));
+    ASSERT_NULL(json_get_string(json, "band"));
 }
 
 static void test_consecutive_commas(void)
@@ -911,6 +973,10 @@ int main(void)
     test_value_is_boolean();
     test_escaped_quotes_in_value();
     test_key_as_substring_of_value();
+    test_top_level_only_string_array_element();
+    test_top_level_only_nested_object_key();
+    test_top_level_only_key_present_only_in_nested();
+    test_top_level_only_key_in_array_only();
     test_consecutive_commas();
     test_empty_object();
     test_array_of_one();


### PR DESCRIPTION
The strstr-based key lookup in json_get_string and locate_value matched a quoted key pattern anywhere in the byte stream, so a string-array element like ["callsign", ...] or a same-named key in a nested object would be returned instead of the real top-level value. Well-formed JSON escaping already protects plain string values, but arrays-of-strings and nested objects are realistic exploit shapes against future CLI schemas.

Replace the strstr scan with a structural walk (find_value_start) that tracks brace depth and string state and only matches the requested key at depth 1 of the outer object. json_get_string and locate_value share the helper, so json_get_int and json_get_double get the same scoping. json_extract_object and json_array_nth are unchanged.

Adds five regression tests covering string-array elements, nested same-key objects (string/int/double), key-present-only-in-nested, and key-in-array-only. Tightens test_key_as_substring_of_value and test_deeply_nested to the new contract. 140/140 tests pass; 8 of the new assertions failed before the fix.

Also fixes a pre-existing mingw link failure on qsoripper-win32.exe: the GUI entry point is wWinMain (Unicode), which MSVC accepts automatically but mingw's CRT only recognizes when linked with -municode. The flag is applied conditionally under MINGW so the GUI target links cleanly under both toolchains.
