### PR TITLE
FFI: add optional station_callsign to QsrLogQsoRequest

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -66,7 +66,6 @@ jobs:
           cargo llvm-cov \
             --manifest-path src/rust/Cargo.toml \
             --workspace \
-            --exclude qsoripper-ffi \
             --exclude qsoripper-stress \
             --exclude qsoripper-stress-tui \
             --lcov \

--- a/src/c/qsoripper-win32/include/qsoripper_ffi.h
+++ b/src/c/qsoripper-win32/include/qsoripper_ffi.h
@@ -35,6 +35,11 @@ typedef struct QsrLogQsoRequest {
    */
   uint8_t callsign[32];
   /**
+   * Operator's own (logging) station callsign (null-terminated UTF-8). Optional:
+   * if empty, the server materializes it from the active station profile.
+   */
+  uint8_t station_callsign[32];
+  /**
    * Band string, e.g. "20M" (null-terminated).
    */
   uint8_t band[8];

--- a/src/rust/qsoripper-ffi/qsoripper_ffi.h
+++ b/src/rust/qsoripper-ffi/qsoripper_ffi.h
@@ -35,6 +35,11 @@ typedef struct QsrLogQsoRequest {
    */
   uint8_t callsign[32];
   /**
+   * Operator's own (logging) station callsign (null-terminated UTF-8). Optional:
+   * if empty, the server materializes it from the active station profile.
+   */
+  uint8_t station_callsign[32];
+  /**
    * Band string, e.g. "20M" (null-terminated).
    */
   uint8_t band[8];

--- a/src/rust/qsoripper-ffi/src/client.rs
+++ b/src/rust/qsoripper-ffi/src/client.rs
@@ -329,9 +329,15 @@ impl QsrClient {
 /// Build a `QsoRecord` proto from the FFI request struct.
 fn build_qso_record(req: &QsrLogQsoRequest) -> Result<QsoRecord, String> {
     let callsign = buf_to_str(&req.callsign);
+    let station_callsign = buf_to_str(&req.station_callsign);
     let band_str = buf_to_str(&req.band);
     let mode_str = buf_to_str(&req.mode);
     let datetime_str = buf_to_str(&req.datetime);
+
+    if station_callsign.trim().is_empty() {
+        // Optional at the FFI layer: leave empty so the server can materialize
+        // it from the active station profile (legacy Win32 app behavior).
+    }
 
     let band = band_from_adif(&band_str.to_uppercase())
         .ok_or_else(|| format!("Unknown band: {band_str}"))?;
@@ -342,6 +348,7 @@ fn build_qso_record(req: &QsrLogQsoRequest) -> Result<QsoRecord, String> {
 
     let mut qso = QsoRecord {
         worked_callsign: callsign.to_uppercase(),
+        station_callsign: station_callsign.to_uppercase(),
         band: band.into(),
         mode: mode.into(),
         utc_timestamp: Some(timestamp),
@@ -891,9 +898,55 @@ fn populate_rig_status(
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
-    use super::{buf_to_str, parse_datetime, qso_to_summary};
+    use super::{buf_to_str, build_qso_record, parse_datetime, qso_to_summary};
+    use crate::types::{str_to_buf, QsrLogQsoRequest, QsrRstReport};
     use qsoripper_core::proto::qsoripper::domain::{QsoRecord, StationSnapshot};
+
+    fn baseline_request() -> QsrLogQsoRequest {
+        let mut req: QsrLogQsoRequest = unsafe { std::mem::zeroed() };
+        str_to_buf("W1AW", &mut req.callsign);
+        str_to_buf("K7TST", &mut req.station_callsign);
+        str_to_buf("20M", &mut req.band);
+        str_to_buf("SSB", &mut req.mode);
+        str_to_buf("2025-01-15 14:30", &mut req.datetime);
+        req.rst_sent = QsrRstReport {
+            readability: 5,
+            strength: 9,
+            tone: 0,
+        };
+        req.rst_rcvd = QsrRstReport {
+            readability: 5,
+            strength: 9,
+            tone: 0,
+        };
+        req
+    }
+
+    #[test]
+    fn build_qso_record_populates_station_callsign() {
+        let req = baseline_request();
+        let qso = build_qso_record(&req).expect("build_qso_record should succeed");
+        assert_eq!(qso.station_callsign, "K7TST");
+        assert_eq!(qso.worked_callsign, "W1AW");
+        assert!(
+            !qso.station_callsign.trim().is_empty(),
+            "station_callsign must be populated so the server's persistence validator accepts the QSO"
+        );
+    }
+
+    #[test]
+    fn build_qso_record_leaves_station_callsign_empty_for_server_materialization() {
+        let mut req = baseline_request();
+        req.station_callsign = [0u8; 32];
+        let qso = build_qso_record(&req)
+            .expect("empty station_callsign is optional so the server can materialize it");
+        assert!(
+            qso.station_callsign.trim().is_empty(),
+            "empty FFI station_callsign must round-trip as empty so the server fills it"
+        );
+    }
 
     #[test]
     fn qso_to_summary_does_not_use_station_snapshot_country_when_worked_country_missing() {

--- a/src/rust/qsoripper-ffi/src/types.rs
+++ b/src/rust/qsoripper-ffi/src/types.rs
@@ -21,6 +21,9 @@ pub struct QsrRstReport {
 pub struct QsrLogQsoRequest {
     /// Worked station callsign (null-terminated UTF-8).
     pub callsign: [u8; 32],
+    /// Operator's own (logging) station callsign (null-terminated UTF-8). Optional:
+    /// if empty, the server materializes it from the active station profile.
+    pub station_callsign: [u8; 32],
     /// Band string, e.g. "20M" (null-terminated).
     pub band: [u8; 8],
     /// Mode string, e.g. "SSB" (null-terminated).

--- a/src/rust/qsoripper-ffi/tests/integration.rs
+++ b/src/rust/qsoripper-ffi/tests/integration.rs
@@ -158,6 +158,7 @@ fn log_list_get_delete_round_trip() {
     // 1. Log a QSO
     let mut req: QsrLogQsoRequest = unsafe { std::mem::zeroed() };
     fill_buf(&mut req.callsign, "W1AW");
+    fill_buf(&mut req.station_callsign, "K7TST");
     fill_buf(&mut req.band, "20M");
     fill_buf(&mut req.mode, "SSB");
     fill_buf(&mut req.datetime, "2025-01-15 14:30");
@@ -225,6 +226,7 @@ fn update_qso_round_trip() {
     // Log a QSO
     let mut req: QsrLogQsoRequest = unsafe { std::mem::zeroed() };
     fill_buf(&mut req.callsign, "K1ABC");
+    fill_buf(&mut req.station_callsign, "K7TST");
     fill_buf(&mut req.band, "40M");
     fill_buf(&mut req.mode, "CW");
     fill_buf(&mut req.datetime, "2025-01-15 20:00");


### PR DESCRIPTION
The qsr_log_qso FFI path had no way for callers to supply the operator's own station callsign. Server-side persistence requires station_callsign, and only filled it in via the active station profile, so any FFI caller (the Win32 app, the integration tests under qsoripper-ffi/tests/integration.rs) silently depended on a profile being configured server-side and failed against a fresh server with the validator error "station_callsign is required.".

This adds a station_callsign field to QsrLogQsoRequest (mirrored in qsoripper_ffi.h and the bundled Win32 header). build_qso_record passes it through to QsoRecord when non-empty, and leaves it empty otherwise so the server can still materialize it from the active station profile. The Win32 app zeroes its request struct, so its behavior is unchanged. The two FFI integration tests now set station_callsign = K7TST explicitly so they pass against a fresh server with no profile configured.

CI gap: .github/workflows/rust-quality.yml excluded qsoripper-ffi entirely from cargo llvm-cov, so no qsoripper-ffi tests ran in CI - the regression that prompted this fix could never have been caught there. Drop --exclude qsoripper-ffi. Integration tests still skip cleanly when no server is reachable via the existing skip_if_no_server! macro. The --ignore-filename-regex for the coverage threshold step is unchanged, so the 80% line-coverage gate is unaffected. New unit tests in client.rs cover both the populated and empty station_callsign cases and will now run in CI.

Validated locally with cargo fmt --check, cargo clippy --all-targets -- -D warnings, and cargo test across the workspace.