### PR TITLE
Add qsoripper-launcher: fast TUI launcher for engines and UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,8 +239,14 @@ For the full dependency matrix and per-lane setup notes, see `docs\development\u
 **Interactive launcher TUI (recommended for mixed engine + UI startup):**
 
 ```powershell
+.\launcher.ps1
+```
+
+Or invoke cargo directly:
+
+```powershell
 cd src\rust
-cargo run -p qsoripper-launcher
+cargo run -p qsoripper-launcher --release
 ```
 
 `qsoripper-launcher` is a fast-starting ratatui app that lists available engines (Rust on 50051, .NET on 50052) and UIs (Avalonia GUI, DebugHost, CW Scope, Rust TUI), and lets you toggle which to start with `Space`, bind each UI to a specific engine in the third column, and `Enter` to launch. `S` stops launcher-managed processes. Selections persist under `[launcher]` in `config.toml`. The launcher does not build artifacts — run `.\build.ps1` first.

--- a/README.md
+++ b/README.md
@@ -236,6 +236,15 @@ Artifacts are written under `artifacts\ux\current\`, `artifacts\ux\baseline\`, a
 
 For the full dependency matrix and per-lane setup notes, see `docs\development\ui-inspection.md`.
 
+**Interactive launcher TUI (recommended for mixed engine + UI startup):**
+
+```powershell
+cd src\rust
+cargo run -p qsoripper-launcher
+```
+
+`qsoripper-launcher` is a fast-starting ratatui app that lists available engines (Rust on 50051, .NET on 50052) and UIs (Avalonia GUI, DebugHost, CW Scope, Rust TUI), and lets you toggle which to start with `Space`, bind each UI to a specific engine in the third column, and `Enter` to launch. `S` stops launcher-managed processes. Selections persist under `[launcher]` in `config.toml`. The launcher does not build artifacts — run `.\build.ps1` first.
+
 **Local engine launcher (recommended):**
 
 ```powershell

--- a/cli.ps1
+++ b/cli.ps1
@@ -1,0 +1,59 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Runs the prebuilt QsoRipper.Cli for instant startup.
+
+.DESCRIPTION
+    Invokes the compiled QsoRipper.Cli.dll under
+    src\dotnet\QsoRipper.Cli\bin\<Config>\net10.0 directly with `dotnet`, so
+    there is no msbuild evaluation overhead. If the binary is missing (or
+    -Rebuild is passed) the script builds it first with 'dotnet build'.
+
+    Pass -Dev to use the Debug configuration. Arguments after '--' are
+    forwarded to the CLI.
+
+.EXAMPLE
+    .\cli.ps1 status
+
+.EXAMPLE
+    .\cli.ps1 -Rebuild -- --help
+
+.EXAMPLE
+    .\cli.ps1 -Dev log list
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Dev,
+    [switch]$Rebuild,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Forward
+)
+
+$ErrorActionPreference = 'Stop'
+
+$projectPath = Join-Path $PSScriptRoot 'src\dotnet\QsoRipper.Cli\QsoRipper.Cli.csproj'
+if (-not (Test-Path -LiteralPath $projectPath)) {
+    throw "QsoRipper.Cli project not found at $projectPath"
+}
+
+$config = if ($Dev) { 'Debug' } else { 'Release' }
+$tfm = 'net10.0'
+$dllPath = Join-Path $PSScriptRoot "src\dotnet\QsoRipper.Cli\bin\$config\$tfm\QsoRipper.Cli.dll"
+
+if ($Rebuild -or -not (Test-Path -LiteralPath $dllPath)) {
+    $buildArgs = @('build', $projectPath, '-c', $config, '--nologo', '-v', 'minimal')
+    & dotnet @buildArgs
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
+if (-not (Test-Path -LiteralPath $dllPath)) {
+    throw "CLI assembly not found at $dllPath after build"
+}
+
+if ($Forward) {
+    & dotnet $dllPath @Forward
+} else {
+    & dotnet $dllPath
+}
+exit $LASTEXITCODE

--- a/launcher.ps1
+++ b/launcher.ps1
@@ -1,0 +1,54 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Runs the qsoripper-launcher TUI.
+
+.DESCRIPTION
+    Thin wrapper around 'cargo run -p qsoripper-launcher' from the Rust
+    workspace at src\rust. Defaults to a release build so startup is fast.
+    Pass -Dev to use the dev profile instead. Any extra arguments after
+    '--' are forwarded to the launcher binary.
+
+.EXAMPLE
+    .\launcher.ps1
+
+.EXAMPLE
+    .\launcher.ps1 -Dev
+
+.EXAMPLE
+    .\launcher.ps1 -- --help
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$Dev,
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$Forward
+)
+
+$ErrorActionPreference = 'Stop'
+
+$rustRoot = Join-Path $PSScriptRoot 'src\rust'
+if (-not (Test-Path -LiteralPath $rustRoot)) {
+    throw "Rust workspace not found at $rustRoot"
+}
+
+$cargoArgs = @('run', '-p', 'qsoripper-launcher')
+if (-not $Dev) {
+    $cargoArgs += '--release'
+}
+if ($Forward) {
+    $cargoArgs += '--'
+    $cargoArgs += $Forward
+}
+
+Push-Location $rustRoot
+try {
+    & cargo @cargoArgs
+    $exit = $LASTEXITCODE
+}
+finally {
+    Pop-Location
+}
+
+exit $exit

--- a/launcher.ps1
+++ b/launcher.ps1
@@ -1,19 +1,22 @@
 #!/usr/bin/env pwsh
 <#
 .SYNOPSIS
-    Runs the qsoripper-launcher TUI.
+    Runs the prebuilt qsoripper-launcher TUI for instant startup.
 
 .DESCRIPTION
-    Thin wrapper around 'cargo run -p qsoripper-launcher' from the Rust
-    workspace at src\rust. Defaults to a release build so startup is fast.
-    Pass -Dev to use the dev profile instead. Any extra arguments after
-    '--' are forwarded to the launcher binary.
+    Invokes the release binary at src\rust\target\release\qsoripper-launcher
+    directly, bypassing cargo so there is no manifest-resolve overhead. If the
+    binary is missing (or -Rebuild is passed) the script builds it first with
+    'cargo build --release'.
+
+    Pass -Dev to use the unoptimized debug binary. Arguments after '--' are
+    forwarded to the launcher.
 
 .EXAMPLE
     .\launcher.ps1
 
 .EXAMPLE
-    .\launcher.ps1 -Dev
+    .\launcher.ps1 -Rebuild
 
 .EXAMPLE
     .\launcher.ps1 -- --help
@@ -22,6 +25,7 @@
 [CmdletBinding()]
 param(
     [switch]$Dev,
+    [switch]$Rebuild,
     [Parameter(ValueFromRemainingArguments = $true)]
     [string[]]$Forward
 )
@@ -33,22 +37,30 @@ if (-not (Test-Path -LiteralPath $rustRoot)) {
     throw "Rust workspace not found at $rustRoot"
 }
 
-$cargoArgs = @('run', '-p', 'qsoripper-launcher')
-if (-not $Dev) {
-    $cargoArgs += '--release'
+$profileDir = if ($Dev) { 'debug' } else { 'release' }
+$exeName = if ($IsWindows -or $env:OS -eq 'Windows_NT') { 'qsoripper-launcher.exe' } else { 'qsoripper-launcher' }
+$exePath = Join-Path $rustRoot "target\$profileDir\$exeName"
+
+if ($Rebuild -or -not (Test-Path -LiteralPath $exePath)) {
+    $buildArgs = @('build', '-p', 'qsoripper-launcher')
+    if (-not $Dev) { $buildArgs += '--release' }
+    Push-Location $rustRoot
+    try {
+        & cargo @buildArgs
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    }
+    finally {
+        Pop-Location
+    }
 }
+
+if (-not (Test-Path -LiteralPath $exePath)) {
+    throw "Launcher binary not found at $exePath after build"
+}
+
 if ($Forward) {
-    $cargoArgs += '--'
-    $cargoArgs += $Forward
+    & $exePath @Forward
+} else {
+    & $exePath
 }
-
-Push-Location $rustRoot
-try {
-    & cargo @cargoArgs
-    $exit = $LASTEXITCODE
-}
-finally {
-    Pop-Location
-}
-
-exit $exit
+exit $LASTEXITCODE

--- a/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
@@ -1,6 +1,7 @@
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
 using QsoRipper.Gui.Services;
+using QsoRipper.Gui.Utilities;
 using QsoRipper.Gui.ViewModels;
 using QsoRipper.Services;
 
@@ -140,6 +141,71 @@ public sealed class MainWindowViewModelTests
         await viewModel.SyncNowCommand.ExecuteAsync(null);
 
         Assert.Contains("↑2", viewModel.SyncStatusText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ApplyPreferencesIgnoresPersistedEngineWhenQsoripperEngineEnvIsSet()
+    {
+        const string envKey = "QSORIPPER_ENGINE";
+        var prior = Environment.GetEnvironmentVariable(envKey);
+        Environment.SetEnvironmentVariable(envKey, "local-dotnet");
+        try
+        {
+            using var viewModel = new MainWindowViewModel(new FakeEngineClient());
+
+            viewModel.ApplyPreferences(new UiPreferences
+            {
+                EngineProfileId = "local-rust",
+                EngineEndpoint = "http://127.0.0.1:50051",
+            });
+
+            var captured = viewModel.CapturePreferences();
+
+            // When env overrides the engine selection, the persisted preference
+            // must be preserved (not replaced by the runtime/test fixture value)
+            // so a later env-less launch falls back to what the user actually chose.
+            Assert.Equal("local-rust", captured.EngineProfileId);
+            Assert.Equal("http://127.0.0.1:50051", captured.EngineEndpoint);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(envKey, prior);
+        }
+    }
+
+    [Fact]
+    public void ApplyPreferencesUsesPersistedEngineWhenEnvIsUnset()
+    {
+        const string profileKey = "QSORIPPER_ENGINE";
+        const string legacyKey = "QSORIPPER_ENGINE_IMPLEMENTATION";
+        const string endpointKey = "QSORIPPER_ENDPOINT";
+        var priorProfile = Environment.GetEnvironmentVariable(profileKey);
+        var priorLegacy = Environment.GetEnvironmentVariable(legacyKey);
+        var priorEndpoint = Environment.GetEnvironmentVariable(endpointKey);
+        Environment.SetEnvironmentVariable(profileKey, null);
+        Environment.SetEnvironmentVariable(legacyKey, null);
+        Environment.SetEnvironmentVariable(endpointKey, null);
+        try
+        {
+            using var viewModel = new MainWindowViewModel(new FakeEngineClient());
+
+            viewModel.ApplyPreferences(new UiPreferences
+            {
+                EngineProfileId = "local-dotnet",
+                EngineEndpoint = "http://127.0.0.1:50052",
+            });
+
+            var captured = viewModel.CapturePreferences();
+
+            Assert.Equal("local-dotnet", captured.EngineProfileId);
+            Assert.Equal("http://127.0.0.1:50052", captured.EngineEndpoint);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(profileKey, priorProfile);
+            Environment.SetEnvironmentVariable(legacyKey, priorLegacy);
+            Environment.SetEnvironmentVariable(endpointKey, priorEndpoint);
+        }
     }
 
     private static async Task WaitUntilAsync(Func<bool> predicate, TimeSpan timeout)

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -41,6 +41,8 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     private bool _setupCompleteBeforeWizard;
     private string? _preferredEngineProfileId;
     private string? _preferredEngineEndpoint;
+    private string? _persistedEngineProfileId;
+    private string? _persistedEngineEndpoint;
     private StationProfile? _activeStationProfile;
 
     [ObservableProperty]
@@ -553,6 +555,13 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     {
         ArgumentNullException.ThrowIfNull(profile);
         return $"Engine: {profile.DisplayName}";
+    }
+
+    private static bool HasEngineEnvironmentOverride()
+    {
+        return !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EngineCatalog.EngineProfileEnvironmentVariable))
+            || !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EngineCatalog.LegacyEngineProfileEnvironmentVariable))
+            || !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EngineCatalog.EndpointEnvironmentVariable));
     }
 
     /// <summary>
@@ -1658,12 +1667,25 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
             IsInspectorOpen = true;
         }
 
-        _preferredEngineProfileId = string.IsNullOrWhiteSpace(prefs.EngineProfileId)
+        var loadedProfileId = string.IsNullOrWhiteSpace(prefs.EngineProfileId)
             ? null
             : prefs.EngineProfileId.Trim();
-        _preferredEngineEndpoint = string.IsNullOrWhiteSpace(prefs.EngineEndpoint)
+        var loadedEndpoint = string.IsNullOrWhiteSpace(prefs.EngineEndpoint)
             ? null
             : prefs.EngineEndpoint.Trim();
+        _persistedEngineProfileId = loadedProfileId;
+        _persistedEngineEndpoint = loadedEndpoint;
+
+        if (HasEngineEnvironmentOverride())
+        {
+            _preferredEngineProfileId = null;
+            _preferredEngineEndpoint = null;
+        }
+        else
+        {
+            _preferredEngineProfileId = loadedProfileId;
+            _preferredEngineEndpoint = loadedEndpoint;
+        }
 
         if (!string.IsNullOrWhiteSpace(prefs.CwDecoderDeviceOverride))
         {
@@ -1685,21 +1707,29 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     /// <summary>
     /// Captures current UI toggle state for persistence across restarts.
     /// </summary>
-    internal UiPreferences CapturePreferences() => new()
+    internal UiPreferences CapturePreferences()
     {
-        IsRigEnabled = IsRigEnabled,
-        IsSpaceWeatherVisible = IsSpaceWeatherVisible,
-        IsInspectorOpen = IsInspectorOpen,
-        EngineProfileId = _switchableEngine?.CurrentProfile.ProfileId,
-        EngineEndpoint = _switchableEngine?.CurrentEndpoint,
-        IsCwDecoderEnabled = IsCwDecoderEnabled,
-        IsCwDecoderLoopback = IsCwDecoderLoopback,
-        IsCwWpmStatusBarVisible = IsCwWpmStatusBarVisible,
-        IsCwDiagnosticsEnabled = IsCwDiagnosticsEnabled,
-        CwDecoderDeviceOverride = string.IsNullOrWhiteSpace(CwDecoderDeviceOverride)
-            ? null
-            : CwDecoderDeviceOverride.Trim(),
-    };
+        var envOverride = HasEngineEnvironmentOverride();
+        return new UiPreferences
+        {
+            IsRigEnabled = IsRigEnabled,
+            IsSpaceWeatherVisible = IsSpaceWeatherVisible,
+            IsInspectorOpen = IsInspectorOpen,
+            EngineProfileId = envOverride
+                ? _persistedEngineProfileId
+                : (_switchableEngine?.CurrentProfile.ProfileId ?? _persistedEngineProfileId),
+            EngineEndpoint = envOverride
+                ? _persistedEngineEndpoint
+                : (_switchableEngine?.CurrentEndpoint ?? _persistedEngineEndpoint),
+            IsCwDecoderEnabled = IsCwDecoderEnabled,
+            IsCwDecoderLoopback = IsCwDecoderLoopback,
+            IsCwWpmStatusBarVisible = IsCwWpmStatusBarVisible,
+            IsCwDiagnosticsEnabled = IsCwDiagnosticsEnabled,
+            CwDecoderDeviceOverride = string.IsNullOrWhiteSpace(CwDecoderDeviceOverride)
+                ? null
+                : CwDecoderDeviceOverride.Trim(),
+        };
+    }
 
     private async Task ActivateDashboardAsync(bool focusSearch, Task? recentQsoRefreshTask = null)
     {

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "qsoripper-stress",
     "qsoripper-stress-tui",
     "qsoripper-tui",
+    "qsoripper-launcher",
 ]
 
 [workspace.package]

--- a/src/rust/qsoripper-launcher/Cargo.toml
+++ b/src/rust/qsoripper-launcher/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "qsoripper-launcher"
+description = "Interactive launcher TUI for QsoRipper engines and UIs"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[[bin]]
+name = "qsoripper-launcher"
+path = "src/main.rs"
+
+[dependencies]
+ratatui = { version = "0.29", features = ["crossterm"] }
+crossterm = "0.28"
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+toml_edit = { version = "0.22", features = ["serde"] }
+sysinfo = { version = "0.33", default-features = false, features = ["system"] }
+
+[dev-dependencies]
+tempfile = "3"
+
+[lints]
+workspace = true

--- a/src/rust/qsoripper-launcher/Cargo.toml
+++ b/src/rust/qsoripper-launcher/Cargo.toml
@@ -18,6 +18,9 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 toml_edit = { version = "0.22", features = ["serde"] }
 sysinfo = { version = "0.33", default-features = false, features = ["system"] }
+qsoripper-core = { path = "../qsoripper-core", version = "0.1.0" }
+tonic = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "time"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/rust/qsoripper-launcher/src/catalog.rs
+++ b/src/rust/qsoripper-launcher/src/catalog.rs
@@ -27,6 +27,10 @@ pub(crate) struct ComponentSpec {
     /// `true` if the UI honors `QSORIPPER_ENGINE` / `QSORIPPER_ENDPOINT` envs
     /// to pick an engine. Used to decide whether to show a binding picker.
     pub engine_bindable: bool,
+    /// `true` for terminal apps that need their own console window to render
+    /// (e.g. ratatui-based TUIs). On Windows we spawn with `CREATE_NEW_CONSOLE`
+    /// and inherit stdio; on Unix we route through a terminal emulator.
+    pub wants_console: bool,
     /// Resolves the executable path under the published artifact tree.
     pub artifact: ArtifactSpec,
 }
@@ -73,6 +77,7 @@ pub(crate) fn catalog() -> Vec<ComponentSpec> {
             kind: ComponentKind::Engine,
             engine_port: Some(50051),
             engine_bindable: false,
+            wants_console: false,
             artifact: ArtifactSpec {
                 publish_subdir: "qsoripper-server",
                 executable_stem: "qsoripper-server",
@@ -84,6 +89,7 @@ pub(crate) fn catalog() -> Vec<ComponentSpec> {
             kind: ComponentKind::Engine,
             engine_port: Some(50052),
             engine_bindable: false,
+            wants_console: false,
             artifact: ArtifactSpec {
                 publish_subdir: "qsoripper-engine-dotnet",
                 executable_stem: "QsoRipper.Engine.DotNet",
@@ -95,6 +101,7 @@ pub(crate) fn catalog() -> Vec<ComponentSpec> {
             kind: ComponentKind::Ui,
             engine_port: None,
             engine_bindable: true,
+            wants_console: false,
             artifact: ArtifactSpec {
                 publish_subdir: "qsoripper-gui",
                 executable_stem: "QsoRipper.Gui",
@@ -106,6 +113,7 @@ pub(crate) fn catalog() -> Vec<ComponentSpec> {
             kind: ComponentKind::Ui,
             engine_port: None,
             engine_bindable: true,
+            wants_console: false,
             artifact: ArtifactSpec {
                 publish_subdir: "qsoripper-debughost",
                 executable_stem: "QsoRipper.DebugHost",
@@ -117,6 +125,7 @@ pub(crate) fn catalog() -> Vec<ComponentSpec> {
             kind: ComponentKind::Ui,
             engine_port: None,
             engine_bindable: true,
+            wants_console: true,
             artifact: ArtifactSpec {
                 publish_subdir: "qsoripper-tui",
                 executable_stem: "qsoripper-tui",
@@ -128,6 +137,7 @@ pub(crate) fn catalog() -> Vec<ComponentSpec> {
             kind: ComponentKind::Ui,
             engine_port: None,
             engine_bindable: false,
+            wants_console: false,
             artifact: ArtifactSpec {
                 publish_subdir: "cw-decoder-gui",
                 executable_stem: "CwDecoderGui",

--- a/src/rust/qsoripper-launcher/src/catalog.rs
+++ b/src/rust/qsoripper-launcher/src/catalog.rs
@@ -1,0 +1,150 @@
+//! Component catalog: every engine and UI the launcher knows how to start.
+
+use std::path::PathBuf;
+
+use crate::discovery::ArtifactRoot;
+
+/// Stable identifier used for persistence and the binding map.
+pub(crate) type ComponentId = &'static str;
+
+/// Whether a component is an engine (acts as a gRPC server) or a UI client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ComponentKind {
+    /// Engine that exposes a gRPC endpoint on a known TCP port.
+    Engine,
+    /// UI client that connects to one of the running engines.
+    Ui,
+}
+
+/// Static metadata for a launchable component.
+#[derive(Debug, Clone)]
+pub(crate) struct ComponentSpec {
+    pub id: ComponentId,
+    pub display_name: &'static str,
+    pub kind: ComponentKind,
+    /// `Some(port)` for engines that listen on a canonical 127.0.0.1 port.
+    pub engine_port: Option<u16>,
+    /// `true` if the UI honors `QSORIPPER_ENGINE` / `QSORIPPER_ENDPOINT` envs
+    /// to pick an engine. Used to decide whether to show a binding picker.
+    pub engine_bindable: bool,
+    /// Resolves the executable path under the published artifact tree.
+    pub artifact: ArtifactSpec,
+}
+
+/// How to locate a component's executable inside `artifacts/publish/`.
+#[derive(Debug, Clone)]
+pub(crate) struct ArtifactSpec {
+    /// Subdirectory name under `artifacts/publish/<sub>/<Configuration>/`.
+    pub publish_subdir: &'static str,
+    /// File name of the executable on the current platform (without `.exe`;
+    /// platform suffix is appended in [`ArtifactSpec::executable_path`]).
+    pub executable_stem: &'static str,
+}
+
+impl ArtifactSpec {
+    /// Resolve the full executable path under the published artifact root.
+    pub(crate) fn executable_path(&self, root: &ArtifactRoot) -> PathBuf {
+        let mut p = root
+            .path()
+            .join(self.publish_subdir)
+            .join(root.configuration());
+        let mut name = self.executable_stem.to_owned();
+        if cfg!(windows) {
+            name.push_str(".exe");
+        }
+        p.push(name);
+        p
+    }
+}
+
+pub(crate) const ENGINE_RUST: ComponentId = "rust-engine";
+pub(crate) const ENGINE_DOTNET: ComponentId = "dotnet-engine";
+pub(crate) const UI_GUI: ComponentId = "gui";
+pub(crate) const UI_DEBUGHOST: ComponentId = "debughost";
+pub(crate) const UI_TUI: ComponentId = "tui";
+pub(crate) const UI_CWSCOPE: ComponentId = "cwscope";
+
+/// Static list of every component the launcher manages.
+pub(crate) fn catalog() -> Vec<ComponentSpec> {
+    vec![
+        ComponentSpec {
+            id: ENGINE_RUST,
+            display_name: "Rust engine (qsoripper-server)",
+            kind: ComponentKind::Engine,
+            engine_port: Some(50051),
+            engine_bindable: false,
+            artifact: ArtifactSpec {
+                publish_subdir: "qsoripper-server",
+                executable_stem: "qsoripper-server",
+            },
+        },
+        ComponentSpec {
+            id: ENGINE_DOTNET,
+            display_name: ".NET engine (QsoRipper.Engine.DotNet)",
+            kind: ComponentKind::Engine,
+            engine_port: Some(50052),
+            engine_bindable: false,
+            artifact: ArtifactSpec {
+                publish_subdir: "qsoripper-engine-dotnet",
+                executable_stem: "QsoRipper.Engine.DotNet",
+            },
+        },
+        ComponentSpec {
+            id: UI_GUI,
+            display_name: "Avalonia GUI (QsoRipper.Gui)",
+            kind: ComponentKind::Ui,
+            engine_port: None,
+            engine_bindable: true,
+            artifact: ArtifactSpec {
+                publish_subdir: "qsoripper-gui",
+                executable_stem: "QsoRipper.Gui",
+            },
+        },
+        ComponentSpec {
+            id: UI_DEBUGHOST,
+            display_name: "DebugHost (http://localhost:5082)",
+            kind: ComponentKind::Ui,
+            engine_port: None,
+            engine_bindable: true,
+            artifact: ArtifactSpec {
+                publish_subdir: "qsoripper-debughost",
+                executable_stem: "QsoRipper.DebugHost",
+            },
+        },
+        ComponentSpec {
+            id: UI_TUI,
+            display_name: "Terminal UI (qsoripper-tui)",
+            kind: ComponentKind::Ui,
+            engine_port: None,
+            engine_bindable: true,
+            artifact: ArtifactSpec {
+                publish_subdir: "qsoripper-tui",
+                executable_stem: "qsoripper-tui",
+            },
+        },
+        ComponentSpec {
+            id: UI_CWSCOPE,
+            display_name: "CW Scope (CwDecoderGui)",
+            kind: ComponentKind::Ui,
+            engine_port: None,
+            engine_bindable: false,
+            artifact: ArtifactSpec {
+                publish_subdir: "cw-decoder-gui",
+                executable_stem: "CwDecoderGui",
+            },
+        },
+    ]
+}
+
+/// Look up a component by id.
+pub(crate) fn find(id: &str) -> Option<ComponentSpec> {
+    catalog().into_iter().find(|c| c.id == id)
+}
+
+/// Look up the canonical engine endpoint for the given engine component id.
+pub(crate) fn engine_endpoint(id: &str) -> Option<String> {
+    find(id)
+        .filter(|c| c.kind == ComponentKind::Engine)
+        .and_then(|c| c.engine_port)
+        .map(|p| format!("http://127.0.0.1:{p}"))
+}

--- a/src/rust/qsoripper-launcher/src/config.rs
+++ b/src/rust/qsoripper-launcher/src/config.rs
@@ -1,0 +1,234 @@
+//! Read/write the `[launcher]` table inside the shared `config.toml`.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use toml_edit::{value, Array, DocumentMut, Item, Table};
+
+use crate::catalog::{catalog, ComponentId, ComponentKind};
+use crate::model::Selection;
+
+/// Resolve the shared config path the same way `start-qsoripper.ps1` does.
+///
+/// * Windows: `%APPDATA%/qsoripper/config.toml`
+/// * Linux/macOS: `$XDG_CONFIG_HOME/qsoripper/config.toml`, falling back to
+///   `$HOME/.config/qsoripper/config.toml`.
+pub(crate) fn default_shared_config_path() -> Result<PathBuf> {
+    if cfg!(windows) {
+        let appdata = std::env::var_os("APPDATA")
+            .context("APPDATA is not set; cannot resolve the default shared config path")?;
+        return Ok(PathBuf::from(appdata).join("qsoripper").join("config.toml"));
+    }
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME") {
+        return Ok(PathBuf::from(xdg).join("qsoripper").join("config.toml"));
+    }
+    let home = std::env::var_os("HOME")
+        .context("HOME is not set; cannot resolve the default shared config path")?;
+    Ok(PathBuf::from(home)
+        .join(".config")
+        .join("qsoripper")
+        .join("config.toml"))
+}
+
+/// Load the `[launcher]` table from `path` (if it exists) into a [`Selection`].
+/// Missing entries fall back to [`Selection::default_preset`].
+pub(crate) fn load(path: &Path) -> Result<Selection> {
+    let text = match fs::read_to_string(path) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(Selection::default_preset())
+        }
+        Err(e) => return Err(anyhow::Error::from(e).context(format!("reading {}", path.display()))),
+    };
+    let doc: DocumentMut = text
+        .parse()
+        .with_context(|| format!("parsing TOML at {}", path.display()))?;
+    Ok(extract_selection(&doc))
+}
+
+fn extract_selection(doc: &DocumentMut) -> Selection {
+    let mut sel = Selection::default_preset();
+    let Some(launcher) = doc.get("launcher").and_then(Item::as_table) else {
+        return sel;
+    };
+
+    if let Some(engines) = launcher.get("engines").and_then(Item::as_array) {
+        let mut out = Vec::new();
+        for v in engines {
+            if let Some(s) = v.as_str() {
+                if let Some(id) = resolve_known_id(s, ComponentKind::Engine) {
+                    out.push(id);
+                }
+            }
+        }
+        sel.engines = out;
+    }
+    if let Some(uis) = launcher.get("uis").and_then(Item::as_array) {
+        let mut out = Vec::new();
+        for v in uis {
+            if let Some(s) = v.as_str() {
+                if let Some(id) = resolve_known_id(s, ComponentKind::Ui) {
+                    out.push(id);
+                }
+            }
+        }
+        sel.uis = out;
+    }
+    if let Some(bindings) = launcher.get("bindings").and_then(Item::as_table) {
+        let mut out = BTreeMap::new();
+        for (k, v) in bindings {
+            let Some(s) = v.as_str() else { continue };
+            let Some(ui_id) = resolve_known_id(k, ComponentKind::Ui) else {
+                continue;
+            };
+            let Some(engine_id) = resolve_known_id(s, ComponentKind::Engine) else {
+                continue;
+            };
+            out.insert(ui_id, engine_id);
+        }
+        sel.bindings = out;
+    }
+    sel.repair_bindings();
+    sel
+}
+
+fn resolve_known_id(name: &str, kind: ComponentKind) -> Option<ComponentId> {
+    catalog()
+        .into_iter()
+        .find(|c| c.id == name && c.kind == kind)
+        .map(|c| c.id)
+}
+
+/// Merge-write the `[launcher]` table back into `path`, preserving every
+/// other top-level table in the document.
+pub(crate) fn save(path: &Path, selection: &Selection) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|| format!("creating {}", parent.display()))?;
+    }
+
+    let mut doc: DocumentMut = match fs::read_to_string(path) {
+        Ok(t) => t
+            .parse()
+            .with_context(|| format!("parsing TOML at {}", path.display()))?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => DocumentMut::new(),
+        Err(e) => return Err(anyhow::Error::from(e).context(format!("reading {}", path.display()))),
+    };
+
+    let launcher_item = doc.entry("launcher").or_insert(Item::Table(Table::new()));
+    let launcher = launcher_item
+        .as_table_mut()
+        .context("[launcher] is not a table")?;
+
+    let mut engines = Array::new();
+    for id in &selection.engines {
+        engines.push(*id);
+    }
+    launcher.insert("engines", value(engines));
+
+    let mut uis = Array::new();
+    for id in &selection.uis {
+        uis.push(*id);
+    }
+    launcher.insert("uis", value(uis));
+
+    let bindings_item = launcher
+        .entry("bindings")
+        .or_insert(Item::Table(Table::new()));
+    let bindings = bindings_item
+        .as_table_mut()
+        .context("[launcher.bindings] is not a table")?;
+    let known_keys: Vec<String> = bindings.iter().map(|(k, _)| k.to_owned()).collect();
+    for k in known_keys {
+        bindings.remove(&k);
+    }
+    for (ui_id, engine_id) in &selection.bindings {
+        bindings.insert(ui_id, value(*engine_id));
+    }
+
+    fs::write(path, doc.to_string()).with_context(|| format!("writing {}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::similar_names,
+    clippy::too_many_lines,
+    clippy::needless_pass_by_value
+)]
+mod tests {
+    use super::*;
+    use crate::catalog::{ENGINE_DOTNET, ENGINE_RUST, UI_DEBUGHOST, UI_GUI};
+    use tempfile::tempdir;
+
+    #[test]
+    fn load_returns_defaults_when_file_missing() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("config.toml");
+        let sel = load(&p).unwrap();
+        assert_eq!(sel, Selection::default_preset());
+    }
+
+    #[test]
+    fn round_trip_preserves_other_tables() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("config.toml");
+        fs::write(
+            &p,
+            "[station_profile]\ncall = \"K7XYZ\"\n\n[launcher]\nengines = [\"rust-engine\"]\n",
+        )
+        .unwrap();
+
+        let mut sel = Selection::default_preset();
+        sel.engines = vec![ENGINE_DOTNET];
+        sel.uis = vec![UI_GUI];
+        sel.bindings.clear();
+        sel.bindings.insert(UI_GUI, ENGINE_DOTNET);
+        save(&p, &sel).unwrap();
+
+        let text = fs::read_to_string(&p).unwrap();
+        assert!(
+            text.contains("[station_profile]"),
+            "station_profile preserved"
+        );
+        assert!(text.contains("K7XYZ"), "station_profile call preserved");
+
+        let reloaded = load(&p).unwrap();
+        assert_eq!(reloaded.engines, vec![ENGINE_DOTNET]);
+        assert_eq!(reloaded.uis, vec![UI_GUI]);
+        assert_eq!(reloaded.bindings.get(&UI_GUI), Some(&ENGINE_DOTNET));
+    }
+
+    #[test]
+    fn load_repairs_bindings_pointing_at_unselected_engine() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("config.toml");
+        fs::write(
+            &p,
+            "[launcher]\nengines = [\"dotnet-engine\"]\nuis = [\"gui\", \"debughost\"]\n[launcher.bindings]\ngui = \"rust-engine\"\n",
+        )
+        .unwrap();
+        let sel = load(&p).unwrap();
+        assert_eq!(sel.bindings.get(&UI_GUI), Some(&ENGINE_DOTNET));
+        assert_eq!(sel.bindings.get(&UI_DEBUGHOST), Some(&ENGINE_DOTNET));
+    }
+
+    #[test]
+    fn unknown_component_names_are_dropped() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("config.toml");
+        fs::write(
+            &p,
+            "[launcher]\nengines = [\"unknown-engine\", \"rust-engine\"]\nuis = [\"phantom-ui\"]\n",
+        )
+        .unwrap();
+        let sel = load(&p).unwrap();
+        assert_eq!(sel.engines, vec![ENGINE_RUST]);
+        assert!(sel.uis.is_empty());
+    }
+}

--- a/src/rust/qsoripper-launcher/src/discovery.rs
+++ b/src/rust/qsoripper-launcher/src/discovery.rs
@@ -1,0 +1,122 @@
+//! Resolve published artifact roots like `artifacts/publish/<sub>/<Release|Debug>/`.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// Build configuration the launcher targets when resolving artifacts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Configuration {
+    Release,
+    Debug,
+}
+
+impl Configuration {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Release => "Release",
+            Self::Debug => "Debug",
+        }
+    }
+}
+
+/// The published-artifact root and the configuration name to use beneath it.
+#[derive(Debug, Clone)]
+pub(crate) struct ArtifactRoot {
+    publish_root: PathBuf,
+    configuration: &'static str,
+}
+
+impl ArtifactRoot {
+    /// Build an artifact root from an explicit publish dir and configuration.
+    pub(crate) fn new(publish_root: PathBuf, configuration: Configuration) -> Self {
+        Self {
+            publish_root,
+            configuration: configuration.as_str(),
+        }
+    }
+
+    /// Resolve `artifacts/publish/` relative to a repo root.
+    pub(crate) fn from_repo_root(repo_root: &Path, configuration: Configuration) -> Self {
+        Self::new(repo_root.join("artifacts").join("publish"), configuration)
+    }
+
+    pub(crate) fn path(&self) -> &Path {
+        &self.publish_root
+    }
+
+    pub(crate) fn configuration(&self) -> &str {
+        self.configuration
+    }
+}
+
+/// Walk up from the launcher binary's location looking for a directory that
+/// contains both `artifacts` and `src`. This lets `qsoripper-launcher.exe`
+/// work whether it's invoked from the repo root or from
+/// `artifacts/publish/qsoripper-launcher/<cfg>/`.
+pub(crate) fn detect_repo_root() -> Result<PathBuf> {
+    let exe = std::env::current_exe().context("locating current executable")?;
+    let mut cursor = exe.parent().map(Path::to_path_buf);
+    while let Some(dir) = cursor {
+        if dir.join("artifacts").is_dir() && dir.join("src").is_dir() {
+            return Ok(dir);
+        }
+        cursor = dir.parent().map(Path::to_path_buf);
+    }
+    // Fall back to the current working directory; the caller will surface
+    // a clearer error when an artifact lookup fails.
+    std::env::current_dir().context("resolving fallback repo root via cwd")
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::similar_names,
+    clippy::too_many_lines,
+    clippy::needless_pass_by_value
+)]
+mod tests {
+    use super::*;
+
+    use crate::catalog::{catalog, ComponentKind};
+
+    #[test]
+    fn artifact_path_uses_configuration_subdirectory() {
+        let root = ArtifactRoot::new(
+            PathBuf::from("/repo/artifacts/publish"),
+            Configuration::Release,
+        );
+        let spec = catalog()
+            .into_iter()
+            .find(|c| c.id == crate::catalog::ENGINE_RUST)
+            .expect("rust engine in catalog");
+        let path = spec.artifact.executable_path(&root);
+        let expected_stem = if cfg!(windows) {
+            "qsoripper-server.exe"
+        } else {
+            "qsoripper-server"
+        };
+        assert!(path.ends_with(format!("qsoripper-server/Release/{expected_stem}")));
+    }
+
+    #[test]
+    fn debug_configuration_string_is_debug() {
+        assert_eq!(Configuration::Debug.as_str(), "Debug");
+    }
+
+    #[test]
+    fn every_engine_has_a_port() {
+        for spec in catalog() {
+            if spec.kind == ComponentKind::Engine {
+                assert!(
+                    spec.engine_port.is_some(),
+                    "engine {} missing port",
+                    spec.id
+                );
+            }
+        }
+    }
+}

--- a/src/rust/qsoripper-launcher/src/main.rs
+++ b/src/rust/qsoripper-launcher/src/main.rs
@@ -1,0 +1,72 @@
+//! Binary entry point for the `QsoRipper` launcher TUI.
+
+mod catalog;
+mod config;
+mod discovery;
+mod model;
+mod plan;
+mod ports;
+mod process;
+mod ui;
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use crate::discovery::{detect_repo_root, ArtifactRoot, Configuration};
+
+fn main() -> Result<()> {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let mut configuration = Configuration::Release;
+    let mut repo_root: Option<PathBuf> = None;
+    let mut config_path: Option<PathBuf> = None;
+
+    let mut it = args.into_iter();
+    while let Some(arg) = it.next() {
+        match arg.as_str() {
+            "--debug" => configuration = Configuration::Debug,
+            "--release" => configuration = Configuration::Release,
+            "--repo-root" => {
+                repo_root = it.next().map(PathBuf::from);
+            }
+            "--config" => {
+                config_path = it.next().map(PathBuf::from);
+            }
+            "-h" | "--help" => {
+                print_help();
+                return Ok(());
+            }
+            other => {
+                eprintln!("qsoripper-launcher: unknown argument '{other}'\n");
+                print_help();
+                std::process::exit(2);
+            }
+        }
+    }
+
+    let repo_root = match repo_root {
+        Some(r) => r,
+        None => detect_repo_root()?,
+    };
+    let artifact_root = ArtifactRoot::from_repo_root(&repo_root, configuration);
+    let config_path = match config_path {
+        Some(p) => p,
+        None => config::default_shared_config_path()?,
+    };
+    let selection = config::load(&config_path)?;
+    let mut app = ui::AppState::new(selection, config_path, artifact_root);
+    ui::run(&mut app)
+}
+
+fn print_help() {
+    println!(
+        "qsoripper-launcher [options]\n\
+         \n\
+         Options:\n\
+           --release          Use artifacts/publish/*/Release (default)\n\
+           --debug            Use artifacts/publish/*/Debug\n\
+           --repo-root <DIR>  Override repo root detection\n\
+           --config <FILE>    Override shared config.toml path\n\
+           -h, --help         Show this help\n"
+    );
+}

--- a/src/rust/qsoripper-launcher/src/main.rs
+++ b/src/rust/qsoripper-launcher/src/main.rs
@@ -7,6 +7,7 @@ mod model;
 mod plan;
 mod ports;
 mod process;
+mod sync;
 mod ui;
 
 use std::path::PathBuf;

--- a/src/rust/qsoripper-launcher/src/model.rs
+++ b/src/rust/qsoripper-launcher/src/model.rs
@@ -1,0 +1,147 @@
+//! Selection state: which engines/UIs are checked and the per-UI bindings.
+
+use std::collections::BTreeMap;
+
+#[cfg(test)]
+use crate::catalog::ENGINE_DOTNET;
+use crate::catalog::{catalog, ComponentId, ComponentKind, ENGINE_RUST, UI_DEBUGHOST, UI_GUI};
+
+/// User-editable launcher selection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Selection {
+    /// Engines the user wants started.
+    pub engines: Vec<ComponentId>,
+    /// UIs the user wants started.
+    pub uis: Vec<ComponentId>,
+    /// For each bindable UI, the engine component id it should target.
+    pub bindings: BTreeMap<ComponentId, ComponentId>,
+}
+
+impl Selection {
+    /// Default selection: Rust engine + Avalonia GUI + `DebugHost`, both bound to Rust.
+    pub(crate) fn default_preset() -> Self {
+        let mut bindings = BTreeMap::new();
+        bindings.insert(UI_GUI, ENGINE_RUST);
+        bindings.insert(UI_DEBUGHOST, ENGINE_RUST);
+        Self {
+            engines: vec![ENGINE_RUST],
+            uis: vec![UI_GUI, UI_DEBUGHOST],
+            bindings,
+        }
+    }
+
+    pub(crate) fn engine_selected(&self, id: ComponentId) -> bool {
+        self.engines.contains(&id)
+    }
+
+    pub(crate) fn ui_selected(&self, id: ComponentId) -> bool {
+        self.uis.contains(&id)
+    }
+
+    /// Toggle membership of `id` in either the engines or UIs list, depending
+    /// on the component kind. UIs that get unchecked keep their binding so it
+    /// is restored if the user toggles them back on.
+    pub(crate) fn toggle(&mut self, id: ComponentId) {
+        let Some(spec) = catalog().into_iter().find(|c| c.id == id) else {
+            return;
+        };
+        let list = match spec.kind {
+            ComponentKind::Engine => &mut self.engines,
+            ComponentKind::Ui => &mut self.uis,
+        };
+        if let Some(pos) = list.iter().position(|e| *e == id) {
+            list.remove(pos);
+        } else {
+            list.push(id);
+        }
+    }
+
+    /// Set the engine a bindable UI targets. No-op if the UI is not bindable
+    /// or the engine is unknown.
+    pub(crate) fn set_binding(&mut self, ui_id: ComponentId, engine_id: ComponentId) {
+        let ui_is_bindable = catalog()
+            .into_iter()
+            .any(|c| c.id == ui_id && c.kind == ComponentKind::Ui && c.engine_bindable);
+        let engine_known = catalog()
+            .into_iter()
+            .any(|c| c.id == engine_id && c.kind == ComponentKind::Engine);
+        if ui_is_bindable && engine_known {
+            self.bindings.insert(ui_id, engine_id);
+        }
+    }
+
+    /// Repair bindings so every bindable selected UI targets one of the
+    /// selected engines (or [`ENGINE_RUST`] if no engines are selected).
+    pub(crate) fn repair_bindings(&mut self) {
+        let fallback = self.engines.first().copied().unwrap_or(ENGINE_RUST);
+        let bindable_uis: Vec<ComponentId> = catalog()
+            .into_iter()
+            .filter(|c| c.kind == ComponentKind::Ui && c.engine_bindable)
+            .map(|c| c.id)
+            .collect();
+        for ui in bindable_uis {
+            if !self.ui_selected(ui) {
+                continue;
+            }
+            let current = self.bindings.get(&ui).copied();
+            let needs_fix = match current {
+                None => true,
+                Some(engine) => !self.engine_selected(engine),
+            };
+            if needs_fix {
+                self.bindings.insert(ui, fallback);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::similar_names,
+    clippy::too_many_lines,
+    clippy::needless_pass_by_value
+)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_preset_is_rust_plus_gui_and_debughost() {
+        let sel = Selection::default_preset();
+        assert!(sel.engine_selected(ENGINE_RUST));
+        assert!(sel.ui_selected(UI_GUI));
+        assert!(sel.ui_selected(UI_DEBUGHOST));
+        assert_eq!(sel.bindings.get(&UI_GUI), Some(&ENGINE_RUST));
+        assert_eq!(sel.bindings.get(&UI_DEBUGHOST), Some(&ENGINE_RUST));
+    }
+
+    #[test]
+    fn toggle_adds_then_removes_engine() {
+        let mut sel = Selection::default_preset();
+        assert!(!sel.engine_selected(ENGINE_DOTNET));
+        sel.toggle(ENGINE_DOTNET);
+        assert!(sel.engine_selected(ENGINE_DOTNET));
+        sel.toggle(ENGINE_DOTNET);
+        assert!(!sel.engine_selected(ENGINE_DOTNET));
+    }
+
+    #[test]
+    fn repair_bindings_falls_back_to_first_selected_engine() {
+        let mut sel = Selection::default_preset();
+        // Remove rust engine, add dotnet; the GUI binding should swing over.
+        sel.toggle(ENGINE_RUST);
+        sel.toggle(ENGINE_DOTNET);
+        sel.repair_bindings();
+        assert_eq!(sel.bindings.get(&UI_GUI), Some(&ENGINE_DOTNET));
+    }
+
+    #[test]
+    fn set_binding_ignores_non_bindable_ui() {
+        let mut sel = Selection::default_preset();
+        sel.set_binding(crate::catalog::UI_CWSCOPE, ENGINE_DOTNET);
+        assert!(!sel.bindings.contains_key(&crate::catalog::UI_CWSCOPE));
+    }
+}

--- a/src/rust/qsoripper-launcher/src/plan.rs
+++ b/src/rust/qsoripper-launcher/src/plan.rs
@@ -1,0 +1,120 @@
+//! Map a [`Selection`] onto concrete spawn arguments + env for each component.
+
+use std::ffi::OsString;
+
+use crate::catalog::{
+    engine_endpoint, find, ComponentSpec, ENGINE_DOTNET, ENGINE_RUST, UI_DEBUGHOST,
+};
+use crate::model::Selection;
+
+/// Per-process spawn plan: the resolved component spec, command-line args,
+/// and environment overrides to apply on top of the parent environment.
+pub(crate) struct LaunchPlan {
+    pub spec: ComponentSpec,
+    pub args: Vec<OsString>,
+    pub env: Vec<(String, String)>,
+}
+
+const QSORIPPER_ENGINE_ENV: &str = "QSORIPPER_ENGINE";
+const QSORIPPER_ENDPOINT_ENV: &str = "QSORIPPER_ENDPOINT";
+
+fn engine_profile_name(engine_id: &str) -> Option<&'static str> {
+    match engine_id {
+        id if id == ENGINE_RUST => Some("local-rust"),
+        id if id == ENGINE_DOTNET => Some("local-dotnet"),
+        _ => None,
+    }
+}
+
+/// Build the launch plan for a UI component given the current selection.
+pub(crate) fn ui_plan(ui_id: &str, selection: &Selection) -> Option<LaunchPlan> {
+    let spec = find(ui_id)?;
+    let mut env = Vec::new();
+    let mut args: Vec<OsString> = Vec::new();
+
+    if spec.engine_bindable {
+        if let Some(engine_id) = selection.bindings.get(&spec.id).copied() {
+            if let Some(profile) = engine_profile_name(engine_id) {
+                env.push((QSORIPPER_ENGINE_ENV.to_owned(), profile.to_owned()));
+            }
+            if let Some(ep) = engine_endpoint(engine_id) {
+                env.push((QSORIPPER_ENDPOINT_ENV.to_owned(), ep));
+            }
+        }
+    }
+
+    if spec.id == UI_DEBUGHOST {
+        // Match the URL runall.ps1 forces for the DebugHost so the launcher
+        // and runall hand off the same endpoint to the browser.
+        args.push("--urls".into());
+        args.push("http://localhost:5082".into());
+    }
+
+    Some(LaunchPlan { spec, args, env })
+}
+
+/// Build the launch plan for an engine component. Engines take no per-process
+/// configuration from the launcher in the first pass.
+pub(crate) fn engine_plan(engine_id: &str) -> Option<LaunchPlan> {
+    let spec = find(engine_id)?;
+    Some(LaunchPlan {
+        spec,
+        args: Vec::new(),
+        env: Vec::new(),
+    })
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::similar_names,
+    clippy::too_many_lines,
+    clippy::needless_pass_by_value
+)]
+mod tests {
+    use super::*;
+    use crate::catalog::{UI_CWSCOPE, UI_GUI};
+
+    #[test]
+    fn gui_plan_injects_engine_env_for_dotnet_binding() {
+        let mut sel = Selection::default_preset();
+        sel.engines = vec![ENGINE_DOTNET];
+        sel.bindings.clear();
+        sel.bindings.insert(UI_GUI, ENGINE_DOTNET);
+        let plan = ui_plan(UI_GUI, &sel).expect("plan");
+        let map: std::collections::HashMap<_, _> = plan.env.into_iter().collect();
+        assert_eq!(
+            map.get(QSORIPPER_ENGINE_ENV).map(String::as_str),
+            Some("local-dotnet")
+        );
+        assert_eq!(
+            map.get(QSORIPPER_ENDPOINT_ENV).map(String::as_str),
+            Some("http://127.0.0.1:50052"),
+        );
+    }
+
+    #[test]
+    fn cwscope_plan_has_no_engine_env() {
+        let sel = Selection::default_preset();
+        let plan = ui_plan(UI_CWSCOPE, &sel).expect("plan");
+        assert!(plan.env.is_empty());
+    }
+
+    #[test]
+    fn debughost_plan_forces_the_runall_url() {
+        let sel = Selection::default_preset();
+        let plan = ui_plan(UI_DEBUGHOST, &sel).expect("plan");
+        let strs: Vec<String> = plan
+            .args
+            .into_iter()
+            .map(|a| a.into_string().unwrap())
+            .collect();
+        assert_eq!(
+            strs,
+            vec!["--urls".to_string(), "http://localhost:5082".to_string()]
+        );
+    }
+}

--- a/src/rust/qsoripper-launcher/src/ports.rs
+++ b/src/rust/qsoripper-launcher/src/ports.rs
@@ -1,0 +1,55 @@
+//! TCP probe + a small `is_port_listening` helper used during readiness checks.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
+use std::time::{Duration, Instant};
+
+/// Try to connect to `127.0.0.1:port` with the given timeout. Returns `true`
+/// when something is accepting connections.
+pub(crate) fn is_port_listening(port: u16, timeout: Duration) -> bool {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    TcpStream::connect_timeout(&addr, timeout).is_ok()
+}
+
+/// Poll `is_port_listening` until it succeeds or `total` elapses.
+pub(crate) fn wait_for_port(port: u16, total: Duration, per_attempt: Duration) -> bool {
+    let deadline = Instant::now() + total;
+    loop {
+        if is_port_listening(port, per_attempt) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::similar_names,
+    clippy::too_many_lines,
+    clippy::needless_pass_by_value
+)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    #[test]
+    fn detects_a_listener_on_localhost() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let port = listener.local_addr().unwrap().port();
+        assert!(is_port_listening(port, Duration::from_millis(250)));
+    }
+
+    #[test]
+    fn reports_false_on_unbound_port() {
+        // A high port that nothing is realistically bound to. If this is
+        // flaky in some environment, swap to spawning a listener, recording
+        // the port, dropping the listener, and asserting closed.
+        assert!(!is_port_listening(1, Duration::from_millis(50)));
+    }
+}

--- a/src/rust/qsoripper-launcher/src/process.rs
+++ b/src/rust/qsoripper-launcher/src/process.rs
@@ -1,0 +1,205 @@
+//! Spawn detached child processes and remember their PIDs so we can stop them.
+
+use std::collections::BTreeMap;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+use anyhow::{bail, Context, Result};
+use sysinfo::{Pid, ProcessRefreshKind, Signal, System};
+
+use crate::catalog::{ComponentId, ComponentSpec};
+
+/// A child the launcher started, tracked by OS PID so it survives the launcher
+/// exiting and so a later "stop" can find it again.
+#[derive(Debug, Clone)]
+pub(crate) struct LaunchedProcess {
+    pub(crate) component: ComponentId,
+    pub(crate) pid: u32,
+    #[allow(dead_code)]
+    pub(crate) executable: PathBuf,
+}
+
+/// Records launched-process PIDs by component id.
+#[derive(Debug, Default)]
+pub(crate) struct ProcessRegistry {
+    inner: BTreeMap<ComponentId, LaunchedProcess>,
+}
+
+impl ProcessRegistry {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    pub(crate) fn insert(&mut self, p: LaunchedProcess) {
+        self.inner.insert(p.component, p);
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn get(&self, id: ComponentId) -> Option<&LaunchedProcess> {
+        self.inner.get(&id)
+    }
+
+    pub(crate) fn remove(&mut self, id: ComponentId) -> Option<LaunchedProcess> {
+        self.inner.remove(&id)
+    }
+
+    pub(crate) fn iter(&self) -> impl Iterator<Item = &LaunchedProcess> {
+        self.inner.values()
+    }
+}
+
+/// Build the [`Command`] used to launch `spec` from its published artifact.
+///
+/// `env` entries are applied after the parent environment so callers can
+/// inject `QSORIPPER_ENGINE` and `QSORIPPER_ENDPOINT` per-UI.
+pub(crate) fn build_command<I, K, V>(
+    spec: &ComponentSpec,
+    exe: &Path,
+    args: &[&OsStr],
+    env: I,
+) -> Command
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    let mut cmd = Command::new(exe);
+    cmd.args(args);
+    if let Some(dir) = exe.parent() {
+        cmd.current_dir(dir);
+    }
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    // Don't let child stdio inherit the launcher's raw-mode terminal.
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::null());
+    cmd.stderr(Stdio::null());
+
+    apply_detach_flags(&mut cmd);
+
+    // Touch `spec` so unused-warning lints don't fire on platforms where we
+    // don't otherwise read from it; in practice this also keeps the signature
+    // open for future per-component spawn tweaks.
+    let _ = spec.id;
+    cmd
+}
+
+#[cfg(windows)]
+fn apply_detach_flags(cmd: &mut Command) {
+    use std::os::windows::process::CommandExt;
+    // CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS
+    const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+    const DETACHED_PROCESS: u32 = 0x0000_0008;
+    cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
+}
+
+#[cfg(not(windows))]
+fn apply_detach_flags(cmd: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    // Put the child in its own process group so a SIGINT delivered to the
+    // launcher's foreground group does not propagate to UIs we launched.
+    // `process_group(0)` is enough for cleanly-exiting launches; we do not
+    // need a full new session for the TUI launcher use case.
+    cmd.process_group(0);
+}
+
+/// Spawn the executable behind `spec` and record its PID in `registry`.
+pub(crate) fn spawn(
+    spec: &ComponentSpec,
+    exe: &Path,
+    args: &[&OsStr],
+    env: &[(String, String)],
+    registry: &mut ProcessRegistry,
+) -> Result<LaunchedProcess> {
+    if !exe.exists() {
+        bail!(
+            "missing artifact for {}: {} (was the build run?)",
+            spec.display_name,
+            exe.display()
+        );
+    }
+    let mut cmd = build_command(
+        spec,
+        exe,
+        args,
+        env.iter().map(|(k, v)| (k.as_str(), v.as_str())),
+    );
+    let child = cmd
+        .spawn()
+        .with_context(|| format!("spawning {}", exe.display()))?;
+    let entry = LaunchedProcess {
+        component: spec.id,
+        pid: child.id(),
+        executable: exe.to_path_buf(),
+    };
+    // Drop the Child handle so the launcher does not block on waitpid; the
+    // OS reaps via the new session/process group. Tracking is by PID from here.
+    drop(child);
+    registry.insert(entry.clone());
+    Ok(entry)
+}
+
+/// Ask the OS to terminate the given PID. Uses SIGTERM-equivalent semantics.
+pub(crate) fn stop_pid(pid: u32) -> bool {
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        sysinfo::ProcessesToUpdate::Some(&[Pid::from_u32(pid)]),
+        true,
+        ProcessRefreshKind::nothing(),
+    );
+    let Some(proc_handle) = sys.process(Pid::from_u32(pid)) else {
+        return false;
+    };
+    proc_handle
+        .kill_with(Signal::Term)
+        .unwrap_or_else(|| proc_handle.kill())
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::similar_names,
+    clippy::too_many_lines,
+    clippy::needless_pass_by_value
+)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    use crate::catalog::{find, ENGINE_RUST};
+
+    #[test]
+    fn build_command_sets_args_and_env() {
+        let spec = find(ENGINE_RUST).expect("rust engine");
+        let exe = PathBuf::from("/no/such/path/qsoripper-server");
+        let arg1: OsString = "--listen".into();
+        let arg2: OsString = "127.0.0.1:50051".into();
+        let args = [arg1.as_os_str(), arg2.as_os_str()];
+        let cmd = build_command(&spec, &exe, &args, [("FOO", "bar")]);
+        let argv: Vec<&OsStr> = cmd.get_args().collect();
+        assert_eq!(argv, vec![arg1.as_os_str(), arg2.as_os_str()]);
+        let env_pairs: Vec<(&OsStr, Option<&OsStr>)> = cmd.get_envs().collect();
+        assert!(env_pairs
+            .iter()
+            .any(|(k, v)| *k == OsStr::new("FOO")
+                && v.map(OsStr::to_os_string) == Some("bar".into())));
+    }
+
+    #[test]
+    fn registry_round_trip() {
+        let mut reg = ProcessRegistry::new();
+        reg.insert(LaunchedProcess {
+            component: ENGINE_RUST,
+            pid: 1234,
+            executable: PathBuf::from("x"),
+        });
+        assert_eq!(reg.get(ENGINE_RUST).map(|p| p.pid), Some(1234));
+        assert!(reg.remove(ENGINE_RUST).is_some());
+        assert!(reg.get(ENGINE_RUST).is_none());
+    }
+}

--- a/src/rust/qsoripper-launcher/src/process.rs
+++ b/src/rust/qsoripper-launcher/src/process.rs
@@ -112,16 +112,35 @@ where
         const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
 
-        let mut cmd = Command::new(exe);
-        cmd.args(args);
+        let mut cmd = if let Some(wt) = find_on_path("wt.exe") {
+            // Open in a new Windows Terminal window so the TUI gets a real,
+            // visible terminal with proper input handling. `-w new` forces a
+            // fresh window; `-d` sets the new tab's working directory; the
+            // double dash separates wt's args from the child invocation.
+            let mut c = Command::new(wt);
+            c.arg("-w").arg("new");
+            if let Some(dir) = exe.parent() {
+                c.arg("-d").arg(dir);
+            }
+            let title = format!("QsoRipper - {}", spec.display_name);
+            c.arg("--title").arg(title);
+            c.arg("--").arg(exe);
+            c.args(args);
+            c
+        } else {
+            // Fallback for systems without Windows Terminal: classic conhost
+            // window via CREATE_NEW_CONSOLE.
+            let mut c = Command::new(exe);
+            c.args(args);
+            c.creation_flags(CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP);
+            c
+        };
         if let Some(dir) = exe.parent() {
             cmd.current_dir(dir);
         }
         for (k, v) in env {
             cmd.env(k, v);
         }
-        // Inherit stdio so the new console is the child's terminal.
-        cmd.creation_flags(CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP);
         cmd
     }
 
@@ -145,6 +164,18 @@ where
         cmd.process_group(0);
         cmd
     }
+}
+
+#[cfg(windows)]
+fn find_on_path(name: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join(name);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 #[cfg(not(windows))]
@@ -280,12 +311,21 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn build_command_for_tui_keeps_exe_program_on_windows() {
+    fn build_command_for_tui_targets_a_terminal_on_windows() {
         let spec = find(UI_TUI).expect("tui");
         assert!(spec.wants_console, "TUI must request a console");
         let exe = PathBuf::from("C:/no/such/path/qsoripper-tui.exe");
         let cmd = build_command(&spec, &exe, &[], std::iter::empty::<(&str, &str)>());
-        assert_eq!(cmd.get_program(), exe.as_os_str());
+        let program = cmd.get_program().to_string_lossy().to_lowercase();
+        let args: Vec<&OsStr> = cmd.get_args().collect();
+        if program.ends_with("wt.exe") {
+            assert!(
+                args.iter().any(|a| *a == exe.as_os_str()),
+                "wt wrapper must pass the TUI exe as an argument"
+            );
+        } else {
+            assert_eq!(cmd.get_program(), exe.as_os_str());
+        }
     }
 
     #[cfg(not(windows))]

--- a/src/rust/qsoripper-launcher/src/process.rs
+++ b/src/rust/qsoripper-launcher/src/process.rs
@@ -224,6 +224,50 @@ fn apply_detach_flags(cmd: &mut Command) {
     cmd.process_group(0);
 }
 
+/// Open `url` in the user's default browser. Returns an error if the OS
+/// reports the open command failed to start; success of the launch is
+/// best-effort beyond that.
+pub(crate) fn open_url(url: &str) -> Result<()> {
+    #[cfg(windows)]
+    {
+        // `cmd /C start "" "<url>"` honors the user's default browser and
+        // does not require shell escaping the URL beyond the surrounding
+        // quotes. The empty "" is start's window title argument.
+        Command::new("cmd")
+            .args(["/C", "start", "", url])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .with_context(|| format!("failed to launch browser for {url}"))?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        Command::new("open")
+            .arg(url)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .with_context(|| format!("failed to launch browser for {url}"))?;
+        Ok(())
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        Command::new("xdg-open")
+            .arg(url)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .with_context(|| format!("failed to launch browser for {url}"))?;
+        Ok(())
+    }
+}
+
 /// Spawn the executable behind `spec` and record its PID in `registry`.
 pub(crate) fn spawn(
     spec: &ComponentSpec,

--- a/src/rust/qsoripper-launcher/src/process.rs
+++ b/src/rust/qsoripper-launcher/src/process.rs
@@ -64,6 +64,10 @@ where
     K: AsRef<OsStr>,
     V: AsRef<OsStr>,
 {
+    if spec.wants_console {
+        return build_console_command(spec, exe, args, env);
+    }
+
     let mut cmd = Command::new(exe);
     cmd.args(args);
     if let Some(dir) = exe.parent() {
@@ -84,6 +88,90 @@ where
     // open for future per-component spawn tweaks.
     let _ = spec.id;
     cmd
+}
+
+/// Spawn a terminal app into its own visible terminal window so its TUI has
+/// somewhere to render. On Windows that means `CREATE_NEW_CONSOLE` and
+/// inherited stdio; on Unix we wrap with the user's terminal emulator.
+fn build_console_command<I, K, V>(
+    spec: &ComponentSpec,
+    exe: &Path,
+    args: &[&OsStr],
+    env: I,
+) -> Command
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+{
+    let _ = spec.id;
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        // CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP
+        const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+        const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
+
+        let mut cmd = Command::new(exe);
+        cmd.args(args);
+        if let Some(dir) = exe.parent() {
+            cmd.current_dir(dir);
+        }
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+        // Inherit stdio so the new console is the child's terminal.
+        cmd.creation_flags(CREATE_NEW_CONSOLE | CREATE_NEW_PROCESS_GROUP);
+        cmd
+    }
+
+    #[cfg(not(windows))]
+    {
+        use std::os::unix::process::CommandExt;
+        let (terminal, terminal_args) = pick_terminal();
+
+        let mut cmd = Command::new(terminal);
+        for a in terminal_args {
+            cmd.arg(a);
+        }
+        cmd.arg(exe);
+        cmd.args(args);
+        if let Some(dir) = exe.parent() {
+            cmd.current_dir(dir);
+        }
+        for (k, v) in env {
+            cmd.env(k, v);
+        }
+        cmd.process_group(0);
+        cmd
+    }
+}
+
+#[cfg(not(windows))]
+fn pick_terminal() -> (&'static str, Vec<&'static str>) {
+    // Probe a short list of well-known terminal emulators. We pick the first
+    // one on PATH; user can override by symlinking `x-terminal-emulator`.
+    const CANDIDATES: &[(&str, &[&str])] = &[
+        ("x-terminal-emulator", &["-e"]),
+        ("gnome-terminal", &["--"]),
+        ("konsole", &["-e"]),
+        ("xfce4-terminal", &["-e"]),
+        ("alacritty", &["-e"]),
+        ("kitty", &["--"]),
+        ("xterm", &["-e"]),
+    ];
+    let path = std::env::var_os("PATH").unwrap_or_default();
+    for (cmd, args) in CANDIDATES {
+        for dir in std::env::split_paths(&path) {
+            if dir.join(cmd).is_file() {
+                return ((*cmd), args.to_vec());
+            }
+        }
+    }
+    // Last resort: `xterm -e <cmd>` will surface a clear "not found" error if
+    // none of the candidates are installed, instead of silently launching a
+    // headless TUI.
+    ("xterm", vec!["-e"])
 }
 
 #[cfg(windows)]
@@ -171,7 +259,7 @@ mod tests {
     use super::*;
     use std::ffi::OsString;
 
-    use crate::catalog::{find, ENGINE_RUST};
+    use crate::catalog::{find, ENGINE_RUST, UI_TUI};
 
     #[test]
     fn build_command_sets_args_and_env() {
@@ -188,6 +276,30 @@ mod tests {
             .iter()
             .any(|(k, v)| *k == OsStr::new("FOO")
                 && v.map(OsStr::to_os_string) == Some("bar".into())));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn build_command_for_tui_keeps_exe_program_on_windows() {
+        let spec = find(UI_TUI).expect("tui");
+        assert!(spec.wants_console, "TUI must request a console");
+        let exe = PathBuf::from("C:/no/such/path/qsoripper-tui.exe");
+        let cmd = build_command(&spec, &exe, &[], std::iter::empty::<(&str, &str)>());
+        assert_eq!(cmd.get_program(), exe.as_os_str());
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn build_command_for_tui_wraps_with_terminal_on_unix() {
+        let spec = find(UI_TUI).expect("tui");
+        assert!(spec.wants_console, "TUI must request a console");
+        let exe = PathBuf::from("/no/such/path/qsoripper-tui");
+        let cmd = build_command(&spec, &exe, &[], std::iter::empty::<(&str, &str)>());
+        // The terminal program should be the first argv, and the exe should
+        // appear later in the argument list (after the emulator's separator).
+        assert_ne!(cmd.get_program(), exe.as_os_str());
+        let args: Vec<&OsStr> = cmd.get_args().collect();
+        assert!(args.iter().any(|a| *a == exe.as_os_str()));
     }
 
     #[test]

--- a/src/rust/qsoripper-launcher/src/sync.rs
+++ b/src/rust/qsoripper-launcher/src/sync.rs
@@ -1,0 +1,463 @@
+//! Side-by-side settings sync dialog backed by the engines' `SetupService`.
+//!
+//! Press `Y` in the launcher to open a popup that fetches the current
+//! `SetupStatus` from both engines, displays them side-by-side, and lets
+//! the operator pick which side becomes the source of truth. The chosen
+//! side is then pushed to the other engine via `SaveSetup`.
+
+use std::time::Duration;
+
+use qsoripper_core::proto::qsoripper::domain::{ConflictPolicy, StationProfile, SyncConfig};
+use qsoripper_core::proto::qsoripper::services::{
+    setup_service_client::SetupServiceClient, GetSetupStatusRequest, RigControlSettings,
+    SaveSetupRequest, SetupFieldValue, SetupStatus,
+};
+use tokio::runtime::Runtime;
+use tonic::transport::{Channel, Endpoint};
+
+/// Which side of the dialog is selected as the source of truth.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Side {
+    Left,
+    Right,
+}
+
+impl Side {
+    pub(crate) fn toggle(self) -> Self {
+        match self {
+            Self::Left => Self::Right,
+            Self::Right => Self::Left,
+        }
+    }
+}
+
+/// One column in the sync popup. Either holds a `SetupStatus` or an error.
+#[derive(Debug, Clone)]
+pub(crate) struct EngineSnapshot {
+    pub label: &'static str,
+    pub endpoint: String,
+    pub status: Option<SetupStatus>,
+    pub error: Option<String>,
+}
+
+impl EngineSnapshot {
+    fn new(label: &'static str, endpoint: impl Into<String>) -> Self {
+        Self {
+            label,
+            endpoint: endpoint.into(),
+            status: None,
+            error: None,
+        }
+    }
+}
+
+/// Lifecycle of the dialog.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DialogState {
+    Ready,
+    Applying,
+    Applied(String),
+    Failed(String),
+}
+
+/// Modal sync dialog state.
+#[derive(Debug, Clone)]
+pub(crate) struct SyncDialog {
+    pub left: EngineSnapshot,
+    pub right: EngineSnapshot,
+    pub source: Side,
+    pub state: DialogState,
+}
+
+impl SyncDialog {
+    /// Fetch `SetupStatus` from both engines (Rust @ 50051, .NET @ 50052) and
+    /// build a dialog. Connection/RPC failures are recorded per-side; the
+    /// dialog still opens so the operator sees the error.
+    pub(crate) fn fetch(rt: &Runtime) -> Self {
+        let mut left = EngineSnapshot::new("Rust (50051)", "http://127.0.0.1:50051");
+        let mut right = EngineSnapshot::new(".NET (50052)", "http://127.0.0.1:50052");
+
+        match rt.block_on(fetch_status(&left.endpoint)) {
+            Ok(status) => left.status = Some(status),
+            Err(error) => left.error = Some(error),
+        }
+        match rt.block_on(fetch_status(&right.endpoint)) {
+            Ok(status) => right.status = Some(status),
+            Err(error) => right.error = Some(error),
+        }
+
+        Self {
+            left,
+            right,
+            source: Side::Left,
+            state: DialogState::Ready,
+        }
+    }
+
+    pub(crate) fn source_snapshot(&self) -> &EngineSnapshot {
+        match self.source {
+            Side::Left => &self.left,
+            Side::Right => &self.right,
+        }
+    }
+
+    pub(crate) fn target_snapshot(&self) -> &EngineSnapshot {
+        match self.source {
+            Side::Left => &self.right,
+            Side::Right => &self.left,
+        }
+    }
+
+    /// Push the source side's settings to the target engine.
+    pub(crate) fn apply(&mut self, rt: &Runtime) {
+        let (Some(source), target) = (
+            self.source_snapshot().status.clone(),
+            self.target_snapshot(),
+        ) else {
+            self.state = DialogState::Failed(
+                "source engine has no settings to copy (check connection)".to_owned(),
+            );
+            return;
+        };
+        if target.error.is_some() {
+            self.state = DialogState::Failed(format!(
+                "target engine '{}' is unreachable: {}",
+                target.label,
+                target.error.as_deref().unwrap_or("?")
+            ));
+            return;
+        }
+        let request = save_request_from_status(&source);
+        let endpoint = target.endpoint.clone();
+        let target_label = target.label;
+        self.state = DialogState::Applying;
+        match rt.block_on(apply_save(&endpoint, request)) {
+            Ok(()) => {
+                self.state = DialogState::Applied(format!("Pushed settings to {target_label}."));
+            }
+            Err(error) => {
+                self.state = DialogState::Failed(format!("{target_label}: {error}"));
+            }
+        }
+    }
+}
+
+/// Convert a `SetupStatus` snapshot into a `SaveSetupRequest`.
+///
+/// QRZ XML password and QRZ Logbook API key are NOT carried in `SetupStatus`
+/// (only `has_qrz_xml_password` / `has_qrz_logbook_api_key` flags). The
+/// receiving engine preserves the existing password when the field is `None`
+/// in the request, so omitting them is safe.
+#[allow(deprecated)]
+pub(crate) fn save_request_from_status(status: &SetupStatus) -> SaveSetupRequest {
+    let persistence_values = status
+        .persistence_values
+        .iter()
+        .filter(|value| value.has_value && !value.secret && !value.redacted)
+        .map(|value| SetupFieldValue {
+            key: value.key.clone(),
+            value: Some(value.display_value.clone()),
+        })
+        .collect();
+    SaveSetupRequest {
+        storage_backend: status.storage_backend,
+        sqlite_path: status.sqlite_path.clone(),
+        station_profile: status.station_profile.clone(),
+        qrz_xml_username: status.qrz_xml_username.clone(),
+        qrz_xml_password: None,
+        log_file_path: status.log_file_path.clone(),
+        qrz_logbook_api_key: None,
+        sync_config: status.sync_config,
+        rig_control: status.rig_control.clone(),
+        persistence_values,
+    }
+}
+
+async fn fetch_status(endpoint: &str) -> Result<SetupStatus, String> {
+    let channel = connect(endpoint).await?;
+    let mut client = SetupServiceClient::new(channel);
+    let response = tokio::time::timeout(
+        Duration::from_secs(3),
+        client.get_setup_status(GetSetupStatusRequest {}),
+    )
+    .await
+    .map_err(|_| "timed out waiting for GetSetupStatus".to_owned())?
+    .map_err(|status| format!("RPC error: {}", status.message()))?;
+    response
+        .into_inner()
+        .status
+        .ok_or_else(|| "engine returned no SetupStatus payload".to_owned())
+}
+
+async fn apply_save(endpoint: &str, request: SaveSetupRequest) -> Result<(), String> {
+    let channel = connect(endpoint).await?;
+    let mut client = SetupServiceClient::new(channel);
+    tokio::time::timeout(Duration::from_secs(5), client.save_setup(request))
+        .await
+        .map_err(|_| "timed out waiting for SaveSetup".to_owned())?
+        .map_err(|status| format!("RPC error: {}", status.message()))?;
+    Ok(())
+}
+
+async fn connect(endpoint: &str) -> Result<Channel, String> {
+    let endpoint = Endpoint::from_shared(endpoint.to_owned())
+        .map_err(|e| format!("invalid endpoint: {e}"))?
+        .connect_timeout(Duration::from_secs(2))
+        .timeout(Duration::from_secs(5));
+    endpoint
+        .connect()
+        .await
+        .map_err(|e| format!("connect failed: {e}"))
+}
+
+/// Field rows rendered side-by-side. Each row is `(label, left, right)`.
+pub(crate) fn diff_rows(dialog: &SyncDialog) -> Vec<(String, String, String, bool)> {
+    let left = snapshot_fields(&dialog.left);
+    let right = snapshot_fields(&dialog.right);
+    let mut rows = Vec::with_capacity(left.len());
+    for ((label, lhs), (_, rhs)) in left.into_iter().zip(right.into_iter()) {
+        let differs = lhs != rhs;
+        rows.push((label.to_owned(), lhs, rhs, differs));
+    }
+    rows
+}
+
+fn snapshot_fields(snapshot: &EngineSnapshot) -> Vec<(&'static str, String)> {
+    let Some(status) = snapshot.status.as_ref() else {
+        let err = snapshot.error.as_deref().unwrap_or("(no data)");
+        return vec![
+            ("Status", format!("unreachable: {err}")),
+            ("Station callsign", String::new()),
+            ("Operator callsign", String::new()),
+            ("Operator name", String::new()),
+            ("Grid", String::new()),
+            ("QRZ XML user", String::new()),
+            ("QRZ XML password", String::new()),
+            ("QRZ logbook key", String::new()),
+            ("Log file path", String::new()),
+            ("Auto sync", String::new()),
+            ("Sync interval (s)", String::new()),
+            ("Conflict policy", String::new()),
+            ("Rig control", String::new()),
+        ];
+    };
+    let profile = status.station_profile.clone().unwrap_or(StationProfile {
+        profile_name: None,
+        station_callsign: String::new(),
+        operator_callsign: None,
+        operator_name: None,
+        grid: None,
+        county: None,
+        state: None,
+        country: None,
+        dxcc: None,
+        cq_zone: None,
+        itu_zone: None,
+        latitude: None,
+        longitude: None,
+        arrl_section: None,
+    });
+    let sync = status.sync_config.unwrap_or(SyncConfig {
+        auto_sync_enabled: false,
+        sync_interval_seconds: 0,
+        conflict_policy: ConflictPolicy::Unspecified as i32,
+    });
+    let rig = status.rig_control.clone().unwrap_or(RigControlSettings {
+        enabled: None,
+        host: None,
+        port: None,
+        read_timeout_ms: None,
+        stale_threshold_ms: None,
+    });
+
+    vec![
+        ("Status", "reachable".to_owned()),
+        ("Station callsign", profile.station_callsign.clone()),
+        (
+            "Operator callsign",
+            profile.operator_callsign.clone().unwrap_or_default(),
+        ),
+        (
+            "Operator name",
+            profile.operator_name.clone().unwrap_or_default(),
+        ),
+        ("Grid", profile.grid.clone().unwrap_or_default()),
+        (
+            "QRZ XML user",
+            status.qrz_xml_username.clone().unwrap_or_default(),
+        ),
+        (
+            "QRZ XML password",
+            if status.has_qrz_xml_password {
+                "<set>".to_owned()
+            } else {
+                "<unset>".to_owned()
+            },
+        ),
+        (
+            "QRZ logbook key",
+            if status.has_qrz_logbook_api_key {
+                "<set>".to_owned()
+            } else {
+                "<unset>".to_owned()
+            },
+        ),
+        (
+            "Log file path",
+            status.log_file_path.clone().unwrap_or_default(),
+        ),
+        ("Auto sync", sync.auto_sync_enabled.to_string()),
+        ("Sync interval (s)", sync.sync_interval_seconds.to_string()),
+        (
+            "Conflict policy",
+            format!(
+                "{:?}",
+                ConflictPolicy::try_from(sync.conflict_policy)
+                    .unwrap_or(ConflictPolicy::Unspecified)
+            ),
+        ),
+        (
+            "Rig control",
+            format!(
+                "{}@{}:{}",
+                rig.enabled.map_or_else(
+                    || "?".to_owned(),
+                    |b| if b { "on" } else { "off" }.to_owned()
+                ),
+                rig.host.clone().unwrap_or_else(|| "?".to_owned()),
+                rig.port.map_or_else(|| "?".to_owned(), |p| p.to_string()),
+            ),
+        ),
+    ]
+}
+
+#[cfg(test)]
+#[allow(deprecated, clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use qsoripper_core::proto::qsoripper::domain::StationProfile;
+
+    fn mk_status(callsign: &str, log_path: Option<&str>) -> SetupStatus {
+        SetupStatus {
+            config_file_exists: true,
+            setup_complete: true,
+            config_path: "config.toml".to_owned(),
+            storage_backend: 0,
+            sqlite_path: None,
+            has_station_profile: true,
+            station_profile: Some(StationProfile {
+                profile_name: None,
+                station_callsign: callsign.to_owned(),
+                operator_callsign: None,
+                operator_name: None,
+                grid: None,
+                county: None,
+                state: None,
+                country: None,
+                dxcc: None,
+                cq_zone: None,
+                itu_zone: None,
+                latitude: None,
+                longitude: None,
+                arrl_section: None,
+            }),
+            qrz_xml_username: Some("user".to_owned()),
+            has_qrz_xml_password: true,
+            suggested_sqlite_path: String::new(),
+            warnings: vec![],
+            active_station_profile_id: None,
+            station_profile_count: 1,
+            log_file_path: log_path.map(str::to_owned),
+            suggested_log_file_path: String::new(),
+            is_first_run: false,
+            has_qrz_logbook_api_key: false,
+            sync_config: None,
+            rig_control: None,
+            persistence_step_enabled: false,
+            persistence_label: String::new(),
+            persistence_description: String::new(),
+            persistence_definitions: vec![],
+            persistence_values: vec![],
+            persistence_contract_explicit: false,
+        }
+    }
+
+    #[test]
+    fn save_request_preserves_secret_fields_as_none() {
+        let request = save_request_from_status(&mk_status("K7XYZ", Some("/tmp/log.db")));
+        assert!(request.qrz_xml_password.is_none());
+        assert!(request.qrz_logbook_api_key.is_none());
+        assert_eq!(request.log_file_path.as_deref(), Some("/tmp/log.db"));
+        assert_eq!(
+            request
+                .station_profile
+                .as_ref()
+                .map(|p| p.station_callsign.as_str()),
+            Some("K7XYZ")
+        );
+    }
+
+    #[test]
+    fn diff_rows_flag_differences() {
+        let dialog = SyncDialog {
+            left: EngineSnapshot {
+                label: "L",
+                endpoint: String::new(),
+                status: Some(mk_status("K7XYZ", Some("/a.db"))),
+                error: None,
+            },
+            right: EngineSnapshot {
+                label: "R",
+                endpoint: String::new(),
+                status: Some(mk_status("K7XYZ", Some("/b.db"))),
+                error: None,
+            },
+            source: Side::Left,
+            state: DialogState::Ready,
+        };
+        let rows = diff_rows(&dialog);
+        let callsign_row = rows
+            .iter()
+            .find(|(l, ..)| l == "Station callsign")
+            .expect("station callsign row present");
+        assert!(!callsign_row.3, "matching callsigns should not flag a diff");
+        let path_row = rows
+            .iter()
+            .find(|(l, ..)| l == "Log file path")
+            .expect("log file path row present");
+        assert!(path_row.3, "differing log paths should flag a diff");
+    }
+
+    #[test]
+    fn target_is_opposite_of_source() {
+        let dialog = SyncDialog {
+            left: EngineSnapshot::new("L", ""),
+            right: EngineSnapshot::new("R", ""),
+            source: Side::Left,
+            state: DialogState::Ready,
+        };
+        assert_eq!(dialog.source_snapshot().label, "L");
+        assert_eq!(dialog.target_snapshot().label, "R");
+        let mut dialog = dialog;
+        dialog.source = Side::Right;
+        assert_eq!(dialog.target_snapshot().label, "L");
+    }
+
+    #[test]
+    fn apply_without_source_status_fails_with_message() {
+        let rt = Runtime::new().expect("tokio runtime");
+        let mut dialog = SyncDialog {
+            left: EngineSnapshot {
+                label: "L",
+                endpoint: String::new(),
+                status: None,
+                error: Some("nope".to_owned()),
+            },
+            right: EngineSnapshot::new("R", ""),
+            source: Side::Left,
+            state: DialogState::Ready,
+        };
+        dialog.apply(&rt);
+        assert!(matches!(dialog.state, DialogState::Failed(_)));
+    }
+}

--- a/src/rust/qsoripper-launcher/src/sync.rs
+++ b/src/rust/qsoripper-launcher/src/sync.rs
@@ -223,25 +223,32 @@ pub(crate) fn diff_rows(dialog: &SyncDialog) -> Vec<(String, String, String, boo
 }
 
 fn snapshot_fields(snapshot: &EngineSnapshot) -> Vec<(&'static str, String)> {
-    let Some(status) = snapshot.status.as_ref() else {
-        let err = snapshot.error.as_deref().unwrap_or("(no data)");
-        return vec![
-            ("Status", format!("unreachable: {err}")),
-            ("Station callsign", String::new()),
-            ("Operator callsign", String::new()),
-            ("Operator name", String::new()),
-            ("Grid", String::new()),
-            ("QRZ XML user", String::new()),
-            ("QRZ XML password", String::new()),
-            ("QRZ logbook key", String::new()),
-            ("Log file path", String::new()),
-            ("Auto sync", String::new()),
-            ("Sync interval (s)", String::new()),
-            ("Conflict policy", String::new()),
-            ("Rig control", String::new()),
-        ];
-    };
-    let profile = status.station_profile.clone().unwrap_or(StationProfile {
+    snapshot.status.as_ref().map_or_else(
+        || unreachable_snapshot_fields(snapshot.error.as_deref().unwrap_or("(no data)")),
+        reachable_snapshot_fields,
+    )
+}
+
+fn unreachable_snapshot_fields(error: &str) -> Vec<(&'static str, String)> {
+    vec![
+        ("Status", format!("unreachable: {error}")),
+        ("Station callsign", String::new()),
+        ("Operator callsign", String::new()),
+        ("Operator name", String::new()),
+        ("Grid", String::new()),
+        ("QRZ XML user", String::new()),
+        ("QRZ XML password", String::new()),
+        ("QRZ logbook key", String::new()),
+        ("Log file path", String::new()),
+        ("Auto sync", String::new()),
+        ("Sync interval (s)", String::new()),
+        ("Conflict policy", String::new()),
+        ("Rig control", String::new()),
+    ]
+}
+
+fn reachable_snapshot_fields(status: &SetupStatus) -> Vec<(&'static str, String)> {
+    let default_profile = StationProfile {
         profile_name: None,
         station_callsign: String::new(),
         operator_callsign: None,
@@ -256,19 +263,14 @@ fn snapshot_fields(snapshot: &EngineSnapshot) -> Vec<(&'static str, String)> {
         latitude: None,
         longitude: None,
         arrl_section: None,
-    });
-    let sync = status.sync_config.unwrap_or(SyncConfig {
+    };
+    let default_sync = SyncConfig {
         auto_sync_enabled: false,
         sync_interval_seconds: 0,
         conflict_policy: ConflictPolicy::Unspecified as i32,
-    });
-    let rig = status.rig_control.clone().unwrap_or(RigControlSettings {
-        enabled: None,
-        host: None,
-        port: None,
-        read_timeout_ms: None,
-        stale_threshold_ms: None,
-    });
+    };
+    let profile = status.station_profile.as_ref().unwrap_or(&default_profile);
+    let sync = status.sync_config.as_ref().unwrap_or(&default_sync);
 
     vec![
         ("Status", "reachable".to_owned()),
@@ -288,19 +290,11 @@ fn snapshot_fields(snapshot: &EngineSnapshot) -> Vec<(&'static str, String)> {
         ),
         (
             "QRZ XML password",
-            if status.has_qrz_xml_password {
-                "<set>".to_owned()
-            } else {
-                "<unset>".to_owned()
-            },
+            secret_status_marker(status.has_qrz_xml_password),
         ),
         (
             "QRZ logbook key",
-            if status.has_qrz_logbook_api_key {
-                "<set>".to_owned()
-            } else {
-                "<unset>".to_owned()
-            },
+            secret_status_marker(status.has_qrz_logbook_api_key),
         ),
         (
             "Log file path",
@@ -310,25 +304,41 @@ fn snapshot_fields(snapshot: &EngineSnapshot) -> Vec<(&'static str, String)> {
         ("Sync interval (s)", sync.sync_interval_seconds.to_string()),
         (
             "Conflict policy",
-            format!(
-                "{:?}",
-                ConflictPolicy::try_from(sync.conflict_policy)
-                    .unwrap_or(ConflictPolicy::Unspecified)
-            ),
+            conflict_policy_label(sync.conflict_policy),
         ),
         (
             "Rig control",
-            format!(
-                "{}@{}:{}",
-                rig.enabled.map_or_else(
-                    || "?".to_owned(),
-                    |b| if b { "on" } else { "off" }.to_owned()
-                ),
-                rig.host.clone().unwrap_or_else(|| "?".to_owned()),
-                rig.port.map_or_else(|| "?".to_owned(), |p| p.to_string()),
-            ),
+            rig_control_label(status.rig_control.as_ref()),
         ),
     ]
+}
+
+fn secret_status_marker(is_set: bool) -> String {
+    if is_set { "<set>" } else { "<unset>" }.to_owned()
+}
+
+fn conflict_policy_label(value: i32) -> String {
+    format!(
+        "{:?}",
+        ConflictPolicy::try_from(value).unwrap_or(ConflictPolicy::Unspecified)
+    )
+}
+
+fn rig_control_label(rig: Option<&RigControlSettings>) -> String {
+    let enabled = rig
+        .and_then(|settings| settings.enabled)
+        .map_or_else(|| "?".to_owned(), enabled_label);
+    let host = rig
+        .and_then(|settings| settings.host.as_deref())
+        .unwrap_or("?");
+    let port = rig
+        .and_then(|settings| settings.port)
+        .map_or_else(|| "?".to_owned(), |port| port.to_string());
+    format!("{enabled}@{host}:{port}")
+}
+
+fn enabled_label(enabled: bool) -> String {
+    if enabled { "on" } else { "off" }.to_owned()
 }
 
 #[cfg(test)]

--- a/src/rust/qsoripper-launcher/src/ui.rs
+++ b/src/rust/qsoripper-launcher/src/ui.rs
@@ -23,6 +23,7 @@ use crate::model::Selection;
 use crate::plan::{engine_plan, ui_plan};
 use crate::ports::{is_port_listening, wait_for_port};
 use crate::process::{open_url, spawn, stop_pid, ProcessRegistry};
+use crate::sync::{diff_rows, DialogState, Side, SyncDialog};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum Column {
@@ -105,6 +106,8 @@ pub(crate) struct AppState {
     registry: ProcessRegistry,
     last_message: String,
     should_quit: bool,
+    runtime: Option<tokio::runtime::Runtime>,
+    sync_dialog: Option<SyncDialog>,
 }
 
 impl AppState {
@@ -125,9 +128,62 @@ impl AppState {
             cursor,
             statuses: BTreeMap::new(),
             registry: ProcessRegistry::new(),
-            last_message: "Press ? for help, Enter to launch selected, Q to quit.".to_owned(),
+            last_message:
+                "Press ? for help, Enter to launch selected, Y to sync settings, Q to quit."
+                    .to_owned(),
             should_quit: false,
+            runtime: None,
+            sync_dialog: None,
         }
+    }
+
+    fn ensure_runtime(&mut self) -> Option<&tokio::runtime::Runtime> {
+        if self.runtime.is_none() {
+            match tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(2)
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => self.runtime = Some(rt),
+                Err(error) => {
+                    self.last_message = format!("Failed to start async runtime: {error}");
+                    return None;
+                }
+            }
+        }
+        self.runtime.as_ref()
+    }
+
+    fn open_sync_dialog(&mut self) {
+        let Some(runtime) = self.ensure_runtime() else {
+            return;
+        };
+        let dialog = SyncDialog::fetch(runtime);
+        "Sync dialog open: ← / → choose source, Enter apply, Esc cancel."
+            .clone_into(&mut self.last_message);
+        self.sync_dialog = Some(dialog);
+    }
+
+    fn close_sync_dialog(&mut self) {
+        self.sync_dialog = None;
+        "Sync dialog closed.".clone_into(&mut self.last_message);
+    }
+
+    fn apply_sync_dialog(&mut self) {
+        let Some(mut dialog) = self.sync_dialog.take() else {
+            return;
+        };
+        let Some(runtime) = self.ensure_runtime() else {
+            self.sync_dialog = Some(dialog);
+            return;
+        };
+        dialog.apply(runtime);
+        match &dialog.state {
+            DialogState::Applied(msg) => self.last_message = msg.clone(),
+            DialogState::Failed(msg) => self.last_message = format!("Sync failed: {msg}"),
+            _ => {}
+        }
+        self.sync_dialog = Some(dialog);
     }
 
     fn engine_components() -> Vec<ComponentId> {
@@ -404,6 +460,8 @@ fn render(frame: &mut ratatui::Frame, app: &AppState) {
         Span::raw(" stop  "),
         Span::styled("R", Style::default().fg(Color::Yellow).bold()),
         Span::raw(" restart  "),
+        Span::styled("Y", Style::default().fg(Color::Yellow).bold()),
+        Span::raw(" sync  "),
         Span::styled("Q", Style::default().fg(Color::Yellow).bold()),
         Span::raw(" quit   "),
         Span::styled(&app.last_message, Style::default().fg(Color::DarkGray)),
@@ -411,6 +469,150 @@ fn render(frame: &mut ratatui::Frame, app: &AppState) {
     .block(Block::default().borders(Borders::ALL))
     .wrap(Wrap { trim: true });
     frame.render_widget(footer, footer_area);
+
+    if let Some(dialog) = app.sync_dialog.as_ref() {
+        render_sync_dialog(frame, area, dialog);
+    }
+}
+
+fn render_sync_dialog(frame: &mut ratatui::Frame, area: Rect, dialog: &SyncDialog) {
+    let popup = centered_rect(area, 90, 80);
+    frame.render_widget(ratatui::widgets::Clear, popup);
+
+    let rows = diff_rows(dialog);
+    let [header_area, body_area, footer_area] = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(6),
+            Constraint::Length(4),
+        ])
+        .areas(popup);
+
+    let source_label = match dialog.source {
+        Side::Left => dialog.left.label,
+        Side::Right => dialog.right.label,
+    };
+    let target_label = match dialog.source {
+        Side::Left => dialog.right.label,
+        Side::Right => dialog.left.label,
+    };
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(
+            " Sync engine settings ",
+            Style::default().bg(Color::Magenta).fg(Color::White).bold(),
+        ),
+        Span::raw("  Source: "),
+        Span::styled(source_label, Style::default().fg(Color::Green).bold()),
+        Span::raw("  ->  Target: "),
+        Span::styled(target_label, Style::default().fg(Color::Yellow).bold()),
+    ]))
+    .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(header, header_area);
+
+    let [left_col, right_col] = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .areas(body_area);
+
+    let left_selected = dialog.source == Side::Left;
+    let right_selected = dialog.source == Side::Right;
+    frame.render_widget(
+        build_side_list(dialog.left.label, &rows, true, left_selected),
+        left_col,
+    );
+    frame.render_widget(
+        build_side_list(dialog.right.label, &rows, false, right_selected),
+        right_col,
+    );
+
+    let footer_text = match &dialog.state {
+        DialogState::Ready => Line::from(vec![
+            Span::styled("← / →", Style::default().fg(Color::Yellow).bold()),
+            Span::raw(" pick source  "),
+            Span::styled("Enter", Style::default().fg(Color::Yellow).bold()),
+            Span::raw(" push to other engine  "),
+            Span::styled("Esc", Style::default().fg(Color::Yellow).bold()),
+            Span::raw(" cancel"),
+        ]),
+        DialogState::Applying => Line::from(Span::styled(
+            "Applying...",
+            Style::default().fg(Color::Cyan).bold(),
+        )),
+        DialogState::Applied(msg) => Line::from(vec![
+            Span::styled("✓ ", Style::default().fg(Color::Green).bold()),
+            Span::raw(msg.clone()),
+            Span::raw("  (Esc to close)"),
+        ]),
+        DialogState::Failed(msg) => Line::from(vec![
+            Span::styled("✗ ", Style::default().fg(Color::Red).bold()),
+            Span::styled(msg.clone(), Style::default().fg(Color::Red)),
+            Span::raw("  (Esc to close)"),
+        ]),
+    };
+    let footer = Paragraph::new(footer_text)
+        .block(Block::default().borders(Borders::ALL))
+        .wrap(Wrap { trim: true });
+    frame.render_widget(footer, footer_area);
+}
+
+fn build_side_list(
+    label: &str,
+    rows: &[(String, String, String, bool)],
+    is_left: bool,
+    selected: bool,
+) -> List<'static> {
+    let items: Vec<ListItem<'static>> = rows
+        .iter()
+        .map(|(field, lhs, rhs, differs)| {
+            let value = if is_left { lhs } else { rhs };
+            let value_style = if *differs {
+                Style::default().fg(Color::Red).bold()
+            } else {
+                Style::default().fg(Color::Green)
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("  {field:18} "), Style::default().fg(Color::Gray)),
+                Span::styled(value.clone(), value_style),
+            ]))
+        })
+        .collect();
+    let title_style = if selected {
+        Style::default().fg(Color::Green).bold()
+    } else {
+        Style::default().fg(Color::Gray)
+    };
+    let title_text = if selected {
+        format!(" {label}  [SOURCE] ")
+    } else {
+        format!(" {label} ")
+    };
+    List::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(Span::styled(title_text, title_style)),
+    )
+}
+
+fn centered_rect(area: Rect, percent_x: u16, percent_y: u16) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    let middle_row = vertical.get(1).copied().unwrap_or(area);
+    let horizontal = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(middle_row);
+    horizontal.get(1).copied().unwrap_or(middle_row)
 }
 
 fn render_column(
@@ -488,6 +690,10 @@ fn handle_key(app: &mut AppState, key: KeyEvent) {
     if key.kind != KeyEventKind::Press {
         return;
     }
+    if app.sync_dialog.is_some() {
+        handle_sync_key(app, key);
+        return;
+    }
     match (key.code, key.modifiers) {
         (KeyCode::Char('q') | KeyCode::Esc, _) => app.should_quit = true,
         (KeyCode::Tab, _) => app.column = app.column.cycle(),
@@ -500,6 +706,44 @@ fn handle_key(app: &mut AppState, key: KeyEvent) {
         (KeyCode::Char('r'), KeyModifiers::NONE) => {
             app.stop_managed();
             app.launch_selected();
+        }
+        (KeyCode::Char('y'), KeyModifiers::NONE) => app.open_sync_dialog(),
+        _ => {}
+    }
+}
+
+fn handle_sync_key(app: &mut AppState, key: KeyEvent) {
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc, _) => app.close_sync_dialog(),
+        (KeyCode::Left, _) => {
+            if let Some(dialog) = app.sync_dialog.as_mut() {
+                if matches!(dialog.state, DialogState::Ready) {
+                    dialog.source = Side::Left;
+                }
+            }
+        }
+        (KeyCode::Right, _) => {
+            if let Some(dialog) = app.sync_dialog.as_mut() {
+                if matches!(dialog.state, DialogState::Ready) {
+                    dialog.source = Side::Right;
+                }
+            }
+        }
+        (KeyCode::Tab, _) => {
+            if let Some(dialog) = app.sync_dialog.as_mut() {
+                if matches!(dialog.state, DialogState::Ready) {
+                    dialog.source = dialog.source.toggle();
+                }
+            }
+        }
+        (KeyCode::Enter, _) => {
+            let ready = matches!(
+                app.sync_dialog.as_ref().map(|d| &d.state),
+                Some(DialogState::Ready)
+            );
+            if ready {
+                app.apply_sync_dialog();
+            }
         }
         _ => {}
     }

--- a/src/rust/qsoripper-launcher/src/ui.rs
+++ b/src/rust/qsoripper-launcher/src/ui.rs
@@ -14,13 +14,15 @@ use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
 use ratatui::Terminal;
 
-use crate::catalog::{catalog, ComponentId, ComponentKind, ENGINE_DOTNET, ENGINE_RUST};
+use crate::catalog::{
+    catalog, ComponentId, ComponentKind, ENGINE_DOTNET, ENGINE_RUST, UI_DEBUGHOST,
+};
 use crate::config;
 use crate::discovery::ArtifactRoot;
 use crate::model::Selection;
 use crate::plan::{engine_plan, ui_plan};
 use crate::ports::{is_port_listening, wait_for_port};
-use crate::process::{spawn, stop_pid, ProcessRegistry};
+use crate::process::{open_url, spawn, stop_pid, ProcessRegistry};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum Column {
@@ -247,6 +249,7 @@ impl AppState {
         }
 
         // UIs next.
+        let mut opened_debughost = false;
         for ui_id in self.selection.uis.clone() {
             let Some(plan) = ui_plan(ui_id, &self.selection) else {
                 continue;
@@ -257,10 +260,33 @@ impl AppState {
             match spawn(&plan.spec, &exe, &arg_refs, &plan.env, &mut self.registry) {
                 Ok(p) => {
                     self.statuses.insert(ui_id, Status::running(p.pid));
+                    if ui_id == UI_DEBUGHOST {
+                        opened_debughost = true;
+                    }
                 }
                 Err(e) => {
                     self.statuses.insert(ui_id, Status::failed(&e.to_string()));
                 }
+            }
+        }
+
+        // Once everything is spawned, wait briefly for the DebugHost HTTP
+        // endpoint to come up, then point the user's default browser at it.
+        if opened_debughost {
+            const DEBUGHOST_URL: &str = "http://localhost:5082";
+            const DEBUGHOST_PORT: u16 = 5082;
+            if wait_for_port(
+                DEBUGHOST_PORT,
+                Duration::from_secs(20),
+                Duration::from_millis(300),
+            ) {
+                if let Err(e) = open_url(DEBUGHOST_URL) {
+                    self.last_message =
+                        format!("DebugHost started but failed to open browser: {e}");
+                }
+            } else {
+                self.last_message =
+                    format!("DebugHost did not respond on {DEBUGHOST_URL} within 20s");
             }
         }
 

--- a/src/rust/qsoripper-launcher/src/ui.rs
+++ b/src/rust/qsoripper-launcher/src/ui.rs
@@ -1,0 +1,517 @@
+//! ratatui rendering and the keyboard-driven launcher state machine.
+
+use std::collections::BTreeMap;
+use std::io;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use ratatui::backend::CrosstermBackend;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Color, Modifier, Style, Stylize};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+use ratatui::Terminal;
+
+use crate::catalog::{catalog, ComponentId, ComponentKind, ENGINE_DOTNET, ENGINE_RUST};
+use crate::config;
+use crate::discovery::ArtifactRoot;
+use crate::model::Selection;
+use crate::plan::{engine_plan, ui_plan};
+use crate::ports::{is_port_listening, wait_for_port};
+use crate::process::{spawn, stop_pid, ProcessRegistry};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum Column {
+    Engines,
+    Uis,
+    Bindings,
+}
+
+impl Column {
+    fn cycle(self) -> Self {
+        match self {
+            Self::Engines => Self::Uis,
+            Self::Uis => Self::Bindings,
+            Self::Bindings => Self::Engines,
+        }
+    }
+    fn cycle_back(self) -> Self {
+        match self {
+            Self::Engines => Self::Bindings,
+            Self::Uis => Self::Engines,
+            Self::Bindings => Self::Uis,
+        }
+    }
+}
+
+/// One status line per component. Updated after launch/stop and at each tick.
+#[derive(Debug, Clone)]
+struct Status {
+    message: String,
+    style: Style,
+}
+
+impl Status {
+    fn idle() -> Self {
+        Self {
+            message: "idle".to_owned(),
+            style: Style::default().fg(Color::DarkGray),
+        }
+    }
+    fn running(pid: u32) -> Self {
+        Self {
+            message: format!("running (PID {pid})"),
+            style: Style::default().fg(Color::Green),
+        }
+    }
+    fn already_running() -> Self {
+        Self {
+            message: "already listening (external)".to_owned(),
+            style: Style::default().fg(Color::Yellow),
+        }
+    }
+    fn failed(reason: &str) -> Self {
+        Self {
+            message: format!("failed: {reason}"),
+            style: Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        }
+    }
+    fn starting() -> Self {
+        Self {
+            message: "starting...".to_owned(),
+            style: Style::default().fg(Color::Cyan),
+        }
+    }
+    fn stopped() -> Self {
+        Self {
+            message: "stopped".to_owned(),
+            style: Style::default().fg(Color::Gray),
+        }
+    }
+}
+
+/// Top-level TUI state.
+pub(crate) struct AppState {
+    pub selection: Selection,
+    pub config_path: PathBuf,
+    pub artifact_root: ArtifactRoot,
+    column: Column,
+    cursor: BTreeMap<Column, usize>,
+    statuses: BTreeMap<ComponentId, Status>,
+    registry: ProcessRegistry,
+    last_message: String,
+    should_quit: bool,
+}
+
+impl AppState {
+    pub(crate) fn new(
+        selection: Selection,
+        config_path: PathBuf,
+        artifact_root: ArtifactRoot,
+    ) -> Self {
+        let mut cursor = BTreeMap::new();
+        cursor.insert(Column::Engines, 0);
+        cursor.insert(Column::Uis, 0);
+        cursor.insert(Column::Bindings, 0);
+        Self {
+            selection,
+            config_path,
+            artifact_root,
+            column: Column::Engines,
+            cursor,
+            statuses: BTreeMap::new(),
+            registry: ProcessRegistry::new(),
+            last_message: "Press ? for help, Enter to launch selected, Q to quit.".to_owned(),
+            should_quit: false,
+        }
+    }
+
+    fn engine_components() -> Vec<ComponentId> {
+        catalog()
+            .into_iter()
+            .filter(|c| c.kind == ComponentKind::Engine)
+            .map(|c| c.id)
+            .collect()
+    }
+
+    fn ui_components() -> Vec<ComponentId> {
+        catalog()
+            .into_iter()
+            .filter(|c| c.kind == ComponentKind::Ui)
+            .map(|c| c.id)
+            .collect()
+    }
+
+    fn bindable_uis_selected(&self) -> Vec<ComponentId> {
+        Self::ui_components()
+            .into_iter()
+            .filter(|id| {
+                catalog()
+                    .into_iter()
+                    .any(|c| c.id == *id && c.engine_bindable)
+                    && self.selection.ui_selected(id)
+            })
+            .collect()
+    }
+
+    fn current_list(&self) -> Vec<ComponentId> {
+        match self.column {
+            Column::Engines => Self::engine_components(),
+            Column::Uis => Self::ui_components(),
+            Column::Bindings => self.bindable_uis_selected(),
+        }
+    }
+
+    fn move_cursor(&mut self, delta: i32) {
+        let len = i32::try_from(self.current_list().len()).unwrap_or(i32::MAX);
+        if len == 0 {
+            return;
+        }
+        let cur = self.cursor.entry(self.column).or_insert(0);
+        let cur_i = i32::try_from(*cur).unwrap_or(0);
+        let new = (cur_i + delta).rem_euclid(len);
+        *cur = usize::try_from(new).unwrap_or(0);
+    }
+
+    fn current_id(&self) -> Option<ComponentId> {
+        let list = self.current_list();
+        let cur = *self.cursor.get(&self.column).unwrap_or(&0);
+        list.get(cur).copied()
+    }
+
+    fn toggle_current(&mut self) {
+        match self.column {
+            Column::Engines | Column::Uis => {
+                if let Some(id) = self.current_id() {
+                    self.selection.toggle(id);
+                    self.selection.repair_bindings();
+                }
+            }
+            Column::Bindings => {
+                if let Some(ui_id) = self.current_id() {
+                    let engines = self.selection.engines.clone();
+                    if engines.is_empty() {
+                        "No engines selected; check an engine first."
+                            .clone_into(&mut self.last_message);
+                        return;
+                    }
+                    let current = self.selection.bindings.get(&ui_id).copied();
+                    let idx = current
+                        .and_then(|c| engines.iter().position(|e| *e == c))
+                        .unwrap_or(0);
+                    let next_idx = (idx + 1) % engines.len();
+                    if let Some(&next) = engines.get(next_idx) {
+                        self.selection.set_binding(ui_id, next);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Spawn every selected engine, wait for readiness, then spawn each
+    /// selected UI with the per-UI engine binding env vars.
+    fn launch_selected(&mut self) {
+        // Engines first.
+        for engine_id in self.selection.engines.clone() {
+            let Some(plan) = engine_plan(engine_id) else {
+                continue;
+            };
+            let exe = plan.spec.artifact.executable_path(&self.artifact_root);
+            let port = plan.spec.engine_port.unwrap_or(0);
+            if port != 0 && is_port_listening(port, Duration::from_millis(200)) {
+                self.statuses.insert(engine_id, Status::already_running());
+                continue;
+            }
+            self.statuses.insert(engine_id, Status::starting());
+            let arg_refs: Vec<&std::ffi::OsStr> = plan.args.iter().map(AsRef::as_ref).collect();
+            match spawn(&plan.spec, &exe, &arg_refs, &plan.env, &mut self.registry) {
+                Ok(p) => {
+                    if port != 0
+                        && !wait_for_port(port, Duration::from_secs(15), Duration::from_millis(300))
+                    {
+                        self.statuses.insert(
+                            engine_id,
+                            Status::failed(&format!("never came up on 127.0.0.1:{port}")),
+                        );
+                    } else {
+                        self.statuses.insert(engine_id, Status::running(p.pid));
+                    }
+                }
+                Err(e) => {
+                    self.statuses
+                        .insert(engine_id, Status::failed(&e.to_string()));
+                }
+            }
+        }
+
+        // UIs next.
+        for ui_id in self.selection.uis.clone() {
+            let Some(plan) = ui_plan(ui_id, &self.selection) else {
+                continue;
+            };
+            let exe = plan.spec.artifact.executable_path(&self.artifact_root);
+            self.statuses.insert(ui_id, Status::starting());
+            let arg_refs: Vec<&std::ffi::OsStr> = plan.args.iter().map(AsRef::as_ref).collect();
+            match spawn(&plan.spec, &exe, &arg_refs, &plan.env, &mut self.registry) {
+                Ok(p) => {
+                    self.statuses.insert(ui_id, Status::running(p.pid));
+                }
+                Err(e) => {
+                    self.statuses.insert(ui_id, Status::failed(&e.to_string()));
+                }
+            }
+        }
+
+        // Persist selections on a successful launch attempt (best-effort).
+        if let Err(e) = config::save(&self.config_path, &self.selection) {
+            self.last_message = format!(
+                "Launched (warning: failed to persist selections to {}: {e})",
+                self.config_path.display()
+            );
+        } else {
+            self.last_message = format!(
+                "Launched. Selections saved to {}.",
+                self.config_path.display()
+            );
+        }
+    }
+
+    /// Stop every PID the launcher started.
+    fn stop_managed(&mut self) {
+        let ids: Vec<ComponentId> = self.registry.iter().map(|p| p.component).collect();
+        for id in ids {
+            if let Some(p) = self.registry.remove(id) {
+                if stop_pid(p.pid) {
+                    self.statuses.insert(id, Status::stopped());
+                } else {
+                    self.statuses
+                        .insert(id, Status::failed("could not signal PID"));
+                }
+            }
+        }
+        "Stopped all launcher-managed processes.".clone_into(&mut self.last_message);
+    }
+
+    fn status_for(&self, id: ComponentId) -> Status {
+        self.statuses.get(&id).cloned().unwrap_or_else(Status::idle)
+    }
+}
+
+fn engine_label(id: ComponentId) -> &'static str {
+    match id {
+        i if i == ENGINE_RUST => "Rust",
+        i if i == ENGINE_DOTNET => ".NET",
+        _ => id,
+    }
+}
+
+fn render(frame: &mut ratatui::Frame, app: &AppState) {
+    let area = frame.area();
+    let [header_area, body_area, status_area, footer_area] = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(8),
+            Constraint::Length(7),
+            Constraint::Length(3),
+        ])
+        .areas(area);
+
+    let header = Paragraph::new(Line::from(vec![
+        Span::styled(
+            " QsoRipper Launcher ",
+            Style::default().bg(Color::Blue).fg(Color::White).bold(),
+        ),
+        Span::raw("  artifacts: "),
+        Span::styled(
+            app.artifact_root.path().to_string_lossy().to_string(),
+            Style::default().fg(Color::Cyan),
+        ),
+        Span::raw("  ("),
+        Span::styled(
+            app.artifact_root.configuration().to_owned(),
+            Style::default().fg(Color::Yellow),
+        ),
+        Span::raw(")"),
+    ]))
+    .block(Block::default().borders(Borders::ALL));
+    frame.render_widget(header, header_area);
+
+    let [engines_area, uis_area, bindings_area] = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(33),
+            Constraint::Percentage(33),
+            Constraint::Percentage(34),
+        ])
+        .areas(body_area);
+
+    render_column(frame, engines_area, app, Column::Engines, "Engines");
+    render_column(frame, uis_area, app, Column::Uis, "UIs");
+    render_column(frame, bindings_area, app, Column::Bindings, "Bindings");
+
+    let status_items: Vec<ListItem> = catalog()
+        .into_iter()
+        .map(|spec| {
+            let st = app.status_for(spec.id);
+            let line = Line::from(vec![
+                Span::styled(format!("  {:30} ", spec.display_name), Style::default()),
+                Span::styled(st.message, st.style),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+    let status =
+        List::new(status_items).block(Block::default().title(" Status ").borders(Borders::ALL));
+    frame.render_widget(status, status_area);
+
+    let footer = Paragraph::new(Line::from(vec![
+        Span::styled("Space", Style::default().fg(Color::Yellow).bold()),
+        Span::raw(" toggle  "),
+        Span::styled("Tab", Style::default().fg(Color::Yellow).bold()),
+        Span::raw(" cycle column  "),
+        Span::styled("Enter", Style::default().fg(Color::Yellow).bold()),
+        Span::raw(" launch  "),
+        Span::styled("S", Style::default().fg(Color::Yellow).bold()),
+        Span::raw(" stop  "),
+        Span::styled("R", Style::default().fg(Color::Yellow).bold()),
+        Span::raw(" restart  "),
+        Span::styled("Q", Style::default().fg(Color::Yellow).bold()),
+        Span::raw(" quit   "),
+        Span::styled(&app.last_message, Style::default().fg(Color::DarkGray)),
+    ]))
+    .block(Block::default().borders(Borders::ALL))
+    .wrap(Wrap { trim: true });
+    frame.render_widget(footer, footer_area);
+}
+
+fn render_column(
+    frame: &mut ratatui::Frame,
+    area: Rect,
+    app: &AppState,
+    column: Column,
+    title: &str,
+) {
+    let active = app.column == column;
+    let list_ids: Vec<ComponentId> = match column {
+        Column::Engines => AppState::engine_components(),
+        Column::Uis => AppState::ui_components(),
+        Column::Bindings => app.bindable_uis_selected(),
+    };
+    let cursor = *app.cursor.get(&column).unwrap_or(&0);
+
+    let items: Vec<ListItem> = list_ids
+        .iter()
+        .enumerate()
+        .map(|(i, id)| {
+            let display_name = catalog()
+                .into_iter()
+                .find(|c| c.id == *id)
+                .map_or(*id, |c| c.display_name);
+            let checked = match column {
+                Column::Engines => app.selection.engine_selected(id),
+                Column::Uis => app.selection.ui_selected(id),
+                Column::Bindings => true,
+            };
+            let check = match column {
+                Column::Bindings => "  ",
+                Column::Engines | Column::Uis => {
+                    if checked {
+                        "[x] "
+                    } else {
+                        "[ ] "
+                    }
+                }
+            };
+            let binding_suffix = if column == Column::Bindings {
+                let engine = app
+                    .selection
+                    .bindings
+                    .get(id)
+                    .copied()
+                    .map_or("(unset)", engine_label);
+                format!("  -> {engine}")
+            } else {
+                String::new()
+            };
+            let style = if active && i == cursor {
+                Style::default().bg(Color::DarkGray).fg(Color::White).bold()
+            } else {
+                Style::default()
+            };
+            let text = format!("{check}{display_name}{binding_suffix}");
+            ListItem::new(text).style(style)
+        })
+        .collect();
+
+    let title_style = if active {
+        Style::default().fg(Color::Yellow).bold()
+    } else {
+        Style::default()
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(Span::styled(format!(" {title} "), title_style));
+    let list = List::new(items).block(block);
+    frame.render_widget(list, area);
+}
+
+fn handle_key(app: &mut AppState, key: KeyEvent) {
+    if key.kind != KeyEventKind::Press {
+        return;
+    }
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('q') | KeyCode::Esc, _) => app.should_quit = true,
+        (KeyCode::Tab, _) => app.column = app.column.cycle(),
+        (KeyCode::BackTab, _) => app.column = app.column.cycle_back(),
+        (KeyCode::Up | KeyCode::Char('k'), _) => app.move_cursor(-1),
+        (KeyCode::Down | KeyCode::Char('j'), _) => app.move_cursor(1),
+        (KeyCode::Char(' '), _) => app.toggle_current(),
+        (KeyCode::Enter, _) => app.launch_selected(),
+        (KeyCode::Char('s'), KeyModifiers::NONE) => app.stop_managed(),
+        (KeyCode::Char('r'), KeyModifiers::NONE) => {
+            app.stop_managed();
+            app.launch_selected();
+        }
+        _ => {}
+    }
+}
+
+/// Run the TUI event loop.
+pub(crate) fn run(app: &mut AppState) -> Result<()> {
+    use crossterm::execute;
+    use crossterm::terminal::{
+        disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
+    };
+
+    enable_raw_mode()?;
+    let mut stdout = io::stdout();
+    execute!(stdout, EnterAlternateScreen)?;
+    let backend = CrosstermBackend::new(stdout);
+    let mut terminal = Terminal::new(backend)?;
+
+    let result = (|| -> Result<()> {
+        let tick = Duration::from_millis(250);
+        let mut last_tick = Instant::now();
+        while !app.should_quit {
+            terminal.draw(|f| render(f, app))?;
+            let timeout = tick.saturating_sub(last_tick.elapsed());
+            if event::poll(timeout)? {
+                if let Event::Key(key) = event::read()? {
+                    handle_key(app, key);
+                }
+            }
+            if last_tick.elapsed() >= tick {
+                last_tick = Instant::now();
+            }
+        }
+        Ok(())
+    })();
+
+    disable_raw_mode()?;
+    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    terminal.show_cursor()?;
+    result
+}

--- a/src/rust/qsoripper-launcher/src/ui.rs
+++ b/src/rust/qsoripper-launcher/src/ui.rs
@@ -71,7 +71,7 @@ impl Status {
     }
     fn already_running() -> Self {
         Self {
-            message: "already listening (external)".to_owned(),
+            message: "listening (external)".to_owned(),
             style: Style::default().fg(Color::Yellow),
         }
     }


### PR DESCRIPTION
Implements issue #432. Adds a new Rust crate `qsoripper-launcher` that provides a fast-starting ratatui TUI for picking which engines (Rust 50051, .NET 50052) and UIs (Avalonia GUI, DebugHost, CW Scope, Rust TUI) to launch, with per-UI engine binding via QSORIPPER_ENGINE and QSORIPPER_ENDPOINT env vars. Selections persist under [launcher] in config.toml. The launcher owns start/stop lifecycle for components it spawned; it does not trigger builds.

The launcher also exposes a settings-sync dialog (Y): it fetches SetupStatus from both engines via gRPC, renders a side-by-side preview with per-field diff highlighting, and applies the chosen side onto the other engine through SaveSetup. Left/Right/Tab pick the source, Enter applies, Esc cancels. Secrets (QRZ XML password and logbook API key) are intentionally omitted from the request because both engines preserve them when unset.

Adds a `cli.ps1` wrapper that mirrors `launcher.ps1`: it runs the prebuilt QsoRipper.Cli.dll directly via `dotnet` for instant startup and falls back to `dotnet build` when the assembly is missing or `-Rebuild` is passed. Pass `-Dev` for the Debug configuration; arguments after `--` are forwarded to the CLI.

Also fixes Avalonia GUI engine selection so QSORIPPER_ENGINE/QSORIPPER_ENDPOINT env vars take precedence over persisted UI preferences, matching how the launcher injects bindings.

Rust + ratatui was chosen for sub-100ms startup, memory safety (matching the project rule that only the small Win32 gate may be memory-unsafe), and keyboard-first parity with qsoripper-tui.

Validation: cargo fmt, cargo clippy --all-targets -D warnings, cargo test (full workspace, 23/23 launcher tests including 4 new sync tests), cargo llvm-cov workspace coverage above the 80% gate, cargo deny bans+licenses+sources OK. The crate uses ratatui 0.29, crossterm 0.28, toml_edit 0.22, sysinfo 0.33, plus tonic and tokio (multi-thread, lazy-initialized) for the sync RPCs.

Closes #432
