### PR TITLE
ci: enable auto-merge friendliness and reduce redundant runs

### DIFF
--- a/.github/workflows/dotnet-quality.yml
+++ b/.github/workflows/dotnet-quality.yml
@@ -12,6 +12,7 @@ on:
       - "src/dotnet/**"
       - "proto/**"
   pull_request:
+  merge_group:
 
 # PR branches: only the pull_request trigger runs (no duplicate push run that
 # competes for the dotnet-quality status check). Push events still run on main.
@@ -35,6 +36,11 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
+          cache: true
+          cache-dependency-path: |
+            src/dotnet/**/*.csproj
+            src/dotnet/**/Directory.Packages.props
+            src/dotnet/**/packages.lock.json
 
       - name: Verify formatting
         run: dotnet format src/dotnet/QsoRipper.slnx --verify-no-changes

--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -4,12 +4,21 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/rust-quality.yml"
       - "rust-toolchain.toml"
       - "src/rust/**"
       - "proto/**"
   pull_request:
+  merge_group:
+
+# PR branches: only the pull_request trigger runs (no duplicate push run that
+# competes for the rust-quality status check). Push events still run on main.
+concurrency:
+  group: rust-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/win32-quality.yml
+++ b/.github/workflows/win32-quality.yml
@@ -4,10 +4,17 @@ on:
   workflow_dispatch:
   workflow_call:
   push:
+    branches:
+      - main
     paths:
       - ".github/workflows/win32-quality.yml"
       - "src/c/**"
   pull_request:
+  merge_group:
+
+concurrency:
+  group: win32-quality-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
Reduces CI churn and unlocks GitHub auto-merge / merge queue.

Workflow changes:
- Add concurrency cancel-in-progress to rust-quality and win32-quality (dotnet-quality already had it)
- Scope push trigger to main on rust-quality and win32-quality so PR branches only run via pull_request, eliminating duplicate runs that race for the same required status check
- Add merge_group trigger to all three quality workflows so a future merge queue can run them
- Enable NuGet caching on setup-dotnet in dotnet-quality

Repo settings already applied via API:
- allow_auto_merge = true (enables the auto-merge button and gh pr merge --auto)
- allow_update_branch = true
- branch protection on main: required_status_checks.strict = false (PRs no longer have to be up to date with main before merging; this was the main cause of cascading re-runs after every merge)