### PR TITLE
CLI: wire --after / --before / --contest into export-adif

### DIFF
--- a/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
@@ -548,6 +548,90 @@ public sealed class CommandHelperTests
     }
 
     [Fact]
+    public void Export_TryParseArgs_accepts_after_before_and_contest_filters()
+    {
+        var request = new ExportAdifRequest();
+        var success = ExportAdifCommand.TryParseArgs(
+            ["--after", "2026-04-21T18:03:42Z", "--before", "2026-05-01", "--contest", "CQWWSSB", "--include-header"],
+            request,
+            out var outputFile,
+            out var error);
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.Null(outputFile);
+        Assert.True(request.IncludeHeader);
+        Assert.Equal("CQWWSSB", request.ContestId);
+        Assert.NotNull(request.After);
+        Assert.Equal(new DateTime(2026, 4, 21, 18, 3, 42, DateTimeKind.Utc), request.After!.ToDateTime());
+        Assert.NotNull(request.Before);
+        Assert.Equal(new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc), request.Before!.ToDateTime());
+    }
+
+    [Fact]
+    public void Export_TryParseArgs_accepts_relative_after_filter()
+    {
+        var request = new ExportAdifRequest();
+        var before = DateTime.UtcNow;
+        var success = ExportAdifCommand.TryParseArgs(
+            ["--after", "2.days"],
+            request,
+            out _,
+            out var error);
+        var after = DateTime.UtcNow;
+
+        Assert.True(success);
+        Assert.Null(error);
+        Assert.NotNull(request.After);
+        var parsed = request.After!.ToDateTime();
+        Assert.InRange(parsed, before.AddDays(-2).AddSeconds(-5), after.AddDays(-2).AddSeconds(5));
+    }
+
+    [Fact]
+    public void Export_TryParseArgs_rejects_invalid_after_value()
+    {
+        var request = new ExportAdifRequest();
+        var success = ExportAdifCommand.TryParseArgs(
+            ["--after", "not-a-time"],
+            request,
+            out _,
+            out var error);
+
+        Assert.False(success);
+        Assert.NotNull(error);
+        Assert.Contains("--after", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Export_TryParseArgs_rejects_missing_value_for_filters()
+    {
+        var request = new ExportAdifRequest();
+        var success = ExportAdifCommand.TryParseArgs(
+            ["--before"],
+            request,
+            out _,
+            out var error);
+
+        Assert.False(success);
+        Assert.Equal("Missing value for --before.", error);
+    }
+
+    [Fact]
+    public void Export_TryParseArgs_rejects_unknown_option()
+    {
+        var request = new ExportAdifRequest();
+        var success = ExportAdifCommand.TryParseArgs(
+            ["--bogus"],
+            request,
+            out _,
+            out var error);
+
+        Assert.False(success);
+        Assert.NotNull(error);
+        Assert.Contains("--bogus", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void TryParseArgs_deleted_flag_sets_deleted_only_filter()
     {
         var success = ListQsosCommand.TryParseArgs(["--deleted"], out var request, out var displayOptions, out var error);

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -174,6 +174,15 @@ internal static class CliHelpText
                   --file <path>        Write to file (default: stdout). If <path> is a
                                        directory, writes <logdbname>-yyyy-MM-dd.adi there.
                   --include-header     Include ADIF header
+                  --after <time>       Only QSOs after this time. Relative (2.days, 3.hours)
+                                       or absolute (2026-04-21, 2026-04-21T18:03:42Z).
+                  --before <time>      Only QSOs before this time. Same formats as --after.
+                  --contest <id>       Only QSOs tagged with this contest id (e.g., CQWWSSB).
+
+                Examples:
+                  export --file recent.adi --after 7.days
+                  export --file cqww.adi --contest CQWWSSB
+                  export --after 2026-04-21T18:03:42Z --file new-for-lotw.adi
                 """,
             "lookup" => """
                 Usage: lookup <callsign> [--skip-cache]

--- a/src/dotnet/QsoRipper.Cli/Commands/ExportAdifCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ExportAdifCommand.cs
@@ -15,23 +15,11 @@ internal static class ExportAdifCommand
         string[] args,
         CancellationToken cancellationToken = default)
     {
-        string? outputFile = null;
-        var includeHeader = false;
-
-        for (var i = 0; i < args.Length; i++)
+        var request = new ExportAdifRequest();
+        if (!TryParseArgs(args, request, out var outputFile, out var error))
         {
-            switch (args[i])
-            {
-                case "--file" when i < args.Length - 1:
-                    outputFile = args[++i];
-                    break;
-                case "--file":
-                    Console.Error.WriteLine("Missing value for --file.");
-                    return 1;
-                case "--include-header":
-                    includeHeader = true;
-                    break;
-            }
+            Console.Error.WriteLine(error);
+            return 1;
         }
 
         string? resolvedOutputFile;
@@ -57,7 +45,7 @@ internal static class ExportAdifCommand
             try
             {
                 using var output = OpenOutputFile(resolvedOutputFile);
-                await WriteExportAsync(channel, includeHeader, output, cancellationToken);
+                await WriteExportAsync(channel, request, output, cancellationToken);
             }
             catch (Exception ex) when (ex is ArgumentException
                                           or DirectoryNotFoundException
@@ -75,19 +63,82 @@ internal static class ExportAdifCommand
         }
 
         using var stdout = Console.OpenStandardOutput();
-        await WriteExportAsync(channel, includeHeader, stdout, cancellationToken);
+        await WriteExportAsync(channel, request, stdout, cancellationToken);
         return 0;
+    }
+
+    internal static bool TryParseArgs(
+        string[] args,
+        ExportAdifRequest request,
+        out string? outputFile,
+        out string? error)
+    {
+        outputFile = null;
+        error = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--file" when i < args.Length - 1:
+                    outputFile = args[++i];
+                    break;
+                case "--file":
+                    error = "Missing value for --file.";
+                    return false;
+                case "--include-header":
+                    request.IncludeHeader = true;
+                    break;
+                case "--after" when i < args.Length - 1:
+                    var after = TimeParser.Parse(args[++i]);
+                    if (after is null)
+                    {
+                        error = "Invalid --after value. Use relative (2.days, 3.hours) or absolute (2026-04-10).";
+                        return false;
+                    }
+
+                    request.After = after;
+                    break;
+                case "--after":
+                    error = "Missing value for --after.";
+                    return false;
+                case "--before" when i < args.Length - 1:
+                    var before = TimeParser.Parse(args[++i]);
+                    if (before is null)
+                    {
+                        error = "Invalid --before value. Use relative (2.days, 3.hours) or absolute (2026-04-10).";
+                        return false;
+                    }
+
+                    request.Before = before;
+                    break;
+                case "--before":
+                    error = "Missing value for --before.";
+                    return false;
+                case "--contest" when i < args.Length - 1:
+                    request.ContestId = args[++i];
+                    break;
+                case "--contest":
+                    error = "Missing value for --contest.";
+                    return false;
+                default:
+                    error = $"Unknown option: {args[i]}";
+                    return false;
+            }
+        }
+
+        return true;
     }
 
     private static async Task WriteExportAsync(
         GrpcChannel channel,
-        bool includeHeader,
+        ExportAdifRequest request,
         Stream output,
         CancellationToken cancellationToken)
     {
         var client = new LogbookService.LogbookServiceClient(channel);
         using var call = client.ExportAdif(
-            new ExportAdifRequest { IncludeHeader = includeHeader },
+            request,
             cancellationToken: cancellationToken);
 
         while (await call.ResponseStream.MoveNext(cancellationToken))


### PR DESCRIPTION
Closes #438.

The export-adif CLI command was only forwarding --file and --include-header even though the ExportAdifRequest proto and both engines (Rust qsoripper-server and .NET ManagedEngineState) already implement after/before/contest_id filtering via QsoListQuery. This patch wires those three flags into the CLI, mirroring the list-qsos command surface and reusing the existing TimeParser for the time values (relative like 2.days/3.hours or absolute like 2026-04-21T18:03:42Z).

This unblocks the LoTW upload workflow (export only QSOs newer than the most recent LoTW confirmation, then sign and upload with tqsl) and contest-specific exports without engine, proto, or spec changes.

Coverage

- New ExportAdifCommand.TryParseArgs helper extracted from RunAsync (kept internal for testability).
- Tests in QsoRipper.Cli.Tests covering: combined --after / --before / --contest / --include-header parse, relative --after, invalid time value, missing value for --before, unknown option.
- Existing tests for ResolveOutputFile and the missing-parent error path still pass.

Validation

- dotnet build src\dotnet\QsoRipper.Cli\QsoRipper.Cli.csproj  succeeded with no warnings.
- dotnet test src\dotnet\QsoRipper.Cli.Tests\QsoRipper.Cli.Tests.csproj  all 210 tests passing including the 5 new ones.
- dotnet format --verify-no-changes  clean on both Cli and Cli.Tests projects.
- Live smoke against running Rust engine:
  qsoripper --engine local-rust export --file out.adi --after 2026-04-21T18:03:42Z --include-header
  produced 83 QSO records with a proper ADIF header and correctly excluded earlier QSOs.

Help text

The export section of CliHelpText now documents --after, --before, --contest with examples.