### PR TITLE
docs: align LookupService docs with implemented BatchLookup and GetDxccEntity (#393)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Proto files under `proto/` are the **single source of truth** for all shared typ
 | **DeveloperControlService** | Developer-only runtime config inspection and mutation |
 | **SpaceWeatherService** | Current NOAA SWPC snapshot reads and explicit refresh for engine clients |
 
-The built-in engine hosts intentionally advertise only the lookup capabilities they actually implement in this first slice (`lookup-callsign`, `lookup-stream`, `lookup-cache`). That keeps engine discovery truthful while `BatchLookup` and `GetDxccEntity` remain out of scope in both hosts.
+The built-in engine hosts advertise fine-grained lookup capabilities (`lookup-callsign`, `lookup-stream`, `lookup-cache`) so discovery matches the actually implemented surface. `BatchLookup` and DXCC lookup by code are implemented in both Rust and .NET hosts; DXCC lookup by prefix still returns `UNIMPLEMENTED`.
 
 **Building a client or a new engine host?** See the [Engine API Documentation](docs/api/README.md) for the shared contract reference, stub generation guidance, transport notes, and implementation-status details.
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -73,8 +73,8 @@ Not every contract entry is implemented by every current engine host. The refere
 In general:
 
 - Both built-in engine hosts implement the common first slice used by the conformance harness: engine info, setup, station profiles, runtime config, logbook CRUD, sync status, ADIF import/export, rig status, space weather, and callsign lookup via unary/stream/cache RPCs.
-- Both built-in hosts still leave `LookupService.GetDxccEntity` and `LookupService.BatchLookup` unimplemented in this slice.
-- The built-in engine hosts intentionally report fine-grained lookup capabilities (`lookup-callsign`, `lookup-stream`, `lookup-cache`) instead of a broad `lookup` bucket so discovery matches the actual implemented surface.
+- Both built-in hosts also implement `LookupService.BatchLookup` and `LookupService.GetDxccEntity` for the `dxcc_code` query case. The `prefix` query case of `GetDxccEntity` still returns `UNIMPLEMENTED` in both hosts.
+- The built-in engine hosts report fine-grained lookup capabilities (`lookup-callsign`, `lookup-stream`, `lookup-cache`) instead of a broad `lookup` bucket so discovery matches the actually implemented surface.
 
 The current proto contract should now be treated as the stable **post-1-1-1 baseline**. PR [#74](https://github.com/rtreit/qsoripper/pull/74) was a deliberate breaking-contract cutover while the project is still early. From this baseline forward, additive changes are preferred and client code generated from the current proto files should continue to compile as new fields and RPCs are added. See [client-integration.md](client-integration.md#schema-evolution-and-compatibility) for field tolerance guidance.
 

--- a/docs/api/lookup-service.md
+++ b/docs/api/lookup-service.md
@@ -21,8 +21,16 @@ All RPCs use unique request/response envelopes. Shared domain payloads stay nest
 | `Lookup` | ✅ Implemented | Unary callsign lookup via coordinator |
 | `StreamLookup` | ✅ Implemented | Server-streaming with `Loading → Found/Error` state transitions |
 | `GetCachedCallsign` | ✅ Implemented | L1 in-memory cache check only, no network call |
-| `GetDxccEntity` | ⚠️ Planned | Returns `UNIMPLEMENTED` — deferred from first lookup slice |
-| `BatchLookup` | ⚠️ Planned | Returns `UNIMPLEMENTED` — deferred from first lookup slice |
+| `GetDxccEntity` (by `dxcc_code`) | ✅ Implemented | Returns the entity for a numeric DXCC code, or `NOT_FOUND` |
+| `GetDxccEntity` (by `prefix`) | ⚠️ Unimplemented | Returns `UNIMPLEMENTED` in both hosts |
+| `BatchLookup` | ✅ Implemented | Bounded-concurrency parallel lookup over the coordinator (max 5 in-flight) |
+
+Source-of-truth references for parity checks:
+
+- Rust: [`src/rust/qsoripper-server/src/main.rs`](../../src/rust/qsoripper-server/src/main.rs) (`get_dxcc_entity`, `batch_lookup`)
+- .NET: [`src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs`](../../src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs) (`GetDxccEntity`, `BatchLookup`)
+
+When changing or adding RPCs, update this table and the matching capability list in the engine specification in the same change.
 
 ## RPCs
 
@@ -165,14 +173,14 @@ Look up a DXCC (DX Century Club) entity by numeric code or callsign prefix.
 rpc GetDxccEntity(GetDxccEntityRequest) returns (GetDxccEntityResponse)
 ```
 
-> ⚠️ **Status:** Planned. Currently returns `UNIMPLEMENTED`.
+> ✅ **Status:** Implemented for the `dxcc_code` query case. The `prefix` query case still returns `UNIMPLEMENTED` in both built-in hosts.
 
 **Request:** `GetDxccEntityRequest` (oneof)
 
 | Field | Type | Description |
 |---|---|---|
 | `dxcc_code` | `uint32` | Numeric DXCC entity code |
-| `prefix` | `string` | Callsign prefix — QRZ performs a 4→3→2 letter reduction to find the entity |
+| `prefix` | `string` | Callsign prefix — reserved for future QRZ-style 4→3→2 letter reduction; currently `UNIMPLEMENTED` |
 
 **Response:** `GetDxccEntityResponse`
 
@@ -181,8 +189,9 @@ rpc GetDxccEntity(GetDxccEntityRequest) returns (GetDxccEntityResponse)
 | `entity` | `DxccEntity` | The matched DXCC payload |
 
 **Notable status codes:**
-- `UNIMPLEMENTED` — current server response (planned feature).
-- `NOT_FOUND` — expected future status code when the entity does not exist.
+- `NOT_FOUND` — `dxcc_code` does not match any known DXCC entity.
+- `UNIMPLEMENTED` — `prefix` query case is not yet supported.
+- `INVALID_ARGUMENT` — neither `dxcc_code` nor `prefix` was supplied.
 
 ---
 
@@ -194,7 +203,7 @@ Look up multiple callsigns in a single request. Intended for contest prefetch sc
 rpc BatchLookup(BatchLookupRequest) returns (BatchLookupResponse)
 ```
 
-> ⚠️ **Status:** Planned. Currently returns `UNIMPLEMENTED`.
+> ✅ **Status:** Implemented in both built-in hosts. Runs the supplied callsigns through the lookup coordinator in parallel with a bounded concurrency cap (currently 5 in-flight).
 
 **Request:** `BatchLookupRequest`
 
@@ -211,7 +220,8 @@ rpc BatchLookup(BatchLookupRequest) returns (BatchLookupResponse)
 **Use case:** Pre-populate the cache before a contest session begins by looking up a list of expected callsigns in one call.
 
 **Notable status codes:**
-- `UNIMPLEMENTED` — current server response (planned feature).
+- `OK` — normal response, including the empty-input case (returns an empty `results` list).
+- `INTERNAL` — surfaced if a per-callsign worker task fails unexpectedly.
 
 ---
 


### PR DESCRIPTION
Fixes #393. Updates README, docs/api/README.md, and docs/api/lookup-service.md to reflect that BatchLookup and GetDxccEntity (by dxcc_code) are implemented in both engine hosts. Documents that the prefix case of GetDxccEntity still returns UNIMPLEMENTED. Adds a short source-of-truth pointer in lookup-service.md so future RPC additions can be cross-checked against the engine implementations without drifting again.