### PR TITLE
Add contest calendar engine support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,7 +83,10 @@ stress-report.html
 
 
 # Syncthing-managed local data, captures, corpora, and runtime databases.
-data/
+data/*
+!data/contest-calendar/
+data/contest-calendar/*
+!data/contest-calendar/contest-details.json
 
 # cw-decoder stress-test generated audio (large, regenerable via stress-gen.ps1)
 experiments/cw-decoder/bench-runs/

--- a/data/contest-calendar/contest-details.json
+++ b/data/contest-calendar/contest-details.json
@@ -1,0 +1,5805 @@
+{
+  "version": 1,
+  "generatedAtUtc": "2026-05-23T23:12:21.3978764+00:00",
+  "sourceName": "WA7BNM Contest Calendar",
+  "sourceUrl": "https://www.contestcalendar.com/contestcal.php",
+  "entries": [
+    {
+      "name": "10-10 Int. 10-10 Day Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=156",
+      "rulesUrl": "https://www.ten-ten.org/qso-party-rules/",
+      "bands": [
+        "10m"
+      ],
+      "modes": [
+        "am",
+        "cw",
+        "digital",
+        "fm",
+        "ft8",
+        "rtty",
+        "ssb"
+      ],
+      "exchange": "10-10 Member: Name \u002B 10-10 number \u002B (state/province/country); Non-Member: Name \u002B 0 \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "10-10 Int. Fall Contest, Digital",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=464",
+      "rulesUrl": "https://www.ten-ten.org/qso-party-rules/",
+      "bands": [
+        "10m"
+      ],
+      "modes": [
+        "digital"
+      ],
+      "exchange": "10-10 Member: Name \u002B 10-10 number \u002B (state/province/country); Non-Member: Name \u002B 0 \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "10-10 Int. Summer Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=81",
+      "rulesUrl": "https://www.ten-ten.org/qso-party-rules/",
+      "bands": [
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "10-10 Member: Name \u002B 10-10 number \u002B (state/province/country); Non-Member: Name \u002B 0 \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "10-10 Int. Winter Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=237",
+      "rulesUrl": "https://www.ten-ten.org/qso-party-rules/",
+      "bands": [
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "10-10 Member: Name \u002B 10-10 number \u002B (state/province/country); Non-Member: Name \u002B 0 \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "4 States QRP Group Second Sunday Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=611",
+      "rulesUrl": "http://www.4sqrp.com/SSS/sss_rules_revised_02_2026.pdf",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "Member: RS(T) \u002B (State/Province/Country) \u002B Member No.; Non-member: RS(T) \u002B (State/Province/Country) \u002B Power",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "50 MHz Spring Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=19",
+      "rulesUrl": "https://sites.google.com/site/springvhfupsprints/home/2026-information",
+      "bands": [
+        "6m"
+      ],
+      "modes": [
+        "digital"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "7th Call Area QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=404",
+      "rulesUrl": "http://7qp.org/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ft8",
+        "ssb"
+      ],
+      "exchange": "7th Area: RS(T) \u002B 5-letter state/county code; non-7th Area: RS(T) \u002B (state/province/DX)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "A1Club AWT",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=715",
+      "rulesUrl": "https://a1club.org/contest/awt/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Member: RST \u002B Name",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Africa FT4 DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=752",
+      "rulesUrl": "https://mysarl.org.za/contest-resources/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "ft4"
+      ],
+      "exchange": "Signal report \u002B 4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "AGB NEMIGA Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=487",
+      "rulesUrl": "http://ev5agb.com/contest/contests.htm",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "AGB Member: RST \u002B QSO No. \u002B Member No.; non-Member: RST \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "AGB New Year Snowball Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=466",
+      "rulesUrl": "https://www.qsl.net/eu1eu/agb_nysb.htm",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "AGB Member: RST \u002B QSO No. \u002B Member No.; non-Member: RST \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "AGB-Party Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=445",
+      "rulesUrl": "http://www.ev5agb.com/contest/agb_party.htm",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "AGB Member: RST \u002B QSO No. \u002B Member No.; non-Member: RST \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "AGCW Happy New Year Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=212",
+      "rulesUrl": "https://www.agcw.de/contest/hnyc/hnyc-engl/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "AGCW: RST \u002B Serial No. \u002B \u0022/\u0022 \u002B Member No.; non-AGCW: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "AGCW QRP Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=288",
+      "rulesUrl": "https://www.agcw.de/contest/qrp/qrp-c-engl/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B QSO No. \u002B class(pwr) \u002B (AGCW Member No./\u0022NM\u0022 if not member)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "AGCW QRP/QRP Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=7",
+      "rulesUrl": "https://www.agcw.de/contest/qrp-qrp",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B QSO No. \u002B \u0022/\u0022 \u002B Class ID (A/B)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "AGCW Semi-Automatic Key Evening",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=255",
+      "rulesUrl": "https://www.agcw.de/contest/sta/",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No. \u002B \u0022/\u0022 \u002B 2-digit year first used a bug",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "AGCW Straight Key Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=109",
+      "rulesUrl": "https://www.agcw.de/contest/htp/htp-en/",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "AGCW: RST \u002B Serial No. \u002B \u0022/\u0022 \u002B Class \u002B \u0022/\u0022 \u002B Name \u002B \u0022/\u0022 \u002B Age",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "AGCW VHF/UHF Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=214",
+      "rulesUrl": "https://www.agcw.de/contest/vhf-uhf/",
+      "bands": [
+        "2m",
+        "70cm"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B \u0022/\u0022 \u002B Serial No. \u002B \u0022/\u0022 Power class \u002B \u0022/\u0022 \u002B 6-character grid locator",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "AGCW YL-CW Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=287",
+      "rulesUrl": "https://www.agcw.de/contest/yl-cw-party/",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "YL: RST \u002B Serial No. \u002B \u0022/YL/\u0022 \u002B name; OM: RST \u002B Serial No. \u002B \u0022/\u0022 \u002B name",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Alabama QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=134",
+      "rulesUrl": "http://alabamacontestgroup.org/aqp/rules/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "AL: RS(T) \u002B County; non-AL: RS(T) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ALARA Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=95",
+      "rulesUrl": "http://www.alara.org.au/contests/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "ALARA: RS(T) \u002B Serial No. \u002B ALARA Member \u002B Name; non-ALARA: RS(T) \u002B Serial No. \u002B Name \u002B (whether YL/OM/club station)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "All Asian DX Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=47",
+      "rulesUrl": "https://www.jarl.org/English/4_Library/A-4-3_Contests/AA_rule_en.htm",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B 2-digit age",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "All Asian DX Contest, Phone",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=102",
+      "rulesUrl": "https://www.jarl.org/English/4_Library/A-4-3_Contests/AA_rule_en.htm",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B 2-digit age",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "All Austrian 160-Meter Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=188",
+      "rulesUrl": "https://www.oevsv.at/export/shared/.content/.galleries/Downloads_Referate/HF-Referat-Downloads/Rules_AOEC_160m.pdf",
+      "bands": [
+        "160m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "OE: RST \u002B Serial No. \u002B District Code; non-OE: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARAM 50 MHz Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=726",
+      "rulesUrl": "https://www.aram.pt/?pagina=eventos\u0026subpg=concurso50MHz\u0026lang=en",
+      "bands": [
+        "6m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Serial number \u002B 6-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARI 40/80 Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=686",
+      "rulesUrl": "http://www.ari.it/en/contest-hf/contest-4080.html",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B 2-letter province car code",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARI International DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=9",
+      "rulesUrl": "https://www.ari.it/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "rtty",
+        "ssb"
+      ],
+      "exchange": "I: RS(T) \u002B 2-letter province; non-I: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Arizona QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=482",
+      "rulesUrl": "https://www.azqp.org/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "AZ: RS(T) \u002B county; non-AZ: RS(T) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Arkansas QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=132",
+      "rulesUrl": "https://www.arkqp.com/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ft8",
+        "ssb"
+      ],
+      "exchange": "AR: RS(T) \u002B County; non-AR: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL 10 GHz and Up Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=88",
+      "rulesUrl": "https://www.arrl.org/10-ghz-up",
+      "bands": [
+        "10m"
+      ],
+      "modes": [
+        "digital",
+        "rtty"
+      ],
+      "exchange": "6-Character Maidenhead Locator",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL 10-Meter Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=199",
+      "rulesUrl": "http://www.arrl.org/10-meter",
+      "bands": [
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "W/VE: RST \u002B State/Province; XE: RST \u002B State; DX: RST \u002B Serial No.; MM: RST \u002B ITU Region",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL 160-Meter Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=194",
+      "rulesUrl": "http://www.arrl.org/160-meter",
+      "bands": [
+        "160m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "W/VE: RST \u002B ARRL/RAC Section; DX: RST",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL 222 MHz and Up Distance Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=615",
+      "rulesUrl": "https://www.arrl.org/222-mhz-and-up-distance-contest",
+      "bands": [
+        "160m",
+        "10m"
+      ],
+      "modes": [
+        "digital",
+        "rtty"
+      ],
+      "exchange": "6-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL Field Day",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=57",
+      "rulesUrl": "http://www.arrl.org/field-day",
+      "bands": [
+        "30m",
+        "17m",
+        "12m"
+      ],
+      "modes": [
+        "digital",
+        "rtty"
+      ],
+      "exchange": "W/VE: Number of transmitters (see rules) \u002B Operating class \u002B ARRL/RAC section; DX: Number of transmitters (see rules) \u002B Operating class \u002B \u0022DX\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL Inter. Digital Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=716",
+      "rulesUrl": "https://www.arrl.org/arrl-digital-contest",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "digital",
+        "rtty"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL Inter. DX Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=256",
+      "rulesUrl": "https://www.arrl.org/arrl-dx",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "W/VE: RST \u002B (state/province); non-W/VE: RST \u002B power",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL Inter. DX Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=289",
+      "rulesUrl": "https://www.arrl.org/arrl-dx",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "W/VE: RS \u002B (state/province); non-W/VE: RS \u002B power",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL January VHF Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=231",
+      "rulesUrl": "https://www.arrl.org/january-vhf",
+      "bands": [
+        "160m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "fm",
+        "rtty",
+        "ssb"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL June VHF Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=43",
+      "rulesUrl": "https://www.arrl.org/june-vhf",
+      "bands": [
+        "160m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "fm",
+        "rtty",
+        "ssb"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL Kids Day",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=224",
+      "rulesUrl": "http://www.arrl.org/kids-day",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "17m",
+        "15m",
+        "12m",
+        "10m",
+        "2m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "name \u002B age \u002B QTH \u002B favorite color",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL Rookie Roundup, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=502",
+      "rulesUrl": "http://www.arrl.org/rookie-roundup",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "NA: Name \u002B 2-digit year first licensed \u002B (state/province/XE area/DX)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL Rookie Roundup, RTTY",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=501",
+      "rulesUrl": "https://www.arrl.org/rookie-roundup",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "NA: Name \u002B 2-digit year first licensed \u002B (state/province/XE area/DX)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL Rookie Roundup, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=500",
+      "rulesUrl": "http://www.arrl.org/rookie-roundup",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "Name \u002B 2-digit year first licensed \u002B (state/province/XE area/DX)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL RTTY Roundup",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=217",
+      "rulesUrl": "https://www.arrl.org/rtty-roundup",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "W/VE: RST \u002B (state/province); non-W/VE: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL School Club Roundup",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=254",
+      "rulesUrl": "https://www.arrl.org/school-club-roundup",
+      "bands": [
+        "30m",
+        "17m",
+        "12m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "rtty",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Class (I/C/S) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL September VHF Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=113",
+      "rulesUrl": "http://www.arrl.org/september-vhf",
+      "bands": [
+        "160m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "fm",
+        "rtty",
+        "ssb"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL Sweepstakes Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=177",
+      "rulesUrl": "https://www.arrl.org/sweepstakes",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Serial No. \u002B Precedence (Q/A/B/U/M/S) \u002B [your call sign] \u002B Check \u002B ARRL/RAC Section",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARRL Sweepstakes Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=178",
+      "rulesUrl": "https://www.arrl.org/sweepstakes",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "Serial No. \u002B Precedence (Q/A/B/U/M/S) \u002B [your call sign] \u002B Check \u002B ARRL/RAC Section",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARS Flight of the Bumblebees",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=76",
+      "rulesUrl": "http://ars-qrp.com/FOBB/FOBB.html",
+      "bands": [
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Home: RST \u002B (state/province/country) \u002B Power; Bumblebee: RST \u002B (state/province/country) \u002B Bumblebee no.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ARS Spartan Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=283",
+      "rulesUrl": "http://ars-qrp.com/Spartan_Sprint/Spartan_Sprint.html",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B Power",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Asia-Pacific Fall Sprint, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=164",
+      "rulesUrl": "http://jsfc.org/apsprint/aprule.txt",
+      "bands": [
+        "20m",
+        "15m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Asia-Pacific Spring Sprint, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=248",
+      "rulesUrl": "http://jsfc.org/apsprint/aprule.txt",
+      "bands": [
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Asia-Pacific Sprint, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=42",
+      "rulesUrl": "http://jsfc.org/apsprint/aprule.txt",
+      "bands": [
+        "20m",
+        "15m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Atlantic Canada QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=773",
+      "rulesUrl": "https://acqp.ca/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "VE1/9,VO1/2,VY2: RS(T) \u002B province \u002B county/division; Non-VE1/9,VO1/2,VY2: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "AWA Bruce Kelley 1929 QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=511",
+      "rulesUrl": "https://antiquewireless.org/homepage/bk-qso-party-details/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Name \u002B QTH \u002B Eqpt Year \u002B Transmitter Type (see rules for format) \u002B\r\n Input Power(W)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Balkan HF Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=599",
+      "rulesUrl": "https://bfra.bg/en/news/578",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Baltic Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=28",
+      "rulesUrl": "http://www.lrsf.lt/en/",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "BARTG HF RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=309",
+      "rulesUrl": "http://www.bartg.org.uk/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B Serial No. \u002B 4-digit time (UTC)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "BARTG RTTY Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=230",
+      "rulesUrl": "http://bartg.org.uk/wp/bartg-sprint-contest/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "Serial No. (no signal report)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "BARTG Sprint 75",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=513",
+      "rulesUrl": "http://bartg.org.uk/wp/bartg-sprint75-contests/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "BARTG Sprint PSK63 Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=703",
+      "rulesUrl": "http://bartg.org.uk/wp/bartg-sprint-psk63-contest/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ft8",
+        "rtty"
+      ],
+      "exchange": "Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Bill Windle QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=479",
+      "rulesUrl": "https://www.g4foc.org/bill-windle-qso-party/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "FOC-Member: RST \u002B Name \u002B Member No.; non-Members: RST \u002B Name",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "British Columbia QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=269",
+      "rulesUrl": "https://www.orcadxcc.org/bcqp_rules.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "BC: RS(T) \u002B District; non-BC: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Bucharest Digital Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=427",
+      "rulesUrl": "https://yo3test201x.blogspot.com/",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "ft4"
+      ],
+      "exchange": "RST \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "California QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=140",
+      "rulesUrl": "https://www.cqp.org/Rules.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "CA: Serial No. \u002B County; non-CA: Serial No. \u002B (state/VE province or territory/DX)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Canadian Prairies QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=717",
+      "rulesUrl": "https://cpqp.ve6hams.ca/",
+      "bands": [
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "VE4/5/6: RS(T) \u002B district code; Non-VE4/5/6: RST \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Colorado QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=431",
+      "rulesUrl": "https://coloradoqsoparty.org/",
+      "bands": [],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "CO: Name \u002B county; W/VE: Name \u002B (state/province); DX: Name \u002B DXCC prefix",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Commonwealth (BERU) Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=282",
+      "rulesUrl": "https://www.rsgbcc.org/hf/rules/2026/rcwc.shtml",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ 160-Meter Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=232",
+      "rulesUrl": "http://www.cq160.com/rules.htm",
+      "bands": [
+        "160m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "W/VE: RST \u002B (state/province); DX: RST \u002B CQ Zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ 160-Meter Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=259",
+      "rulesUrl": "http://www.cq160.com/rules.htm",
+      "bands": [
+        "160m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "W/VE: RS \u002B (state/province); DX: RS \u002B CQ Zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ Worldwide DX Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=192",
+      "rulesUrl": "https://www.cqww.com/rules.htm",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B CQ Zone No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ Worldwide DX Contest, RTTY",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=130",
+      "rulesUrl": "https://www.cqwwrtty.com/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "48 States/Canada: RST \u002B CQ Zone \u002B (state/VE area); All Others: RST \u002B CQ Zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ Worldwide DX Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=172",
+      "rulesUrl": "https://www.cqww.com/rules.htm",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B CQ Zone No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ Worldwide VHF Digital Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=768",
+      "rulesUrl": "https://www.cqww-vhf.com/",
+      "bands": [
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "digital"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ Worldwide VHF SSB/CW Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=73",
+      "rulesUrl": "https://www.cqww-vhf.com/",
+      "bands": [
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "fm",
+        "ssb"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ WW RTTY WPX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=245",
+      "rulesUrl": "https://www.cqwpxrtty.com/rules.htm",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ WW WPX Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=29",
+      "rulesUrl": "https://www.cqwpx.com/rules.htm",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ WW WPX Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=291",
+      "rulesUrl": "https://www.cqwpx.com/rules.htm",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ-M International DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=14",
+      "rulesUrl": "https://cqm.srr.ru/en/rules/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQ-WE Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=402",
+      "rulesUrl": "https://w8zpf.com/cqwe/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "Name \u002B Location Code (see rules) \u002B Years of Service (see rules)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CQMM DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=21",
+      "rulesUrl": "http://www.cqmmdx.com/rules/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "All: RST\u002Bcontinent abbreviation; CWJF members: RST \u002B continent \u002B \u0022M\u0022; QRP: RST \u002B continent \u002B \u0022Q\u0022; YL: RST \u002B continent \u002B \u0022Y\u0022; Multi-Op,Clubs,Groups: RST \u002B continent \u002B \u0022C\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Croatian DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=206",
+      "rulesUrl": "https://www.hamradio.hr/9a-dx-contest/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "9A: RS(T) \u002B county; non-9A: RS(T) \u002B ITU Zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CVA DX Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=534",
+      "rulesUrl": "https://cvadx.org/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Brazil: RST \u002B state; Non-Brazil: RST \u002B continent; Military: RST \u002B \u0022MIL\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CVA DX Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=535",
+      "rulesUrl": "https://cvadx.org/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "Brazil: RST \u002B state; Non-Brazil: RST \u002B continent; Military: RST \u002B \u0022MIL\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CWOps CW Open",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=532",
+      "rulesUrl": "https://cwops.org/cwops-tests/cw-open/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Serial No. \u002B Name",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "CWops Test (CWT)",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=498",
+      "rulesUrl": "https://cwops.org/cwops-tests/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Member: Name \u002B Member No./\u0022CWA\u0022; non-Member: Name \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "DARC 10-Meter Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=223",
+      "rulesUrl": "https://www.darc.de/der-club/referate/conteste/darc-10m-contest/regeln/",
+      "bands": [
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "DL: RS(T) \u002B QSO No. \u002B DOK; non-DL: RS(T) \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "DARC Christmas Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=210",
+      "rulesUrl": "https://www.darc.de/der-club/referate/conteste/weihnachtswettbewerb/en/",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "DL: RS(T) \u002B DOK (or \u0022NM\u0022 if not a DARC member); non-DL: RS(T) \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "DARC CW-Training Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=776",
+      "rulesUrl": "https://www.darc.de/der-club/referate/conteste/cwa/darc-cw-training-rules/",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "DE: RST \u002B DOK/NM; non-DE: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "DARC FT4 Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=745",
+      "rulesUrl": "https://www.darc.de/der-club/referate/conteste/ft4-contest/ft4-rules/",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "ft4"
+      ],
+      "exchange": "Signal report \u002B 4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "DARC RTTY Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=744",
+      "rulesUrl": "https://www.darc.de/der-club/referate/conteste/rtty-kurz/darc-rtty-contest-english-version/darc-rtty-rules/",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "DL: RST \u002B (DOK/\u0022NM\u0022); non-DL: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Delaware QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=240",
+      "rulesUrl": "https://www.fsarc.org/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "rtty",
+        "ssb"
+      ],
+      "exchange": "DE: RS(T) \u002B County; non-DE: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "DIG QSO Party, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=691",
+      "rulesUrl": "https://dig-contest.de/rules",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "DIG Member: RST \u002B Member No.; non-Member: RST",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "DIG QSO Party, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=690",
+      "rulesUrl": "https://dig-contest.de/rules",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "DIG Member: RS \u002B Member No.; non-Member: RS",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Dutch PACC Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=249",
+      "rulesUrl": "https://pacc.veron.nl/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "PA: RS(T) \u002B province; non-PA: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Dutch PACCdigi Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=693",
+      "rulesUrl": "https://www.veron.nl/vereniging/commissies-en-werkgroepen/traffic-bureau/hf-contesten/paccdigi-rules/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ft4",
+        "rtty"
+      ],
+      "exchange": "PA: Signal report \u002B 2-character province; non-PA: Signal report \u002B serial number",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "EA PSK63 Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=403",
+      "rulesUrl": "https://concursos.ure.es/en/eapsk63/bases/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "EA: RSQ \u002B province code; non-EA: RSQ \u002B Serial no.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "EA RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=313",
+      "rulesUrl": "https://concursos.ure.es/en/eartty/bases/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "EA: RSQ \u002B province; non-EA: RSQ \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "EA-QRP CW Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=369",
+      "rulesUrl": "https://www.eaqrp.com/index.php/actividades/concurso?id=310",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B 1-letter category \u002B \u0022M\u0022 (if EA-QRP member)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ES Open HF Championship",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=321",
+      "rulesUrl": "https://erau.ee/images/LL/ES-Open_rules.pdf",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "EU PSK DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=27",
+      "rulesUrl": "https://eupsk.club/eupskdx/eupskdxrules.pdf",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "am",
+        "cw",
+        "fm"
+      ],
+      "exchange": "EU: RST \u002B EU area; non-EU: RST \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "EUCW 160m Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=219",
+      "rulesUrl": "https://www.uft.net/activites-et-concours/concours-eucw-uft-on5me/",
+      "bands": [
+        "160m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Affiliated Club Member: RST \u002B name \u002B club \u002B membership no.; Other: RST \u002B name \u002B \u0022NM\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "European HF Championship",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=82",
+      "rulesUrl": "https://euhf.s5cc.eu/euhfc_rules/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B 2-digit year first licensed",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "European Union DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=687",
+      "rulesUrl": "https://www.eudx-contest.com/rules/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "EU Union: RS(T) \u002B EU Union Region (4-characters); Non-EU Union: RS(T) \u002B ITU Zone No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "F9AA Cup, PSK",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=577",
+      "rulesUrl": "https://www.site.urc.asso.fr/index.php/om-yl/concours/trophee-f9aa",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Feld Hell Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=436",
+      "rulesUrl": "https://sites.google.com/site/feldhellclub/Home/contests/sprints/early-bird-sprint",
+      "bands": [
+        "10m"
+      ],
+      "modes": [],
+      "exchange": "(see rules)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Flemish Windmill Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=786",
+      "rulesUrl": "https://www.vlaamsemolencontest.be/contestreglement/",
+      "bands": [
+        "40m",
+        "2m"
+      ],
+      "modes": [
+        "fm",
+        "ssb"
+      ],
+      "exchange": "Activator: RST \u002B QSO No. \u002B Mill Reference; Hunter: RST \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Florida QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=325",
+      "rulesUrl": "http://floridaqsoparty.org/rules/",
+      "bands": [
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "FL: RS(T) \u002B county; W/VE: RS(T) \u002B (state/province); DX: RS(T) \u002B DXCC prefix",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "FOC Old School Classic 1960s QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=771",
+      "rulesUrl": "https://www.g4foc.org/foc-old-school-classic-1960s-qso-party/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Real RST \u002B 3-letter class \u002B year first licensed \u002B name",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "FRAPR 10M Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=762",
+      "rulesUrl": "https://www.frapr.org/concursos/",
+      "bands": [
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B power",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "FT Challenge",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=766",
+      "rulesUrl": "http://www.rttycontesting.com/ft-challenge",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ft4",
+        "ft8"
+      ],
+      "exchange": "signal report \u002B 4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "FYBO Winter QRP Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=356",
+      "rulesUrl": "https://azscqrpions.org/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B (state/province/country)\u002B name \u002B power out \u002B temperature(F)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "GACW WWSA CW DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=45",
+      "rulesUrl": "https://www.gacw.ar/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B CQ Zone No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Georgia QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=328",
+      "rulesUrl": "https://gaqsoparty.com/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "GA: RST \u002B county; non-GA: RST \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "German Telegraphy Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=146",
+      "rulesUrl": "https://www.agcw.de/contest/dtc/",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "DL: RST \u002B LDK; non-DL: RST",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "HA3NS Sprint Memorial Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=449",
+      "rulesUrl": "https://radioamator.honlapepites.hu/?p=1280",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "HACWG Members: RST \u002B Membership No.; non-Members: RST \u002B NM",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Hawaii QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=96",
+      "rulesUrl": "http://www.hawaiiqsoparty.org/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "HI: RS(T) \u002B HI district; non-HI W/VE: RS(T) \u002B (state/province); DX: RS(T)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Helvetia Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=326",
+      "rulesUrl": "https://uska.ch/wp-content/uploads/2026/03/2026-01-Rules-and-Regulations-for-Helvetia-Contest-issued-March-2026.pdf",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "HB: RS(T) \u002B 2-letter canton; non-HB: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Hemus VHF Contest - 144 MHz",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=750",
+      "rulesUrl": "https://radioclub-troyan.bg/activity-vhf.php",
+      "bands": [
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "fm",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B QSO No. \u002B 6-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "High Speed Club CW Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=264",
+      "rulesUrl": "http://www.highspeedclub.org/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Members: RST \u002B HSC No.; non-Members: RST \u002B \u0022NM\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "His Maj. King of Spain Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=23",
+      "rulesUrl": "https://concursos.ure.es/en/s-m-el-rey-de-espana-cw/bases/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "EA: RST \u002B province; non-EA: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "His Maj. King of Spain Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=59",
+      "rulesUrl": "https://concursos.ure.es/en/s-m-el-rey-de-espana-ssb/bases/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "EA: RST \u002B province; non-EA: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Homebrew and Oldtime Equipment Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=490",
+      "rulesUrl": "http://www.qrpcc.de/contestrules/hotr.html",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No. \u002B \u0022/\u0022 \u002B class",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Hungarian DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=228",
+      "rulesUrl": "https://ha-dx.com/en/contest-rules",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "HA: RS(T) \u002B 2-letter county; non-HA: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Hungarian Straight Key Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=512",
+      "rulesUrl": "https://hskc.ha8kux.com/",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No. \u002B Power Code",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "IARU HF World Championship",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=67",
+      "rulesUrl": "http://www.arrl.org/iaru-hf-world-championship",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "IARU HQ: RS(T) \u002B IARU Society; Non-HQ: RS(T) \u002B ITU Zone No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "IARU Region 1 145 MHz Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=654",
+      "rulesUrl": "https://www.iaru-r1.org/wp-content/uploads/2021/03/Rules-2021.pdf",
+      "bands": [
+        "2m"
+      ],
+      "modes": [
+        "am",
+        "cw",
+        "fm"
+      ],
+      "exchange": "RS(T) \u002B QSO No. \u002B 6-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "IARU Region 1 50 MHz Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=701",
+      "rulesUrl": "https://www.iaru-r1.org/wp-content/uploads/2024/02/Rules-IARU-R1-VHF-up-Contests.pdf",
+      "bands": [
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B QSO No. \u002B 6-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "IARU Region 1 70 MHz Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=702",
+      "rulesUrl": "https://www.iaru-r1.org/wp-content/uploads/2024/02/Rules-IARU-R1-VHF-up-Contests.pdf",
+      "bands": [
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B QSO No. \u002B 6-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "IARU Region 1 Field Day, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=35",
+      "rulesUrl": "https://www.darc.de/der-club/referate/conteste/iaru-region-1-fieldday/en/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "IARU Region 1 Field Day, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=105",
+      "rulesUrl": "https://www.darc.de/der-club/referate/conteste/iaru-region-1-fieldday/en/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "ICWC Medium Speed Test",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=720",
+      "rulesUrl": "https://internationalcwcouncil.org/mst-contest/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Name \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Idaho QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=305",
+      "rulesUrl": "https://www.idahoqsoparty.org/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ft8",
+        "ssb"
+      ],
+      "exchange": "ID: County; non-ID: (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "IG-RY World Wide RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=688",
+      "rulesUrl": "https://www.ig-ry.de/ig-ry-ww-contest",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B 4-digit year license first issued",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Illinois QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=167",
+      "rulesUrl": "https://w9awe.org/ilqp/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ft4",
+        "ssb"
+      ],
+      "exchange": "IL: RS(T) \u002B County; non-IL: RS(T) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Indiana QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=8",
+      "rulesUrl": "http://www.hdxcc.org/inqp/rules.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "IN: RS(T) \u002B county; non-IN: W/VE: RS(T) \u002B (state/province); DX: RS(T) \u002B \u0022DX\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Iowa QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=484",
+      "rulesUrl": "http://www.w0yl.com/IAQP",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "30m",
+        "20m",
+        "17m",
+        "15m",
+        "12m",
+        "10m",
+        "6m",
+        "2m",
+        "70cm"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "IA: RS(T) \u002B County; non-IA: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "JARTS WW RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=161",
+      "rulesUrl": "http://jarts.jp/rules/2024_rule_en.htm",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "SO: RST \u002B age of operator; MO: RST \u002B callsign owner\u0027s age or zero zero; Club: RST \u002B 99",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "JIDX CW Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=314",
+      "rulesUrl": "http://www.jidx.org/jidxrule-e.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "JA: RST \u002B Prefecture No.; non-JA: RST \u002B CQ Zone No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "JIDX Phone Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=184",
+      "rulesUrl": "http://www.jidx.org/jidxrule-e.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "JA: RST \u002B Prefecture No.; non-JA: RST \u002B CQ Zone No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "K1USN Slow Speed Test",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=681",
+      "rulesUrl": "http://www.k1usn.com/sst.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Maximum 20 wpm; Name \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "K1USN SST Open",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=763",
+      "rulesUrl": "http://www.k1usn.com/sso_rules.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Name \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Kansas QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=483",
+      "rulesUrl": "https://ksqsoparty.org/rules/KSQPRules2025.pdf?1",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "rtty",
+        "ssb"
+      ],
+      "exchange": "KS: RS(T) \u002B county; non-KS: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "KCJ Topband Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=244",
+      "rulesUrl": "https://www.kcj-cw.com/",
+      "bands": [
+        "160m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "JA: RST \u002B Prefecture/District Code; non-JA: RST \u002B CQ Zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Kentucky QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=371",
+      "rulesUrl": "http://www.kyqsoparty.org/rules/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "rtty",
+        "ssb"
+      ],
+      "exchange": "KY: RS(T) \u002B county; non-KY: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Keyman\u0027s Club of Japan Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=89",
+      "rulesUrl": "https://kcj-cw.com/contest/rule/2025_46_kcj_dx_.pdf",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "JA: RST \u002B prefecture/district code; non-JA: RST \u002B CQ zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "LABRE DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=761",
+      "rulesUrl": "https://www.labre.org.br/contest/en/regulamento/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "Brazilian: RS(T) \u002B 2-letter state; Non-Brazilian: RS(T) \u002B 2-letter continent",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Louisiana QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=250",
+      "rulesUrl": "https://laqp.w5gad.org/rules",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "LA: RS(T) \u002B Parish; non-LA: RS(T) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "LZ DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=187",
+      "rulesUrl": "http://lzdx.bfra.org/rulesen.html",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "LZ: RS(T) \u002B 2-letter district; non-LZ: RS(T) \u002B ITU Zone No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "LZ International 6-Meter Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=751",
+      "rulesUrl": "https://www.radioclub-troyan.bg/media/activities/6-meters/rules-en-2024.pdf",
+      "bands": [
+        "6m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B QSO No. \u002B 6-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Maine QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=592",
+      "rulesUrl": "http://www.ws1sm.com/MEQP.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "ME: RS(T) \u002B county; non-ME: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Makrothen RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=159",
+      "rulesUrl": "https://www.pl259.org/makrothen/makrothen-rules/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Marconi Club ARI Loano QSO Party Day",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=710",
+      "rulesUrl": "http://www.ariloano.it/marconiclub/mcd_reg/regolamentomcday_ENG.pdf",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Marconi Club Member: RST \u002B \u0022MC\u0022 \u002B Member No.; non-Members: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Marconi Club ARI Loano Slow CW QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=769",
+      "rulesUrl": "https://www.marconiclub.it/contest1/slow-cw-qso-party/rules-slow-cw-qso-party",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Marconi Club Member: RST \u002B \u0022MC\u0022 \u002B Member No.; non-Members: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Marconi Memorial HF Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=56",
+      "rulesUrl": "http://www.arifano.it/contest_marconi.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Maryland-DC QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=86",
+      "rulesUrl": "https://www.w3vpr.org/Maryland-DC_QSO_Party",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "MDC: county/city; non-MDC: (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Mexico RTTY International Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=241",
+      "rulesUrl": "https://rtty.fmre.mx/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "XE: RST \u002B State; non-XE: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "MI QRP Labor Day CW Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=108",
+      "rulesUrl": "https://www.miqrp.net/contest",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B (member no./power output)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Michigan QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=323",
+      "rulesUrl": "https://miqp.org/index.php/rules/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "MI: RST \u002B county; non-MI: RST \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Microwave Spring Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=6",
+      "rulesUrl": "https://sites.google.com/site/springvhfupsprints/home/2026-information",
+      "bands": [],
+      "modes": [
+        "am",
+        "cw",
+        "digital",
+        "fm",
+        "ft4",
+        "ft8",
+        "ssb"
+      ],
+      "exchange": "6-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "MIE 33 Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=467",
+      "rulesUrl": "https://www.ztv.ne.jp/isoda/33/annual/49/49rule-e.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m",
+        "70cm"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "Mie: RS(T) \u002B age \u002B \u0022ME\u0022; non-Mie JA: RS(T) \u002B age \u002B \u0022MEJ\u0022; non-Mie non-JA: RS(T) \u002B age",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Mini-Test 40",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=711",
+      "rulesUrl": "http://minitest.narod.ru/",
+      "bands": [
+        "40m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Mini-Test 80",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=712",
+      "rulesUrl": "http://minitest.narod.ru/",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Minnesota QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=238",
+      "rulesUrl": "https://www.w0aa.org/mnqp-rules/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "am",
+        "cw",
+        "fm",
+        "ssb"
+      ],
+      "exchange": "MN: Name \u002B County; W/VE: Name \u002B (state/province); DX: Name",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Missouri QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=327",
+      "rulesUrl": "http://www.w0ma.org/index.php/missouri-qso-party",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "MO: RS(T) \u002B county; non-MO W/VE: RS(T) \u002B (state/province/territory); DX: RS(T) \u002B \u0022DX\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "NAQCC CW Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=358",
+      "rulesUrl": "http://naqcc.info/sprint_rules.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B (NAQCC No./power)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "NCCC FT4 Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=741",
+      "rulesUrl": "https://www.ncccsprint.com/ft4ns.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "ft4"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "NCCC Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=44",
+      "rulesUrl": "https://ncccsprint.com/rules.html",
+      "bands": [
+        "160m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Serial No. \u002B Name \u002B QTH",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "New England QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=10",
+      "rulesUrl": "https://neqp.org/rules/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "CT,ME,MA,NH,RI,VT: RS(T) \u002B state \u002B county; non-NE: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "New Hampshire QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=71",
+      "rulesUrl": "https://w1wqm.org/wp-content/uploads/2025/08/NHQP_Rules.pdf",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "NH: RS(T) \u002B county; non-NH W/VE: RS(T) \u002B (state/province); DX: RS(T) \u002B \u0022DX\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "New Jersey QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=92",
+      "rulesUrl": "http://www.k2td-bcrc.org/njqp/rules.html",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "NJ: RS(T) \u002B county; non-NJ: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "New Mexico QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=286",
+      "rulesUrl": "http://www.newmexicoqsoparty.org/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "NM: RS(T) \u002B county; non-NM: RS(T) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "New York QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=473",
+      "rulesUrl": "https://www.nyqp.org/",
+      "bands": [],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "NY: RS(T) \u002B county; non-NY: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "NJQRP Skeeter Hunt",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=648",
+      "rulesUrl": "https://www.qsl.net/w2lj/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "Skeeter: RS(T) \u002B (state/province/country)\u002B Skeeter No.; Non-Skeeter: RS(T) \u002B (state/province/country)\u002B Power \u002B \u0022W\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "North American QSO Party, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=218",
+      "rulesUrl": "https://www.ncjweb.com/NAQP-Rules.pdf",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "NA: Name \u002B (state/DC/province/country); non-NA: Name",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "North American QSO Party, RTTY",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=263",
+      "rulesUrl": "https://www.ncjweb.com/NAQP-Rules.pdf",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "NA: Name \u002B (state/DC/province/country); non-NA: Name",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "North American QSO Party, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=229",
+      "rulesUrl": "https://www.ncjweb.com/NAQP-Rules.pdf",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "NA: Name \u002B (state/DC/province/country); non-NA: Name",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "North American Sprint, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=253",
+      "rulesUrl": "https://ncjweb.com/Sprint-Rules.pdf",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "[other station\u0027s call] \u002B [your call] \u002B [serial no.] \u002B [your name] \u002B [your state/province/country]",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "North American Sprint, RTTY",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=155",
+      "rulesUrl": "http://ncjweb.com/Sprint-Rules.pdf",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "[other station\u0027s call] \u002B [your call] \u002B [serial no.] \u002B [your name] \u002B [your state/DC/province/country]",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "North Carolina QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=265",
+      "rulesUrl": "http://ncqsoparty.org/rules/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ft4",
+        "ssb"
+      ],
+      "exchange": "NC: County; non-NC: (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Novice Rig Roundup",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=605",
+      "rulesUrl": "http://www.novicerigroundup.org/",
+      "bands": [
+        "80m",
+        "40m",
+        "15m",
+        "10m",
+        "2m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Name \u002B QTH \u002B Optional (Rig, NRR number)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "NRAU 10m Activity Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=562",
+      "rulesUrl": "https://nrau.net/nrau-contests-in-general/",
+      "bands": [
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "fm",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B 6-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "NRAU-Baltic Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=220",
+      "rulesUrl": "https://www.nraubaltic.eu/",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No. \u002B 2-letter Fylke/Lan/Province/Region",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "NRAU-Baltic Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=222",
+      "rulesUrl": "https://www.nraubaltic.eu/",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RST \u002B Serial No. \u002B 2-letter Fylke/Lan/Province/Region",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "NSARA Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=299",
+      "rulesUrl": "http://nsara.ca/",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "Nova Scotia: RS(T) \u002B county; non-NS: RS(T) \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "NTC QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=713",
+      "rulesUrl": "https://pi4ntc.nl/ntcqp/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "NTC Member: RST \u002B Member No.; non-Member: RST \u002B \u0022NM\u0022; Less than 25 wpm",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "NZART Memorial Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=721",
+      "rulesUrl": "https://www.nzart.org.nz/activities/contests/memorial-contest/",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "NZART Sangster Shield Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=589",
+      "rulesUrl": "https://www.nzart.org.nz/activities/contests/sangster-shield",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "ZL: RST \u002B Serial No. \u002B Branch No.; non-ZL: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Oceania DX Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=151",
+      "rulesUrl": "https://www.oceaniadxcontest.com/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Oceania DX Contest, Phone",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=142",
+      "rulesUrl": "https://www.oceaniadxcontest.com/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Ohio QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=100",
+      "rulesUrl": "http://www.ohqp.org/index.php/rules/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "OH: RS(T) \u002B county; non-OH: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "OK DX RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=204",
+      "rulesUrl": "http://okrtty.crk.cz/index.php?page=english",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B CQ Zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "OK/OM DX Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=185",
+      "rulesUrl": "http://okomdx.crk.cz/index.php?page=CW-rules-english",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "OK/OM: RST \u002B county; non-OK/OM: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "OK/OM DX Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=567",
+      "rulesUrl": "http://okomdx.crk.cz/index.php?page=SSB-rules-english",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "OK/OM: RS \u002B 3-letter county code; non-OK/OM: RS \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "OK1WC Memorial (MWC)",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=683",
+      "rulesUrl": "https://memorial-ok1wc.cz/index.php?page=rules2l",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Oklahoma QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=293",
+      "rulesUrl": "http://k5cm.com/okqp.htm",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ft8",
+        "ssb"
+      ],
+      "exchange": "OK: RS(T) \u002B County; non-OK: RS(T) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Ontario QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=357",
+      "rulesUrl": "http://www.va3cco.com/oqp/rules.htm",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "ON: RS(T) \u002B county; non-ON: RST \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Open Ukraine RTTY Championship",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=334",
+      "rulesUrl": "http://krs.ho.ua/openrtty/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "2-letter regional abbrev. (state/province/canton, etc.) \u002B Serial No.(restart serial no. for high band)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Original QRP Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=213",
+      "rulesUrl": "http://www.qrpcc.de/contestrules/oqrpr.html",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RST \u002B Serial No. \u002B \u0022/\u0022 \u002B Power category",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Pajajaran Bogor DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=722",
+      "rulesUrl": "http://www.pbdx-contest.id/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Peanut Power QRP Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=571",
+      "rulesUrl": "http://www.nogaqrp.org/PeanutPower/rules.pdf",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B (state/province/country) \u002B (peanut no./power output)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Pennsylvania QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=153",
+      "rulesUrl": "http://paqso.org/pa-qso-party-rules.html",
+      "bands": [],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "PA: Serial No. \u002B County; non-PA: Serial No. \u002B ARRL/RAC Section",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Phone Weekly Test",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=593",
+      "rulesUrl": "http://www.perluma.com/Phone_Fray_Contest_Rules.pdf",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "NA: Name \u002B (state/province/country); non-NA: Name",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "PODXS 070 Club 160m Great Pumpkin Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=438",
+      "rulesUrl": "http://www.podxs070.com/o7o-club-sponsored-contests/160m-great-pumpkin-sprint",
+      "bands": [
+        "160m"
+      ],
+      "modes": [],
+      "exchange": "RST \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "PODXS 070 Club 40m Firecracker Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=439",
+      "rulesUrl": "http://www.podxs070.com/o7o-club-sponsored-contests/40m-firecracker-sprint",
+      "bands": [
+        "40m"
+      ],
+      "modes": [],
+      "exchange": "RST \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "PODXS 070 Club Jay Hudak Memorial 80m Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=437",
+      "rulesUrl": "http://www.podxs070.com/o7o-club-sponsored-contests/jay-hudak-memorial-80m-sprint",
+      "bands": [
+        "80m"
+      ],
+      "modes": [],
+      "exchange": "RST \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "PODXS 070 Club PSKFest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=267",
+      "rulesUrl": "http://www.podxs070.com/o7o-club-sponsored-contests/pskfest",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [],
+      "exchange": "RST \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "PODXS 070 Club St Patrick\u0027s Day Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=739",
+      "rulesUrl": "https://www.podxs070.com/o7o-club-sponsored-contests/saint-patrick-s-day-contest",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [],
+      "exchange": "(state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "PODXS 070 Club Three Day Weekend Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=646",
+      "rulesUrl": "http://www.podxs070.com/o7o-club-sponsored-contests/three-day-weekend",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [],
+      "exchange": "070 Members: Member No.; Non-Members: \u00220000\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "PODXS 070 Club Triple Play Low Band Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=622",
+      "rulesUrl": "http://www.podxs070.com/o7o-club-sponsored-contests/triple-play-low-band-sprint",
+      "bands": [
+        "160m",
+        "80m",
+        "40m"
+      ],
+      "modes": [],
+      "exchange": "RST \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "PODXS 070 Club Valentine Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=448",
+      "rulesUrl": "http://www.podxs070.com/o7o-club-sponsored-contests/valentine-sprint",
+      "bands": [
+        "160m",
+        "80m",
+        "40m"
+      ],
+      "modes": [],
+      "exchange": "Name \u002B (OM/YL) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Portugal Day Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=41",
+      "rulesUrl": "https://portugaldaycontest.rep.pt/rules.php",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "CT: RS(T) \u002B District; non-CT: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "PRO CW Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=266",
+      "rulesUrl": "https://proradiocontestclub.com/PCC%20Rules.html",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "CW Club Member: RST \u002B Serial No. \u002B \u0022/M\u0022; non-Members: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "PRO Digi Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=657",
+      "rulesUrl": "https://proradiocontestclub.com/PDC%20Rules.html",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "digital",
+        "ft4",
+        "rtty"
+      ],
+      "exchange": "Digi Club Member: RST \u002B Serial No. \u002B \u0022M\u0022; non-Members: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "PVRC Reunion",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=454",
+      "rulesUrl": "http://pvrc.org/reunion/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "rtty",
+        "ssb"
+      ],
+      "exchange": "PVRC Member: 1st year of membership \u002B name \u002B (state/province/country) \u002B callsign when joined PVRC; non-Member: name \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "QCX Challenge",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=644",
+      "rulesUrl": "http://www.qrp-labs.com/party.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Name \u002B (state/province/country) \u002B Rig",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "QRP Afield",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=124",
+      "rulesUrl": "https://www.newenglandqrp.org/qrp-afield-2018/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "am",
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B (state/province/country) \u002B (power or NE QRP No.)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "QRP ARCI Fall QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=168",
+      "rulesUrl": "http://qrparci.org/contest/fall-qso-party",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "ARCI: RST \u002B (state/province/country) \u002B ARCI No.; non-ARCI: RST \u002B (state/province/country) \u002B power out",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "QRP ARCI Holiday Spirits Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=198",
+      "rulesUrl": "http://qrparci.org/contest/holiday-spirit-sprint",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B (ARCI number/power)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "QRP ARCI Hootowl Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=31",
+      "rulesUrl": "http://qrparci.org/contest/hoot-owl-sprint",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B (ARCI no./power)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "QRP ARCI Spring QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=315",
+      "rulesUrl": "http://qrparci.org/contest/spring-qso-party",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RS \u002B (state/province/country) \u002B (ARCI number/power)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "QRP ARCI Summer Homebrew Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=69",
+      "rulesUrl": "http://qrparci.org/contest/summer-homebrew-sprint-2020",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B (ARCI no./power)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "QRP ARCI Topband Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=193",
+      "rulesUrl": "http://qrparci.org/contest/topband-sprint",
+      "bands": [
+        "160m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "ARCI: RST \u002B (state/province/country) \u002B ARCI No.; non-ARCI: RST \u002B (state/province/country) \u002B power out",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "QRP Fox Hunt",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=518",
+      "rulesUrl": "https://www.k4oaq.com/fox/",
+      "bands": [
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B name \u002B power output",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "QRP Minimal Art Session",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=406",
+      "rulesUrl": "http://qrpcc.de/contestrules/mas/index.html",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B \u0022/\u0022 \u002B class \u002B number of components",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "QRP to the Field",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=432",
+      "rulesUrl": "http://www.zianet.com/qrp/qrpttf/pg.html",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B name",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Quebec QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=53",
+      "rulesUrl": "https://quebecqsoparty.org/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "QC: RS(T) \u002B QC zone; non-QC: RST \u002B (state/province/\u0027DX\u0027)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "RAC Canada Day Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=60",
+      "rulesUrl": "https://www.rac.ca/contesting-results/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "VE: RS(T) \u002B province/territory; non-VE: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "RAC Winter Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=205",
+      "rulesUrl": "https://www.rac.ca/contesting-results/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "VE: RS(T) \u002B (province/territory); non-VE and VE0: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "RAEM Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=209",
+      "rulesUrl": "https://raem.srr.ru/rules/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Serial No. \u002B latitude (degs only) \u002B hemisphere \u002B longitude (degs only) \u002B hemisphere (see rules); N=North, S=South, W=West, O=East (e.g. 57N 85O)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "RCC Cup",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=645",
+      "rulesUrl": "https://www.contest.ru/rcc-cup-rules/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RCC Members: RS(T) \u002B \u0022RCC\u0022 \u002B member number; Non-Members: RS(T) \u002B ITU Zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Real Time Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=782",
+      "rulesUrl": "https://blog.contestonlinescore.com/real-time-contest-rtc-rules/",
+      "bands": [
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "Serial No. \u002B 4-character grid",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "REF 160-Meter Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=606",
+      "rulesUrl": "https://concours.r-e-f.org/reglements/actuels/reg_ref160_en_20250312.pdf",
+      "bands": [
+        "160m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No. \u002B Department Code",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "REF Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=233",
+      "rulesUrl": "https://concours.r-e-f.org/reglements/actuels/reg_cdfhfdx_en_20250315.pdf",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "French: RST \u002B Department/Prefix; non-French: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "REF Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=260",
+      "rulesUrl": "https://concours.r-e-f.org/reglements/actuels/reg_cdfhfdx_en_20250315.pdf",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "French: RS \u002B Department/Prefix; non-French: RS \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "REF DDFM 6m Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=372",
+      "rulesUrl": "https://concours.r-e-f.org/reglements/actuels/reg_ddfm50_fr_20250312.pdf",
+      "bands": [
+        "6m"
+      ],
+      "modes": [
+        "cw",
+        "fm",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Serial No. \u002B 4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Romanian Diaspora SSB Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=780",
+      "rulesUrl": "https://concursdiaspora.ro/en/regulament",
+      "bands": [
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "YO/ER: RS \u002B county/district; non-YO/ER: RS \u002B \u0022DX\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "RSGB 80m Club Championship, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=275",
+      "rulesUrl": "https://www.rsgbcc.org/hf/rules/2026/r80mcc.shtml",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "RSGB 80m Club Championship, Data",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=274",
+      "rulesUrl": "https://www.rsgbcc.org/hf/rules/2026/r80mcc.shtml",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "RSGB 80m Club Championship, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=273",
+      "rulesUrl": "https://www.rsgbcc.org/hf/rules/2026/r80mcc.shtml",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "RSGB FT4 Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=653",
+      "rulesUrl": "https://www.rsgbcc.org/hf/rules/2026/r80m_ft4.shtml",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ft4"
+      ],
+      "exchange": "Signal report",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "RSGB International Low Power Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=74",
+      "rulesUrl": "https://www.rsgbcc.org/hf/rules/2026/rqrp.shtml",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No. \u002B Power",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "RSGB IOTA Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=75",
+      "rulesUrl": "https://www.rsgbcc.org/hf/rules/2026/riota.shtml",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Serial No. \u002B IOTA No.(if applicable)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "RSGB National Field Day",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=37",
+      "rulesUrl": "https://www.rsgbcc.org/hf/rules/2026/rnfd.shtml",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Run for the Bacon QRP Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=385",
+      "rulesUrl": "http://qrpcontest.com/pigrun/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B (Member No./power)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Russian DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=310",
+      "rulesUrl": "https://www.rdxc.org/rules_eng",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "Ru: RS(T) \u002B 2-character oblast; non-Ru: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Russian Radio Team Championship",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=456",
+      "rulesUrl": "http://srr.ru/chempionat-rossii-po-radiosvyazi-na-kv-rrtc/",
+      "bands": [
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RRTC: RS(T) \u002B 3-character code; Non-RRTC: RS(T) \u002B ITU Zone No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Russian WW MultiMode Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=574",
+      "rulesUrl": "http://www.rdrclub.ru/news-radio/russian-ww-mm-contest/159-rus-ww-multimode-contest",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "rtty",
+        "ssb"
+      ],
+      "exchange": "UA: RST(Q) \u002B 2-character oblast; non-UA: RST(Q) \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SARL 80m QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=158",
+      "rulesUrl": "https://mysarl.org.za/contest-resources/",
+      "bands": [
+        "80m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B Serial No. \u002B Grid Locator or QTH",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SARL Field Day Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=186",
+      "rulesUrl": "https://mysarl.org.za/contest-resources/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Number of transmitters \u002B Category (see rules) \u002B Province (or \u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SARL Hamnet 40m Simulated Emerg Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=318",
+      "rulesUrl": "https://mysarl.org.za/contest-resources/",
+      "bands": [
+        "40m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "Class A: RS \u002B Serial No. (starting with 201); Class B: RS \u002B Serial No. (starting with 401); Class C: RS \u002B Serial No. (starting with 601); Class D: RS \u002B Serial No. (starting with 801); Non-participants: RS \u002B Serial No. (starting with 001)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SARL HF CW Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=101",
+      "rulesUrl": "https://mysarl.org.za/contest-resources/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SARL HF Digital Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=545",
+      "rulesUrl": "https://mysarl.org.za/contest-resources/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SARL HF Phone Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=78",
+      "rulesUrl": "https://mysarl.org.za/contest-resources/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SARL VHF/UHF FM Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=120",
+      "rulesUrl": "https://mysarl.org.za/contest-resources/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "6m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B 6-character grid locator",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SARL Youth QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=246",
+      "rulesUrl": "https://mysarl.org.za/contest-resources/",
+      "bands": [
+        "40m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B age",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SARTG New Year RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=211",
+      "rulesUrl": "http://www.sartg.com/contest/nyrules.htm",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B QSO No. \u002B name \u002B happy new year (native language)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SARTG WW RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=87",
+      "rulesUrl": "http://www.sartg.com/contest/wwrules.htm",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SBMS 2.3 GHz and Up Contest and Club Challenge",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=359",
+      "rulesUrl": "https://w6ife.com/Page/2GHzContest",
+      "bands": [
+        "2m"
+      ],
+      "modes": [
+        "am"
+      ],
+      "exchange": "6-character Maidenhead locator",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Scandinavian Activity Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=121",
+      "rulesUrl": "https://www.sactest.net/blog/scandinavian-activity-contest-2025-rules/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Scandinavian Activity Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=131",
+      "rulesUrl": "https://www.sactest.net/blog/scandinavian-activity-contest-2025-rules/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SEANET Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=90",
+      "rulesUrl": "https://dxindia.in/seanet-contest-2026.html",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SKCC QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=631",
+      "rulesUrl": "https://www.skccgroup.com/operating_activities/QSO_Party/",
+      "bands": [
+        "12m",
+        "6m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B Name \u002B 4-Character Grid Square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SKCC Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=425",
+      "rulesUrl": "https://www.skccgroup.com/operating_activities/weekday_sprint/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B Name \u002B (SKCC No./\u0022NONE\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SKCC Sprint Europe",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=629",
+      "rulesUrl": "https://www.skccgroup.com/operating_activities/skse/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B Name \u002B (SKCC No./\u0022NONE\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SKCC Weekend Sprintathon",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=428",
+      "rulesUrl": "https://www.skccgroup.com/operating_activities/weekend_sprintathon/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B (state/province/country) \u002B Name \u002B (SKCC No./\u0022NONE\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SMIRK Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=48",
+      "rulesUrl": "http://smirk.info/contest.html",
+      "bands": [
+        "6m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "4-character grid square \u002B SMIRK No. (optional)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "South America 10 Meter Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=598",
+      "rulesUrl": "http://sa10m.com.ar/wp/rules/",
+      "bands": [
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B CQ zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "South American Integration Contest CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=728",
+      "rulesUrl": "https://sacw.cwsp.com.br/en/2021/09/21/pdf/",
+      "bands": [
+        "80m",
+        "40m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "CWSP Members: RST \u002B \u0022M\u0022; QRP: RST \u002B \u0022QRP\u0022; YL: RST \u002B \u0022YL\u0022; All Others: RST \u002B ITU Zone No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "South Carolina QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=123",
+      "rulesUrl": "http://scqso.com/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "SC: RS(T) \u002B County; non-SC: RS(T) \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "South Dakota QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=492",
+      "rulesUrl": "http://www.sdqsoparty.com/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "SD: RS(T) \u002B county; non-SD: RS(T) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SP DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=312",
+      "rulesUrl": "https://spdxcontest.pzk.org.pl/2026/rules.php",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "SP: RS(T) \u002B 1-character province; non-SP: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "SP DX RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=324",
+      "rulesUrl": "https://pkrvg.org/strona,spdxrttyen.html",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "SP: RST \u002B 2-letter province; Non-SP: RST \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Stew Perry Topband Challenge",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=207",
+      "rulesUrl": "http://www.kkn.net/stew/",
+      "bands": [
+        "160m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "4-Character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "TA VHF/UHF Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=676",
+      "rulesUrl": "https://trac.org.tr/tr/ta-vhf-uhf-contest-2025",
+      "bands": [
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "cw",
+        "fm",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Serial No. \u002B 6-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Tennessee QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=115",
+      "rulesUrl": "https://tnqp.org/rules/",
+      "bands": [],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "TN: RS(T) \u002B county; non-TN: RS(T) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Texas QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=133",
+      "rulesUrl": "https://www.txqp.net/",
+      "bands": [],
+      "modes": [],
+      "exchange": "TX: RS(T) \u002B County; non-TX: RS(T) \u002B (state/province/country/MM region)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Tisza Cup CW Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=678",
+      "rulesUrl": "https://www.tiszacup.eu/index.php/en/contest-rules",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RST \u002B CQ Zone No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Trans-Tasman Low-Bands Challenge",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=588",
+      "rulesUrl": "https://www.wia.org.au/members/contests/transtasman/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "TRC Digi Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=637",
+      "rulesUrl": "https://trcdx.org/rules-trc-digi/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "TRC Members: RST \u002B Serial No. \u002B \u0022TRC\u0022; non-TRC Members: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "TRC DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=536",
+      "rulesUrl": "https://trcdx.org/rules-trc-dx/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "TRC Members: RST \u002B Serial No. \u002B \u0022TRC\u0022; non-TRC Members: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Tuesday\u0027s Telegraphy Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=788",
+      "rulesUrl": "https://spcwc.pl/ttc/rules/en",
+      "bands": [
+        "80m",
+        "40m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "U.S. Islands QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=169",
+      "rulesUrl": "http://usislands.org/qso-party-rules/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "Islands: RS(T) \u002B USI/CISA Island Designation (see rules for digital); Non-Islands: RS(T) \u002B (state/province/country)(see rules for digital)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "UBA DX Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=261",
+      "rulesUrl": "https://www.uba.be/en/hf/contest-rules/uba-dx-contest",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "ON: RST \u002B Serial No. \u002B section; non-ON: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "UBA DX Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=235",
+      "rulesUrl": "https://www.uba.be/en/hf/contest-rules/uba-dx-contest",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "ON: RST \u002B Serial No. \u002B section; non-ON: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "UBA PSK63 Prefix Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=576",
+      "rulesUrl": "https://www.uba.be/en/hf/contest-rules/uba-psk63-prefix-contest",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "digital"
+      ],
+      "exchange": "ON: RSQ \u002B UBA Section; non-ON: RSQ \u002B Serial No. (starting with 001)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "UFT QRP Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=603",
+      "rulesUrl": "https://www.uft.net/concours-qrp-uft/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Member: RST \u002B QRP/QRO \u002B UFT member no.; non-member: RST \u002B QRP/QRO \u002B \u0022NM\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "UK/EI DX Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=597",
+      "rulesUrl": "https://www.ukeicc.com/dx-contest-rules.php",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "UK/EI: RST \u002B Serial No. \u002B District Code; DX: RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "UK/EI DX Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=596",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "UK/EI: RS \u002B Serial No. \u002B District Code; DX: RS \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "UKSMG Summer Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=34",
+      "rulesUrl": "https://uksmg.org/summer-contest-rules.php",
+      "bands": [
+        "6m"
+      ],
+      "modes": [],
+      "exchange": "RST \u002B Serial No. \u002B 6-character grid square \u002B (optional UKSMG member no.)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "UN DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=480",
+      "rulesUrl": "http://undxc.kz/rules-eng/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "Kazakhstan: RS(T) \u002B District Code; non-Kazakhstan: RS(T) \u002B QSO No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "URC DX RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=765",
+      "rulesUrl": "https://unicomradio.com/urc-dx-rtty-contest/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B 3-letter territory code (see rules)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Venezuelan Ind. Day Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=61",
+      "rulesUrl": "https://radioclubvenezolano.org/independenciadevenezuela.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Vermont QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=236",
+      "rulesUrl": "http://www.ranv.org/vtqso.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ft8"
+      ],
+      "exchange": "VT: RS(T) \u002B County; non-VT W/VE: RS(T) \u002B (state/province); DX: RS(T)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "VHF-UHF FT8 Activity Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=674",
+      "rulesUrl": "https://ft8activity.eu/rules/",
+      "bands": [
+        "2m",
+        "70cm"
+      ],
+      "modes": [
+        "ft8"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "VHF-UHF FT8 Activity Contest-NA",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=784",
+      "rulesUrl": "https://ft8activity-na.net/rules/",
+      "bands": [
+        "2m",
+        "70cm"
+      ],
+      "modes": [
+        "ft8"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Virginia QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=302",
+      "rulesUrl": "https://www.qsl.net/sterling/VA_QSO_Party/2026_VQP/2026_VQP_Main.html",
+      "bands": [],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "VA: Serial No. \u002B county; non-VA: Serial No. \u002B (state/province/\u0022DX\u0022)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "VK Shires Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=481",
+      "rulesUrl": "https://www.wia.org.au/members/contests/wavks/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "VK: RS(T) \u002B Shire; non-VK: RS(T) \u002B CQ Zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "VOLTA WW RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=13",
+      "rulesUrl": "https://www.contestvolta.it/rules.pdf",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B QSO No. \u002B CQ Zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "WAB 50 MHz Phone",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=505",
+      "rulesUrl": "http://wab.intermip.net/Contest%20Rules.php#OtherRules",
+      "bands": [
+        "6m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "British Isles: RS \u002B serial no. \u002B WAB square; Other: RS \u002B serial no. \u002B country",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "WAB 7 MHz Phone",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=581",
+      "rulesUrl": "http://wab.intermip.net/Contests.php",
+      "bands": [
+        "40m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "British Isles: RS \u002B serial no. \u002B WAB square; Other: RS \u002B serial no. \u002B country",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "WAE DX Contest, CW",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=85",
+      "rulesUrl": "https://www.darc.de/der-club/referate/conteste/wae-dx-contest/en/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "WAE DX Contest, RTTY",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=183",
+      "rulesUrl": "https://www.darc.de/der-club/referate/conteste/wae-dx-contest/en/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "WAE DX Contest, SSB",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=111",
+      "rulesUrl": "https://www.darc.de/der-club/referate/referat-conteste/worked-all-europe-dx-contest/en/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Wake-Up! QRP Sprint",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=301",
+      "rulesUrl": "http://qrp.ru/contest/wakeup/333-wakeup-eng",
+      "bands": [
+        "40m",
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "RST \u002B Serial No. \u002B suffix of previous QSO (\u0022QRP\u0022 for 1st QSO)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Walk for the Bacon QRP Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=699",
+      "rulesUrl": "https://qrpcontest.com/pigwalk20/",
+      "bands": [
+        "20m"
+      ],
+      "modes": [
+        "cw"
+      ],
+      "exchange": "Maximum 13 wpm; RST \u002B (state/province/country) \u002B Name \u002B (Member No./power)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Washington State Salmon Run",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=126",
+      "rulesUrl": "http://salmonrun.wwdxc.org/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "WA: RS(T) \u002B County; non-WA: RS(T) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Weekly RTTY Test",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=753",
+      "rulesUrl": "https://radiosport.world/wrt.html",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "Name \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "West Virginia QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=49",
+      "rulesUrl": "https://www.qsl.net/wvqp/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "digital",
+        "ssb"
+      ],
+      "exchange": "WV: RS(T) \u002B county; non-WV: RS(T) \u002B (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Winter Field Day",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=421",
+      "rulesUrl": "https://www.winterfieldday.com/",
+      "bands": [],
+      "modes": [],
+      "exchange": "Category \u002B ARRL Section (or MX or DX)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Wisconsin Parks on the Air",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=656",
+      "rulesUrl": "http://wipota.com/files/WIPOTA_contest_rules.pdf",
+      "bands": [
+        "6m",
+        "2m"
+      ],
+      "modes": [
+        "am",
+        "cw",
+        "digital",
+        "fm"
+      ],
+      "exchange": "WI Park: K-POTA Park No.; Non-Park: (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Wisconsin QSO Party",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=330",
+      "rulesUrl": "http://www.warac.org/wqp/wqp.htm",
+      "bands": [],
+      "modes": [
+        "cw",
+        "digital",
+        "ft4",
+        "ssb"
+      ],
+      "exchange": "WI: county; non-WI: (state/province/country)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Worked All Germany Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=163",
+      "rulesUrl": "http://www.darc.de/der-club/referate/conteste/worked-all-germany-contest/en/rules/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "DL, DARC-Member: RS(T) \u002B DOK (chapter code); DL, non-DARC: RS(T) \u002B \u0022NM\u0022; non-DL: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Worked All Provinces of China DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=546",
+      "rulesUrl": "http://www.mulandxc.com/index/match_info?id=13",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "am",
+        "cw",
+        "ssb"
+      ],
+      "exchange": "BY: RS(T) \u002B 2-character province; non-BY: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "World Time Zone Challenge",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=783",
+      "rulesUrl": "https://wtzc-contest.com/rules",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "RS(T) \u002B TZ offset code",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "World Wide Digi DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=650",
+      "rulesUrl": "https://ww-digi.com/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ft4"
+      ],
+      "exchange": "4-character grid square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "World Wide Holyland Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=319",
+      "rulesUrl": "https://tools.iarc.org/wwhc/#/rules",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "4X: RS(T) \u002B area; non-4X: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "Worldwide Sideband Activity Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=672",
+      "rulesUrl": "https://wwsac.com/rules.html",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m",
+        "6m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B age group (OM, YL, Youth YL or Youth)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "WW PMC Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=471",
+      "rulesUrl": "http://www.s59dcd.si/index.php/sl/ww-pmc/ww-pmc-contest-rules",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "PMC: RS(T) \u002B PMC abbreviation; World: RS(T) \u002B CQ Zone",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "YB DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=621",
+      "rulesUrl": "https://ybdxcontest.com/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "RS \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "YB DX RTTY Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=642",
+      "rulesUrl": "https://rtty.ybdxcontest.com/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "rtty"
+      ],
+      "exchange": "RST \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "YB ORARI DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=772",
+      "rulesUrl": "https://www.oraricontest.id/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ssb"
+      ],
+      "exchange": "YB: RS \u002B \u0022ORARI\u0022; non-YB: RS \u002B \u0022DX\u0022",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "YBDXPI FT8 Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=707",
+      "rulesUrl": "https://contest.ybdxpi.net/rules/",
+      "bands": [
+        "160m",
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "ft8"
+      ],
+      "exchange": "4-Character Grid Square",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "YO DX HF Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=98",
+      "rulesUrl": "http://www.yodx.ro/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "YO: RS(T) \u002B county; non-YO: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "YOTA Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=696",
+      "rulesUrl": "https://yotacontest.mrasz.org/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "Single Op: RS(T) \u002B age (on Jan 1 of year of contest); Multi-Op: RS(T) \u002B average age of ops (on Jan 1 of year of contest)",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    },
+    {
+      "name": "YU DX Contest",
+      "sourceUrl": "https://www.contestcalendar.com/contestdetails.php?ref=322",
+      "rulesUrl": "http://www.yudx.yu1srs.org.rs/",
+      "bands": [
+        "80m",
+        "40m",
+        "20m",
+        "15m",
+        "10m"
+      ],
+      "modes": [
+        "cw",
+        "ssb"
+      ],
+      "exchange": "YU/YT: RS(T) \u002B County; non-YU/YT: RS(T) \u002B Serial No.",
+      "detailsStatus": "partial",
+      "reviewStatus": "generated"
+    }
+  ]
+}

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -15,6 +15,7 @@ QsoRipper is **contract-first**. `proto/` is the stable seam. Engine hosts imple
 | **LogbookService** | QSO CRUD, QRZ logbook sync, ADIF import/export | [logbook-service.md](logbook-service.md) |
 | **DeveloperControlService** | Developer-only runtime config overrides and diagnostics | [`proto/services/developer_control_service.proto`](../../proto/services/developer_control_service.proto) |
 | **SpaceWeatherService** | Current space-weather snapshot plus explicit refresh | [`proto/services/space_weather_service.proto`](../../proto/services/space_weather_service.proto) |
+| **ContestCalendarService** | Active contest lookup plus explicit calendar refresh | [`proto/services/contest_calendar_service.proto`](../../proto/services/contest_calendar_service.proto) |
 
 ## Contract Source of Truth
 
@@ -72,7 +73,7 @@ Not every contract entry is implemented by every current engine host. The refere
 
 In general:
 
-- Both built-in engine hosts implement the common first slice used by the conformance harness: engine info, setup, station profiles, runtime config, logbook CRUD, sync status, ADIF import/export, rig status, space weather, and callsign lookup via unary/stream/cache RPCs.
+- Both built-in engine hosts implement the common first slice used by the conformance harness: engine info, setup, station profiles, runtime config, logbook CRUD, sync status, ADIF import/export, rig status, space weather, contest calendar lookup, and callsign lookup via unary/stream/cache RPCs.
 - Both built-in hosts also implement `LookupService.BatchLookup` and `LookupService.GetDxccEntity` for the `dxcc_code` query case. The `prefix` query case of `GetDxccEntity` still returns `UNIMPLEMENTED` in both hosts.
 - The built-in engine hosts report fine-grained lookup capabilities (`lookup-callsign`, `lookup-stream`, `lookup-cache`) instead of a broad `lookup` bucket so discovery matches the actually implemented surface.
 

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -4,7 +4,7 @@
 >
 > This is a living document. When proto files, services, or behavioral contracts change, update this specification in the same change.
 
-A QsoRipper engine is the core runtime that owns QSO logging, callsign lookup, rig control, space weather, station profiles, and external sync. Engines expose a gRPC API over HTTP/2 that any client — TUI, GUI, CLI, or web — can consume. The architecture is explicitly multi-engine: any conformant implementation, regardless of language, can serve as the engine behind any QsoRipper client.
+A QsoRipper engine is the core runtime that owns QSO logging, callsign lookup, rig control, space weather, contest calendar lookup, station profiles, and external sync. Engines expose a gRPC API over HTTP/2 that any client — TUI, GUI, CLI, or web — can consume. The architecture is explicitly multi-engine: any conformant implementation, regardless of language, can serve as the engine behind any QsoRipper client.
 
 This document is self-contained. A developer should be able to implement a fully conformant engine using only this specification and the `.proto` files under `proto/`.
 
@@ -37,6 +37,7 @@ The engine is a long-running server process responsible for:
 | QRZ logbook sync | Bidirectional synchronization with the QRZ logbook API |
 | Rig control | Polling a rigctld daemon for frequency and mode |
 | Space weather | Fetching and caching NOAA space weather indices |
+| Contest calendar | Fetching and caching active contest metadata |
 | Station profiles | Managing station identity and per-session overrides |
 | Setup/bootstrap | First-run wizard state, credential validation, and configuration persistence |
 | Runtime config | Live developer-facing configuration overrides |
@@ -684,6 +685,50 @@ Temporarily overrides the active station profile for the current session.
 
 Removes the session override, reverting to the base active profile.
 
+### 3.8 ContestCalendarService
+
+**Proto file:** `proto/services/contest_calendar_service.proto`
+
+Cached contest calendar metadata for operator "what contest is active?" queries.
+
+#### RPCs
+
+| RPC | Request | Response | Mode |
+|---|---|---|---|
+| `GetActiveContests` | `GetActiveContestsRequest` | `GetActiveContestsResponse` | Unary |
+| `RefreshContestCalendar` | `RefreshContestCalendarRequest` | `RefreshContestCalendarResponse` | Unary |
+
+#### GetActiveContests
+
+Returns contests whose UTC window overlaps the requested time and lookahead window. If `at_utc` is omitted, the engine uses its current UTC time. `band` and `mode` filters are optional. If a contest entry does not include band or mode metadata, it only matches a band or mode filter when `include_partial_matches=true`.
+
+**Behavior:**
+- Use cached calendar data when it is fresh.
+- Refresh the provider cache when there is no cache or the refresh interval has elapsed.
+- Return stale cached data with `ContestCalendarStatus.CONTEST_CALENDAR_STATUS_STALE` if refresh fails after a previous successful fetch.
+- Separate provider/cache status from data completeness. `ContestCalendarStatus` describes current/stale/error/disabled state, while `ContestDetailsStatus` describes whether a contest has metadata-only, partial, or full details.
+- Preserve source attribution through `source_name` and `source_url`.
+
+**Source limitation:**
+The built-in WA7BNM provider uses the public RSS calendar feed and treats it as a metadata source. RSS-derived entries include name, UTC start/end, source link, and metadata-only status. The runtime engine must not scrape WA7BNM HTML detail pages for exchange, band, mode, or rules data. Richer details require an authorized data source, a user-configured source, a curated local catalog, or a reviewed catalog generated offline.
+
+**Local details catalog:**
+The engine loads a reviewed JSON catalog from `QSORIPPER_CONTEST_CALENDAR_DETAILS_PATH`, or from `data\contest-calendar\contest-details.json` when the variable is unset and that file exists. It uses the catalog to enrich RSS entries with known bands, modes, exchange text, rules URL, and `ContestDetailsStatus`. Catalog entries may match by `contestId`, `sourceUrl`, or normalized contest `name`. This catalog is offline input to the engine. Generated catalog candidates must be reviewed before they become authoritative engine input, and tools that produce them must respect rules-site terms.
+
+**Error semantics:**
+- This RPC should usually succeed. Data unavailability is reported through `ContestCalendarStatus` and `error_message`.
+- Invalid band or mode enum values are rejected by protobuf validation before service logic.
+
+#### RefreshContestCalendar
+
+Forces an immediate provider refresh and returns the resulting contest entries plus status metadata.
+
+**Behavior:**
+1. Fetch fresh data from the configured contest calendar provider.
+2. Parse and normalize contest entries into `ContestCalendarEntry`.
+3. Update the cache on success.
+4. On provider failure, return stale cached data when available; otherwise return `CONTEST_CALENDAR_STATUS_ERROR` or `CONTEST_CALENDAR_STATUS_DISABLED`.
+
 ### 3.9 GreatCircleService
 
 **Proto file:** `proto/services/great_circle_service.proto`
@@ -999,6 +1044,47 @@ All backends must implement the `EngineStorage` trait, which decomposes into:
 
 **Parsed fields:** K-index, A-index, solar flux (SFI), sunspot number, geomagnetic storm scale.
 
+### 5.5 Contest Calendar (WA7BNM RSS)
+
+**Data source:** `https://www.contestcalendar.com/calendar.rss`
+
+**Usage policy:** The built-in runtime provider is limited to the public RSS metadata feed. It must not automate access to WA7BNM HTML detail pages or copy detail-page content while serving engine requests. Exchange, band, mode, and rules details are only populated from authorized, curated, or reviewed offline-generated sources.
+
+**Refresh model:**
+- Background refresh at `QSORIPPER_CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS` (default: 3600 seconds / 1 hour).
+- Cached data becomes stale after `QSORIPPER_CONTEST_CALENDAR_STALE_AFTER_SECONDS` (default: 86400 seconds / 24 hours).
+- HTTP timeout controlled by `QSORIPPER_CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS`.
+- If refresh fails, the engine retains the last known good calendar and reports the error in the response status.
+
+**Parsed fields:** contest name, UTC start time, UTC end time, source URL, source name, and deterministic `contest_id`.
+
+**Optional enrichment:** `QSORIPPER_CONTEST_CALENDAR_DETAILS_PATH` may point to a reviewed JSON file. If unset, the engine uses `data\contest-calendar\contest-details.json` when the file exists:
+
+```json
+{
+  "entries": [
+    {
+      "name": "Example Contest",
+      "sourceUrl": "https://www.contestcalendar.com/weeklycontdetails.php?ref=example",
+      "bands": [ "160m", "80m", "40m", "20m", "15m", "10m" ],
+      "modes": [ "cw", "ssb" ],
+      "exchange": "RST + serial",
+      "rulesUrl": "https://example.test/rules",
+      "detailsStatus": "full"
+    }
+  ]
+}
+```
+
+The standalone generator creates a review file from the WA7BNM 12-month calendar by default. It follows calendar detail links as an offline build step, extracts factual fields such as mode, bands, exchange, and the official rules URL, then optionally fetches official rules pages to fill gaps. It can also consume RSS metadata or an optional seed catalog of known official rules URLs:
+
+```powershell
+dotnet run --project src\dotnet\QsoRipper.Tools.ContestCatalog -- --output artifacts\contest-calendar\contest-details.generated.json
+dotnet run --project src\dotnet\QsoRipper.Tools.ContestCatalog -- --promote-candidates --output data\contest-calendar\contest-details.json
+```
+
+The default output is `artifacts\contest-calendar\contest-details.generated.json`. It is not loaded by the engine. By default, extracted facts are written as `candidateBands`, `candidateModes`, and `candidateExchange` so a maintainer can verify facts and copy only factual fields into `data\contest-calendar\contest-details.json`. `--promote-candidates` writes those factual candidates into canonical catalog fields for a reviewed local database and omits the review-only candidate fields. The generator may read WA7BNM detail pages only as offline calendar metadata, but it refuses to treat WA7BNM or ContestCalendar URLs as official rules pages and should not copy rules prose into the catalog.
+
 ---
 
 ## 6. Configuration
@@ -1037,6 +1123,17 @@ All configuration is driven by environment variables prefixed with `QSORIPPER_`.
 |---|---|---|---|
 | `QSORIPPER_QRZ_LOGBOOK_API_KEY` | String | | QRZ logbook API key (secret) |
 | `QSORIPPER_QRZ_LOGBOOK_BASE_URL` | URL | `https://logbook.qrz.com/api` | QRZ logbook API base URL |
+
+#### Contest Calendar
+
+| Variable | Type | Default | Description |
+|---|---|---|---|
+| `QSORIPPER_CONTEST_CALENDAR_ENABLED` | Bool | `true` | Enable engine-backed contest calendar lookup |
+| `QSORIPPER_CONTEST_CALENDAR_RSS_URL` | URL | `https://www.contestcalendar.com/calendar.rss` | Contest calendar RSS source URL |
+| `QSORIPPER_CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS` | Integer | `8` | Contest calendar HTTP timeout |
+| `QSORIPPER_CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS` | Integer | `3600` | Provider refresh interval |
+| `QSORIPPER_CONTEST_CALENDAR_STALE_AFTER_SECONDS` | Integer | `86400` | Age after which cached contest data is stale |
+| `QSORIPPER_CONTEST_CALENDAR_DETAILS_PATH` | Path | `data\contest-calendar\contest-details.json` | Optional reviewed local JSON catalog for bands, modes, exchange, and rules URL |
 
 #### Sync
 
@@ -1083,6 +1180,7 @@ The engine must start and function even when external integrations are unavailab
 | QRZ logbook API key | Logbook sync disabled. `SyncWithQrz` returns `FAILED_PRECONDITION`. |
 | rigctld host/port | Rig control disabled. `GetRigStatus` returns `RIG_CONNECTION_STATUS_DISABLED`. |
 | NOAA weather disabled | Space weather disabled. `GetCurrentSpaceWeather` returns `SPACE_WEATHER_STATUS_DISABLED`. |
+| Contest calendar disabled | Contest lookup disabled. `GetActiveContests` returns `CONTEST_CALENDAR_STATUS_DISABLED`. |
 | No station profile | QSO logging requires a profile. `LogQso` returns `FAILED_PRECONDITION` until a profile is set. |
 
 **Core invariant:** Local QSO storage and CRUD always work, regardless of external integration state. The engine must never fail to start because an external service is unavailable.
@@ -1476,6 +1574,7 @@ Both engines currently report the following capabilities:
 | `runtime-config` | Runtime configuration updates |
 | `rig-control` | rigctld integration |
 | `space-weather` | NOAA space weather data |
+| `contest-calendar` | Contest calendar lookup |
 | `purge` | Permanent removal of soft-deleted QSOs (§7.9) |
 
 > **Note:** Earlier drafts listed aspirational names (`sync`, `rig_control`, `stress`, `adif_import`, `adif_export`) that were never adopted. The canonical names above use kebab-case and match what both engines actually report. New capabilities should follow this convention.
@@ -1596,6 +1695,7 @@ A conformant engine must pass all of the following scenarios:
 | `proto/domain/station_snapshot.proto` | `StationSnapshot` | Immutable per-QSO station capture |
 | `proto/domain/rig_snapshot.proto` | `RigSnapshot` | Rig frequency/mode snapshot |
 | `proto/domain/space_weather_snapshot.proto` | `SpaceWeatherSnapshot` | Space weather indices |
+| `proto/domain/contest_calendar_entry.proto` | `ContestCalendarEntry` | Normalized contest calendar entry |
 | `proto/domain/sync_config.proto` | `SyncConfig` | Sync policy configuration |
 | `proto/domain/band.proto` | `Band` | Band enumeration (ADIF-aligned) |
 | `proto/domain/mode.proto` | `Mode` | Mode enumeration (ADIF-aligned) |
@@ -1605,6 +1705,8 @@ A conformant engine must pass all of the following scenarios:
 | `proto/domain/qso_completion.proto` | `QsoCompletion` | ADIF `QSO_COMPLETE` enum (Y/N/NIL/?) |
 | `proto/domain/rig_connection_status.proto` | `RigConnectionStatus` | Rig connection state |
 | `proto/domain/space_weather_status.proto` | `SpaceWeatherStatus` | Space weather data state |
+| `proto/domain/contest_calendar_status.proto` | `ContestCalendarStatus` | Contest calendar cache/provider state |
+| `proto/domain/contest_details_status.proto` | `ContestDetailsStatus` | Contest entry detail completeness |
 
 ## Appendix B: Proto File Conventions
 

--- a/proto/domain/contest_calendar_entry.proto
+++ b/proto/domain/contest_calendar_entry.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package qsoripper.domain;
+
+option csharp_namespace = "QsoRipper.Domain";
+
+import "domain/band.proto";
+import "domain/contest_details_status.proto";
+import "domain/mode.proto";
+import "google/protobuf/timestamp.proto";
+
+message ContestCalendarEntry {
+  string contest_id = 1;
+  string name = 2;
+  google.protobuf.Timestamp start_time_utc = 3;
+  google.protobuf.Timestamp end_time_utc = 4;
+  repeated Band bands = 5;
+  repeated Mode modes = 6;
+  optional string exchange = 7;
+  optional string rules_url = 8;
+  optional string source_url = 9;
+  string source_name = 10;
+  ContestDetailsStatus details_status = 11;
+}

--- a/proto/domain/contest_calendar_status.proto
+++ b/proto/domain/contest_calendar_status.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package qsoripper.domain;
+
+option csharp_namespace = "QsoRipper.Domain";
+
+enum ContestCalendarStatus {
+  CONTEST_CALENDAR_STATUS_UNSPECIFIED = 0;
+  CONTEST_CALENDAR_STATUS_CURRENT = 1;
+  CONTEST_CALENDAR_STATUS_STALE = 2;
+  CONTEST_CALENDAR_STATUS_ERROR = 3;
+  CONTEST_CALENDAR_STATUS_DISABLED = 4;
+}

--- a/proto/domain/contest_details_status.proto
+++ b/proto/domain/contest_details_status.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package qsoripper.domain;
+
+option csharp_namespace = "QsoRipper.Domain";
+
+enum ContestDetailsStatus {
+  CONTEST_DETAILS_STATUS_UNSPECIFIED = 0;
+  CONTEST_DETAILS_STATUS_METADATA_ONLY = 1;
+  CONTEST_DETAILS_STATUS_PARTIAL = 2;
+  CONTEST_DETAILS_STATUS_FULL = 3;
+}

--- a/proto/services/contest_calendar_service.proto
+++ b/proto/services/contest_calendar_service.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "services/get_active_contests_request.proto";
+import "services/get_active_contests_response.proto";
+import "services/refresh_contest_calendar_request.proto";
+import "services/refresh_contest_calendar_response.proto";
+
+service ContestCalendarService {
+  rpc GetActiveContests(GetActiveContestsRequest) returns (GetActiveContestsResponse);
+  rpc RefreshContestCalendar(RefreshContestCalendarRequest) returns (RefreshContestCalendarResponse);
+}

--- a/proto/services/get_active_contests_request.proto
+++ b/proto/services/get_active_contests_request.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "domain/band.proto";
+import "domain/mode.proto";
+import "google/protobuf/timestamp.proto";
+
+message GetActiveContestsRequest {
+  google.protobuf.Timestamp at_utc = 1;
+  optional qsoripper.domain.Band band = 2;
+  optional qsoripper.domain.Mode mode = 3;
+  uint32 lookahead_minutes = 4;
+  bool include_partial_matches = 5;
+}

--- a/proto/services/get_active_contests_response.proto
+++ b/proto/services/get_active_contests_response.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "domain/contest_calendar_entry.proto";
+import "domain/contest_calendar_status.proto";
+import "google/protobuf/timestamp.proto";
+
+message GetActiveContestsResponse {
+  repeated qsoripper.domain.ContestCalendarEntry contests = 1;
+  qsoripper.domain.ContestCalendarStatus status = 2;
+  google.protobuf.Timestamp fetched_at = 3;
+  google.protobuf.Timestamp valid_until = 4;
+  optional string error_message = 5;
+}

--- a/proto/services/refresh_contest_calendar_request.proto
+++ b/proto/services/refresh_contest_calendar_request.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+message RefreshContestCalendarRequest {}

--- a/proto/services/refresh_contest_calendar_response.proto
+++ b/proto/services/refresh_contest_calendar_response.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "domain/contest_calendar_entry.proto";
+import "domain/contest_calendar_status.proto";
+import "google/protobuf/timestamp.proto";
+
+message RefreshContestCalendarResponse {
+  repeated qsoripper.domain.ContestCalendarEntry contests = 1;
+  qsoripper.domain.ContestCalendarStatus status = 2;
+  google.protobuf.Timestamp fetched_at = 3;
+  google.protobuf.Timestamp valid_until = 4;
+  optional string error_message = 5;
+}

--- a/src/dotnet/QsoRipper.Cli.Tests/CliArgumentParserTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliArgumentParserTests.cs
@@ -176,6 +176,16 @@ public class CliArgumentParserTests
         Assert.Null(arguments.Callsign);
     }
 
+    [Fact]
+    public void Parse_contests_preserves_command_arguments()
+    {
+        var arguments = CliArgumentParser.Parse(["contests", "active", "--band", "20m", "--mode", "CW", "--lookahead-minutes", "30"]);
+
+        Assert.Equal("contests", arguments.Command);
+        Assert.Equal(["active", "--band", "20m", "--mode", "CW", "--lookahead-minutes", "30"], arguments.RemainingArgs);
+        Assert.Null(arguments.Callsign);
+    }
+
     [Theory]
     [InlineData("http://localhost:50051", true)]
     [InlineData("https://example.com:7443", true)]

--- a/src/dotnet/QsoRipper.Cli.Tests/CliArgumentParserTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliArgumentParserTests.cs
@@ -179,10 +179,10 @@ public class CliArgumentParserTests
     [Fact]
     public void Parse_contests_preserves_command_arguments()
     {
-        var arguments = CliArgumentParser.Parse(["contests", "active", "--band", "20m", "--mode", "CW", "--lookahead-minutes", "30"]);
+        var arguments = CliArgumentParser.Parse(["contests", "active", "--band", "20m", "--mode", "CW", "--lookahead-hours", "12"]);
 
         Assert.Equal("contests", arguments.Command);
-        Assert.Equal(["active", "--band", "20m", "--mode", "CW", "--lookahead-minutes", "30"], arguments.RemainingArgs);
+        Assert.Equal(["active", "--band", "20m", "--mode", "CW", "--lookahead-hours", "12"], arguments.RemainingArgs);
         Assert.Null(arguments.Callsign);
     }
 

--- a/src/dotnet/QsoRipper.Cli.Tests/ContestCalendarCommandTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/ContestCalendarCommandTests.cs
@@ -1,0 +1,91 @@
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Cli.Commands;
+using QsoRipper.Domain;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli.Tests;
+
+#pragma warning disable CA1707
+[Collection("ConsoleCapture")]
+public sealed class ContestCalendarCommandTests
+{
+    [Fact]
+    public void HandleActiveResponse_writes_contest_details()
+    {
+        var response = new GetActiveContestsResponse
+        {
+            Status = ContestCalendarStatus.Current,
+            FetchedAt = UtcTimestamp(2026, 5, 24, 15, 0, 0),
+            ValidUntil = UtcTimestamp(2026, 5, 24, 16, 0, 0),
+        };
+        response.Contests.Add(new ContestCalendarEntry
+        {
+            ContestId = "wa7bnm-test",
+            Name = "Example Sprint",
+            StartTimeUtc = UtcTimestamp(2026, 5, 24, 16, 0, 0),
+            EndTimeUtc = UtcTimestamp(2026, 5, 24, 20, 0, 0),
+            Exchange = "RST + serial",
+            SourceName = "WA7BNM Contest Calendar",
+            SourceUrl = "https://www.contestcalendar.com/",
+            DetailsStatus = ContestDetailsStatus.MetadataOnly,
+        });
+
+        var output = ConsoleCapture.Out(() => Assert.Equal(0, ContestCalendarCommand.HandleActiveResponse(response, false)));
+
+        Assert.Contains("Status:           current", output, StringComparison.Ordinal);
+        Assert.Contains("Example Sprint", output, StringComparison.Ordinal);
+        Assert.Contains("UTC window:     2026-05-24 16:00:00Z to 2026-05-24 20:00:00Z", output, StringComparison.Ordinal);
+        Assert.Contains("Exchange:       RST + serial", output, StringComparison.Ordinal);
+        Assert.Contains("Details:        metadata only", output, StringComparison.Ordinal);
+        Assert.Contains("Source URL:     https://www.contestcalendar.com/", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HandleActiveResponse_reports_empty_matches()
+    {
+        var response = new GetActiveContestsResponse
+        {
+            Status = ContestCalendarStatus.Current,
+            FetchedAt = UtcTimestamp(2026, 5, 24, 15, 0, 0),
+            ValidUntil = UtcTimestamp(2026, 5, 24, 16, 0, 0),
+        };
+
+        var output = ConsoleCapture.Out(() => Assert.Equal(0, ContestCalendarCommand.HandleActiveResponse(response, false)));
+
+        Assert.Contains("No active contests matched.", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HandleActiveResponse_returns_error_for_disabled_status()
+    {
+        var response = new GetActiveContestsResponse
+        {
+            Status = ContestCalendarStatus.Disabled,
+            ErrorMessage = "contest calendar disabled",
+        };
+
+        var output = ConsoleCapture.Out(() => Assert.Equal(1, ContestCalendarCommand.HandleActiveResponse(response, false)));
+
+        Assert.Contains("Status:           disabled", output, StringComparison.Ordinal);
+        Assert.Contains("Error:            contest calendar disabled", output, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HandleActiveResponse_writes_json_when_requested()
+    {
+        var response = new GetActiveContestsResponse
+        {
+            Status = ContestCalendarStatus.Stale,
+        };
+
+        var output = ConsoleCapture.Out(() => Assert.Equal(0, ContestCalendarCommand.HandleActiveResponse(response, true)));
+
+        Assert.Contains("\"status\": \"CONTEST_CALENDAR_STATUS_STALE\"", output, StringComparison.Ordinal);
+    }
+
+    private static Timestamp UtcTimestamp(int year, int month, int day, int hour, int minute, int second)
+    {
+        return Timestamp.FromDateTime(DateTime.SpecifyKind(new DateTime(year, month, day, hour, minute, second), DateTimeKind.Utc));
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli.Tests/ContestCalendarCommandTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/ContestCalendarCommandTests.cs
@@ -108,7 +108,7 @@ public sealed class ContestCalendarCommandTests
 
     private static string FormatExpectedLocalTimestamp(Timestamp timestamp)
     {
-        return timestamp.ToDateTimeOffset().ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz", CultureInfo.InvariantCulture);
+        return timestamp.ToDateTimeOffset().ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
     }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli.Tests/ContestCalendarCommandTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/ContestCalendarCommandTests.cs
@@ -83,6 +83,22 @@ public sealed class ContestCalendarCommandTests
         Assert.Contains("\"status\": \"CONTEST_CALENDAR_STATUS_STALE\"", output, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void TryParseLookaheadHours_converts_to_minutes()
+    {
+        Assert.True(ContestCalendarCommand.TryParseLookaheadHours("12", out var minutes));
+        Assert.Equal(720U, minutes);
+    }
+
+    [Theory]
+    [InlineData("-1")]
+    [InlineData("1.5")]
+    [InlineData("71582789")]
+    public void TryParseLookaheadHours_rejects_invalid_values(string value)
+    {
+        Assert.False(ContestCalendarCommand.TryParseLookaheadHours(value, out _));
+    }
+
     private static Timestamp UtcTimestamp(int year, int month, int day, int hour, int minute, int second)
     {
         return Timestamp.FromDateTime(DateTime.SpecifyKind(new DateTime(year, month, day, hour, minute, second), DateTimeKind.Utc));

--- a/src/dotnet/QsoRipper.Cli.Tests/ContestCalendarCommandTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/ContestCalendarCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Cli.Commands;
 using QsoRipper.Domain;
@@ -35,6 +36,7 @@ public sealed class ContestCalendarCommandTests
         Assert.Contains("Status:           current", output, StringComparison.Ordinal);
         Assert.Contains("Example Sprint", output, StringComparison.Ordinal);
         Assert.Contains("UTC window:     2026-05-24 16:00:00Z to 2026-05-24 20:00:00Z", output, StringComparison.Ordinal);
+        Assert.Contains($"Local window:   {FormatExpectedLocalTimestamp(response.Contests[0].StartTimeUtc)} to {FormatExpectedLocalTimestamp(response.Contests[0].EndTimeUtc)}", output, StringComparison.Ordinal);
         Assert.Contains("Exchange:       RST + serial", output, StringComparison.Ordinal);
         Assert.Contains("Details:        metadata only", output, StringComparison.Ordinal);
         Assert.Contains("Source URL:     https://www.contestcalendar.com/", output, StringComparison.Ordinal);
@@ -102,6 +104,11 @@ public sealed class ContestCalendarCommandTests
     private static Timestamp UtcTimestamp(int year, int month, int day, int hour, int minute, int second)
     {
         return Timestamp.FromDateTime(DateTime.SpecifyKind(new DateTime(year, month, day, hour, minute, second), DateTimeKind.Utc));
+    }
+
+    private static string FormatExpectedLocalTimestamp(Timestamp timestamp)
+    {
+        return timestamp.ToDateTimeOffset().ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz", CultureInfo.InvariantCulture);
     }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli.Tests/EngineReachabilityTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/EngineReachabilityTests.cs
@@ -53,6 +53,20 @@ public sealed class EngineReachabilityTests
     }
 
     [Fact]
+    public void FormatUnimplementedServiceMessageExplainsStaleEngine()
+    {
+        var profile = EngineCatalog.RustProfile;
+        var endpoint = "http://127.0.0.1:50051";
+
+        var message = EngineReachability.FormatUnimplementedServiceMessage(profile, endpoint, "ContestCalendarService");
+
+        Assert.Contains(endpoint, message, StringComparison.Ordinal);
+        Assert.Contains("ContestCalendarService", message, StringComparison.Ordinal);
+        Assert.Contains("Restart the updated", message, StringComparison.Ordinal);
+        Assert.Contains(EngineReachability.SuggestedCommand(profile), message, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task ProbeAsyncReportsUnreachableForClosedPort()
     {
         using var channel = GrpcChannel.ForAddress("http://127.0.0.1:1");

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -33,6 +33,8 @@ internal static class CliHelpText
               sync-status                      Detailed sync status and scheduling info
               test-logbook [--api-key <key>]   Test QRZ logbook API key
               space-weather [--refresh]        Show current NOAA space weather snapshot
+              contests active [filters]        Show active or upcoming contests
+              contests refresh                 Refresh contest calendar cache
               config [--set KEY=VALUE]         View or modify runtime config
               setup [--status | --from-env]    Interactive setup wizard or headless config
 
@@ -273,6 +275,23 @@ internal static class CliHelpText
 
                   --refresh          Force an immediate refresh before printing
                   --json             Output the snapshot as JSON
+                """,
+            "contests" => """
+                Usage: contests active [--band 20m] [--mode CW] [--at <utc>] [--lookahead-minutes N]
+                       contests refresh
+
+                Show engine-backed active contests from the contest calendar cache.
+                Partial source matches are included by default because the initial
+                WA7BNM RSS source does not publish band, mode, or exchange details.
+
+                  --band <band>             Filter by band, such as 20m
+                  --mode <mode>             Filter by mode, such as CW or SSB
+                  --at <utc>                Query time, default engine current UTC
+                  --lookahead-minutes <n>   Include contests starting soon
+                  --exact-matches           Exclude metadata-only partial matches
+                  --include-partial         Include metadata-only partial matches
+                  --refresh                 Force an immediate refresh before printing
+                  --json                    Output the response as JSON
                 """,
             _ => $"No help available for '{command}'."
         };

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -277,7 +277,7 @@ internal static class CliHelpText
                   --json             Output the snapshot as JSON
                 """,
             "contests" => """
-                Usage: contests active [--band 20m] [--mode CW] [--at <utc>] [--lookahead-minutes N]
+                Usage: contests active [--band 20m] [--mode CW] [--at <utc>] [--lookahead-hours N]
                        contests refresh
 
                 Show engine-backed active contests from the contest calendar cache.
@@ -287,7 +287,7 @@ internal static class CliHelpText
                   --band <band>             Filter by band, such as 20m
                   --mode <mode>             Filter by mode, such as CW or SSB
                   --at <utc>                Query time, default engine current UTC
-                  --lookahead-minutes <n>   Include contests starting soon
+                  --lookahead-hours <n>     Include contests starting soon
                   --exact-matches           Exclude metadata-only partial matches
                   --include-partial         Include metadata-only partial matches
                   --refresh                 Force an immediate refresh before printing

--- a/src/dotnet/QsoRipper.Cli/Commands/ContestCalendarCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ContestCalendarCommand.cs
@@ -284,7 +284,7 @@ internal static class ContestCalendarCommand
     {
         return timestamp is null
             ? "(unavailable)"
-            : timestamp.ToDateTimeOffset().ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz", CultureInfo.InvariantCulture);
+            : timestamp.ToDateTimeOffset().ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
     }
 
     private static string FormatBands(RepeatedField<Band> bands)

--- a/src/dotnet/QsoRipper.Cli/Commands/ContestCalendarCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ContestCalendarCommand.cs
@@ -229,6 +229,7 @@ internal static class ContestCalendarCommand
         Console.WriteLine();
         Console.WriteLine(contest.Name);
         Console.WriteLine($"  UTC window:     {FormatTimestamp(contest.StartTimeUtc)} to {FormatTimestamp(contest.EndTimeUtc)}");
+        Console.WriteLine($"  Local window:   {FormatLocalTimestamp(contest.StartTimeUtc)} to {FormatLocalTimestamp(contest.EndTimeUtc)}");
         Console.WriteLine($"  Bands:          {FormatBands(contest.Bands)}");
         Console.WriteLine($"  Modes:          {FormatModes(contest.Modes)}");
         Console.WriteLine($"  Exchange:       {FormatOptional(contest.HasExchange ? contest.Exchange : null)}");
@@ -277,6 +278,13 @@ internal static class ContestCalendarCommand
     private static string FormatTimestamp(Timestamp? timestamp)
     {
         return timestamp is null ? "(unavailable)" : timestamp.ToDateTime().ToString("u", CultureInfo.InvariantCulture);
+    }
+
+    private static string FormatLocalTimestamp(Timestamp? timestamp)
+    {
+        return timestamp is null
+            ? "(unavailable)"
+            : timestamp.ToDateTimeOffset().ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss zzz", CultureInfo.InvariantCulture);
     }
 
     private static string FormatBands(RepeatedField<Band> bands)

--- a/src/dotnet/QsoRipper.Cli/Commands/ContestCalendarCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ContestCalendarCommand.cs
@@ -156,15 +156,15 @@ internal static class ContestCalendarCommand
 
                     options = options with { AtUtc = atUtc.ToUniversalTime() };
                     break;
-                case "--lookahead-minutes":
+                case "--lookahead-hours":
                     if (!TryReadValue(args, ref i, arg, out var lookaheadValue, out error))
                     {
                         return false;
                     }
 
-                    if (!uint.TryParse(lookaheadValue, NumberStyles.None, CultureInfo.InvariantCulture, out var lookaheadMinutes))
+                    if (!TryParseLookaheadHours(lookaheadValue, out var lookaheadMinutes))
                     {
-                        error = $"Invalid --lookahead-minutes value: {lookaheadValue}.";
+                        error = $"Invalid --lookahead-hours value: {lookaheadValue}.";
                         return false;
                     }
 
@@ -182,6 +182,19 @@ internal static class ContestCalendarCommand
             }
         }
 
+        return true;
+    }
+
+    internal static bool TryParseLookaheadHours(string value, out uint lookaheadMinutes)
+    {
+        lookaheadMinutes = 0;
+        if (!uint.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var lookaheadHours)
+            || lookaheadHours > uint.MaxValue / 60)
+        {
+            return false;
+        }
+
+        lookaheadMinutes = lookaheadHours * 60;
         return true;
     }
 

--- a/src/dotnet/QsoRipper.Cli/Commands/ContestCalendarCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/ContestCalendarCommand.cs
@@ -1,0 +1,291 @@
+using System.Globalization;
+using Google.Protobuf.Collections;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Net.Client;
+using QsoRipper.Domain;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli.Commands;
+
+internal static class ContestCalendarCommand
+{
+    public static async Task<int> RunAsync(GrpcChannel channel, string[] args, bool refresh, bool jsonOutput)
+    {
+        if (!TryParseOptions(args, out var options, out var error))
+        {
+            Console.Error.WriteLine(error);
+            return 1;
+        }
+
+        var client = new ContestCalendarService.ContestCalendarServiceClient(channel);
+        if (options.Refresh || refresh)
+        {
+            var response = await client.RefreshContestCalendarAsync(new RefreshContestCalendarRequest());
+            return HandleRefreshResponse(response, jsonOutput);
+        }
+
+        var request = new GetActiveContestsRequest
+        {
+            IncludePartialMatches = options.IncludePartialMatches,
+            LookaheadMinutes = options.LookaheadMinutes
+        };
+
+        if (options.AtUtc is not null)
+        {
+            request.AtUtc = Timestamp.FromDateTimeOffset(options.AtUtc.Value);
+        }
+
+        if (options.Band is not null)
+        {
+            request.Band = options.Band.Value;
+        }
+
+        if (options.Mode is not null)
+        {
+            request.Mode = options.Mode.Value;
+        }
+
+        var activeResponse = await client.GetActiveContestsAsync(request);
+        return HandleActiveResponse(activeResponse, jsonOutput);
+    }
+
+    internal static int HandleActiveResponse(GetActiveContestsResponse response, bool jsonOutput)
+    {
+        if (jsonOutput)
+        {
+            JsonOutput.Print(response);
+            return StatusExitCode(response.Status);
+        }
+
+        PrintHeader(response.Status, response.FetchedAt, response.ValidUntil, response.HasErrorMessage ? response.ErrorMessage : null);
+
+        if (response.Contests.Count == 0)
+        {
+            Console.WriteLine("No active contests matched.");
+            return StatusExitCode(response.Status);
+        }
+
+        foreach (var contest in response.Contests)
+        {
+            PrintContest(contest);
+        }
+
+        return StatusExitCode(response.Status);
+    }
+
+    internal static int HandleRefreshResponse(RefreshContestCalendarResponse response, bool jsonOutput)
+    {
+        if (jsonOutput)
+        {
+            JsonOutput.Print(response);
+            return StatusExitCode(response.Status);
+        }
+
+        PrintHeader(response.Status, response.FetchedAt, response.ValidUntil, response.HasErrorMessage ? response.ErrorMessage : null);
+        Console.WriteLine($"Loaded contests:  {response.Contests.Count.ToString(CultureInfo.InvariantCulture)}");
+
+        foreach (var contest in response.Contests)
+        {
+            PrintContest(contest);
+        }
+
+        return StatusExitCode(response.Status);
+    }
+
+    private static bool TryParseOptions(string[] args, out ContestCalendarOptions options, out string error)
+    {
+        options = new ContestCalendarOptions();
+        error = string.Empty;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+
+            switch (arg)
+            {
+                case "active" when i == 0:
+                    break;
+                case "refresh" when i == 0:
+                    options = options with { Refresh = true };
+                    break;
+                case "--band":
+                    if (!TryReadValue(args, ref i, arg, out var bandValue, out error))
+                    {
+                        return false;
+                    }
+
+                    try
+                    {
+                        options = options with { Band = EnumHelpers.ParseBand(bandValue) };
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        error = ex.Message;
+                        return false;
+                    }
+
+                    break;
+                case "--mode":
+                    if (!TryReadValue(args, ref i, arg, out var modeValue, out error))
+                    {
+                        return false;
+                    }
+
+                    try
+                    {
+                        options = options with { Mode = EnumHelpers.ParseMode(modeValue) };
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        error = ex.Message;
+                        return false;
+                    }
+
+                    break;
+                case "--at":
+                    if (!TryReadValue(args, ref i, arg, out var atValue, out error))
+                    {
+                        return false;
+                    }
+
+                    if (!DateTimeOffset.TryParse(atValue, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var atUtc))
+                    {
+                        error = $"Invalid --at value: {atValue}. Use an ISO-8601 UTC timestamp.";
+                        return false;
+                    }
+
+                    options = options with { AtUtc = atUtc.ToUniversalTime() };
+                    break;
+                case "--lookahead-minutes":
+                    if (!TryReadValue(args, ref i, arg, out var lookaheadValue, out error))
+                    {
+                        return false;
+                    }
+
+                    if (!uint.TryParse(lookaheadValue, NumberStyles.None, CultureInfo.InvariantCulture, out var lookaheadMinutes))
+                    {
+                        error = $"Invalid --lookahead-minutes value: {lookaheadValue}.";
+                        return false;
+                    }
+
+                    options = options with { LookaheadMinutes = lookaheadMinutes };
+                    break;
+                case "--exact-matches":
+                    options = options with { IncludePartialMatches = false };
+                    break;
+                case "--include-partial":
+                    options = options with { IncludePartialMatches = true };
+                    break;
+                default:
+                    error = $"Unknown contests argument: {arg}";
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryReadValue(string[] args, ref int index, string optionName, out string value, out string error)
+    {
+        if (index == args.Length - 1)
+        {
+            value = string.Empty;
+            error = $"Missing value for {optionName}.";
+            return false;
+        }
+
+        value = args[++index];
+        error = string.Empty;
+        return true;
+    }
+
+    private static void PrintHeader(ContestCalendarStatus status, Timestamp? fetchedAt, Timestamp? validUntil, string? error)
+    {
+        Console.WriteLine($"Status:           {FormatStatus(status)}");
+        Console.WriteLine($"Fetched at:       {FormatTimestamp(fetchedAt)}");
+        Console.WriteLine($"Valid until:      {FormatTimestamp(validUntil)}");
+
+        if (!string.IsNullOrWhiteSpace(error))
+        {
+            Console.WriteLine($"Error:            {error}");
+        }
+    }
+
+    private static void PrintContest(ContestCalendarEntry contest)
+    {
+        Console.WriteLine();
+        Console.WriteLine(contest.Name);
+        Console.WriteLine($"  UTC window:     {FormatTimestamp(contest.StartTimeUtc)} to {FormatTimestamp(contest.EndTimeUtc)}");
+        Console.WriteLine($"  Bands:          {FormatBands(contest.Bands)}");
+        Console.WriteLine($"  Modes:          {FormatModes(contest.Modes)}");
+        Console.WriteLine($"  Exchange:       {FormatOptional(contest.HasExchange ? contest.Exchange : null)}");
+        Console.WriteLine($"  Details:        {FormatDetailsStatus(contest.DetailsStatus)}");
+        Console.WriteLine($"  Source:         {FormatOptional(contest.SourceName)}");
+
+        if (contest.HasRulesUrl)
+        {
+            Console.WriteLine($"  Rules:          {contest.RulesUrl}");
+        }
+
+        if (contest.HasSourceUrl)
+        {
+            Console.WriteLine($"  Source URL:     {contest.SourceUrl}");
+        }
+    }
+
+    private static int StatusExitCode(ContestCalendarStatus status)
+    {
+        return status is ContestCalendarStatus.Error or ContestCalendarStatus.Disabled ? 1 : 0;
+    }
+
+    private static string FormatStatus(ContestCalendarStatus status)
+    {
+        return status switch
+        {
+            ContestCalendarStatus.Current => "current",
+            ContestCalendarStatus.Stale => "stale",
+            ContestCalendarStatus.Error => "error",
+            ContestCalendarStatus.Disabled => "disabled",
+            _ => "unspecified"
+        };
+    }
+
+    private static string FormatDetailsStatus(ContestDetailsStatus status)
+    {
+        return status switch
+        {
+            ContestDetailsStatus.MetadataOnly => "metadata only",
+            ContestDetailsStatus.Partial => "partial",
+            ContestDetailsStatus.Full => "full",
+            _ => "unspecified"
+        };
+    }
+
+    private static string FormatTimestamp(Timestamp? timestamp)
+    {
+        return timestamp is null ? "(unavailable)" : timestamp.ToDateTime().ToString("u", CultureInfo.InvariantCulture);
+    }
+
+    private static string FormatBands(RepeatedField<Band> bands)
+    {
+        return bands.Count == 0 ? "(unknown from source)" : string.Join(", ", bands.Select(EnumHelpers.FormatBand));
+    }
+
+    private static string FormatModes(RepeatedField<Mode> modes)
+    {
+        return modes.Count == 0 ? "(unknown from source)" : string.Join(", ", modes.Select(EnumHelpers.FormatMode));
+    }
+
+    private static string FormatOptional(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? "(unavailable)" : value;
+    }
+
+    private sealed record ContestCalendarOptions(
+        bool Refresh = false,
+        Band? Band = null,
+        Mode? Mode = null,
+        DateTimeOffset? AtUtc = null,
+        uint LookaheadMinutes = 0,
+        bool IncludePartialMatches = true);
+}

--- a/src/dotnet/QsoRipper.Cli/EngineReachability.cs
+++ b/src/dotnet/QsoRipper.Cli/EngineReachability.cs
@@ -62,6 +62,18 @@ internal static class EngineReachability
         return $"Could not connect to {profile.DisplayName} at {endpoint}.\nMake sure the engine is running. Suggested start command:\n  {SuggestedCommand(profile)}";
     }
 
+    public static string FormatUnimplementedServiceMessage(
+        EngineTargetProfile profile,
+        string endpoint,
+        string serviceName)
+    {
+        ArgumentNullException.ThrowIfNull(profile);
+        ArgumentNullException.ThrowIfNull(endpoint);
+        ArgumentException.ThrowIfNullOrWhiteSpace(serviceName);
+
+        return $"The engine at {endpoint} does not implement {serviceName}.\nRestart the updated {profile.DisplayName}, or point --endpoint at an engine built from this branch.\nSuggested start command:\n  {SuggestedCommand(profile)}";
+    }
+
     public static string SuggestedCommand(EngineTargetProfile profile)
     {
         ArgumentNullException.ThrowIfNull(profile);

--- a/src/dotnet/QsoRipper.Cli/Program.cs
+++ b/src/dotnet/QsoRipper.Cli/Program.cs
@@ -49,6 +49,7 @@ try
                 arguments.EngineProfile,
                 arguments.JsonOutput),
             "space-weather" => await SpaceWeatherCommand.RunAsync(channel, arguments.Refresh, arguments.JsonOutput),
+            "contests" => await ContestCalendarCommand.RunAsync(channel, arguments.RemainingArgs, arguments.Refresh, arguments.JsonOutput),
             "lookup" => await LookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache, arguments.JsonOutput),
             "stream-lookup" => await StreamLookupCommand.RunAsync(channel, arguments.Callsign!, arguments.SkipCache, cancellationSource.Token),
             "cache-check" => await CacheCheckCommand.RunAsync(channel, arguments.Callsign!, arguments.JsonOutput),
@@ -78,6 +79,14 @@ try
 catch (RpcException ex) when (ex.StatusCode == StatusCode.Unavailable)
 {
     Console.Error.WriteLine(EngineReachability.FormatUnreachableMessage(arguments.EngineProfile, arguments.Endpoint));
+    return 1;
+}
+catch (RpcException ex) when (ex.StatusCode == StatusCode.Unimplemented && arguments.Command is "contests")
+{
+    Console.Error.WriteLine(EngineReachability.FormatUnimplementedServiceMessage(
+        arguments.EngineProfile,
+        arguments.Endpoint,
+        "ContestCalendarService"));
     return 1;
 }
 catch (RpcException ex)

--- a/src/dotnet/QsoRipper.DebugHost/Services/SampleProtoFactory.cs
+++ b/src/dotnet/QsoRipper.DebugHost/Services/SampleProtoFactory.cs
@@ -515,8 +515,7 @@ internal sealed class SampleProtoFactory
     {
         var enumValue = field.EnumType.Values.FirstOrDefault(static value => value.Number != 0)
             ?? field.EnumType.Values[0];
-        var enumType = field.Accessor.GetValue(message).GetType();
-        return System.Enum.ToObject(enumType, enumValue.Number);
+        return CreateEnumValue(message, field, enumValue.Number);
     }
 
     private IMessage? CreateSampleNestedMessage(
@@ -558,8 +557,28 @@ internal sealed class SampleProtoFactory
         var enumValue = preferredValue
             ?? field.EnumType.Values.FirstOrDefault(static value => value.Number != 0 && !value.Name.Contains("UNSPECIFIED", StringComparison.Ordinal))
             ?? field.EnumType.Values[0];
-        var enumType = field.Accessor.GetValue(message).GetType();
-        return System.Enum.ToObject(enumType, enumValue.Number);
+        return CreateEnumValue(message, field, enumValue.Number);
+    }
+
+    private static object CreateEnumValue(IMessage message, FieldDescriptor field, int value)
+    {
+        var fieldValue = field.Accessor.GetValue(message);
+        var fieldType = fieldValue.GetType();
+        if (fieldType.IsEnum)
+        {
+            return System.Enum.ToObject(fieldType, value);
+        }
+
+        if (field.IsRepeated)
+        {
+            var itemType = fieldType.GetGenericArguments().FirstOrDefault();
+            if (itemType is not null && itemType.IsEnum)
+            {
+                return System.Enum.ToObject(itemType, value);
+            }
+        }
+
+        throw new InvalidOperationException($"Could not resolve enum CLR type for field '{field.FullName}'.");
     }
 
     private static string CreateSampleString(FieldDescriptor field, SampleGenerationContext context)

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar.Tests/ContestCalendarMonitorTests.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar.Tests/ContestCalendarMonitorTests.cs
@@ -1,0 +1,123 @@
+#pragma warning disable CA1707 // xUnit method names use underscores.
+
+using System.Globalization;
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Domain;
+
+namespace QsoRipper.Engine.ContestCalendar.Tests;
+
+public sealed class ContestCalendarMonitorTests
+{
+    [Fact]
+    public void CurrentSnapshot_NoCacheFetchesFromProvider()
+    {
+        var provider = new FakeProvider(MakeContest());
+        var clock = new TestClock(ParseUtc("2026-05-24T16:00:00Z"));
+        var monitor = new ContestCalendarMonitor(provider, TimeSpan.FromHours(1), TimeSpan.FromDays(1), clock);
+
+        var result = monitor.CurrentSnapshot();
+
+        Assert.Equal(ContestCalendarStatus.Current, result.Status);
+        Assert.Single(result.Contests);
+        Assert.Equal(1, provider.FetchCount);
+    }
+
+    [Fact]
+    public void CurrentSnapshot_FreshCacheReturnsWithoutFetching()
+    {
+        var provider = new FakeProvider(MakeContest());
+        var clock = new TestClock(ParseUtc("2026-05-24T16:00:00Z"));
+        var monitor = new ContestCalendarMonitor(provider, TimeSpan.FromHours(1), TimeSpan.FromDays(1), clock);
+
+        monitor.CurrentSnapshot();
+        clock.Advance(TimeSpan.FromMinutes(5));
+        monitor.CurrentSnapshot();
+
+        Assert.Equal(1, provider.FetchCount);
+    }
+
+    [Fact]
+    public void RefreshFailure_WithCacheReturnsStaleCached()
+    {
+        var provider = new FakeProvider(MakeContest());
+        var clock = new TestClock(ParseUtc("2026-05-24T16:00:00Z"));
+        var monitor = new ContestCalendarMonitor(provider, TimeSpan.FromMinutes(1), TimeSpan.FromDays(1), clock);
+
+        monitor.CurrentSnapshot();
+        provider.FailWith(ContestCalendarProviderException.Transport("connection refused"));
+        clock.Advance(TimeSpan.FromMinutes(2));
+        var result = monitor.CurrentSnapshot();
+
+        Assert.Equal(ContestCalendarStatus.Stale, result.Status);
+        Assert.Contains("connection refused", result.ErrorMessage, StringComparison.Ordinal);
+        Assert.Single(result.Contests);
+    }
+
+    [Fact]
+    public void DisabledProviderWithoutCacheReturnsDisabled()
+    {
+        var monitor = new ContestCalendarMonitor(
+            new DisabledContestCalendarProvider("disabled"),
+            TimeSpan.FromHours(1),
+            TimeSpan.FromDays(1),
+            new TestClock(ParseUtc("2026-05-24T16:00:00Z")));
+
+        var result = monitor.CurrentSnapshot();
+
+        Assert.Equal(ContestCalendarStatus.Disabled, result.Status);
+        Assert.Contains("disabled", result.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    private static ContestCalendarEntry MakeContest()
+    {
+        return new ContestCalendarEntry
+        {
+            ContestId = "contest",
+            Name = "Contest",
+            StartTimeUtc = Timestamp.FromDateTimeOffset(ParseUtc("2026-05-24T16:00:00Z")),
+            EndTimeUtc = Timestamp.FromDateTimeOffset(ParseUtc("2026-05-24T20:00:00Z")),
+            SourceName = "WA7BNM Contest Calendar",
+            DetailsStatus = ContestDetailsStatus.MetadataOnly,
+        };
+    }
+
+    private static DateTimeOffset ParseUtc(string value)
+    {
+        return DateTimeOffset.Parse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
+    }
+
+    private sealed class FakeProvider(ContestCalendarEntry? contest) : IContestCalendarProvider
+    {
+        private ContestCalendarProviderException? _exception;
+
+        public int FetchCount { get; private set; }
+
+        public IReadOnlyList<ContestCalendarEntry> FetchContests()
+        {
+            FetchCount++;
+            if (_exception is not null)
+            {
+                throw _exception;
+            }
+
+            return contest is null ? [] : [contest];
+        }
+
+        public void FailWith(ContestCalendarProviderException exception)
+        {
+            _exception = exception;
+        }
+    }
+
+    private sealed class TestClock(DateTimeOffset now) : TimeProvider
+    {
+        private DateTimeOffset _now = now;
+
+        public override DateTimeOffset GetUtcNow() => _now;
+
+        public void Advance(TimeSpan elapsed)
+        {
+            _now = _now.Add(elapsed);
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar.Tests/ContestDetailsCatalogTests.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar.Tests/ContestDetailsCatalogTests.cs
@@ -1,0 +1,150 @@
+#pragma warning disable CA1707 // xUnit method names use underscores.
+
+using System.Globalization;
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Domain;
+
+namespace QsoRipper.Engine.ContestCalendar.Tests;
+
+public sealed class ContestDetailsCatalogTests
+{
+    [Fact]
+    public void Enrich_MatchesByNameAndAddsReviewedDetails()
+    {
+        using var directory = TempDirectory.Create();
+        var path = Path.Combine(directory.Path, "contest-details.json");
+        File.WriteAllText(path, """
+            {
+              "entries": [
+                {
+                  "name": "Real Time Contest",
+                  "bands": [ "20m", "40m" ],
+                  "modes": [ "cw", "ssb" ],
+                  "exchange": "RST + serial",
+                  "rulesUrl": "https://example.test/rules",
+                  "detailsStatus": "full"
+                }
+              ]
+            }
+            """);
+        var catalog = ContestDetailsCatalog.Load(path);
+        var contest = new ContestCalendarEntry
+        {
+            ContestId = "contest",
+            Name = "Real Time Contest",
+            StartTimeUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-24T16:00:00Z", CultureInfo.InvariantCulture)),
+            EndTimeUtc = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse("2026-05-24T20:00:00Z", CultureInfo.InvariantCulture)),
+            SourceName = "WA7BNM Contest Calendar",
+            DetailsStatus = ContestDetailsStatus.MetadataOnly,
+        };
+
+        var enriched = catalog.Enrich(contest);
+
+        Assert.Equal([Band._20M, Band._40M], enriched.Bands);
+        Assert.Equal([Mode.Cw, Mode.Ssb], enriched.Modes);
+        Assert.Equal("RST + serial", enriched.Exchange);
+        Assert.Equal("https://example.test/rules", enriched.RulesUrl);
+        Assert.Equal(ContestDetailsStatus.Full, enriched.DetailsStatus);
+    }
+
+    [Fact]
+    public void Provider_EnrichesFetchedContests()
+    {
+        using var directory = TempDirectory.Create();
+        var path = Path.Combine(directory.Path, "contest-details.json");
+        File.WriteAllText(path, """
+            {
+              "entries": [
+                {
+                  "contestId": "contest",
+                  "bands": [ "20m" ],
+                  "modes": [ "cw" ],
+                  "exchange": "RST + state",
+                  "rulesUrl": "https://example.test/rules"
+                }
+              ]
+            }
+            """);
+        var provider = new CatalogEnrichingContestCalendarProvider(
+            new FakeProvider(),
+            ContestDetailsCatalog.Load(path));
+
+        var contest = Assert.Single(provider.FetchContests());
+
+        Assert.Equal([Band._20M], contest.Bands);
+        Assert.Equal([Mode.Cw], contest.Modes);
+        Assert.Equal("RST + state", contest.Exchange);
+        Assert.Equal(ContestDetailsStatus.Partial, contest.DetailsStatus);
+    }
+
+    [Fact]
+    public void Enrich_PreservesMetadataOnlyDetailsStatus()
+    {
+        using var directory = TempDirectory.Create();
+        var path = Path.Combine(directory.Path, "contest-details.json");
+        File.WriteAllText(path, """
+            {
+              "entries": [
+                {
+                  "contestId": "contest",
+                  "detailsStatus": "metadataOnly"
+                }
+              ]
+            }
+            """);
+        var catalog = ContestDetailsCatalog.Load(path);
+        var contest = new ContestCalendarEntry
+        {
+            ContestId = "contest",
+            DetailsStatus = ContestDetailsStatus.Partial,
+        };
+
+        var enriched = catalog.Enrich(contest);
+
+        Assert.Equal(ContestDetailsStatus.MetadataOnly, enriched.DetailsStatus);
+    }
+
+    private sealed class FakeProvider : IContestCalendarProvider
+    {
+        public IReadOnlyList<ContestCalendarEntry> FetchContests()
+        {
+            return
+            [
+                new ContestCalendarEntry
+                {
+                    ContestId = "contest",
+                    Name = "Real Time Contest",
+                    SourceName = "WA7BNM Contest Calendar",
+                    DetailsStatus = ContestDetailsStatus.MetadataOnly,
+                },
+            ];
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        private TempDirectory(string path)
+        {
+            Path = path;
+        }
+
+        public string Path { get; }
+
+        public static TempDirectory Create()
+        {
+            var path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"qsoripper-contest-catalog-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(path);
+            return new TempDirectory(path);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Path))
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar.Tests/QsoRipper.Engine.ContestCalendar.Tests.csproj
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar.Tests/QsoRipper.Engine.ContestCalendar.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QsoRipper.Engine.ContestCalendar\QsoRipper.Engine.ContestCalendar.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar.Tests/Wa7bnmRssParserTests.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar.Tests/Wa7bnmRssParserTests.cs
@@ -1,0 +1,45 @@
+#pragma warning disable CA1707 // xUnit method names use underscores.
+
+using QsoRipper.Domain;
+
+namespace QsoRipper.Engine.ContestCalendar.Tests;
+
+public sealed class Wa7bnmRssParserTests
+{
+    [Fact]
+    public void Parse_ReturnsMetadataOnlyEntries()
+    {
+        const string xml = """
+            <?xml version="1.0" encoding="utf-8" ?>
+            <rss version="2.0"><channel>
+            <lastBuildDate>Sat, 23 May 2026 00:00:00 +0000</lastBuildDate>
+            <item><title>Real Time Contest</title><link>https://www.contestcalendar.com/weeklycontdetails.php?ref=x</link><description>1600Z-2000Z, May 24</description></item>
+            </channel></rss>
+            """;
+
+        var contests = Wa7bnmRssParser.Parse(xml, Wa7bnmContestCalendarConfig.DefaultRssUrl);
+
+        var contest = Assert.Single(contests);
+        Assert.Equal("Real Time Contest", contest.Name);
+        Assert.Equal(ContestDetailsStatus.MetadataOnly, contest.DetailsStatus);
+        Assert.Empty(contest.Bands);
+        Assert.Empty(contest.Modes);
+        Assert.Equal(1_779_638_400, contest.StartTimeUtc.Seconds);
+        Assert.Equal(1_779_652_800, contest.EndTimeUtc.Seconds);
+    }
+
+    [Fact]
+    public void Parse_RollsEndTimeToNextDay()
+    {
+        const string xml = """
+            <rss version="2.0"><channel>
+            <lastBuildDate>Sat, 23 May 2026 00:00:00 +0000</lastBuildDate>
+            <item><title>Overnight Contest</title><description>2300Z-0100Z, May 24</description></item>
+            </channel></rss>
+            """;
+
+        var contest = Assert.Single(Wa7bnmRssParser.Parse(xml, Wa7bnmContestCalendarConfig.DefaultRssUrl));
+
+        Assert.Equal(7_200, contest.EndTimeUtc.Seconds - contest.StartTimeUtc.Seconds);
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar/CatalogEnrichingContestCalendarProvider.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar/CatalogEnrichingContestCalendarProvider.cs
@@ -1,0 +1,17 @@
+using QsoRipper.Domain;
+
+namespace QsoRipper.Engine.ContestCalendar;
+
+/// <summary>
+/// Decorates contest calendar metadata with reviewed local contest details.
+/// </summary>
+public sealed class CatalogEnrichingContestCalendarProvider(
+    IContestCalendarProvider inner,
+    ContestDetailsCatalog catalog) : IContestCalendarProvider
+{
+    /// <inheritdoc />
+    public IReadOnlyList<ContestCalendarEntry> FetchContests()
+    {
+        return inner.FetchContests().Select(catalog.Enrich).ToArray();
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar/ContestCalendarMonitor.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar/ContestCalendarMonitor.cs
@@ -1,0 +1,111 @@
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Domain;
+
+namespace QsoRipper.Engine.ContestCalendar;
+
+/// <summary>
+/// On-demand cache and refresh layer for contest calendar data.
+/// Thread-safe; no background polling.
+/// </summary>
+public sealed class ContestCalendarMonitor
+{
+    private readonly IContestCalendarProvider _provider;
+    private readonly TimeSpan _refreshInterval;
+    private readonly TimeSpan _staleAfter;
+    private readonly TimeProvider _clock;
+    private readonly Lock _lock = new();
+    private ContestCalendarSnapshot? _cached;
+    private DateTimeOffset _lastFetchTime;
+
+    public ContestCalendarMonitor(
+        IContestCalendarProvider provider,
+        TimeSpan refreshInterval,
+        TimeSpan staleAfter,
+        TimeProvider? clock = null)
+    {
+        ArgumentNullException.ThrowIfNull(provider);
+
+        _provider = provider;
+        _refreshInterval = refreshInterval;
+        _staleAfter = staleAfter;
+        _clock = clock ?? TimeProvider.System;
+    }
+
+    /// <summary>
+    /// Return the cached snapshot if still fresh, otherwise fetch a new one.
+    /// </summary>
+    public ContestCalendarSnapshot CurrentSnapshot()
+    {
+        lock (_lock)
+        {
+            if (_cached is not null)
+            {
+                var elapsed = _clock.GetUtcNow() - _lastFetchTime;
+                if (elapsed < _refreshInterval)
+                {
+                    var cached = _cached.Clone();
+                    if (elapsed >= _staleAfter)
+                    {
+                        cached.Status = ContestCalendarStatus.Stale;
+                    }
+
+                    return cached;
+                }
+            }
+
+            return RefreshNoLock();
+        }
+    }
+
+    /// <summary>
+    /// Force a fresh fetch from the provider, ignoring any cached data.
+    /// </summary>
+    public ContestCalendarSnapshot RefreshSnapshot()
+    {
+        lock (_lock)
+        {
+            return RefreshNoLock();
+        }
+    }
+
+    private ContestCalendarSnapshot RefreshNoLock()
+    {
+        try
+        {
+            var now = _clock.GetUtcNow();
+            var snapshot = new ContestCalendarSnapshot
+            {
+                Status = ContestCalendarStatus.Current,
+                FetchedAt = Timestamp.FromDateTimeOffset(now),
+                ValidUntil = Timestamp.FromDateTimeOffset(now.Add(_refreshInterval)),
+            };
+
+            foreach (var contest in _provider.FetchContests())
+            {
+                snapshot.Contests.Add(contest.Clone());
+            }
+            _cached = snapshot.Clone();
+            _lastFetchTime = now;
+            return snapshot;
+        }
+        catch (ContestCalendarProviderException ex)
+        {
+            if (_cached is not null)
+            {
+                var stale = _cached.Clone();
+                stale.Status = ContestCalendarStatus.Stale;
+                stale.ErrorMessage = ex.Message;
+                return stale;
+            }
+
+            return new ContestCalendarSnapshot
+            {
+                Status = ex.Kind == ContestCalendarProviderErrorKind.Disabled
+                    ? ContestCalendarStatus.Disabled
+                    : ContestCalendarStatus.Error,
+                FetchedAt = Timestamp.FromDateTimeOffset(_clock.GetUtcNow()),
+                ErrorMessage = ex.Message,
+            };
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar/ContestCalendarProviderException.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar/ContestCalendarProviderException.cs
@@ -1,0 +1,48 @@
+namespace QsoRipper.Engine.ContestCalendar;
+
+/// <summary>
+/// Stable error categories for the contest calendar provider layer.
+/// </summary>
+public enum ContestCalendarProviderErrorKind
+{
+    /// <summary>Provider is disabled by configuration.</summary>
+    Disabled,
+
+    /// <summary>Transport failed before a valid response was received.</summary>
+    Transport,
+
+    /// <summary>Provider returned a payload that could not be parsed.</summary>
+    Parse,
+}
+
+/// <summary>
+/// Exception surfaced by the contest calendar provider layer.
+/// </summary>
+#pragma warning disable CA1032, RCS1194 // Standard constructors intentionally omitted; use factory methods.
+public sealed class ContestCalendarProviderException : Exception
+#pragma warning restore CA1032, RCS1194
+{
+    /// <summary>Gets the stable error category.</summary>
+    public ContestCalendarProviderErrorKind Kind { get; }
+
+    /// <summary>Gets whether the error class is suitable for retry handling.</summary>
+    public bool IsRetryable => Kind == ContestCalendarProviderErrorKind.Transport;
+
+    private ContestCalendarProviderException(ContestCalendarProviderErrorKind kind, string message)
+        : base(message)
+    {
+        Kind = kind;
+    }
+
+    /// <summary>Create an exception indicating the provider is disabled.</summary>
+    public static ContestCalendarProviderException Disabled(string message) =>
+        new(ContestCalendarProviderErrorKind.Disabled, message);
+
+    /// <summary>Create an exception indicating a transport failure.</summary>
+    public static ContestCalendarProviderException Transport(string message) =>
+        new(ContestCalendarProviderErrorKind.Transport, message);
+
+    /// <summary>Create an exception indicating a parse failure.</summary>
+    public static ContestCalendarProviderException Parse(string message) =>
+        new(ContestCalendarProviderErrorKind.Parse, message);
+}

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar/ContestCalendarSnapshot.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar/ContestCalendarSnapshot.cs
@@ -1,6 +1,6 @@
+using System.Collections.ObjectModel;
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
-using System.Collections.ObjectModel;
 
 namespace QsoRipper.Engine.ContestCalendar;
 

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar/ContestCalendarSnapshot.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar/ContestCalendarSnapshot.cs
@@ -1,0 +1,45 @@
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Domain;
+using System.Collections.ObjectModel;
+
+namespace QsoRipper.Engine.ContestCalendar;
+
+/// <summary>
+/// Current contest calendar entries plus freshness metadata.
+/// </summary>
+public sealed class ContestCalendarSnapshot
+{
+    /// <summary>Gets contest calendar entries.</summary>
+    public Collection<ContestCalendarEntry> Contests { get; } = [];
+
+    /// <summary>Gets or sets snapshot freshness/error status.</summary>
+    public ContestCalendarStatus Status { get; set; }
+
+    /// <summary>Gets or sets UTC time when this snapshot was fetched.</summary>
+    public Timestamp? FetchedAt { get; set; }
+
+    /// <summary>Gets or sets UTC time until which the snapshot should be treated as fresh.</summary>
+    public Timestamp? ValidUntil { get; set; }
+
+    /// <summary>Gets or sets provider error text, when present.</summary>
+    public string? ErrorMessage { get; set; }
+
+    /// <summary>Create a defensive copy of the snapshot.</summary>
+    public ContestCalendarSnapshot Clone()
+    {
+        var clone = new ContestCalendarSnapshot
+        {
+            Status = Status,
+            FetchedAt = FetchedAt?.Clone(),
+            ValidUntil = ValidUntil?.Clone(),
+            ErrorMessage = ErrorMessage,
+        };
+
+        foreach (var contest in Contests)
+        {
+            clone.Contests.Add(contest.Clone());
+        }
+
+        return clone;
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar/ContestDetailsCatalog.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar/ContestDetailsCatalog.cs
@@ -1,0 +1,195 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using QsoRipper.Domain;
+
+namespace QsoRipper.Engine.ContestCalendar;
+
+/// <summary>
+/// Reviewed local contest details used to enrich calendar metadata.
+/// </summary>
+public sealed class ContestDetailsCatalog
+{
+    private readonly IReadOnlyList<ContestDetailsCatalogEntry> _entries;
+
+    private ContestDetailsCatalog(IReadOnlyList<ContestDetailsCatalogEntry> entries)
+    {
+        _entries = entries;
+    }
+
+    /// <summary>Load a reviewed contest details catalog from JSON.</summary>
+    public static ContestDetailsCatalog Load(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            var document = JsonSerializer.Deserialize(stream, ContestDetailsCatalogJsonContext.Default.ContestDetailsCatalogFile)
+                ?? new ContestDetailsCatalogFile();
+            return new ContestDetailsCatalog(document.Entries.Select(ToEntry).ToArray());
+        }
+        catch (IOException ex)
+        {
+            throw ContestCalendarProviderException.Parse($"Failed to read contest details catalog '{path}': {ex.Message}");
+        }
+        catch (JsonException ex)
+        {
+            throw ContestCalendarProviderException.Parse($"Failed to parse contest details catalog '{path}': {ex.Message}");
+        }
+    }
+
+    /// <summary>Enrich a contest entry with matching local catalog details.</summary>
+    public ContestCalendarEntry Enrich(ContestCalendarEntry contest)
+    {
+        ArgumentNullException.ThrowIfNull(contest);
+
+        var match = _entries.FirstOrDefault(entry => entry.IsMatch(contest));
+        if (match is null)
+        {
+            return contest.Clone();
+        }
+
+        var enriched = contest.Clone();
+        if (match.Bands.Count > 0)
+        {
+            enriched.Bands.Clear();
+            enriched.Bands.Add(match.Bands);
+        }
+
+        if (match.Modes.Count > 0)
+        {
+            enriched.Modes.Clear();
+            enriched.Modes.Add(match.Modes);
+        }
+
+        if (!string.IsNullOrWhiteSpace(match.Exchange))
+        {
+            enriched.Exchange = match.Exchange;
+        }
+
+        if (!string.IsNullOrWhiteSpace(match.RulesUrl))
+        {
+            enriched.RulesUrl = match.RulesUrl;
+        }
+
+        enriched.DetailsStatus = match.DetailsStatus;
+        return enriched;
+    }
+
+    private static ContestDetailsCatalogEntry ToEntry(ContestDetailsCatalogItem item)
+    {
+        return new ContestDetailsCatalogEntry(
+            Normalize(item.ContestId),
+            Normalize(item.Name),
+            Normalize(item.SourceUrl),
+            item.Bands.Select(ParseBand).Where(static band => band != Band.Unspecified).ToArray(),
+            item.Modes.Select(ParseMode).Where(static mode => mode != Mode.Unspecified).ToArray(),
+            item.Exchange?.Trim(),
+            item.RulesUrl?.Trim(),
+            ParseDetailsStatus(item.DetailsStatus));
+    }
+
+    private static ContestDetailsStatus ParseDetailsStatus(string? value)
+    {
+        return Normalize(value) switch
+        {
+            "FULL" => ContestDetailsStatus.Full,
+            "METADATAONLY" or "METADATA_ONLY" => ContestDetailsStatus.MetadataOnly,
+            "PARTIAL" => ContestDetailsStatus.Partial,
+            _ => ContestDetailsStatus.Partial,
+        };
+    }
+
+    private static Band ParseBand(string value)
+    {
+        return Normalize(value) switch
+        {
+            "160M" => Band._160M,
+            "80M" => Band._80M,
+            "40M" => Band._40M,
+            "30M" => Band._30M,
+            "20M" => Band._20M,
+            "17M" => Band._17M,
+            "15M" => Band._15M,
+            "12M" => Band._12M,
+            "10M" => Band._10M,
+            "6M" => Band._6M,
+            "2M" => Band._2M,
+            "70CM" => Band._70Cm,
+            _ => Band.Unspecified,
+        };
+    }
+
+    private static Mode ParseMode(string value)
+    {
+        return Normalize(value) switch
+        {
+            "CW" => Mode.Cw,
+            "SSB" => Mode.Ssb,
+            "RTTY" => Mode.Rtty,
+            "FT8" => Mode.Ft8,
+            "FM" => Mode.Fm,
+            "AM" => Mode.Am,
+            _ => Mode.Unspecified,
+        };
+    }
+
+    private static string Normalize(string? value)
+    {
+        return string.IsNullOrWhiteSpace(value) ? string.Empty : value.Trim().ToUpperInvariant();
+    }
+
+    private sealed record ContestDetailsCatalogEntry(
+        string ContestId,
+        string Name,
+        string SourceUrl,
+        IReadOnlyList<Band> Bands,
+        IReadOnlyList<Mode> Modes,
+        string? Exchange,
+        string? RulesUrl,
+        ContestDetailsStatus DetailsStatus)
+    {
+        public bool IsMatch(ContestCalendarEntry contest)
+        {
+            if (ContestId.Length > 0 && string.Equals(ContestId, Normalize(contest.ContestId), StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            if (SourceUrl.Length > 0 && string.Equals(SourceUrl, Normalize(contest.SourceUrl), StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            return Name.Length > 0 && string.Equals(Name, Normalize(contest.Name), StringComparison.Ordinal);
+        }
+    }
+}
+
+internal sealed class ContestDetailsCatalogFile
+{
+    public ContestDetailsCatalogItem[] Entries { get; set; } = [];
+}
+
+internal sealed class ContestDetailsCatalogItem
+{
+    public string? ContestId { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? SourceUrl { get; set; }
+
+    public string[] Bands { get; set; } = [];
+
+    public string[] Modes { get; set; } = [];
+
+    public string? Exchange { get; set; }
+
+    public string? RulesUrl { get; set; }
+
+    public string? DetailsStatus { get; set; }
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase, PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(ContestDetailsCatalogFile))]
+internal sealed partial class ContestDetailsCatalogJsonContext : JsonSerializerContext;

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar/DisabledContestCalendarProvider.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar/DisabledContestCalendarProvider.cs
@@ -1,0 +1,14 @@
+using QsoRipper.Domain;
+
+namespace QsoRipper.Engine.ContestCalendar;
+
+/// <summary>
+/// Provider used when contest calendar fetching is disabled.
+/// </summary>
+public sealed class DisabledContestCalendarProvider(string reason) : IContestCalendarProvider
+{
+    public IReadOnlyList<ContestCalendarEntry> FetchContests()
+    {
+        throw ContestCalendarProviderException.Disabled(reason);
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar/IContestCalendarProvider.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar/IContestCalendarProvider.cs
@@ -1,0 +1,12 @@
+using QsoRipper.Domain;
+
+namespace QsoRipper.Engine.ContestCalendar;
+
+/// <summary>
+/// Abstraction over an external contest calendar provider.
+/// </summary>
+public interface IContestCalendarProvider
+{
+    /// <summary>Fetch fresh normalized contest calendar entries.</summary>
+    IReadOnlyList<ContestCalendarEntry> FetchContests();
+}

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar/QsoRipper.Engine.ContestCalendar.csproj
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar/QsoRipper.Engine.ContestCalendar.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QsoRipper.Engine.Storage.Abstractions\QsoRipper.Engine.Storage.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="QsoRipper.Engine.ContestCalendar.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar/Wa7bnmContestCalendarConfig.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar/Wa7bnmContestCalendarConfig.cs
@@ -1,0 +1,105 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace QsoRipper.Engine.ContestCalendar;
+
+/// <summary>
+/// Configuration for the WA7BNM contest calendar provider.
+/// </summary>
+public sealed class Wa7bnmContestCalendarConfig
+{
+    /// <summary>Environment variable controlling whether fetching is enabled.</summary>
+    public const string EnabledEnvVar = "QSORIPPER_CONTEST_CALENDAR_ENABLED";
+
+    /// <summary>Environment variable overriding the RSS URL.</summary>
+    public const string RssUrlEnvVar = "QSORIPPER_CONTEST_CALENDAR_RSS_URL";
+
+    /// <summary>Environment variable overriding the HTTP timeout in seconds.</summary>
+    public const string TimeoutEnvVar = "QSORIPPER_CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS";
+
+    /// <summary>Environment variable overriding the refresh interval in seconds.</summary>
+    public const string RefreshIntervalEnvVar = "QSORIPPER_CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS";
+
+    /// <summary>Environment variable overriding the stale-after threshold in seconds.</summary>
+    public const string StaleAfterEnvVar = "QSORIPPER_CONTEST_CALENDAR_STALE_AFTER_SECONDS";
+
+    /// <summary>Environment variable pointing at a reviewed local contest details catalog.</summary>
+    public const string DetailsPathEnvVar = "QSORIPPER_CONTEST_CALENDAR_DETAILS_PATH";
+
+    /// <summary>Default reviewed local contest details catalog path.</summary>
+    public static readonly string DefaultDetailsPath = Path.Combine("data", "contest-calendar", "contest-details.json");
+
+    /// <summary>Default WA7BNM RSS endpoint.</summary>
+    public const string DefaultRssUrl = "https://www.contestcalendar.com/calendar.rss";
+
+    /// <summary>Default HTTP timeout.</summary>
+    public const int DefaultTimeoutSeconds = 8;
+
+    /// <summary>Default refresh interval.</summary>
+    public const int DefaultRefreshIntervalSeconds = 3600;
+
+    /// <summary>Default stale-after threshold.</summary>
+    public const int DefaultStaleAfterSeconds = 86400;
+
+    /// <summary>Gets or sets whether contest calendar fetching is enabled.</summary>
+    public bool Enabled { get; init; } = true;
+
+    /// <summary>Gets or sets the RSS endpoint URL.</summary>
+    [SuppressMessage("Design", "CA1056:URI-like properties should not be strings", Justification = "Stored as string from env vars; passed directly to HttpRequestMessage.")]
+    public string RssUrl { get; init; } = DefaultRssUrl;
+
+    /// <summary>Gets or sets the HTTP request timeout.</summary>
+    public TimeSpan HttpTimeout { get; init; } = TimeSpan.FromSeconds(DefaultTimeoutSeconds);
+
+    /// <summary>Gets or sets the snapshot refresh interval.</summary>
+    public TimeSpan RefreshInterval { get; init; } = TimeSpan.FromSeconds(DefaultRefreshIntervalSeconds);
+
+    /// <summary>Gets or sets the stale-after threshold.</summary>
+    public TimeSpan StaleAfter { get; init; } = TimeSpan.FromSeconds(DefaultStaleAfterSeconds);
+
+    /// <summary>Gets or sets the optional reviewed local details catalog path.</summary>
+    public string DetailsPath { get; init; } = DefaultDetailsPath;
+
+    /// <summary>Gets or sets whether the details path was explicitly configured.</summary>
+    public bool DetailsPathIsExplicit { get; init; }
+
+    /// <summary>Load provider configuration from environment variables.</summary>
+    public static Wa7bnmContestCalendarConfig FromEnvironment()
+    {
+        return new Wa7bnmContestCalendarConfig
+        {
+            Enabled = ParseBool(Environment.GetEnvironmentVariable(EnabledEnvVar), defaultValue: true),
+            RssUrl = Environment.GetEnvironmentVariable(RssUrlEnvVar)?.Trim() is { Length: > 0 } rssUrl
+                ? rssUrl
+                : DefaultRssUrl,
+            HttpTimeout = TimeSpan.FromSeconds(ParseSeconds(Environment.GetEnvironmentVariable(TimeoutEnvVar), DefaultTimeoutSeconds)),
+            RefreshInterval = TimeSpan.FromSeconds(ParseSeconds(Environment.GetEnvironmentVariable(RefreshIntervalEnvVar), DefaultRefreshIntervalSeconds)),
+            StaleAfter = TimeSpan.FromSeconds(ParseSeconds(Environment.GetEnvironmentVariable(StaleAfterEnvVar), DefaultStaleAfterSeconds)),
+            DetailsPath = Environment.GetEnvironmentVariable(DetailsPathEnvVar)?.Trim() is { Length: > 0 } detailsPath
+                ? detailsPath
+                : DefaultDetailsPath,
+            DetailsPathIsExplicit = Environment.GetEnvironmentVariable(DetailsPathEnvVar)?.Trim() is { Length: > 0 },
+        };
+    }
+
+    private static bool ParseBool(string? raw, bool defaultValue)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return defaultValue;
+        }
+
+        return raw.Trim().ToUpperInvariant() switch
+        {
+            "1" or "TRUE" or "YES" or "Y" or "ON" => true,
+            "0" or "FALSE" or "NO" or "N" or "OFF" => false,
+            _ => defaultValue,
+        };
+    }
+
+    private static int ParseSeconds(string? raw, int defaultValue)
+    {
+        return string.IsNullOrWhiteSpace(raw) || !int.TryParse(raw.Trim(), System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var value)
+            ? defaultValue
+            : value;
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.ContestCalendar/Wa7bnmContestCalendarProvider.cs
+++ b/src/dotnet/QsoRipper.Engine.ContestCalendar/Wa7bnmContestCalendarProvider.cs
@@ -1,0 +1,154 @@
+using System.Globalization;
+using System.Xml.Linq;
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Domain;
+
+namespace QsoRipper.Engine.ContestCalendar;
+
+/// <summary>
+/// WA7BNM RSS contest calendar provider.
+/// </summary>
+public sealed class Wa7bnmContestCalendarProvider : IContestCalendarProvider
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _rssUrl;
+
+    public Wa7bnmContestCalendarProvider(HttpClient httpClient, Wa7bnmContestCalendarConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(config);
+
+        _httpClient = httpClient;
+        _rssUrl = config.RssUrl;
+    }
+
+    /// <inheritdoc/>
+    public IReadOnlyList<ContestCalendarEntry> FetchContests()
+    {
+        string body;
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, _rssUrl);
+            using var response = _httpClient.Send(request, HttpCompletionOption.ResponseContentRead);
+            response.EnsureSuccessStatusCode();
+            body = response.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+        }
+        catch (HttpRequestException ex)
+        {
+            throw ContestCalendarProviderException.Transport($"Failed to fetch WA7BNM contest calendar data: {ex.Message}");
+        }
+        catch (TaskCanceledException ex)
+        {
+            throw ContestCalendarProviderException.Transport($"WA7BNM contest calendar request timed out: {ex.Message}");
+        }
+
+        return Wa7bnmRssParser.Parse(body, _rssUrl);
+    }
+}
+
+internal static class Wa7bnmRssParser
+{
+    public static IReadOnlyList<ContestCalendarEntry> Parse(string xml, string fallbackSourceUrl)
+    {
+        XDocument document;
+        try
+        {
+            document = XDocument.Parse(xml);
+        }
+        catch (System.Xml.XmlException ex)
+        {
+            throw ContestCalendarProviderException.Parse(ex.Message);
+        }
+
+        var channel = document.Root?.Element("channel")
+            ?? throw ContestCalendarProviderException.Parse("RSS channel is missing.");
+        var year = DateTimeOffset.TryParse(
+            channel.Element("lastBuildDate")?.Value,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal,
+            out var builtAt)
+            ? builtAt.Year
+            : DateTimeOffset.UtcNow.Year;
+
+        return channel
+            .Elements("item")
+            .Select(item => EntryFromItem(item, year, fallbackSourceUrl))
+            .ToList();
+    }
+
+    private static ContestCalendarEntry EntryFromItem(XElement item, int sourceYear, string fallbackSourceUrl)
+    {
+        var title = item.Element("title")?.Value?.Trim();
+        var description = item.Element("description")?.Value?.Trim();
+        if (string.IsNullOrWhiteSpace(title) || string.IsNullOrWhiteSpace(description))
+        {
+            throw ContestCalendarProviderException.Parse("RSS contest item is missing a title or description.");
+        }
+
+        var (start, end) = ParseSchedule(description, sourceYear);
+        var sourceUrl = item.Element("link")?.Value?.Trim();
+        return new ContestCalendarEntry
+        {
+            ContestId = StableContestId(title, start),
+            Name = title,
+            StartTimeUtc = Timestamp.FromDateTimeOffset(start),
+            EndTimeUtc = Timestamp.FromDateTimeOffset(end),
+            SourceName = "WA7BNM Contest Calendar",
+            SourceUrl = string.IsNullOrWhiteSpace(sourceUrl) ? fallbackSourceUrl : sourceUrl,
+            DetailsStatus = ContestDetailsStatus.MetadataOnly,
+        };
+    }
+
+    private static (DateTimeOffset Start, DateTimeOffset End) ParseSchedule(string description, int sourceYear)
+    {
+        try
+        {
+            var parts = description.Split(',', 2, StringSplitOptions.TrimEntries);
+            if (parts.Length != 2)
+            {
+                throw ContestCalendarProviderException.Parse($"Missing comma in schedule '{description}'.");
+            }
+
+            var times = parts[0].Split('-', 2, StringSplitOptions.TrimEntries);
+            if (times.Length != 2)
+            {
+                throw ContestCalendarProviderException.Parse($"Missing time range in schedule '{description}'.");
+            }
+
+            var date = DateTime.ParseExact(parts[1], ["MMM d", "MMMM d"], CultureInfo.InvariantCulture, DateTimeStyles.None);
+            var startTime = ParseUtcTime(times[0]);
+            var endTime = ParseUtcTime(times[1]);
+            var start = new DateTimeOffset(sourceYear, date.Month, date.Day, startTime.Hour, startTime.Minute, 0, TimeSpan.Zero);
+            var end = new DateTimeOffset(sourceYear, date.Month, date.Day, endTime.Hour, endTime.Minute, 0, TimeSpan.Zero);
+            if (end <= start)
+            {
+                end = end.AddDays(1);
+            }
+
+            return (start, end);
+        }
+        catch (FormatException ex)
+        {
+            throw ContestCalendarProviderException.Parse($"Invalid schedule '{description}': {ex.Message}");
+        }
+    }
+
+    private static TimeOnly ParseUtcTime(string value)
+    {
+        var trimmed = value.Trim().TrimEnd('Z');
+        return TimeOnly.ParseExact(trimmed, "HHmm", CultureInfo.InvariantCulture, DateTimeStyles.None);
+    }
+
+    private static string StableContestId(string name, DateTimeOffset start)
+    {
+        var input = $"{name.Trim().ToUpperInvariant()}\n{start.ToUnixTimeSeconds()}";
+        var hash = 14695981039346656037UL;
+        foreach (var value in input.Select(character => (byte)character))
+        {
+            hash ^= value;
+            hash *= 1099511628211UL;
+        }
+
+        return string.Create(CultureInfo.InvariantCulture, $"wa7bnm-{hash:x16}");
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
@@ -559,6 +559,73 @@ internal sealed class ManagedSpaceWeatherGrpcService(ManagedEngineState state)
 }
 
 [SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Activated by ASP.NET Core gRPC.")]
+internal sealed class ManagedContestCalendarGrpcService(ManagedEngineState state)
+    : ContestCalendarService.ContestCalendarServiceBase
+{
+    public override Task<GetActiveContestsResponse> GetActiveContests(
+        GetActiveContestsRequest request,
+        ServerCallContext context)
+    {
+        var snapshot = state.BuildContestCalendarSnapshot(refreshed: false);
+        var response = new GetActiveContestsResponse
+        {
+            Status = snapshot.Status,
+            FetchedAt = snapshot.FetchedAt,
+            ValidUntil = snapshot.ValidUntil,
+            ErrorMessage = snapshot.ErrorMessage,
+        };
+        response.Contests.AddRange(snapshot.Contests.Where(contest => IsActiveMatch(contest, request)));
+        return Task.FromResult(response);
+    }
+
+    public override Task<RefreshContestCalendarResponse> RefreshContestCalendar(
+        RefreshContestCalendarRequest request,
+        ServerCallContext context)
+    {
+        var snapshot = state.BuildContestCalendarSnapshot(refreshed: true);
+        var response = new RefreshContestCalendarResponse
+        {
+            Status = snapshot.Status,
+            FetchedAt = snapshot.FetchedAt,
+            ValidUntil = snapshot.ValidUntil,
+            ErrorMessage = snapshot.ErrorMessage,
+        };
+        response.Contests.AddRange(snapshot.Contests);
+        return Task.FromResult(response);
+    }
+
+    private static bool IsActiveMatch(ContestCalendarEntry contest, GetActiveContestsRequest request)
+    {
+        var at = request.AtUtc?.ToDateTimeOffset() ?? DateTimeOffset.UtcNow;
+        var through = at.AddMinutes(request.LookaheadMinutes);
+        if (contest.StartTimeUtc is null || contest.EndTimeUtc is null)
+        {
+            return false;
+        }
+
+        var start = contest.StartTimeUtc.ToDateTimeOffset();
+        var end = contest.EndTimeUtc.ToDateTimeOffset();
+        return start <= through
+            && end >= at
+            && EnumFilterMatches(request.HasBand, request.Band, contest.Bands, request.IncludePartialMatches)
+            && EnumFilterMatches(request.HasMode, request.Mode, contest.Modes, request.IncludePartialMatches);
+    }
+
+    private static bool EnumFilterMatches<TEnum>(
+        bool hasFilter,
+        TEnum filter,
+        Google.Protobuf.Collections.RepeatedField<TEnum> values,
+        bool includePartialMatches)
+        where TEnum : struct, Enum
+    {
+        return !hasFilter
+            || EqualityComparer<TEnum>.Default.Equals(filter, default)
+            || values.Contains(filter)
+            || values.Count == 0 && includePartialMatches;
+    }
+}
+
+[SuppressMessage("Performance", "CA1812:Avoid uninstantiated internal classes", Justification = "Activated by ASP.NET Core gRPC.")]
 internal sealed class ManagedGreatCircleGrpcService
     : GreatCircleService.GreatCircleServiceBase
 {

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using QsoRipper.Domain;
+using QsoRipper.Engine.ContestCalendar;
 using QsoRipper.Engine.Lookup;
 using QsoRipper.Engine.QrzLogbook;
 using QsoRipper.Engine.RigControl;
@@ -63,6 +64,7 @@ internal sealed class ManagedEngineState
     private readonly Lock _gate = new();
     private readonly IEngineStorage _storage;
     private ILookupCoordinator _lookupCoordinator;
+    private readonly ContestCalendarMonitor? _contestCalendarMonitor;
     private readonly RigControlMonitor? _rigControlMonitor;
     private readonly SpaceWeatherMonitor? _spaceWeatherMonitor;
     private readonly string _configPath;
@@ -104,16 +106,16 @@ internal sealed class ManagedEngineState
     }
 
     public ManagedEngineState(string configPath, IEngineStorage storage, ILookupCoordinator? lookupCoordinator, RigControlMonitor? rigControlMonitor, SpaceWeatherMonitor? spaceWeatherMonitor)
-        : this(configPath, storage, lookupCoordinator, rigControlMonitor, spaceWeatherMonitor, null, null, null)
+        : this(configPath, storage, lookupCoordinator, null, rigControlMonitor, spaceWeatherMonitor, null, null, null)
     {
     }
 
     public ManagedEngineState(string configPath, IEngineStorage storage, ILookupCoordinator? lookupCoordinator, RigControlMonitor? rigControlMonitor, SpaceWeatherMonitor? spaceWeatherMonitor, QrzSyncEngine? syncEngine)
-        : this(configPath, storage, lookupCoordinator, rigControlMonitor, spaceWeatherMonitor, syncEngine, null, null)
+        : this(configPath, storage, lookupCoordinator, null, rigControlMonitor, spaceWeatherMonitor, syncEngine, null, null)
     {
     }
 
-    public ManagedEngineState(string configPath, IEngineStorage storage, ILookupCoordinator? lookupCoordinator, RigControlMonitor? rigControlMonitor, SpaceWeatherMonitor? spaceWeatherMonitor, QrzSyncEngine? syncEngine, string? currentPersistenceLocation, LoadedSharedSetupConfig? loadedPersistedSetup)
+    public ManagedEngineState(string configPath, IEngineStorage storage, ILookupCoordinator? lookupCoordinator, ContestCalendarMonitor? contestCalendarMonitor, RigControlMonitor? rigControlMonitor, SpaceWeatherMonitor? spaceWeatherMonitor, QrzSyncEngine? syncEngine, string? currentPersistenceLocation, LoadedSharedSetupConfig? loadedPersistedSetup)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
         ArgumentNullException.ThrowIfNull(storage);
@@ -121,6 +123,7 @@ internal sealed class ManagedEngineState
         _configPath = Path.GetFullPath(configPath.Trim());
         _storage = storage;
         _lookupCoordinator = lookupCoordinator ?? CreateDefaultCoordinator(storage);
+        _contestCalendarMonitor = contestCalendarMonitor;
         _rigControlMonitor = rigControlMonitor;
         _spaceWeatherMonitor = spaceWeatherMonitor;
         _ownsSyncEngine = syncEngine is null;
@@ -184,6 +187,7 @@ internal sealed class ManagedEngineState
                 "station-profiles",
                 "runtime-config",
                 "rig-control",
+                "contest-calendar",
                 "space-weather",
                 "purge",
             }
@@ -1084,6 +1088,22 @@ internal sealed class ManagedEngineState
         return refreshed
             ? _spaceWeatherMonitor.RefreshSnapshot()
             : _spaceWeatherMonitor.CurrentSnapshot();
+    }
+
+    public ContestCalendarSnapshot BuildContestCalendarSnapshot(bool refreshed)
+    {
+        if (_contestCalendarMonitor is null)
+        {
+            return new ContestCalendarSnapshot
+            {
+                Status = ContestCalendarStatus.Disabled,
+                ErrorMessage = "Contest calendar not configured",
+            };
+        }
+
+        return refreshed
+            ? _contestCalendarMonitor.RefreshSnapshot()
+            : _contestCalendarMonitor.CurrentSnapshot();
     }
 
     public RuntimeConfigSnapshot GetRuntimeConfigSnapshot()

--- a/src/dotnet/QsoRipper.Engine.DotNet/Program.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/Program.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using QsoRipper.Engine.ContestCalendar;
 using QsoRipper.Engine.DotNet;
 using QsoRipper.Engine.Lookup;
 using QsoRipper.Engine.Lookup.Qrz;
@@ -23,6 +24,7 @@ builder.Services.AddSingleton(resolvedStorage.Storage);
 var lookupCoordinator = CreateLookupCoordinator(resolvedStorage.Storage, persistedSetup.Config);
 builder.Services.AddSingleton(lookupCoordinator);
 
+var contestCalendarMonitor = CreateContestCalendarMonitor();
 var rigControlMonitor = CreateRigControlMonitor();
 var spaceWeatherMonitor = CreateSpaceWeatherMonitor();
 
@@ -30,6 +32,7 @@ builder.Services.AddSingleton(provider => new ManagedEngineState(
     options.ConfigPath,
     provider.GetRequiredService<IEngineStorage>(),
     provider.GetRequiredService<ILookupCoordinator>(),
+    contestCalendarMonitor,
     rigControlMonitor,
     spaceWeatherMonitor,
     null,
@@ -43,6 +46,7 @@ app.MapGrpcService<ManagedStationProfileGrpcService>();
 app.MapGrpcService<ManagedDeveloperControlGrpcService>();
 app.MapGrpcService<ManagedLogbookGrpcService>();
 app.MapGrpcService<ManagedLookupGrpcService>();
+app.MapGrpcService<ManagedContestCalendarGrpcService>();
 app.MapGrpcService<ManagedRigControlGrpcService>();
 app.MapGrpcService<ManagedSpaceWeatherGrpcService>();
 app.MapGrpcService<ManagedGreatCircleGrpcService>();
@@ -118,6 +122,34 @@ static ILookupCoordinator CreateLookupCoordinator(IEngineStorage storage, Shared
     }
 
     return new LookupCoordinator(provider, storage.LookupSnapshots, logbookStore: storage.Logbook);
+}
+
+static ContestCalendarMonitor? CreateContestCalendarMonitor()
+{
+    var config = Wa7bnmContestCalendarConfig.FromEnvironment();
+    if (!config.Enabled)
+    {
+        Console.WriteLine("Contest calendar: disabled");
+        return null;
+    }
+
+    // HttpClient is intentionally not disposed — it is a singleton owned by the provider for the app lifetime.
+#pragma warning disable CA2000 // Dispose objects before losing scope
+    var httpClient = new HttpClient { Timeout = config.HttpTimeout };
+#pragma warning restore CA2000
+    IContestCalendarProvider provider = new Wa7bnmContestCalendarProvider(httpClient, config);
+    if (File.Exists(config.DetailsPath))
+    {
+        provider = new CatalogEnrichingContestCalendarProvider(provider, ContestDetailsCatalog.Load(config.DetailsPath));
+        Console.WriteLine($"Contest calendar: local details catalog enabled ({config.DetailsPath})");
+    }
+    else if (config.DetailsPathIsExplicit)
+    {
+        throw ContestCalendarProviderException.Parse($"Contest calendar details catalog does not exist: {config.DetailsPath}");
+    }
+
+    Console.WriteLine($"Contest calendar: enabled (refresh every {config.RefreshInterval.TotalSeconds}s, stale after {config.StaleAfter.TotalSeconds}s)");
+    return new ContestCalendarMonitor(provider, config.RefreshInterval, config.StaleAfter);
 }
 
 static RigControlMonitor? CreateRigControlMonitor()

--- a/src/dotnet/QsoRipper.Engine.DotNet/QsoRipper.Engine.DotNet.csproj
+++ b/src/dotnet/QsoRipper.Engine.DotNet/QsoRipper.Engine.DotNet.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\QsoRipper.Engine.Lookup.Abstractions\QsoRipper.Engine.Lookup.Abstractions.csproj" />
     <ProjectReference Include="..\QsoRipper.Engine.Lookup.Qrz\QsoRipper.Engine.Lookup.Qrz.csproj" />
+    <ProjectReference Include="..\QsoRipper.Engine.ContestCalendar\QsoRipper.Engine.ContestCalendar.csproj" />
     <ProjectReference Include="..\QsoRipper.Engine.RigControl\QsoRipper.Engine.RigControl.csproj" />
     <ProjectReference Include="..\QsoRipper.Engine.SpaceWeather\QsoRipper.Engine.SpaceWeather.csproj" />
     <ProjectReference Include="..\QsoRipper.Engine.QrzLogbook\QsoRipper.Engine.QrzLogbook.csproj" />

--- a/src/dotnet/QsoRipper.Tools.ContestCatalog.Tests/ContestCatalogGeneratorTests.cs
+++ b/src/dotnet/QsoRipper.Tools.ContestCatalog.Tests/ContestCatalogGeneratorTests.cs
@@ -1,0 +1,321 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using QsoRipper.Tools.ContestCatalog;
+
+namespace QsoRipper.Tools.ContestCatalog.Tests;
+
+public sealed class ContestCatalogGeneratorTests
+{
+    [Fact]
+    public async Task GenerateKeepsScrapedFieldsAsReviewCandidatesByDefault()
+    {
+        using var temp = new TempDirectory();
+        var seedPath = Path.Combine(temp.Path, "seed.json");
+        await File.WriteAllTextAsync(
+            seedPath,
+            """
+            {
+              "version": 1,
+              "entries": [
+                {
+                  "name": "Sample CW Sprint",
+                  "rulesUrl": "https://sponsor.example.test/rules.html"
+                }
+              ]
+            }
+            """);
+
+        using var handler = new StubHttpMessageHandler(request =>
+        {
+            return request.RequestUri?.AbsoluteUri switch
+            {
+                "https://calendar.example.test/calendar.rss" => Rss("Sample CW Sprint", "https://contestcalendar.com/weeklycont.php#sample"),
+                "https://sponsor.example.test/rules.html" => """
+                    <html><body>
+                    <p>Bands: 80 meters, 40 meters, 20 meters and 15 meters.</p>
+                    <p>Mode: CW only.</p>
+                    <p>Exchange: RST and state/province.</p>
+                    </body></html>
+                    """,
+                _ => throw new InvalidOperationException($"Unexpected URL: {request.RequestUri}"),
+            };
+        });
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+
+        var generator = new ContestCatalogGenerator(
+            httpClient,
+            new FrozenTimeProvider(new DateTimeOffset(2026, 5, 23, 22, 0, 0, TimeSpan.Zero)));
+        var catalog = await generator.Generate(
+            new ContestCatalogOptions("https://calendar.example.test/calendar.rss", seedPath, "unused.json", false, true, TimeSpan.FromSeconds(5)),
+            CancellationToken.None);
+
+        var entry = Assert.Single(catalog.Entries);
+        Assert.Empty(entry.Bands);
+        Assert.Empty(entry.Modes);
+        Assert.Null(entry.Exchange);
+        Assert.Equal("metadataOnly", entry.DetailsStatus);
+        Assert.Equal("needsReview", entry.ReviewStatus);
+        Assert.NotNull(entry.CandidateExtraction);
+        Assert.Equal(["80m", "40m", "20m", "15m"], entry.CandidateExtraction.Bands);
+        Assert.Equal(["cw"], entry.CandidateExtraction.Modes);
+        Assert.Equal("RST and state/province", entry.CandidateExtraction.Exchange);
+    }
+
+    [Fact]
+    public async Task GeneratePromotesCandidatesOnlyWhenRequested()
+    {
+        using var temp = new TempDirectory();
+        var seedPath = Path.Combine(temp.Path, "seed.json");
+        await File.WriteAllTextAsync(
+            seedPath,
+            """
+            {
+              "version": 1,
+              "entries": [
+                {
+                  "rssNameAliases": [ "Sample Phone Sprint" ],
+                  "rulesUrl": "https://sponsor.example.test/phone.html"
+                }
+              ]
+            }
+            """);
+
+        using var handler = new StubHttpMessageHandler(request =>
+        {
+            return request.RequestUri?.AbsoluteUri switch
+            {
+                "https://calendar.example.test/calendar.rss" => Rss("Sample Phone Sprint", "https://contestcalendar.com/weeklycont.php#phone"),
+                "https://sponsor.example.test/phone.html" => """
+                    <html><body>
+                    <p>The event runs on 20m and 10m.</p>
+                    <p>Mode: SSB.</p>
+                    <p>Exchange: serial number.</p>
+                    </body></html>
+                    """,
+                _ => throw new InvalidOperationException($"Unexpected URL: {request.RequestUri}"),
+            };
+        });
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+
+        var generator = new ContestCatalogGenerator(
+            httpClient,
+            new FrozenTimeProvider(new DateTimeOffset(2026, 5, 23, 22, 0, 0, TimeSpan.Zero)));
+        var catalog = await generator.Generate(
+            new ContestCatalogOptions("https://calendar.example.test/calendar.rss", seedPath, "unused.json", true, true, TimeSpan.FromSeconds(5)),
+            CancellationToken.None);
+
+        var entry = Assert.Single(catalog.Entries);
+        Assert.Equal(["20m", "10m"], entry.Bands);
+        Assert.Equal(["ssb"], entry.Modes);
+        Assert.Equal("serial number", entry.Exchange);
+        Assert.Equal("partial", entry.DetailsStatus);
+        Assert.Equal("generated", entry.ReviewStatus);
+        Assert.Null(entry.CandidateExtraction);
+    }
+
+    [Fact]
+    public async Task GenerateRefusesToFetchContestCalendarRulesUrls()
+    {
+        using var temp = new TempDirectory();
+        var seedPath = Path.Combine(temp.Path, "seed.json");
+        await File.WriteAllTextAsync(
+            seedPath,
+            """
+            {
+              "version": 1,
+              "entries": [
+                {
+                  "sourceUrl": "https://contestcalendar.com/weeklycont.php#restricted",
+                  "rulesUrl": "https://www.contestcalendar.com/weeklycont.php#restricted"
+                }
+              ]
+            }
+            """);
+
+        using var handler = new StubHttpMessageHandler(request =>
+        {
+            Assert.Equal("https://calendar.example.test/calendar.rss", request.RequestUri?.AbsoluteUri);
+            return Rss("Restricted Contest", "https://contestcalendar.com/weeklycont.php#restricted");
+        });
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+        var generator = new ContestCatalogGenerator(
+            httpClient,
+            new FrozenTimeProvider(new DateTimeOffset(2026, 5, 23, 22, 0, 0, TimeSpan.Zero)));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() => generator.Generate(
+            new ContestCatalogOptions("https://calendar.example.test/calendar.rss", seedPath, "unused.json", false, true, TimeSpan.FromSeconds(5)),
+            CancellationToken.None));
+        Assert.Contains("Refusing to scrape restricted contest calendar host", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GenerateDiscoversDetailsFromCalendarPage()
+    {
+        using var handler = new StubHttpMessageHandler(request =>
+        {
+            return request.RequestUri?.AbsoluteUri switch
+            {
+                "https://www.contestcalendar.com/contestcal.php" => """
+                    <html><body><table>
+                    <tr><td><span class="expandlink"><a href="contestdetails.php?ref=498">+</a></span> CWops Test (CWT)</td><td>1300Z-1400Z, May 6</td></tr>
+                    <tr><td><span class="expandlink"><a href="contestdetails.php?ref=498">+</a></span> CWops Test (CWT)</td><td>1900Z-2000Z, May 6</td></tr>
+                    </table></body></html>
+                    """,
+                "https://www.contestcalendar.com/contestdetails.php?ref=498" => """
+                    <html><body><table>
+                    <tr><td class="bgray" colspan="3"><strong>CWops Test (CWT)</strong></td></tr>
+                    <tr><td>&nbsp;</td><td>Mode:</td><td>CW</td></tr>
+                    <tr><td>&nbsp;</td><td>Bands:</td><td>160, 80, 40, 20, 15, 10m</td></tr>
+                    <tr><td>&nbsp;</td><td>Exchange:</td><td>Member: Name + Member No./"CWA"<br/>non-Member: Name + state/province/country</td></tr>
+                    <tr><td>&nbsp;</td><td>Find rules at:</td><td><a href="https://cwops.example.test/cwops-tests/">https://cwops.example.test/cwops-tests/</a></td></tr>
+                    </table></body></html>
+                    """,
+                "https://cwops.example.test/cwops-tests/" => """
+                    <html><body><p>Official rules page.</p></body></html>
+                    """,
+                _ => throw new InvalidOperationException($"Unexpected URL: {request.RequestUri}"),
+            };
+        });
+        using var httpClient = new HttpClient(handler, disposeHandler: false);
+        var generator = new ContestCatalogGenerator(
+            httpClient,
+            new FrozenTimeProvider(new DateTimeOffset(2026, 5, 23, 22, 0, 0, TimeSpan.Zero)));
+
+        var catalog = await generator.Generate(
+            new ContestCatalogOptions("https://www.contestcalendar.com/contestcal.php", null, "unused.json", false, true, TimeSpan.FromSeconds(5)),
+            CancellationToken.None);
+
+        var entry = Assert.Single(catalog.Entries);
+        Assert.Equal("CWops Test (CWT)", entry.Name);
+        Assert.Equal("https://www.contestcalendar.com/contestdetails.php?ref=498", entry.SourceUrl);
+        Assert.Equal("https://cwops.example.test/cwops-tests/", entry.RulesUrl);
+        Assert.NotNull(entry.CandidateExtraction);
+        Assert.Equal(["160m", "80m", "40m", "20m", "15m", "10m"], entry.CandidateExtraction.Bands);
+        Assert.Equal(["cw"], entry.CandidateExtraction.Modes);
+        Assert.Equal("Member: Name + Member No./\"CWA\"; non-Member: Name + state/province/country", entry.CandidateExtraction.Exchange);
+        Assert.Equal("official-rules", entry.CandidateExtraction.Confidence);
+    }
+
+    [Fact]
+    public void ContestCalendarPageReaderReadsDistinctContestDetailLinks()
+    {
+        var contests = ContestCalendarPageReader.Read(
+            """
+            <html><body><table>
+            <tr><td><span class="expandlink"><a href="contestdetails.php?ref=1">+</a></span> First Contest</td><td>0000Z</td></tr>
+            <tr><td><span class="expandlink"><a href="contestdetails.php?ref=2">+</a></span> Second &amp; Contest</td><td>0100Z</td></tr>
+            <tr><td><span class="expandlink"><a href="contestdetails.php?ref=1">+</a></span> First Contest</td><td>0200Z</td></tr>
+            </table></body></html>
+            """,
+            "https://www.contestcalendar.com/contestcal.php");
+
+        Assert.Collection(
+            contests,
+            first =>
+            {
+                Assert.Equal("First Contest", first.Name);
+                Assert.Equal("https://www.contestcalendar.com/contestdetails.php?ref=1", first.SourceUrl);
+            },
+            second =>
+            {
+                Assert.Equal("Second & Contest", second.Name);
+                Assert.Equal("https://www.contestcalendar.com/contestdetails.php?ref=2", second.SourceUrl);
+            });
+    }
+
+    [Fact]
+    public void SeedCatalogFindsMatchesByNameSourceUrlAndAlias()
+    {
+        SeedCatalogEntry[] seeds =
+        [
+            new("Name Match", null, [], null, [], [], null),
+            new(null, "https://contestcalendar.com/weeklycont.php#source", [], null, [], [], null),
+            new(null, null, ["Alias Match"], null, [], [], null),
+        ];
+
+        Assert.Same(seeds[0], SeedCatalogEntry.FindMatch(seeds, new RssContest("name match", "unused")));
+        Assert.Same(seeds[1], SeedCatalogEntry.FindMatch(seeds, new RssContest("unused", "https://contestcalendar.com/weeklycont.php#source")));
+        Assert.Same(seeds[2], SeedCatalogEntry.FindMatch(seeds, new RssContest("alias match", "unused")));
+    }
+
+    [Fact]
+    public void GeneratedCatalogSerializesReviewableCandidates()
+    {
+        var catalog = new GeneratedCatalog(
+            1,
+            new DateTimeOffset(2026, 5, 23, 22, 0, 0, TimeSpan.Zero),
+            "WA7BNM Contest Calendar RSS",
+            "https://calendar.example.test/calendar.rss",
+            [
+                new GeneratedCatalogEntry(
+                    "Sample Contest",
+                    "https://contestcalendar.com/weeklycont.php#sample",
+                    "https://sponsor.example.test/rules.html",
+                    [],
+                    [],
+                    null,
+                    "metadataOnly",
+                    "needsReview",
+                    new CandidateExtraction(["20m"], ["cw"], "RST", "https://sponsor.example.test/rules.html", new DateTimeOffset(2026, 5, 23, 22, 0, 0, TimeSpan.Zero), "candidate", "https://sponsor.example.test/rules.html")),
+            ]);
+
+        var json = JsonSerializer.Serialize(catalog, ContestCatalogJsonContext.Default.GeneratedCatalog);
+
+        Assert.Contains("\"candidateBands\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"candidateModes\"", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"candidateExtraction\"", json, StringComparison.Ordinal);
+        Assert.Contains("\"detailsStatus\": \"metadataOnly\"", json, StringComparison.Ordinal);
+    }
+
+    private static string Rss(string title, string link)
+    {
+        return $$"""
+            <?xml version="1.0" encoding="UTF-8"?>
+            <rss version="2.0">
+              <channel>
+                <title>Contest Calendar</title>
+                <item>
+                  <title>{{WebUtility.HtmlEncode(title)}}</title>
+                  <link>{{WebUtility.HtmlEncode(link)}}</link>
+                </item>
+              </channel>
+            </rss>
+            """;
+    }
+
+    private sealed class StubHttpMessageHandler(Func<HttpRequestMessage, string> respond) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(respond(request), Encoding.UTF8, "text/plain"),
+            });
+        }
+    }
+
+    private sealed class FrozenTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow()
+        {
+            return utcNow;
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), System.IO.Path.GetRandomFileName());
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Tools.ContestCatalog.Tests/QsoRipper.Tools.ContestCatalog.Tests.csproj
+++ b/src/dotnet/QsoRipper.Tools.ContestCatalog.Tests/QsoRipper.Tools.ContestCatalog.Tests.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QsoRipper.Tools.ContestCatalog\QsoRipper.Tools.ContestCatalog.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/dotnet/QsoRipper.Tools.ContestCatalog/Program.cs
+++ b/src/dotnet/QsoRipper.Tools.ContestCatalog/Program.cs
@@ -1,0 +1,635 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+using QsoRipper.Engine.ContestCalendar;
+
+namespace QsoRipper.Tools.ContestCatalog;
+
+internal static class Program
+{
+    private static async Task Main(string[] args)
+    {
+        var options = ContestCatalogOptions.Parse(args);
+        using var httpClient = new HttpClient { Timeout = options.HttpTimeout };
+        httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("QsoRipperContestCatalog", "0.1"));
+
+        var generator = new ContestCatalogGenerator(httpClient, TimeProvider.System);
+        var catalog = await generator.Generate(options, CancellationToken.None).ConfigureAwait(false);
+
+        var outputDirectory = Path.GetDirectoryName(Path.GetFullPath(options.OutputPath));
+        if (!string.IsNullOrWhiteSpace(outputDirectory))
+        {
+            Directory.CreateDirectory(outputDirectory);
+        }
+
+        await using var output = File.Create(options.OutputPath);
+        await JsonSerializer.SerializeAsync(output, catalog, ContestCatalogJsonContext.Default.GeneratedCatalog, CancellationToken.None).ConfigureAwait(false);
+        await output.WriteAsync("\n"u8.ToArray()).ConfigureAwait(false);
+
+        Console.WriteLine(string.Create(
+            CultureInfo.InvariantCulture,
+            $"Wrote {catalog.Entries.Length} contest catalog entries to {options.OutputPath}. Review before copying into the engine default catalog."));
+    }
+}
+
+internal sealed record ContestCatalogOptions(
+    string SourceUrl,
+    string? SeedPath,
+    string OutputPath,
+    bool PromoteCandidates,
+    bool FetchOfficialRules,
+    TimeSpan HttpTimeout)
+{
+    private const string DefaultCalendarUrl = "https://www.contestcalendar.com/contestcal.php";
+
+    public static ContestCatalogOptions Parse(string[] args)
+    {
+        var sourceUrl = DefaultCalendarUrl;
+        string? seedPath = null;
+        var outputPath = Path.Combine("artifacts", "contest-calendar", "contest-details.generated.json");
+        var promoteCandidates = false;
+        var fetchOfficialRules = true;
+        var timeout = TimeSpan.FromSeconds(15);
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--calendar-url":
+                case "--rss-url":
+                    sourceUrl = ReadValue(args, ref index);
+                    break;
+                case "--seed":
+                    seedPath = ReadValue(args, ref index);
+                    break;
+                case "--output":
+                    outputPath = ReadValue(args, ref index);
+                    break;
+                case "--promote-candidates":
+                    promoteCandidates = true;
+                    break;
+                case "--skip-official-rules":
+                    fetchOfficialRules = false;
+                    break;
+                case "--timeout-seconds":
+                    timeout = TimeSpan.FromSeconds(int.Parse(ReadValue(args, ref index), CultureInfo.InvariantCulture));
+                    break;
+                case "--help":
+                case "-h":
+                    PrintHelp();
+                    Environment.Exit(0);
+                    break;
+                default:
+                    throw new InvalidOperationException($"Unknown argument: {args[index]}");
+            }
+        }
+
+        return new ContestCatalogOptions(sourceUrl, seedPath, outputPath, promoteCandidates, fetchOfficialRules, timeout);
+    }
+
+    private static string ReadValue(string[] args, ref int index)
+    {
+        if (index == args.Length - 1)
+        {
+            throw new InvalidOperationException($"Missing value for {args[index]}.");
+        }
+
+        return args[++index];
+    }
+
+    private static void PrintHelp()
+    {
+        Console.WriteLine(
+            """
+            QsoRipper contest details catalog generator
+
+            Usage:
+              dotnet run --project src\dotnet\QsoRipper.Tools.ContestCatalog -- [options]
+
+            Options:
+              --calendar-url URL        Contest calendar URL. Defaults to the 12-month WA7BNM calendar.
+              --rss-url URL             Alias for --calendar-url.
+              --seed PATH               Optional reviewed seed JSON containing official rules URLs and known fields.
+              --output PATH             Output JSON path. Defaults to artifacts\contest-calendar\contest-details.generated.json.
+              --promote-candidates      Write scraped candidate fields into canonical catalog fields.
+              --skip-official-rules     Use calendar detail pages only; do not fetch official rules URLs.
+              --timeout-seconds N       HTTP timeout. Defaults to 15 seconds.
+            """);
+    }
+}
+
+internal sealed class ContestCatalogGenerator(HttpClient httpClient, TimeProvider clock)
+{
+    public async Task<GeneratedCatalog> Generate(ContestCatalogOptions options, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+
+        var source = await httpClient.GetStringAsync(new Uri(options.SourceUrl), cancellationToken).ConfigureAwait(false);
+        var contests = ContestSourceReader.Read(source, options.SourceUrl);
+        var seeds = options.SeedPath is null ? [] : SeedCatalog.Load(options.SeedPath).Entries;
+        using var concurrency = new SemaphoreSlim(8);
+
+        var entries = await Task.WhenAll(contests.Select(contest => GenerateEntry(
+            contest,
+            seeds,
+            options,
+            concurrency,
+            cancellationToken))).ConfigureAwait(false);
+
+        return new GeneratedCatalog(
+            1,
+            clock.GetUtcNow(),
+            "WA7BNM Contest Calendar",
+            options.SourceUrl,
+            entries
+                .OrderBy(entry => entry.Name, StringComparer.OrdinalIgnoreCase)
+                .ToArray());
+    }
+
+    private async Task<GeneratedCatalogEntry> GenerateEntry(
+        RssContest contest,
+        SeedCatalogEntry[] seeds,
+        ContestCatalogOptions options,
+        SemaphoreSlim concurrency,
+        CancellationToken cancellationToken)
+    {
+        await concurrency.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var seed = SeedCatalogEntry.FindMatch(seeds, contest);
+            CandidateExtraction? candidates = null;
+            var rulesUrl = seed?.RulesUrl;
+            var rulesUrlFromSeed = !string.IsNullOrWhiteSpace(rulesUrl);
+            if (string.IsNullOrWhiteSpace(rulesUrl) && IsContestCalendarDetailUrl(contest.SourceUrl))
+            {
+                var detailHtml = await httpClient.GetStringAsync(new Uri(contest.SourceUrl), cancellationToken).ConfigureAwait(false);
+                candidates = CalendarDetailExtractor.Extract(contest.SourceUrl, detailHtml, clock.GetUtcNow());
+                rulesUrl = candidates.RulesUrl;
+            }
+
+            if (options.FetchOfficialRules && !string.IsNullOrWhiteSpace(rulesUrl))
+            {
+                try
+                {
+                    RulePagePolicy.ThrowIfDenied(rulesUrl);
+                    var rules = await httpClient.GetStringAsync(new Uri(rulesUrl), cancellationToken).ConfigureAwait(false);
+                    candidates = CandidateExtraction.Merge(
+                        RuleTextExtractor.Extract(rulesUrl, rules, clock.GetUtcNow(), rulesUrl),
+                        candidates);
+                }
+                catch (Exception exception) when (!rulesUrlFromSeed && IsRecoverableRulesFetchFailure(exception))
+                {
+                    Console.Error.WriteLine(string.Create(
+                        CultureInfo.InvariantCulture,
+                        $"Skipped official rules URL for {contest.Name}: {exception.Message}"));
+                }
+            }
+
+            return GeneratedCatalogEntry.From(contest, seed, candidates, options.PromoteCandidates);
+        }
+        finally
+        {
+            concurrency.Release();
+        }
+    }
+
+    private static bool IsContestCalendarDetailUrl(string sourceUrl)
+    {
+        return Uri.TryCreate(sourceUrl, UriKind.Absolute, out var uri)
+            && RulePagePolicy.IsContestCalendarHost(uri)
+            && (uri.AbsolutePath.Contains("contestdetails", StringComparison.OrdinalIgnoreCase)
+                || uri.AbsolutePath.Contains("weeklycontdetails", StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsRecoverableRulesFetchFailure(Exception exception)
+    {
+        return exception is HttpRequestException
+            or TaskCanceledException
+            or InvalidOperationException;
+    }
+}
+
+internal static class ContestSourceReader
+{
+    public static IReadOnlyList<RssContest> Read(string content, string sourceUrl)
+    {
+        return content.TrimStart().StartsWith("<rss", StringComparison.OrdinalIgnoreCase)
+            || content.Contains("<rss", StringComparison.OrdinalIgnoreCase)
+            ? ContestRssReader.Read(content, sourceUrl)
+            : ContestCalendarPageReader.Read(content, sourceUrl);
+    }
+}
+
+internal static class ContestRssReader
+{
+    public static IReadOnlyList<RssContest> Read(string xml, string fallbackSourceUrl)
+    {
+        var document = XDocument.Parse(xml);
+        var channel = document.Root?.Element("channel") ?? throw new InvalidOperationException("RSS channel is missing.");
+        return channel
+            .Elements("item")
+            .Select(item => new RssContest(
+                item.Element("title")?.Value?.Trim() ?? throw new InvalidOperationException("RSS item is missing title."),
+                item.Element("link")?.Value?.Trim() is { Length: > 0 } link ? link : fallbackSourceUrl))
+            .ToArray();
+    }
+}
+
+internal static partial class ContestCalendarPageReader
+{
+    public static IReadOnlyList<RssContest> Read(string html, string sourceUrl)
+    {
+        var baseUri = new Uri(sourceUrl);
+        return CalendarEntryRegex()
+            .Matches(html)
+            .Select(match => new RssContest(
+                CleanHtml(match.Groups["name"].Value),
+                new Uri(baseUri, WebUtility.HtmlDecode(match.Groups["href"].Value)).AbsoluteUri))
+            .Where(contest => !string.IsNullOrWhiteSpace(contest.Name))
+            .GroupBy(contest => contest.Name, StringComparer.OrdinalIgnoreCase)
+            .Select(group => group.First())
+            .ToArray();
+    }
+
+    private static string CleanHtml(string html)
+    {
+        return WebUtility.HtmlDecode(TagRegex().Replace(html, " ")).Trim();
+    }
+
+    [GeneratedRegex("<tr[^>]*>\\s*<td[^>]*>\\s*<span[^>]*>\\s*<a[^>]*href=\"(?<href>[^\"]*contestdetails\\.php\\?ref=[^\"]+)\"[^>]*>\\+</a>\\s*</span>\\s*(?<name>.*?)</td>\\s*<td", RegexOptions.IgnoreCase | RegexOptions.Singleline, 100)]
+    private static partial Regex CalendarEntryRegex();
+
+    [GeneratedRegex("<[^>]+>", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex TagRegex();
+}
+
+internal static class RulePagePolicy
+{
+    private static readonly HashSet<string> DeniedHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "contestcalendar.com",
+        "www.contestcalendar.com",
+        "wa7bnm.com",
+        "www.wa7bnm.com",
+    };
+
+    public static bool IsContestCalendarHost(Uri uri)
+    {
+        return DeniedHosts.Contains(uri.Host);
+    }
+
+    public static void ThrowIfDenied(string rulesUrl)
+    {
+        if (!Uri.TryCreate(rulesUrl, UriKind.Absolute, out var uri))
+        {
+            throw new InvalidOperationException($"Rules URL is not absolute: {rulesUrl}");
+        }
+
+        if (DeniedHosts.Contains(uri.Host))
+        {
+            throw new InvalidOperationException($"Refusing to scrape restricted contest calendar host: {uri.Host}");
+        }
+    }
+}
+
+internal static partial class CalendarDetailExtractor
+{
+    public static CandidateExtraction Extract(string sourceUrl, string html, DateTimeOffset fetchedAtUtc)
+    {
+        var rulesUrl = ExtractRulesUrl(sourceUrl, html);
+        return new CandidateExtraction(
+            ExtractBands(ExtractField(html, "Bands")),
+            ExtractModes(ExtractField(html, "Mode")),
+            ExtractExchange(ExtractField(html, "Exchange")),
+            sourceUrl,
+            fetchedAtUtc,
+            "calendar-detail",
+            rulesUrl);
+    }
+
+    private static string? ExtractField(string html, string label)
+    {
+        var match = Regex.Match(
+            html,
+            string.Create(CultureInfo.InvariantCulture, $@"<td[^>]*>\s*{Regex.Escape(label)}:\s*</td>\s*<td[^>]*>(?<value>.*?)</td>"),
+            RegexOptions.IgnoreCase | RegexOptions.Singleline,
+            TimeSpan.FromMilliseconds(100));
+        return match.Success ? CleanHtml(match.Groups["value"].Value) : null;
+    }
+
+    private static string? ExtractRulesUrl(string sourceUrl, string html)
+    {
+        var match = RulesUrlRegex().Match(html);
+        return match.Success
+            ? new Uri(new Uri(sourceUrl), WebUtility.HtmlDecode(match.Groups["href"].Value)).AbsoluteUri
+            : null;
+    }
+
+    private static string[] ExtractBands(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return [];
+        }
+
+        var bands = new SortedSet<string>(BandComparer.Instance);
+        foreach (Match match in DetailBandRegex().Matches(text))
+        {
+            bands.Add(string.Create(CultureInfo.InvariantCulture, $"{match.Groups[1].Value}m"));
+        }
+
+        if (DetailSeventyCentimeterRegex().IsMatch(text))
+        {
+            bands.Add("70cm");
+        }
+
+        return bands.ToArray();
+    }
+
+    private static string[] ExtractModes(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return [];
+        }
+
+        var modes = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        RuleTextExtractor.AddModeIfPresent(text, "CW", "cw", modes);
+        RuleTextExtractor.AddModeIfPresent(text, "SSB", "ssb", modes);
+        RuleTextExtractor.AddModeIfPresent(text, "PHONE", "ssb", modes);
+        RuleTextExtractor.AddModeIfPresent(text, "RTTY", "rtty", modes);
+        RuleTextExtractor.AddModeIfPresent(text, "FT8", "ft8", modes);
+        RuleTextExtractor.AddModeIfPresent(text, "FT4", "ft4", modes);
+        RuleTextExtractor.AddModeIfPresent(text, "DIG", "digital", modes);
+        RuleTextExtractor.AddModeIfPresent(text, "DIGITAL", "digital", modes);
+        RuleTextExtractor.AddModeIfPresent(text, "FM", "fm", modes);
+        RuleTextExtractor.AddModeIfPresent(text, "AM", "am", modes);
+        return modes.ToArray();
+    }
+
+    private static string? ExtractExchange(string? text)
+    {
+        return string.IsNullOrWhiteSpace(text) ? null : text;
+    }
+
+    private static string CleanHtml(string html)
+    {
+        var withBreaks = BreakRegex().Replace(html, "; ");
+        return WebUtility.HtmlDecode(TagRegex().Replace(withBreaks, " ")).Trim();
+    }
+
+    [GeneratedRegex("<br\\s*/?>", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex BreakRegex();
+
+    [GeneratedRegex("<[^>]+>", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex TagRegex();
+
+    [GeneratedRegex("Find\\s+rules\\s+at:\\s*</td>\\s*<td[^>]*>\\s*<a[^>]*href=\"(?<href>[^\"]+)\"", RegexOptions.IgnoreCase | RegexOptions.Singleline, 100)]
+    private static partial Regex RulesUrlRegex();
+
+    [GeneratedRegex("\\b(160|80|40|30|20|17|15|12|10|6|2)\\s*(?:m|meter|meters|metre|metres)?\\b", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex DetailBandRegex();
+
+    [GeneratedRegex("\\b70\\s*(?:cm|centimeter|centimeters|centimetre|centimetres)\\b", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex DetailSeventyCentimeterRegex();
+}
+
+internal static partial class RuleTextExtractor
+{
+    public static CandidateExtraction Extract(string sourceUrl, string html, DateTimeOffset fetchedAtUtc, string? rulesUrl = null)
+    {
+        var text = NormalizeText(StripHtml(html));
+        return new CandidateExtraction(
+            ExtractBands(text),
+            ExtractModes(text),
+            ExtractExchange(text),
+            sourceUrl,
+            fetchedAtUtc,
+            "official-rules",
+            rulesUrl);
+    }
+
+    private static string StripHtml(string html)
+    {
+        var withoutScripts = ScriptOrStyleRegex().Replace(html, " ");
+        var withoutTags = TagRegex().Replace(withoutScripts, " ");
+        return WebUtility.HtmlDecode(withoutTags);
+    }
+
+    private static string NormalizeText(string text)
+    {
+        return WhitespaceRegex().Replace(text, " ").Trim();
+    }
+
+    private static string[] ExtractBands(string text)
+    {
+        var bands = new SortedSet<string>(BandComparer.Instance);
+        foreach (Match match in BandRegex().Matches(text))
+        {
+            bands.Add(string.Create(CultureInfo.InvariantCulture, $"{match.Groups[1].Value}m"));
+        }
+
+        if (SeventyCentimeterRegex().IsMatch(text))
+        {
+            bands.Add("70cm");
+        }
+
+        return bands.ToArray();
+    }
+
+    private static string[] ExtractModes(string text)
+    {
+        var modes = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        AddModeIfPresent(text, "CW", "cw", modes);
+        AddModeIfPresent(text, "SSB", "ssb", modes);
+        AddModeIfPresent(text, "PHONE", "ssb", modes);
+        AddModeIfPresent(text, "RTTY", "rtty", modes);
+        AddModeIfPresent(text, "FT8", "ft8", modes);
+        AddModeIfPresent(text, "FT4", "ft4", modes);
+        AddModeIfPresent(text, "DIG", "digital", modes);
+        AddModeIfPresent(text, "DIGITAL", "digital", modes);
+        AddModeIfPresent(text, "FM", "fm", modes);
+        AddModeIfPresent(text, "AM", "am", modes);
+        return modes.ToArray();
+    }
+
+    public static void AddModeIfPresent(string text, string token, string mode, SortedSet<string> modes)
+    {
+        if (Regex.IsMatch(text, string.Create(CultureInfo.InvariantCulture, $@"\b{Regex.Escape(token)}\b"), RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100)))
+        {
+            modes.Add(mode);
+        }
+    }
+
+    private static string? ExtractExchange(string text)
+    {
+        var match = ExchangeRegex().Match(text);
+        if (!match.Success)
+        {
+            return null;
+        }
+
+        var exchange = match.Groups[1].Value.Trim(' ', ':', '-', '–');
+        return exchange.Length > 160 ? string.Concat(exchange.AsSpan(0, 157), "...") : exchange;
+    }
+
+    [GeneratedRegex("<(script|style)\\b[^>]*>.*?</\\1>", RegexOptions.IgnoreCase | RegexOptions.Singleline, 100)]
+    private static partial Regex ScriptOrStyleRegex();
+
+    [GeneratedRegex("<[^>]+>", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex TagRegex();
+
+    [GeneratedRegex("\\s+", RegexOptions.None, 100)]
+    private static partial Regex WhitespaceRegex();
+
+    [GeneratedRegex("\\b(160|80|40|30|20|17|15|12|10|6|2)\\s*(?:m|meter|meters|metre|metres)\\b", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex BandRegex();
+
+    [GeneratedRegex("\\b70\\s*(?:cm|centimeter|centimeters|centimetre|centimetres)\\b", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex SeventyCentimeterRegex();
+
+    [GeneratedRegex("\\bexchange\\b\\s*(?:is|:)?\\s*([^.;]{1,220})", RegexOptions.IgnoreCase, 100)]
+    private static partial Regex ExchangeRegex();
+}
+
+internal sealed class BandComparer : IComparer<string>
+{
+    public static readonly BandComparer Instance = new();
+
+    private static readonly string[] Order = ["160m", "80m", "40m", "30m", "20m", "17m", "15m", "12m", "10m", "6m", "2m", "70cm"];
+
+    public int Compare(string? x, string? y)
+    {
+        return Array.IndexOf(Order, x) is var left && Array.IndexOf(Order, y) is var right && left != right
+            ? left.CompareTo(right)
+            : string.Compare(x, y, StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+internal sealed record RssContest(string Name, string SourceUrl);
+
+internal sealed record GeneratedCatalog(
+    int Version,
+    DateTimeOffset GeneratedAtUtc,
+    string SourceName,
+    string SourceUrl,
+    GeneratedCatalogEntry[] Entries);
+
+internal sealed record GeneratedCatalogEntry(
+    string Name,
+    string SourceUrl,
+    string? RulesUrl,
+    string[] Bands,
+    string[] Modes,
+    string? Exchange,
+    string DetailsStatus,
+    string ReviewStatus,
+    [property: JsonIgnore]
+    CandidateExtraction? CandidateExtraction)
+{
+    public string[]? CandidateBands => CandidateExtraction?.Bands;
+
+    public string[]? CandidateModes => CandidateExtraction?.Modes;
+
+    public string? CandidateExchange => CandidateExtraction?.Exchange;
+
+    public string? CandidateSourceUrl => CandidateExtraction?.SourceUrl;
+
+    public DateTimeOffset? CandidateFetchedAtUtc => CandidateExtraction?.FetchedAtUtc;
+
+    public string? CandidateConfidence => CandidateExtraction?.Confidence;
+
+    public static GeneratedCatalogEntry From(RssContest contest, SeedCatalogEntry? seed, CandidateExtraction? candidates, bool promoteCandidates)
+    {
+        var bands = seed?.Bands is { Length: > 0 } seedBands ? seedBands : [];
+        var modes = seed?.Modes is { Length: > 0 } seedModes ? seedModes : [];
+        var exchange = seed?.Exchange;
+        if (promoteCandidates)
+        {
+            bands = bands.Length > 0 ? bands : candidates?.Bands ?? [];
+            modes = modes.Length > 0 ? modes : candidates?.Modes ?? [];
+            exchange = string.IsNullOrWhiteSpace(exchange) ? candidates?.Exchange : exchange;
+        }
+
+        return new GeneratedCatalogEntry(
+            contest.Name,
+            contest.SourceUrl,
+            seed?.RulesUrl ?? candidates?.RulesUrl,
+            bands,
+            modes,
+            exchange,
+            bands.Length > 0 || modes.Length > 0 || !string.IsNullOrWhiteSpace(exchange) ? "partial" : "metadataOnly",
+            promoteCandidates ? "generated" : "needsReview",
+            promoteCandidates ? null : candidates);
+    }
+}
+
+internal sealed record CandidateExtraction(
+    string[] Bands,
+    string[] Modes,
+    string? Exchange,
+    string SourceUrl,
+    DateTimeOffset FetchedAtUtc,
+    string Confidence,
+    string? RulesUrl)
+{
+    public static CandidateExtraction? Merge(CandidateExtraction primary, CandidateExtraction? fallback)
+    {
+        return new CandidateExtraction(
+            fallback?.Bands is { Length: > 0 } fallbackBands ? fallbackBands : primary.Bands,
+            fallback?.Modes is { Length: > 0 } fallbackModes ? fallbackModes : primary.Modes,
+            string.IsNullOrWhiteSpace(fallback?.Exchange) ? primary.Exchange : fallback.Exchange,
+            primary.SourceUrl,
+            primary.FetchedAtUtc,
+            primary.Confidence,
+            primary.RulesUrl ?? fallback?.RulesUrl);
+    }
+}
+
+internal sealed record SeedCatalog(int Version, SeedCatalogEntry[] Entries)
+{
+    public static SeedCatalog Load(string path)
+    {
+        using var stream = File.OpenRead(path);
+        var catalog = JsonSerializer.Deserialize(stream, ContestCatalogJsonContext.Default.SeedCatalog)
+            ?? new SeedCatalog(1, []);
+        return catalog.Entries is null ? catalog with { Entries = [] } : catalog;
+    }
+}
+
+internal sealed record SeedCatalogEntry(
+    string? Name,
+    string? SourceUrl,
+    string[] RssNameAliases,
+    string? RulesUrl,
+    string[] Bands,
+    string[] Modes,
+    string? Exchange)
+{
+    public static SeedCatalogEntry? FindMatch(IEnumerable<SeedCatalogEntry> seeds, RssContest contest)
+    {
+        return seeds.FirstOrDefault(seed =>
+            Matches(seed.Name, contest.Name)
+            || Matches(seed.SourceUrl, contest.SourceUrl)
+            || (seed.RssNameAliases ?? []).Any(alias => Matches(alias, contest.Name)));
+    }
+
+    private static bool Matches(string? left, string right)
+    {
+        return !string.IsNullOrWhiteSpace(left)
+            && string.Equals(left.Trim(), right.Trim(), StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    PropertyNameCaseInsensitive = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+    WriteIndented = true)]
+[JsonSerializable(typeof(GeneratedCatalog))]
+[JsonSerializable(typeof(SeedCatalog))]
+internal sealed partial class ContestCatalogJsonContext : JsonSerializerContext;

--- a/src/dotnet/QsoRipper.Tools.ContestCatalog/QsoRipper.Tools.ContestCatalog.csproj
+++ b/src/dotnet/QsoRipper.Tools.ContestCatalog/QsoRipper.Tools.ContestCatalog.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QsoRipper.Engine.ContestCalendar\QsoRipper.Engine.ContestCalendar.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="QsoRipper.Tools.ContestCatalog.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/src/dotnet/QsoRipper.slnx
+++ b/src/dotnet/QsoRipper.slnx
@@ -6,6 +6,8 @@
   <Project Path="QsoRipper.DebugHost.Tests/QsoRipper.DebugHost.Tests.csproj" />
   <Project Path="QsoRipper.Engine.DotNet/QsoRipper.Engine.DotNet.csproj" />
   <Project Path="QsoRipper.Engine.DotNet.Tests/QsoRipper.Engine.DotNet.Tests.csproj" />
+  <Project Path="QsoRipper.Engine.ContestCalendar/QsoRipper.Engine.ContestCalendar.csproj" />
+  <Project Path="QsoRipper.Engine.ContestCalendar.Tests/QsoRipper.Engine.ContestCalendar.Tests.csproj" />
   <Project Path="QsoRipper.Engine.RigControl/QsoRipper.Engine.RigControl.csproj" />
   <Project Path="QsoRipper.Engine.RigControl.Tests/QsoRipper.Engine.RigControl.Tests.csproj" />
   <Project Path="QsoRipper.Engine.Lookup.Abstractions/QsoRipper.Engine.Lookup.Abstractions.csproj" />
@@ -21,6 +23,8 @@
   <Project Path="QsoRipper.Engine.QrzLogbook/QsoRipper.Engine.QrzLogbook.csproj" />
   <Project Path="QsoRipper.Engine.QrzLogbook.Tests/QsoRipper.Engine.QrzLogbook.Tests.csproj" />
   <Project Path="QsoRipper.EngineSelection/QsoRipper.EngineSelection.csproj" />
+  <Project Path="QsoRipper.Tools.ContestCatalog/QsoRipper.Tools.ContestCatalog.csproj" />
+  <Project Path="QsoRipper.Tools.ContestCatalog.Tests/QsoRipper.Tools.ContestCatalog.Tests.csproj" />
   <Project Path="QsoRipper.Gui/QsoRipper.Gui.csproj" />
   <Project Path="QsoRipper.Gui.Tests/QsoRipper.Gui.Tests.csproj" />
 </Solution>

--- a/src/rust/qsoripper-core/src/contest_calendar/catalog.rs
+++ b/src/rust/qsoripper-core/src/contest_calendar/catalog.rs
@@ -1,0 +1,321 @@
+//! Local reviewed contest details catalog enrichment.
+
+use std::{fs::File, path::Path, sync::Arc};
+
+use serde::Deserialize;
+
+use crate::proto::qsoripper::domain::{Band, ContestCalendarEntry, ContestDetailsStatus, Mode};
+
+use super::provider::{ContestCalendarProvider, ContestCalendarProviderError};
+
+/// Environment variable pointing at a reviewed local contest details catalog.
+pub const CONTEST_CALENDAR_DETAILS_PATH_ENV_VAR: &str = "QSORIPPER_CONTEST_CALENDAR_DETAILS_PATH";
+/// Default reviewed local contest details catalog path.
+pub const DEFAULT_CONTEST_CALENDAR_DETAILS_PATH: &str =
+    "data/contest-calendar/contest-details.json";
+
+/// Reviewed local contest details used to enrich calendar metadata.
+pub struct ContestDetailsCatalog {
+    entries: Vec<ContestDetailsCatalogEntry>,
+}
+
+impl ContestDetailsCatalog {
+    /// Load a reviewed local details catalog from JSON.
+    ///
+    /// # Errors
+    ///
+    /// Returns a parse error when the file cannot be read or decoded.
+    pub fn load(path: impl AsRef<Path>) -> Result<Self, ContestCalendarProviderError> {
+        let path = path.as_ref();
+        let file = File::open(path).map_err(|error| {
+            ContestCalendarProviderError::parse(format!(
+                "failed to read contest details catalog '{}': {error}",
+                path.display()
+            ))
+        })?;
+        let document: ContestDetailsCatalogFile =
+            serde_json::from_reader(file).map_err(|error| {
+                ContestCalendarProviderError::parse(format!(
+                    "failed to parse contest details catalog '{}': {error}",
+                    path.display()
+                ))
+            })?;
+        Ok(Self {
+            entries: document.entries.into_iter().map(Into::into).collect(),
+        })
+    }
+
+    /// Enrich a contest entry with matching local catalog details.
+    #[must_use]
+    pub fn enrich(&self, contest: &ContestCalendarEntry) -> ContestCalendarEntry {
+        let Some(entry) = self.entries.iter().find(|entry| entry.is_match(contest)) else {
+            return contest.clone();
+        };
+
+        let mut enriched = contest.clone();
+        if !entry.bands.is_empty() {
+            enriched.bands.clone_from(&entry.bands);
+        }
+        if !entry.modes.is_empty() {
+            enriched.modes.clone_from(&entry.modes);
+        }
+        if let Some(exchange) = entry.exchange.as_ref().filter(|value| !value.is_empty()) {
+            enriched.exchange = Some(exchange.clone());
+        }
+        if let Some(rules_url) = entry.rules_url.as_ref().filter(|value| !value.is_empty()) {
+            enriched.rules_url = Some(rules_url.clone());
+        }
+        enriched.details_status = entry.details_status;
+        enriched
+    }
+}
+
+/// Decorates contest calendar metadata with reviewed local contest details.
+pub struct CatalogEnrichingContestCalendarProvider {
+    inner: Arc<dyn ContestCalendarProvider>,
+    catalog: ContestDetailsCatalog,
+}
+
+impl CatalogEnrichingContestCalendarProvider {
+    /// Create a catalog-enriching provider.
+    #[must_use]
+    pub fn new(inner: Arc<dyn ContestCalendarProvider>, catalog: ContestDetailsCatalog) -> Self {
+        Self { inner, catalog }
+    }
+}
+
+#[tonic::async_trait]
+impl ContestCalendarProvider for CatalogEnrichingContestCalendarProvider {
+    async fn fetch_contests(
+        &self,
+    ) -> Result<Vec<ContestCalendarEntry>, ContestCalendarProviderError> {
+        Ok(self
+            .inner
+            .fetch_contests()
+            .await?
+            .iter()
+            .map(|contest| self.catalog.enrich(contest))
+            .collect())
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ContestDetailsCatalogFile {
+    #[serde(default)]
+    entries: Vec<ContestDetailsCatalogItem>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ContestDetailsCatalogItem {
+    #[serde(default)]
+    #[serde(alias = "contestId")]
+    contest_id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    #[serde(alias = "sourceUrl")]
+    source_url: Option<String>,
+    #[serde(default)]
+    bands: Vec<String>,
+    #[serde(default)]
+    modes: Vec<String>,
+    #[serde(default)]
+    exchange: Option<String>,
+    #[serde(default)]
+    #[serde(alias = "rulesUrl")]
+    rules_url: Option<String>,
+    #[serde(default)]
+    #[serde(alias = "detailsStatus")]
+    details_status: Option<String>,
+}
+
+struct ContestDetailsCatalogEntry {
+    contest_id: String,
+    name: String,
+    source_url: String,
+    bands: Vec<i32>,
+    modes: Vec<i32>,
+    exchange: Option<String>,
+    rules_url: Option<String>,
+    details_status: i32,
+}
+
+impl ContestDetailsCatalogEntry {
+    fn is_match(&self, contest: &ContestCalendarEntry) -> bool {
+        if !self.contest_id.is_empty()
+            && self.contest_id == normalize(Some(contest.contest_id.as_str()))
+        {
+            return true;
+        }
+
+        if !self.source_url.is_empty()
+            && self.source_url == normalize(contest.source_url.as_deref())
+        {
+            return true;
+        }
+
+        !self.name.is_empty() && self.name == normalize(Some(contest.name.as_str()))
+    }
+}
+
+impl From<ContestDetailsCatalogItem> for ContestDetailsCatalogEntry {
+    fn from(value: ContestDetailsCatalogItem) -> Self {
+        Self {
+            contest_id: normalize(value.contest_id.as_deref()),
+            name: normalize(value.name.as_deref()),
+            source_url: normalize(value.source_url.as_deref()),
+            bands: value
+                .bands
+                .iter()
+                .filter_map(|band| parse_band(band))
+                .map(|band| band as i32)
+                .collect(),
+            modes: value
+                .modes
+                .iter()
+                .filter_map(|mode| parse_mode(mode))
+                .map(|mode| mode as i32)
+                .collect(),
+            exchange: value.exchange.map(|value| value.trim().to_string()),
+            rules_url: value.rules_url.map(|value| value.trim().to_string()),
+            details_status: parse_details_status(value.details_status.as_deref()) as i32,
+        }
+    }
+}
+
+fn normalize(value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_ascii_uppercase)
+        .unwrap_or_default()
+}
+
+fn parse_details_status(value: Option<&str>) -> ContestDetailsStatus {
+    match normalize(value).as_str() {
+        "FULL" => ContestDetailsStatus::Full,
+        "METADATAONLY" | "METADATA_ONLY" => ContestDetailsStatus::MetadataOnly,
+        _ => ContestDetailsStatus::Partial,
+    }
+}
+
+fn parse_band(value: &str) -> Option<Band> {
+    Some(match normalize(Some(value)).as_str() {
+        "160M" => Band::Band160m,
+        "80M" => Band::Band80m,
+        "40M" => Band::Band40m,
+        "30M" => Band::Band30m,
+        "20M" => Band::Band20m,
+        "17M" => Band::Band17m,
+        "15M" => Band::Band15m,
+        "12M" => Band::Band12m,
+        "10M" => Band::Band10m,
+        "6M" => Band::Band6m,
+        "2M" => Band::Band2m,
+        "70CM" => Band::Band70cm,
+        _ => return None,
+    })
+}
+
+fn parse_mode(value: &str) -> Option<Mode> {
+    Some(match normalize(Some(value)).as_str() {
+        "CW" => Mode::Cw,
+        "SSB" => Mode::Ssb,
+        "RTTY" => Mode::Rtty,
+        "FT8" => Mode::Ft8,
+        "FM" => Mode::Fm,
+        "AM" => Mode::Am,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use std::{fs, path::PathBuf, time::SystemTime};
+
+    use super::*;
+
+    #[test]
+    fn catalog_enriches_by_name() {
+        let path = temp_catalog_path();
+        fs::write(
+            &path,
+            r#"{
+                "entries": [{
+                    "name": "Real Time Contest",
+                    "bands": ["20m", "40m"],
+                    "modes": ["cw", "ssb"],
+                    "exchange": "RST + serial",
+                    "rulesUrl": "https://example.test/rules",
+                    "detailsStatus": "full"
+                }]
+            }"#,
+        )
+        .expect("write catalog");
+
+        let catalog = ContestDetailsCatalog::load(path.clone()).expect("catalog");
+        let contest = ContestCalendarEntry {
+            contest_id: "contest".to_string(),
+            name: "Real Time Contest".to_string(),
+            source_name: "WA7BNM Contest Calendar".to_string(),
+            details_status: ContestDetailsStatus::MetadataOnly as i32,
+            ..ContestCalendarEntry::default()
+        };
+
+        let enriched = catalog.enrich(&contest);
+
+        assert_eq!(
+            enriched.bands,
+            vec![Band::Band20m as i32, Band::Band40m as i32]
+        );
+        assert_eq!(enriched.modes, vec![Mode::Cw as i32, Mode::Ssb as i32]);
+        assert_eq!(enriched.exchange.as_deref(), Some("RST + serial"));
+        assert_eq!(
+            enriched.rules_url.as_deref(),
+            Some("https://example.test/rules")
+        );
+        assert_eq!(enriched.details_status, ContestDetailsStatus::Full as i32);
+        fs::remove_file(path).expect("remove catalog");
+    }
+
+    #[test]
+    fn catalog_preserves_metadata_only_status() {
+        let path = temp_catalog_path();
+        fs::write(
+            &path,
+            r#"{
+                "entries": [{
+                    "contestId": "contest",
+                    "detailsStatus": "metadataOnly"
+                }]
+            }"#,
+        )
+        .expect("write catalog");
+
+        let catalog = ContestDetailsCatalog::load(path.clone()).expect("catalog");
+        let contest = ContestCalendarEntry {
+            contest_id: "contest".to_string(),
+            details_status: ContestDetailsStatus::Partial as i32,
+            ..ContestCalendarEntry::default()
+        };
+
+        let enriched = catalog.enrich(&contest);
+
+        assert_eq!(
+            enriched.details_status,
+            ContestDetailsStatus::MetadataOnly as i32
+        );
+        fs::remove_file(path).expect("remove catalog");
+    }
+
+    fn temp_catalog_path() -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "qsoripper-contest-catalog-{:?}.json",
+            SystemTime::now()
+                .duration_since(SystemTime::UNIX_EPOCH)
+                .expect("time")
+                .as_nanos()
+        ))
+    }
+}

--- a/src/rust/qsoripper-core/src/contest_calendar/mod.rs
+++ b/src/rust/qsoripper-core/src/contest_calendar/mod.rs
@@ -1,0 +1,24 @@
+//! Contest calendar providers, caching, and filtering.
+
+mod catalog;
+mod monitor;
+mod provider;
+mod wa7bnm;
+
+pub use catalog::{
+    CatalogEnrichingContestCalendarProvider, ContestDetailsCatalog,
+    CONTEST_CALENDAR_DETAILS_PATH_ENV_VAR, DEFAULT_CONTEST_CALENDAR_DETAILS_PATH,
+};
+pub use monitor::{ContestCalendarMonitor, ContestCalendarSnapshot};
+pub use provider::{
+    ContestCalendarProvider, ContestCalendarProviderError, ContestCalendarProviderErrorKind,
+    DisabledContestCalendarProvider,
+};
+pub use wa7bnm::{
+    Wa7bnmContestCalendarConfig, Wa7bnmContestCalendarProvider, CONTEST_CALENDAR_ENABLED_ENV_VAR,
+    CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS_ENV_VAR,
+    CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS_ENV_VAR, CONTEST_CALENDAR_RSS_URL_ENV_VAR,
+    CONTEST_CALENDAR_STALE_AFTER_SECONDS_ENV_VAR, DEFAULT_CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS,
+    DEFAULT_CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS, DEFAULT_CONTEST_CALENDAR_RSS_URL,
+    DEFAULT_CONTEST_CALENDAR_STALE_AFTER_SECONDS,
+};

--- a/src/rust/qsoripper-core/src/contest_calendar/monitor.rs
+++ b/src/rust/qsoripper-core/src/contest_calendar/monitor.rs
@@ -1,0 +1,151 @@
+//! Cached contest calendar snapshots.
+
+use std::{
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+use prost_types::Timestamp;
+use tokio::sync::RwLock;
+
+use crate::proto::qsoripper::domain::{ContestCalendarEntry, ContestCalendarStatus};
+
+use super::provider::ContestCalendarProvider;
+
+#[derive(Clone)]
+struct CachedSnapshot {
+    contests: Vec<ContestCalendarEntry>,
+    fetched_at: Timestamp,
+    fetched_monotonic: Instant,
+}
+
+/// Current contest calendar entries plus freshness metadata.
+#[derive(Clone, Default)]
+pub struct ContestCalendarSnapshot {
+    /// Normalized contest entries.
+    pub contests: Vec<ContestCalendarEntry>,
+    /// Snapshot freshness/error status.
+    pub status: ContestCalendarStatus,
+    /// UTC time when this snapshot was fetched.
+    pub fetched_at: Option<Timestamp>,
+    /// UTC time until which the snapshot should be treated as fresh.
+    pub valid_until: Option<Timestamp>,
+    /// Human-readable provider error, when present.
+    pub error_message: Option<String>,
+}
+
+/// Small cache around the current contest calendar provider.
+pub struct ContestCalendarMonitor {
+    provider: Arc<dyn ContestCalendarProvider>,
+    refresh_interval: Duration,
+    stale_after: Duration,
+    state: RwLock<Option<CachedSnapshot>>,
+}
+
+impl ContestCalendarMonitor {
+    /// Create a monitor around a provider with refresh and stale thresholds.
+    #[must_use]
+    pub fn new(
+        provider: Arc<dyn ContestCalendarProvider>,
+        refresh_interval: Duration,
+        stale_after: Duration,
+    ) -> Self {
+        Self {
+            provider,
+            refresh_interval,
+            stale_after,
+            state: RwLock::new(None),
+        }
+    }
+
+    /// Return current contest entries, refreshing when needed.
+    pub async fn current_snapshot(&self) -> ContestCalendarSnapshot {
+        if let Some(cached) = self.state.read().await.clone() {
+            if cached.fetched_monotonic.elapsed() < self.refresh_interval {
+                return snapshot_from_cached(&cached, self.refresh_interval, self.stale_after);
+            }
+        }
+
+        self.refresh_snapshot().await
+    }
+
+    /// Force a refresh and return the latest available contest entries.
+    pub async fn refresh_snapshot(&self) -> ContestCalendarSnapshot {
+        let cached = self.state.read().await.clone();
+
+        match self.provider.fetch_contests().await {
+            Ok(contests) => {
+                let fetched_at = now_timestamp();
+                let cached_snapshot = CachedSnapshot {
+                    contests: contests.clone(),
+                    fetched_at,
+                    fetched_monotonic: Instant::now(),
+                };
+                *self.state.write().await = Some(cached_snapshot);
+                ContestCalendarSnapshot {
+                    contests,
+                    status: ContestCalendarStatus::Current,
+                    valid_until: Some(add_duration(&fetched_at, self.refresh_interval)),
+                    fetched_at: Some(fetched_at),
+                    error_message: None,
+                }
+            }
+            Err(error) => {
+                if let Some(cached) = cached {
+                    let mut snapshot =
+                        snapshot_from_cached(&cached, self.refresh_interval, self.stale_after);
+                    snapshot.status = ContestCalendarStatus::Stale;
+                    snapshot.error_message = Some(error.to_string());
+                    snapshot
+                } else {
+                    ContestCalendarSnapshot {
+                        status: if error.to_string().contains("disabled error") {
+                            ContestCalendarStatus::Disabled
+                        } else {
+                            ContestCalendarStatus::Error
+                        },
+                        fetched_at: Some(now_timestamp()),
+                        error_message: Some(error.to_string()),
+                        ..ContestCalendarSnapshot::default()
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn snapshot_from_cached(
+    cached: &CachedSnapshot,
+    refresh_interval: Duration,
+    stale_after: Duration,
+) -> ContestCalendarSnapshot {
+    ContestCalendarSnapshot {
+        contests: cached.contests.clone(),
+        status: if cached.fetched_monotonic.elapsed() >= stale_after {
+            ContestCalendarStatus::Stale
+        } else {
+            ContestCalendarStatus::Current
+        },
+        fetched_at: Some(cached.fetched_at),
+        valid_until: Some(add_duration(&cached.fetched_at, refresh_interval)),
+        error_message: None,
+    }
+}
+
+fn now_timestamp() -> Timestamp {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    Timestamp {
+        seconds: i64::try_from(now.as_secs()).unwrap_or(i64::MAX),
+        nanos: i32::try_from(now.subsec_nanos()).unwrap_or(i32::MAX),
+    }
+}
+
+fn add_duration(timestamp: &Timestamp, duration: Duration) -> Timestamp {
+    let seconds = i64::try_from(duration.as_secs()).unwrap_or(i64::MAX);
+    Timestamp {
+        seconds: timestamp.seconds.saturating_add(seconds),
+        nanos: timestamp.nanos,
+    }
+}

--- a/src/rust/qsoripper-core/src/contest_calendar/provider.rs
+++ b/src/rust/qsoripper-core/src/contest_calendar/provider.rs
@@ -1,0 +1,99 @@
+//! Provider seam for contest calendar data.
+
+use crate::proto::qsoripper::domain::ContestCalendarEntry;
+
+/// Abstraction over an external contest calendar provider.
+#[tonic::async_trait]
+pub trait ContestCalendarProvider: Send + Sync {
+    /// Fetch fresh normalized contest calendar entries.
+    async fn fetch_contests(
+        &self,
+    ) -> Result<Vec<ContestCalendarEntry>, ContestCalendarProviderError>;
+}
+
+/// Stable provider error categories.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContestCalendarProviderErrorKind {
+    /// Provider is disabled by configuration.
+    Disabled,
+    /// Transport failed before a valid response was received.
+    Transport,
+    /// Provider returned a payload that could not be parsed or understood.
+    Parse,
+}
+
+/// Errors surfaced by the contest calendar provider layer.
+#[derive(Debug, Clone)]
+pub struct ContestCalendarProviderError {
+    kind: ContestCalendarProviderErrorKind,
+    message: String,
+}
+
+impl ContestCalendarProviderError {
+    /// Provider is disabled.
+    #[must_use]
+    pub fn disabled(message: impl Into<String>) -> Self {
+        Self::new(ContestCalendarProviderErrorKind::Disabled, message)
+    }
+
+    /// Provider transport failed.
+    #[must_use]
+    pub fn transport(message: impl Into<String>) -> Self {
+        Self::new(ContestCalendarProviderErrorKind::Transport, message)
+    }
+
+    /// Provider returned an unexpected payload.
+    #[must_use]
+    pub fn parse(message: impl Into<String>) -> Self {
+        Self::new(ContestCalendarProviderErrorKind::Parse, message)
+    }
+
+    fn new(kind: ContestCalendarProviderErrorKind, message: impl Into<String>) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for ContestCalendarProviderError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "Contest calendar provider {} error: {}",
+            match self.kind {
+                ContestCalendarProviderErrorKind::Disabled => "disabled",
+                ContestCalendarProviderErrorKind::Transport => "transport",
+                ContestCalendarProviderErrorKind::Parse => "parse",
+            },
+            self.message
+        )
+    }
+}
+
+impl std::error::Error for ContestCalendarProviderError {}
+
+/// Provider used when contest calendar fetching is disabled.
+#[derive(Debug, Clone)]
+pub struct DisabledContestCalendarProvider {
+    reason: String,
+}
+
+impl DisabledContestCalendarProvider {
+    /// Create a disabled provider with a stable reason message.
+    #[must_use]
+    pub fn new(reason: impl Into<String>) -> Self {
+        Self {
+            reason: reason.into(),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl ContestCalendarProvider for DisabledContestCalendarProvider {
+    async fn fetch_contests(
+        &self,
+    ) -> Result<Vec<ContestCalendarEntry>, ContestCalendarProviderError> {
+        Err(ContestCalendarProviderError::disabled(self.reason.clone()))
+    }
+}

--- a/src/rust/qsoripper-core/src/contest_calendar/wa7bnm.rs
+++ b/src/rust/qsoripper-core/src/contest_calendar/wa7bnm.rs
@@ -1,0 +1,444 @@
+//! WA7BNM RSS contest calendar provider.
+
+use std::{env, fmt, path::PathBuf, time::Duration};
+
+use chrono::{DateTime, Datelike, NaiveDate, NaiveTime};
+use prost_types::Timestamp;
+use serde::Deserialize;
+
+use crate::proto::qsoripper::domain::{ContestCalendarEntry, ContestDetailsStatus};
+
+use super::{
+    catalog::{CONTEST_CALENDAR_DETAILS_PATH_ENV_VAR, DEFAULT_CONTEST_CALENDAR_DETAILS_PATH},
+    provider::{ContestCalendarProvider, ContestCalendarProviderError},
+};
+
+/// Environment variable that enables or disables contest calendar fetching.
+pub const CONTEST_CALENDAR_ENABLED_ENV_VAR: &str = "QSORIPPER_CONTEST_CALENDAR_ENABLED";
+/// Environment variable that overrides the WA7BNM RSS URL.
+pub const CONTEST_CALENDAR_RSS_URL_ENV_VAR: &str = "QSORIPPER_CONTEST_CALENDAR_RSS_URL";
+/// Environment variable that overrides the HTTP timeout in seconds.
+pub const CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS_ENV_VAR: &str =
+    "QSORIPPER_CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS";
+/// Environment variable that overrides the refresh interval in seconds.
+pub const CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS_ENV_VAR: &str =
+    "QSORIPPER_CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS";
+/// Environment variable that overrides the stale-after threshold in seconds.
+pub const CONTEST_CALENDAR_STALE_AFTER_SECONDS_ENV_VAR: &str =
+    "QSORIPPER_CONTEST_CALENDAR_STALE_AFTER_SECONDS";
+
+/// Default WA7BNM RSS endpoint.
+pub const DEFAULT_CONTEST_CALENDAR_RSS_URL: &str = "https://www.contestcalendar.com/calendar.rss";
+/// Default contest calendar HTTP timeout.
+pub const DEFAULT_CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS: u64 = 8;
+/// Default contest calendar refresh interval.
+pub const DEFAULT_CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS: u64 = 3600;
+/// Default stale-after threshold.
+pub const DEFAULT_CONTEST_CALENDAR_STALE_AFTER_SECONDS: u64 = 86_400;
+
+/// WA7BNM contest calendar provider configuration.
+#[derive(Clone)]
+pub struct Wa7bnmContestCalendarConfig {
+    enabled: bool,
+    rss_url: String,
+    http_timeout: Duration,
+    refresh_interval: Duration,
+    stale_after: Duration,
+    details_path: Option<PathBuf>,
+    details_path_is_explicit: bool,
+}
+
+impl fmt::Debug for Wa7bnmContestCalendarConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("Wa7bnmContestCalendarConfig")
+            .field("enabled", &self.enabled)
+            .field("rss_url", &self.rss_url)
+            .field("http_timeout", &self.http_timeout)
+            .field("refresh_interval", &self.refresh_interval)
+            .field("stale_after", &self.stale_after)
+            .field("details_path", &self.details_path)
+            .field("details_path_is_explicit", &self.details_path_is_explicit)
+            .finish()
+    }
+}
+
+impl Wa7bnmContestCalendarConfig {
+    /// Load provider configuration from environment variables.
+    ///
+    /// # Errors
+    ///
+    /// Returns a message when integer or boolean settings cannot be parsed.
+    pub fn from_env() -> Result<Self, String> {
+        Self::from_value_provider(|name| env::var(name).ok())
+    }
+
+    /// Load provider configuration from an arbitrary key/value source.
+    ///
+    /// # Errors
+    ///
+    /// Returns a message when integer or boolean settings cannot be parsed.
+    pub fn from_value_provider<F>(mut get_value: F) -> Result<Self, String>
+    where
+        F: FnMut(&'static str) -> Option<String>,
+    {
+        let enabled = optional_value_bool(CONTEST_CALENDAR_ENABLED_ENV_VAR, true, &mut get_value)?;
+        let rss_url = optional_value(CONTEST_CALENDAR_RSS_URL_ENV_VAR, &mut get_value)
+            .unwrap_or_else(|| DEFAULT_CONTEST_CALENDAR_RSS_URL.to_string());
+        let http_timeout_seconds = optional_value_u64(
+            CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS_ENV_VAR,
+            DEFAULT_CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS,
+            &mut get_value,
+        )?;
+        let refresh_interval_seconds = optional_value_u64(
+            CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS_ENV_VAR,
+            DEFAULT_CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS,
+            &mut get_value,
+        )?;
+        let stale_after_seconds = optional_value_u64(
+            CONTEST_CALENDAR_STALE_AFTER_SECONDS_ENV_VAR,
+            DEFAULT_CONTEST_CALENDAR_STALE_AFTER_SECONDS,
+            &mut get_value,
+        )?;
+        let details_path_value =
+            optional_value(CONTEST_CALENDAR_DETAILS_PATH_ENV_VAR, &mut get_value);
+        let details_path_is_explicit = details_path_value.is_some();
+        let details_path =
+            Some(PathBuf::from(details_path_value.unwrap_or_else(|| {
+                DEFAULT_CONTEST_CALENDAR_DETAILS_PATH.to_string()
+            })));
+
+        Ok(Self {
+            enabled,
+            rss_url,
+            http_timeout: Duration::from_secs(http_timeout_seconds),
+            refresh_interval: Duration::from_secs(refresh_interval_seconds),
+            stale_after: Duration::from_secs(stale_after_seconds),
+            details_path,
+            details_path_is_explicit,
+        })
+    }
+
+    /// Return whether contest calendar fetching is enabled.
+    #[must_use]
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Return the refresh interval for cached contest snapshots.
+    #[must_use]
+    pub fn refresh_interval(&self) -> Duration {
+        self.refresh_interval
+    }
+
+    /// Return the stale-after threshold.
+    #[must_use]
+    pub fn stale_after(&self) -> Duration {
+        self.stale_after
+    }
+
+    /// Return the optional reviewed local details catalog path.
+    #[must_use]
+    pub fn details_path(&self) -> Option<&PathBuf> {
+        self.details_path.as_ref()
+    }
+
+    /// Return whether the details catalog path was explicitly configured.
+    #[must_use]
+    pub fn details_path_is_explicit(&self) -> bool {
+        self.details_path_is_explicit
+    }
+}
+
+/// WA7BNM RSS contest calendar provider.
+pub struct Wa7bnmContestCalendarProvider {
+    config: Wa7bnmContestCalendarConfig,
+    client: reqwest::Client,
+}
+
+impl Wa7bnmContestCalendarProvider {
+    /// Create a WA7BNM RSS provider.
+    ///
+    /// # Errors
+    ///
+    /// Returns a provider error if the HTTP client cannot be built.
+    pub fn new(config: Wa7bnmContestCalendarConfig) -> Result<Self, ContestCalendarProviderError> {
+        let client = reqwest::Client::builder()
+            .timeout(config.http_timeout)
+            .build()
+            .map_err(|error| {
+                ContestCalendarProviderError::transport(format!(
+                    "failed to create HTTP client: {error}"
+                ))
+            })?;
+        Ok(Self { config, client })
+    }
+
+    async fn fetch_rss(&self) -> Result<String, ContestCalendarProviderError> {
+        self.client
+            .get(&self.config.rss_url)
+            .send()
+            .await
+            .map_err(|error| ContestCalendarProviderError::transport(error.to_string()))?
+            .error_for_status()
+            .map_err(|error| ContestCalendarProviderError::transport(error.to_string()))?
+            .text()
+            .await
+            .map_err(|error| ContestCalendarProviderError::transport(error.to_string()))
+    }
+}
+
+#[tonic::async_trait]
+impl ContestCalendarProvider for Wa7bnmContestCalendarProvider {
+    async fn fetch_contests(
+        &self,
+    ) -> Result<Vec<ContestCalendarEntry>, ContestCalendarProviderError> {
+        let rss = self.fetch_rss().await?;
+        parse_wa7bnm_rss(&rss, &self.config.rss_url)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct Rss {
+    channel: Channel,
+}
+
+#[derive(Debug, Deserialize)]
+struct Channel {
+    #[serde(rename = "lastBuildDate")]
+    last_build_date: Option<String>,
+    #[serde(default)]
+    item: Vec<Item>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Item {
+    title: String,
+    link: Option<String>,
+    description: String,
+}
+
+fn parse_wa7bnm_rss(
+    xml: &str,
+    source_url: &str,
+) -> Result<Vec<ContestCalendarEntry>, ContestCalendarProviderError> {
+    let rss: Rss = quick_xml::de::from_str(xml)
+        .map_err(|error| ContestCalendarProviderError::parse(error.to_string()))?;
+    let source_year = rss
+        .channel
+        .last_build_date
+        .as_deref()
+        .and_then(|value| DateTime::parse_from_rfc2822(value).ok())
+        .map_or_else(|| chrono::Utc::now().year(), |value| value.year());
+
+    rss.channel
+        .item
+        .into_iter()
+        .map(|item| entry_from_item(item, source_year, source_url))
+        .collect()
+}
+
+fn entry_from_item(
+    item: Item,
+    source_year: i32,
+    fallback_source_url: &str,
+) -> Result<ContestCalendarEntry, ContestCalendarProviderError> {
+    let (start, end) = parse_schedule(&item.description, source_year)?;
+    let source_url = item.link.unwrap_or_else(|| fallback_source_url.to_string());
+    let contest_id = stable_contest_id(&item.title, &start);
+    Ok(ContestCalendarEntry {
+        contest_id,
+        name: item.title,
+        start_time_utc: Some(start),
+        end_time_utc: Some(end),
+        bands: Vec::new(),
+        modes: Vec::new(),
+        exchange: None,
+        rules_url: None,
+        source_url: Some(source_url),
+        source_name: "WA7BNM Contest Calendar".to_string(),
+        details_status: ContestDetailsStatus::MetadataOnly as i32,
+    })
+}
+
+fn parse_schedule(
+    description: &str,
+    source_year: i32,
+) -> Result<(Timestamp, Timestamp), ContestCalendarProviderError> {
+    let (times, date) = description.split_once(',').ok_or_else(|| {
+        ContestCalendarProviderError::parse(format!("missing comma in schedule '{description}'"))
+    })?;
+    let (start_time, end_time) = times.trim().split_once('-').ok_or_else(|| {
+        ContestCalendarProviderError::parse(format!(
+            "missing time range in schedule '{description}'"
+        ))
+    })?;
+    let date = parse_month_day(date.trim(), source_year)?;
+    let start = parse_utc_time(start_time.trim())?;
+    let end = parse_utc_time(end_time.trim())?;
+    let start_date_time = date.and_time(start);
+    let mut end_date_time = date.and_time(end);
+    if end_date_time <= start_date_time {
+        end_date_time = end_date_time
+            .checked_add_signed(chrono::Duration::days(1))
+            .ok_or_else(|| ContestCalendarProviderError::parse("contest end overflow"))?;
+    }
+    Ok((
+        timestamp_from_naive(start_date_time),
+        timestamp_from_naive(end_date_time),
+    ))
+}
+
+fn parse_month_day(value: &str, year: i32) -> Result<NaiveDate, ContestCalendarProviderError> {
+    let mut parts = value.split_whitespace();
+    let month = parts.next().ok_or_else(|| {
+        ContestCalendarProviderError::parse(format!("missing month in '{value}'"))
+    })?;
+    let day = parts
+        .next()
+        .ok_or_else(|| ContestCalendarProviderError::parse(format!("missing day in '{value}'")))?
+        .parse::<u32>()
+        .map_err(|_| ContestCalendarProviderError::parse(format!("invalid day in '{value}'")))?;
+    let month = match month {
+        "Jan" | "January" => 1,
+        "Feb" | "February" => 2,
+        "Mar" | "March" => 3,
+        "Apr" | "April" => 4,
+        "May" => 5,
+        "Jun" | "June" => 6,
+        "Jul" | "July" => 7,
+        "Aug" | "August" => 8,
+        "Sep" | "Sept" | "September" => 9,
+        "Oct" | "October" => 10,
+        "Nov" | "November" => 11,
+        "Dec" | "December" => 12,
+        _ => {
+            return Err(ContestCalendarProviderError::parse(format!(
+                "invalid month '{month}'"
+            )))
+        }
+    };
+    NaiveDate::from_ymd_opt(year, month, day)
+        .ok_or_else(|| ContestCalendarProviderError::parse(format!("invalid date '{value}'")))
+}
+
+fn parse_utc_time(value: &str) -> Result<NaiveTime, ContestCalendarProviderError> {
+    let value = value.trim_end_matches('Z');
+    if value.len() != 4 {
+        return Err(ContestCalendarProviderError::parse(format!(
+            "invalid UTC time '{value}'"
+        )));
+    }
+    let hour = value[0..2]
+        .parse::<u32>()
+        .map_err(|_| ContestCalendarProviderError::parse(format!("invalid UTC hour '{value}'")))?;
+    let minute = value[2..4].parse::<u32>().map_err(|_| {
+        ContestCalendarProviderError::parse(format!("invalid UTC minute '{value}'"))
+    })?;
+    NaiveTime::from_hms_opt(hour, minute, 0)
+        .ok_or_else(|| ContestCalendarProviderError::parse(format!("invalid UTC time '{value}'")))
+}
+
+fn timestamp_from_naive(value: chrono::NaiveDateTime) -> Timestamp {
+    Timestamp {
+        seconds: value.and_utc().timestamp(),
+        nanos: 0,
+    }
+}
+
+fn stable_contest_id(name: &str, start: &Timestamp) -> String {
+    let input = format!("{}\n{}", name.trim().to_ascii_uppercase(), start.seconds);
+    let mut hash = 14_695_981_039_346_656_037_u64;
+    for byte in input.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(1_099_511_628_211);
+    }
+    format!("wa7bnm-{hash:016x}")
+}
+
+fn optional_value<F>(name: &'static str, get_value: &mut F) -> Option<String>
+where
+    F: FnMut(&'static str) -> Option<String>,
+{
+    get_value(name).and_then(|value| {
+        let value = value.trim().to_string();
+        if value.is_empty() {
+            None
+        } else {
+            Some(value)
+        }
+    })
+}
+
+fn optional_value_u64<F>(
+    name: &'static str,
+    default_value: u64,
+    get_value: &mut F,
+) -> Result<u64, String>
+where
+    F: FnMut(&'static str) -> Option<String>,
+{
+    optional_value(name, get_value).map_or(Ok(default_value), |value| {
+        value
+            .parse::<u64>()
+            .map_err(|_| format!("{name} must be an unsigned integer, got '{value}'"))
+    })
+}
+
+fn optional_value_bool<F>(
+    name: &'static str,
+    default_value: bool,
+    get_value: &mut F,
+) -> Result<bool, String>
+where
+    F: FnMut(&'static str) -> Option<String>,
+{
+    optional_value(name, get_value).map_or(Ok(default_value), |value| {
+        match value.to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "y" | "on" => Ok(true),
+            "0" | "false" | "no" | "n" | "off" => Ok(false),
+            _ => Err(format!("{name} must be boolean, got '{value}'")),
+        }
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_wa7bnm_rss_returns_metadata_only_entries() {
+        let xml = r#"<?xml version="1.0" encoding="utf-8" ?>
+<rss version="2.0"><channel>
+<lastBuildDate>Sat, 23 May 2026 00:00:00 +0000</lastBuildDate>
+<item><title>Real Time Contest</title><link>https://www.contestcalendar.com/weeklycontdetails.php?ref=x</link><description>1600Z-2000Z, May 24</description></item>
+</channel></rss>"#;
+
+        let contests = parse_wa7bnm_rss(xml, DEFAULT_CONTEST_CALENDAR_RSS_URL).expect("contests");
+
+        assert_eq!(contests.len(), 1);
+        let contest = contests.first().expect("contest");
+        assert_eq!(contest.name, "Real Time Contest");
+        assert_eq!(
+            contest.details_status,
+            ContestDetailsStatus::MetadataOnly as i32
+        );
+        assert!(contest.bands.is_empty());
+        assert_eq!(
+            contest.start_time_utc.as_ref().expect("start").seconds,
+            1_779_638_400
+        );
+        assert_eq!(
+            contest.end_time_utc.as_ref().expect("end").seconds,
+            1_779_652_800
+        );
+    }
+
+    #[test]
+    fn parse_schedule_rolls_end_time_to_next_day() {
+        let (start, end) = parse_schedule("2300Z-0100Z, May 24", 2026).expect("schedule");
+
+        assert_eq!(end.seconds - start.seconds, 7_200);
+    }
+}

--- a/src/rust/qsoripper-core/src/lib.rs
+++ b/src/rust/qsoripper-core/src/lib.rs
@@ -5,6 +5,8 @@
 pub mod adif;
 /// Application services that coordinate engine workflows above storage ports.
 pub mod application;
+/// Contest calendar providers, caching, and filtering.
+pub mod contest_calendar;
 /// Domain helpers for QSO and lookup-related types.
 pub mod domain;
 /// FFI boundary for DSP helpers.

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -7,7 +7,15 @@ mod station_profile_support;
 mod sync;
 mod sync_scheduler;
 
-use std::{fs, future::Future, io, net::SocketAddr, path::PathBuf, sync::Arc};
+use std::{
+    fs,
+    future::Future,
+    io,
+    net::SocketAddr,
+    path::PathBuf,
+    sync::Arc,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
 use qsoripper_core::adif::{parse_adi_qsos, serialize_adi_qsos};
 use qsoripper_core::application::logbook::LogbookError;
@@ -21,8 +29,10 @@ use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 
-use qsoripper_core::proto::qsoripper::domain::{Band, ConflictPolicy, Mode};
+use prost_types::Timestamp;
+use qsoripper_core::proto::qsoripper::domain::{Band, ConflictPolicy, ContestCalendarEntry, Mode};
 use qsoripper_core::proto::qsoripper::services::{
+    contest_calendar_service_server::{ContestCalendarService, ContestCalendarServiceServer},
     developer_control_service_server::{DeveloperControlService, DeveloperControlServiceServer},
     engine_service_server::{EngineService, EngineServiceServer},
     great_circle_service_server::{GreatCircleService, GreatCircleServiceServer},
@@ -35,18 +45,19 @@ use qsoripper_core::proto::qsoripper::services::{
     AdifChunk, ApplyRuntimeConfigRequest, ApplyRuntimeConfigResponse, BatchLookupRequest,
     BatchLookupResponse, ComputeGreatCircleRequest, ComputeGreatCircleResponse, DeleteQsoRequest,
     DeleteQsoResponse, DeletedRecordsFilter as ProtoDeletedRecordsFilter, EngineInfo,
-    ExportAdifRequest, ExportAdifResponse, GetCachedCallsignRequest, GetCachedCallsignResponse,
-    GetCurrentSpaceWeatherRequest, GetCurrentSpaceWeatherResponse, GetDxccEntityRequest,
-    GetDxccEntityResponse, GetEngineInfoRequest, GetEngineInfoResponse, GetQsoRequest,
-    GetQsoResponse, GetRigSnapshotRequest, GetRigSnapshotResponse, GetRigStatusRequest,
-    GetRigStatusResponse, GetRuntimeConfigRequest, GetRuntimeConfigResponse, GetSyncStatusRequest,
-    GetSyncStatusResponse, ImportAdifRequest, ImportAdifResponse, ListQsosRequest,
-    ListQsosResponse, LogQsoRequest, LogQsoResponse, LookupRequest, LookupResponse,
-    PurgeDeletedQsosRequest, PurgeDeletedQsosResponse, QsoSortOrder as ProtoQsoSortOrder,
-    RefreshSpaceWeatherRequest, RefreshSpaceWeatherResponse, ResetRuntimeConfigRequest,
-    ResetRuntimeConfigResponse, RestoreQsoRequest, RestoreQsoResponse, StreamLookupRequest,
-    StreamLookupResponse, SyncWithQrzRequest, SyncWithQrzResponse, TestRigConnectionRequest,
-    TestRigConnectionResponse, UpdateQsoRequest, UpdateQsoResponse,
+    ExportAdifRequest, ExportAdifResponse, GetActiveContestsRequest, GetActiveContestsResponse,
+    GetCachedCallsignRequest, GetCachedCallsignResponse, GetCurrentSpaceWeatherRequest,
+    GetCurrentSpaceWeatherResponse, GetDxccEntityRequest, GetDxccEntityResponse,
+    GetEngineInfoRequest, GetEngineInfoResponse, GetQsoRequest, GetQsoResponse,
+    GetRigSnapshotRequest, GetRigSnapshotResponse, GetRigStatusRequest, GetRigStatusResponse,
+    GetRuntimeConfigRequest, GetRuntimeConfigResponse, GetSyncStatusRequest, GetSyncStatusResponse,
+    ImportAdifRequest, ImportAdifResponse, ListQsosRequest, ListQsosResponse, LogQsoRequest,
+    LogQsoResponse, LookupRequest, LookupResponse, PurgeDeletedQsosRequest,
+    PurgeDeletedQsosResponse, QsoSortOrder as ProtoQsoSortOrder, RefreshContestCalendarRequest,
+    RefreshContestCalendarResponse, RefreshSpaceWeatherRequest, RefreshSpaceWeatherResponse,
+    ResetRuntimeConfigRequest, ResetRuntimeConfigResponse, RestoreQsoRequest, RestoreQsoResponse,
+    StreamLookupRequest, StreamLookupResponse, SyncWithQrzRequest, SyncWithQrzResponse,
+    TestRigConnectionRequest, TestRigConnectionResponse, UpdateQsoRequest, UpdateQsoResponse,
 };
 use qsoripper_core::rig_control::{
     RigControlProvider, RigctldConfig, RigctldProvider, DEFAULT_RIGCTLD_HOST, DEFAULT_RIGCTLD_PORT,
@@ -112,6 +123,7 @@ where
     let setup_service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
     let station_profile_service =
         StationProfileControlSurface::new(setup_state.clone(), runtime_config.clone());
+    let contest_calendar_service = ContestCalendarControlSurface::new(runtime_config.clone());
     let space_weather_service = SpaceWeatherControlSurface::new(runtime_config.clone());
     let rig_control_service = RigControlControlSurface::new(runtime_config.clone());
     let great_circle_service = GreatCircleControlSurface::new();
@@ -150,6 +162,7 @@ where
         .add_service(LookupServiceServer::new(lookup_service))
         .add_service(SetupServiceServer::new(setup_service))
         .add_service(StationProfileServiceServer::new(station_profile_service))
+        .add_service(ContestCalendarServiceServer::new(contest_calendar_service))
         .add_service(SpaceWeatherServiceServer::new(space_weather_service))
         .add_service(RigControlServiceServer::new(rig_control_service))
         .add_service(GreatCircleServiceServer::new(great_circle_service))
@@ -882,6 +895,7 @@ const RUST_ENGINE_CAPABILITIES: &[&str] = &[
     "station-profiles",
     "runtime-config",
     "rig-control",
+    "contest-calendar",
     "space-weather",
     "purge",
 ];
@@ -946,6 +960,117 @@ impl DeveloperControlService for DeveloperControlSurface {
         Ok(Response::new(ResetRuntimeConfigResponse {
             snapshot: Some(snapshot),
         }))
+    }
+}
+
+#[derive(Clone)]
+struct ContestCalendarControlSurface {
+    runtime_config: Arc<RuntimeConfigManager>,
+}
+
+impl ContestCalendarControlSurface {
+    fn new(runtime_config: Arc<RuntimeConfigManager>) -> Self {
+        Self { runtime_config }
+    }
+}
+
+#[tonic::async_trait]
+impl ContestCalendarService for ContestCalendarControlSurface {
+    async fn get_active_contests(
+        &self,
+        request: Request<GetActiveContestsRequest>,
+    ) -> Result<Response<GetActiveContestsResponse>, Status> {
+        let request = request.into_inner();
+        let snapshot = self
+            .runtime_config
+            .contest_calendar_monitor()
+            .await
+            .current_snapshot()
+            .await;
+        let contests = filter_active_contests(snapshot.contests, &request);
+        Ok(Response::new(GetActiveContestsResponse {
+            contests,
+            status: snapshot.status as i32,
+            fetched_at: snapshot.fetched_at,
+            valid_until: snapshot.valid_until,
+            error_message: snapshot.error_message,
+        }))
+    }
+
+    async fn refresh_contest_calendar(
+        &self,
+        _request: Request<RefreshContestCalendarRequest>,
+    ) -> Result<Response<RefreshContestCalendarResponse>, Status> {
+        let snapshot = self
+            .runtime_config
+            .contest_calendar_monitor()
+            .await
+            .refresh_snapshot()
+            .await;
+        Ok(Response::new(RefreshContestCalendarResponse {
+            contests: snapshot.contests,
+            status: snapshot.status as i32,
+            fetched_at: snapshot.fetched_at,
+            valid_until: snapshot.valid_until,
+            error_message: snapshot.error_message,
+        }))
+    }
+}
+
+fn filter_active_contests(
+    contests: Vec<ContestCalendarEntry>,
+    request: &GetActiveContestsRequest,
+) -> Vec<ContestCalendarEntry> {
+    let at = request.at_utc.unwrap_or_else(now_timestamp);
+    let lookahead_seconds = i64::from(request.lookahead_minutes).saturating_mul(60);
+    let through = at.seconds.saturating_add(lookahead_seconds);
+    contests
+        .into_iter()
+        .filter(|contest| contest_is_active(contest, at.seconds, through))
+        .filter(|contest| {
+            enum_filter_matches(
+                request.band,
+                &contest.bands,
+                request.include_partial_matches,
+            )
+        })
+        .filter(|contest| {
+            enum_filter_matches(
+                request.mode,
+                &contest.modes,
+                request.include_partial_matches,
+            )
+        })
+        .collect()
+}
+
+fn contest_is_active(
+    contest: &ContestCalendarEntry,
+    at_seconds: i64,
+    through_seconds: i64,
+) -> bool {
+    match (&contest.start_time_utc, &contest.end_time_utc) {
+        (Some(start), Some(end)) => start.seconds <= through_seconds && end.seconds >= at_seconds,
+        _ => false,
+    }
+}
+
+fn enum_filter_matches(filter: Option<i32>, values: &[i32], include_partial_matches: bool) -> bool {
+    match filter {
+        Some(value) if value > 0 => {
+            values.contains(&value) || values.is_empty() && include_partial_matches
+        }
+        _ => true,
+    }
+}
+
+fn now_timestamp() -> Timestamp {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    Timestamp {
+        seconds: i64::try_from(now.as_secs()).unwrap_or(i64::MAX),
+        nanos: i32::try_from(now.subsec_nanos()).unwrap_or(i32::MAX),
     }
 }
 

--- a/src/rust/qsoripper-server/src/runtime_config.rs
+++ b/src/rust/qsoripper-server/src/runtime_config.rs
@@ -2,6 +2,16 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use qsoripper_core::application::logbook::LogbookEngine;
+use qsoripper_core::contest_calendar::{
+    CatalogEnrichingContestCalendarProvider, ContestCalendarMonitor, ContestCalendarProvider,
+    ContestDetailsCatalog, DisabledContestCalendarProvider, Wa7bnmContestCalendarConfig,
+    Wa7bnmContestCalendarProvider, CONTEST_CALENDAR_DETAILS_PATH_ENV_VAR,
+    CONTEST_CALENDAR_ENABLED_ENV_VAR, CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS_ENV_VAR,
+    CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS_ENV_VAR, CONTEST_CALENDAR_RSS_URL_ENV_VAR,
+    CONTEST_CALENDAR_STALE_AFTER_SECONDS_ENV_VAR, DEFAULT_CONTEST_CALENDAR_DETAILS_PATH,
+    DEFAULT_CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS, DEFAULT_CONTEST_CALENDAR_RSS_URL,
+    DEFAULT_CONTEST_CALENDAR_STALE_AFTER_SECONDS,
+};
 use qsoripper_core::domain::lookup::normalize_callsign;
 use qsoripper_core::domain::station::station_profile_has_values;
 use qsoripper_core::lookup::{
@@ -74,6 +84,7 @@ const CONFLICT_POLICY_ALLOWED_VALUES: &[&str] = &["last_write_wins", "flag_for_r
 struct RuntimeBindings {
     logbook_engine: LogbookEngine,
     lookup_coordinator: Arc<LookupCoordinator>,
+    contest_calendar_monitor: Arc<ContestCalendarMonitor>,
     space_weather_monitor: Arc<SpaceWeatherMonitor>,
     rig_control_monitor: Arc<RigControlMonitor>,
     active_storage_backend: String,
@@ -181,6 +192,10 @@ impl RuntimeConfigManager {
 
     pub(crate) async fn lookup_coordinator(&self) -> Arc<LookupCoordinator> {
         self.bindings.read().await.lookup_coordinator.clone()
+    }
+
+    pub(crate) async fn contest_calendar_monitor(&self) -> Arc<ContestCalendarMonitor> {
+        self.bindings.read().await.contest_calendar_monitor.clone()
     }
 
     pub(crate) async fn space_weather_monitor(&self) -> Arc<SpaceWeatherMonitor> {
@@ -584,6 +599,60 @@ const SUPPORTED_FIELDS: &[ConfigFieldSpec] = &[
         default_value: Some(DEFAULT_SYNC_CONFLICT_POLICY),
     },
     ConfigFieldSpec {
+        key: CONTEST_CALENDAR_ENABLED_ENV_VAR,
+        label: "Contest calendar enabled",
+        description: "Enable live contest calendar fetching.",
+        kind: RuntimeConfigValueKind::Boolean,
+        secret: false,
+        allowed_values: BOOLEAN_ALLOWED_VALUES,
+        default_value: Some("true"),
+    },
+    ConfigFieldSpec {
+        key: CONTEST_CALENDAR_RSS_URL_ENV_VAR,
+        label: "Contest calendar RSS URL",
+        description: "RSS endpoint used for contest calendar metadata.",
+        kind: RuntimeConfigValueKind::String,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some(DEFAULT_CONTEST_CALENDAR_RSS_URL),
+    },
+    ConfigFieldSpec {
+        key: CONTEST_CALENDAR_HTTP_TIMEOUT_SECONDS_ENV_VAR,
+        label: "Contest calendar HTTP timeout seconds",
+        description: "HTTP timeout used by contest calendar requests.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some("8"),
+    },
+    ConfigFieldSpec {
+        key: CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS_ENV_VAR,
+        label: "Contest calendar refresh interval seconds",
+        description: "How long the engine caches contest calendar metadata before refreshing.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some("3600"),
+    },
+    ConfigFieldSpec {
+        key: CONTEST_CALENDAR_STALE_AFTER_SECONDS_ENV_VAR,
+        label: "Contest calendar stale after seconds",
+        description: "When cached contest calendar metadata should be marked stale.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some("86400"),
+    },
+    ConfigFieldSpec {
+        key: CONTEST_CALENDAR_DETAILS_PATH_ENV_VAR,
+        label: "Contest calendar details path",
+        description: "Optional reviewed local JSON catalog that enriches contest calendar entries.",
+        kind: RuntimeConfigValueKind::Path,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some(DEFAULT_CONTEST_CALENDAR_DETAILS_PATH),
+    },
+    ConfigFieldSpec {
         key: NOAA_SPACE_WEATHER_ENABLED_ENV_VAR,
         label: "NOAA space weather enabled",
         description: "Enable live NOAA SWPC current space weather fetching.",
@@ -920,6 +989,7 @@ fn build_runtime_bindings(values: &BTreeMap<String, String>) -> Result<RuntimeBi
         LookupCoordinatorConfig::default(),
         storage,
     ));
+    let contest_calendar_monitor = build_contest_calendar_monitor(values);
     let space_weather_monitor = build_space_weather_monitor(values);
     let rig_control_monitor = build_rig_control_monitor(values);
     let active_station_profile = build_active_station_profile(values)?;
@@ -927,6 +997,7 @@ fn build_runtime_bindings(values: &BTreeMap<String, String>) -> Result<RuntimeBi
     Ok(RuntimeBindings {
         logbook_engine,
         lookup_coordinator,
+        contest_calendar_monitor,
         space_weather_monitor,
         rig_control_monitor,
         active_storage_backend,
@@ -1044,6 +1115,56 @@ fn build_lookup_provider(values: &BTreeMap<String, String>) -> (Arc<dyn Callsign
                 format!("Disabled: {reason}"),
             )
         }
+    }
+}
+
+fn build_contest_calendar_monitor(
+    values: &BTreeMap<String, String>,
+) -> Arc<ContestCalendarMonitor> {
+    match Wa7bnmContestCalendarConfig::from_value_provider(|name| values.get(name).cloned()) {
+        Ok(config) => {
+            let provider: Arc<dyn ContestCalendarProvider> = if config.enabled() {
+                match Wa7bnmContestCalendarProvider::new(config.clone()) {
+                    Ok(provider) => {
+                        let provider: Arc<dyn ContestCalendarProvider> = Arc::new(provider);
+                        if let Some(path) = config.details_path().filter(|path| path.exists()) {
+                            match ContestDetailsCatalog::load(path) {
+                                Ok(catalog) => Arc::new(
+                                    CatalogEnrichingContestCalendarProvider::new(provider, catalog),
+                                ),
+                                Err(error) => Arc::new(DisabledContestCalendarProvider::new(
+                                    error.to_string(),
+                                )),
+                            }
+                        } else if config.details_path_is_explicit() {
+                            Arc::new(DisabledContestCalendarProvider::new(format!(
+                                "Contest calendar details catalog does not exist: {}",
+                                config
+                                    .details_path()
+                                    .map_or_else(String::new, |path| path.display().to_string())
+                            )))
+                        } else {
+                            provider
+                        }
+                    }
+                    Err(error) => Arc::new(DisabledContestCalendarProvider::new(error.to_string())),
+                }
+            } else {
+                Arc::new(DisabledContestCalendarProvider::new(
+                    "Contest calendar fetching is disabled.",
+                ))
+            };
+            Arc::new(ContestCalendarMonitor::new(
+                provider,
+                config.refresh_interval(),
+                config.stale_after(),
+            ))
+        }
+        Err(error) => Arc::new(ContestCalendarMonitor::new(
+            Arc::new(DisabledContestCalendarProvider::new(error)),
+            std::time::Duration::from_secs(DEFAULT_CONTEST_CALENDAR_REFRESH_INTERVAL_SECONDS),
+            std::time::Duration::from_secs(DEFAULT_CONTEST_CALENDAR_STALE_AFTER_SECONDS),
+        )),
     }
 }
 


### PR DESCRIPTION
Adds contest calendar contracts, Rust and .NET engine providers, CLI commands, and a reviewed local details catalog for bands, modes, exchanges, and rules URLs. Also adds a standalone catalog generator that uses the WA7BNM 12-month calendar as offline input.