### PR TITLE
launcher: expose qsoripper-win32 GUI as a launchable UI

### DIFF
--- a/src/rust/qsoripper-launcher/src/catalog.rs
+++ b/src/rust/qsoripper-launcher/src/catalog.rs
@@ -67,6 +67,7 @@ pub(crate) const UI_GUI: ComponentId = "gui";
 pub(crate) const UI_DEBUGHOST: ComponentId = "debughost";
 pub(crate) const UI_TUI: ComponentId = "tui";
 pub(crate) const UI_CWSCOPE: ComponentId = "cwscope";
+pub(crate) const UI_WIN32: ComponentId = "win32";
 
 /// Static list of every component the launcher manages.
 pub(crate) fn catalog() -> Vec<ComponentSpec> {
@@ -143,6 +144,20 @@ pub(crate) fn catalog() -> Vec<ComponentSpec> {
                 executable_stem: "CwDecoderGui",
             },
         },
+        ComponentSpec {
+            id: UI_WIN32,
+            display_name: "Win32 GUI (qsoripper-win32)",
+            kind: ComponentKind::Ui,
+            engine_port: None,
+            // The Win32 client does not yet honor QSORIPPER_ENGINE /
+            // QSORIPPER_ENDPOINT; engine selection is its own follow-up.
+            engine_bindable: false,
+            wants_console: false,
+            artifact: ArtifactSpec {
+                publish_subdir: "qsoripper-win32",
+                executable_stem: "qsoripper-win32",
+            },
+        },
     ]
 }
 
@@ -157,4 +172,29 @@ pub(crate) fn engine_endpoint(id: &str) -> Option<String> {
         .filter(|c| c.kind == ComponentKind::Engine)
         .and_then(|c| c.engine_port)
         .map(|p| format!("http://127.0.0.1:{p}"))
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn win32_ui_is_in_catalog() {
+        let spec = find(UI_WIN32).expect("win32 ui in catalog");
+        assert_eq!(spec.kind, ComponentKind::Ui);
+        assert!(!spec.wants_console);
+        assert!(!spec.engine_bindable);
+        assert_eq!(spec.artifact.publish_subdir, "qsoripper-win32");
+        assert_eq!(spec.artifact.executable_stem, "qsoripper-win32");
+    }
+
+    #[test]
+    fn catalog_has_unique_component_ids() {
+        let ids: Vec<&'static str> = catalog().into_iter().map(|c| c.id).collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), ids.len(), "duplicate component id in catalog");
+    }
 }

--- a/src/rust/qsoripper-launcher/src/plan.rs
+++ b/src/rust/qsoripper-launcher/src/plan.rs
@@ -104,6 +104,18 @@ mod tests {
     }
 
     #[test]
+    fn win32_plan_has_no_engine_env() {
+        use crate::catalog::UI_WIN32;
+        let sel = Selection::default_preset();
+        let plan = ui_plan(UI_WIN32, &sel).expect("plan");
+        assert!(
+            plan.env.is_empty(),
+            "win32 client does not yet honor QSORIPPER_ENGINE/QSORIPPER_ENDPOINT",
+        );
+        assert!(plan.args.is_empty());
+    }
+
+    #[test]
     fn debughost_plan_forces_the_runall_url() {
         let sel = Selection::default_preset();
         let plan = ui_plan(UI_DEBUGHOST, &sel).expect("plan");


### PR DESCRIPTION
Adds the Win32 C GUI (qsoripper-win32) to the launcher catalog so it shows up next to Avalonia GUI, DebugHost, TUI, and CW Scope.

Spec choices: wants_console is false because the Win32 app is a real WinMain GUI, and engine_bindable is false because the Win32 client does not yet honor QSORIPPER_ENGINE / QSORIPPER_ENDPOINT (no references in src/c/qsoripper-win32). Wiring the Win32 app up to env-based engine binding can be tracked as a follow-up.

The launcher's UI list is data-driven from the catalog (src/rust/qsoripper-launcher/src/ui.rs ui_components), so no UI code changes are needed; the new entry appears automatically.

Tests added in catalog.rs and plan.rs cover catalog membership, id uniqueness, and the empty plan env/args for Win32.

Validation: cargo test -p qsoripper-launcher (27 passed), cargo clippy -p qsoripper-launcher --no-deps --all-targets -D warnings clean, cargo fmt --check clean for changed files.

Fixes #449