### PR TITLE
Rust engine: UpdateQso must flip Synced -> Modified on edit

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -168,7 +168,7 @@ Updates an existing QSO record by `local_id`.
 1. Look up the existing record by `local_id`.
 2. Apply provided field updates. Fields not included in the request are not modified.
 3. Set `updated_at` to the current UTC time.
-4. If the QSO was previously synced, set `sync_status` to `SYNC_STATUS_MODIFIED`.
+4. If the QSO was previously synced, set `sync_status` to `SYNC_STATUS_MODIFIED`. The engine — not the client — is the source of truth for `sync_status` and `qrz_logid` on update: round-tripping the existing values from a client request MUST NOT change them, and a client MUST NOT be able to advance a `LOCAL_ONLY` row to `SYNCED` (or claim a `qrz_logid`) via `UpdateQso`. The only state transitions the engine performs here are `SYNCED → MODIFIED` on edit, and (in step 6) `MODIFIED → SYNCED` on a successful per-op sync.
 5. Persist the updated record.
 6. If `sync_to_qrz=true`, immediately push the updated record to QRZ Logbook (per-operation sync; see §7.3 below). If the row already has a `qrz_logid`, use REPLACE so the same remote row is updated in place; otherwise INSERT. On success, write back the QRZ-assigned `qrz_logid` and `sync_status=SYNC_STATUS_SYNCED`, and set `UpdateQsoResponse.sync_success=true`. On failure, leave the local row in its current state (`SYNC_STATUS_MODIFIED` or `SYNC_STATUS_NOT_SYNCED`), set `sync_success=false`, and put a human-readable message in `sync_error`. The local persist MUST succeed regardless.
 7. Return the updated `QsoRecord`.

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -873,6 +873,51 @@ public sealed class ManagedEngineStateTests : IDisposable
     }
 
     [Fact]
+    public void Update_qso_flips_synced_to_modified_so_next_sync_uses_replace()
+    {
+        // Regression for the .NET parity of the Rust bug fixed in this change:
+        // editing a previously-synced QSO must leave the row marked Modified
+        // (with its qrz_logid intact) so the next bulk sync issues REPLACE
+        // instead of stranding the local correction. See
+        // docs/architecture/engine-specification.md §UpdateQso step 4.
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            QrzLogbookApiKey = "test-api-key",
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87",
+            },
+        });
+        var loggedResp = state.LogQso(new LogQsoRequest
+        {
+            SyncToQrz = true,
+            Qso = new QsoRecord
+            {
+                WorkedCallsign = "WG0Y",
+                Band = Band._20M,
+                Mode = Mode.Cw,
+                UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+        });
+        var logged = state.GetQso(loggedResp.LocalId)!;
+        Assert.Equal(SyncStatus.Synced, logged.SyncStatus);
+        var originalLogid = logged.QrzLogid;
+        Assert.False(string.IsNullOrEmpty(originalLogid));
+
+        // Operator edits a field without re-syncing.
+        var edit = new QsoRecord(logged) { Notes = "Corrected state to CO" };
+        state.UpdateQso(new UpdateQsoRequest { Qso = edit, SyncToQrz = false });
+
+        var reloaded = state.GetQso(loggedResp.LocalId)!;
+        Assert.Equal(SyncStatus.Modified, reloaded.SyncStatus);
+        Assert.Equal(originalLogid, reloaded.QrzLogid);
+    }
+
+    [Fact]
     public void Restore_clears_tombstone_and_pending_flag()
     {
         var state = CreateState();

--- a/src/rust/qsoripper-core/src/application/logbook.rs
+++ b/src/rust/qsoripper-core/src/application/logbook.rs
@@ -122,6 +122,27 @@ impl LogbookEngine {
         qso.created_at = existing.created_at.or_else(|| Some(now_timestamp()));
         qso.updated_at = Some(now_timestamp());
 
+        // The engine — not the client — is the source of truth for `sync_status`.
+        // Per the engine specification (docs/architecture/engine-specification.md
+        // §UpdateQso step 4): "If the QSO was previously synced, set
+        // `sync_status` to `SYNC_STATUS_MODIFIED`." This keeps the QRZ logid
+        // attached to the row so the next bulk sync can issue a REPLACE instead
+        // of stranding the local correction.
+        //
+        // For any other prior state (LocalOnly, Modified, Conflict) we preserve
+        // `existing.sync_status` rather than trust the inbound record, since
+        // clients typically round-trip whatever value they read and have no
+        // authority to advance the sync state on their own. A per-operation
+        // sync attempted by the server layer is what flips Modified → Synced
+        // after a successful REPLACE.
+        qso.sync_status = if existing.sync_status == SyncStatus::Synced as i32 {
+            SyncStatus::Modified as i32
+        } else {
+            existing.sync_status
+        };
+        qso.qrz_logid.clone_from(&existing.qrz_logid);
+        qso.qrz_bookid.clone_from(&existing.qrz_bookid);
+
         let updated = self.storage.logbook().update_qso(&qso).await?;
         if updated {
             Ok(qso)

--- a/src/rust/qsoripper-storage-memory/src/lib.rs
+++ b/src/rust/qsoripper-storage-memory/src/lib.rs
@@ -374,7 +374,9 @@ mod tests {
     use prost_types::Timestamp;
     use qsoripper_core::application::logbook::LogbookEngine;
     use qsoripper_core::domain::qso::QsoRecordBuilder;
-    use qsoripper_core::proto::qsoripper::domain::{Band, LookupResult, LookupState, Mode};
+    use qsoripper_core::proto::qsoripper::domain::{
+        Band, LookupResult, LookupState, Mode, SyncStatus,
+    };
     use qsoripper_core::storage::{
         DeletedRecordsFilter, EngineStorage, LogbookStore, LookupSnapshot, LookupSnapshotStore,
         QsoListQuery, QsoSortOrder,
@@ -890,5 +892,130 @@ mod tests {
         let none = logbook.list_qso_history("NEVER", 5).await.unwrap();
         assert_eq!(none.total, 0);
         assert!(none.entries.is_empty());
+    }
+
+    /// Regression for the bug where editing a previously-synced QSO left the
+    /// row's `sync_status` as `SYNCED`, so the next bulk sync skipped the
+    /// upload and the local correction was stranded on the local DB. See
+    /// docs/architecture/engine-specification.md §UpdateQso step 4: "If the
+    /// QSO was previously synced, set `sync_status` to `SYNC_STATUS_MODIFIED`."
+    #[tokio::test]
+    async fn update_qso_flips_synced_to_modified() {
+        let storage: Arc<dyn EngineStorage> = Arc::new(MemoryStorage::new());
+        let engine = LogbookEngine::new(storage.clone());
+
+        let stored = engine
+            .log_qso(
+                QsoRecordBuilder::new("KC7AVA", "WG0Y")
+                    .band(Band::Band20m)
+                    .mode(Mode::Cw)
+                    .timestamp(Timestamp {
+                        seconds: 1_700_000_000,
+                        nanos: 0,
+                    })
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        // Simulate a successful prior sync: the row carries a QRZ logid and is
+        // marked Synced.
+        let mut synced = stored.clone();
+        synced.sync_status = SyncStatus::Synced as i32;
+        synced.qrz_logid = Some("1451311710".into());
+        assert!(storage.logbook().update_qso(&synced).await.unwrap());
+
+        // Operator corrects a field. The client typically round-trips the
+        // record verbatim, so the inbound `sync_status` is still Synced — the
+        // engine must override it.
+        let mut edit = synced.clone();
+        edit.notes = Some("Corrected state to CO".into());
+        let updated = engine.update_qso(edit).await.unwrap();
+
+        assert_eq!(
+            updated.sync_status,
+            SyncStatus::Modified as i32,
+            "edit of a Synced QSO must flip to Modified so the next sync uploads via REPLACE"
+        );
+        assert_eq!(
+            updated.qrz_logid.as_deref(),
+            Some("1451311710"),
+            "qrz_logid must be preserved so the next sync can issue REPLACE against the same remote row"
+        );
+
+        // And the persisted row reflects the same state — not just the
+        // returned value.
+        let reloaded = engine.get_qso(&updated.local_id).await.unwrap();
+        assert_eq!(reloaded.sync_status, SyncStatus::Modified as i32);
+        assert_eq!(reloaded.qrz_logid.as_deref(), Some("1451311710"));
+    }
+
+    /// Editing a row that's already `Modified` (a second local edit before the
+    /// next sync) keeps it `Modified` — never demotes it back to `LocalOnly`
+    /// or accidentally upgrades it to `Synced`.
+    #[tokio::test]
+    async fn update_qso_keeps_modified_modified() {
+        let storage: Arc<dyn EngineStorage> = Arc::new(MemoryStorage::new());
+        let engine = LogbookEngine::new(storage.clone());
+
+        let stored = engine
+            .log_qso(
+                QsoRecordBuilder::new("KC7AVA", "K7ABC")
+                    .band(Band::Band20m)
+                    .mode(Mode::Cw)
+                    .timestamp(Timestamp {
+                        seconds: 1_700_000_000,
+                        nanos: 0,
+                    })
+                    .build(),
+            )
+            .await
+            .unwrap();
+
+        let mut modified = stored.clone();
+        modified.sync_status = SyncStatus::Modified as i32;
+        modified.qrz_logid = Some("999".into());
+        assert!(storage.logbook().update_qso(&modified).await.unwrap());
+
+        let mut edit = modified.clone();
+        edit.notes = Some("second edit before sync".into());
+        let updated = engine.update_qso(edit).await.unwrap();
+
+        assert_eq!(updated.sync_status, SyncStatus::Modified as i32);
+        assert_eq!(updated.qrz_logid.as_deref(), Some("999"));
+    }
+
+    /// A client that round-trips a stale `Synced` value on a row that the
+    /// engine considers `LocalOnly` (e.g., a freshly logged but never-synced
+    /// row) must not be able to claim the row is synced. The engine is the
+    /// authority on `sync_status` and `qrz_logid`.
+    #[tokio::test]
+    async fn update_qso_ignores_client_supplied_sync_status_for_local_only_row() {
+        let storage: Arc<dyn EngineStorage> = Arc::new(MemoryStorage::new());
+        let engine = LogbookEngine::new(storage.clone());
+
+        let stored = engine
+            .log_qso(
+                QsoRecordBuilder::new("KC7AVA", "K7NEW")
+                    .band(Band::Band20m)
+                    .mode(Mode::Cw)
+                    .timestamp(Timestamp {
+                        seconds: 1_700_000_000,
+                        nanos: 0,
+                    })
+                    .build(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(stored.sync_status, SyncStatus::LocalOnly as i32);
+
+        let mut edit = stored.clone();
+        edit.sync_status = SyncStatus::Synced as i32;
+        edit.qrz_logid = Some("fake-logid".into());
+        edit.notes = Some("client tried to claim synced".into());
+
+        let updated = engine.update_qso(edit).await.unwrap();
+        assert_eq!(updated.sync_status, SyncStatus::LocalOnly as i32);
+        assert!(updated.qrz_logid.as_deref().unwrap_or("").is_empty());
     }
 }


### PR DESCRIPTION
Editing a previously-synced QSO via the Rust engine left the row's sync_status as SYNCED, so F6 sync silently skipped the upload and the local correction was stranded. Real repro on randy's main log: a WG0Y QSO had its STATE corrected from MO to CO locally; F6 reported success but a direct QRZ FETCH (LOGIDS:1451311710) confirmed the remote row was still MO.

This is the same failure mode as #386 (closed), but that fix only covered the .NET sync engine's REPLACE path. The Rust engine's LogbookApplication::update_qso simply never implemented the Synced -> Modified flip required by docs/architecture/engine-specification.md section UpdateQso step 4. The .NET managed engine implements it correctly via ApplySyncFlagsNoLock; the Rust engine just persisted whatever sync_status the client round-tripped.

Fix scope:

- src/rust/qsoripper-core/src/application/logbook.rs: server-authoritative sync_status on UpdateQso. If existing was Synced, mark Modified. qrz_logid and qrz_bookid are also pinned to the existing values so a stale client cannot strip QRZ identity off a synced row.
- src/rust/qsoripper-storage-memory/src/lib.rs: three regression tests (Synced->Modified flip, Modified->Modified preserve, client-cannot-claim-Synced).
- src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs: parity regression test for the managed .NET engine path that previously had no coverage of this rule.
- docs/architecture/engine-specification.md: tighten UpdateQso step 4 to make explicit that the engine owns sync_status and qrz_logid and clients cannot advance them via round-trip.

Validation run locally:

- cargo fmt --manifest-path src/rust/Cargo.toml --all -- --check
- cargo clippy --manifest-path src/rust/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path src/rust/Cargo.toml --workspace --exclude qsoripper-ffi
- dotnet test src/dotnet/QsoRipper.Engine.DotNet.Tests/QsoRipper.Engine.DotNet.Tests.csproj
- dotnet format --verify-no-changes on the touched test project

Note: qsoripper-ffi integration tests were excluded because they connect to a live server on :50051 and one unrelated test (log_list_get_delete_round_trip) was failing pre-existing against the user's stale server build; confirmed unrelated by re-running with this change stashed.

The user's stuck WG0Y row in their main log was repaired in place via SQL (sync_status=2, qrz_logid preserved), so the next F6 with the fixed binary will issue REPLACE and reconcile QRZ. Related to #386, #213.