### PR TITLE
Show QSO comments in TUI list

### DIFF
--- a/src/rust/qsoripper-tui/src/app.rs
+++ b/src/rust/qsoripper-tui/src/app.rs
@@ -101,8 +101,6 @@ pub(crate) struct RecentQso {
     pub(crate) grid: Option<String>,
     /// Worked operator name.
     pub(crate) name: Option<String>,
-    /// Calculated QSO duration (e.g. "2m 35s"), or `None` when end time is absent.
-    pub(crate) duration: Option<String>,
     /// Full proto record from the engine, preserved for lossless round-trip during edits.
     pub(crate) source_record: QsoRecord,
 }
@@ -129,6 +127,13 @@ impl RecentQso {
                 .contains(lower)
             || self
                 .name
+                .as_deref()
+                .unwrap_or("")
+                .to_lowercase()
+                .contains(lower)
+            || self
+                .source_record
+                .comment
                 .as_deref()
                 .unwrap_or("")
                 .to_lowercase()
@@ -350,7 +355,6 @@ mod tests {
             country: None,
             grid: None,
             name: None,
-            duration: None,
             source_record: QsoRecord {
                 local_id: id.to_string(),
                 worked_callsign: callsign.to_string(),
@@ -534,14 +538,17 @@ mod tests {
             country: Some("United States".to_string()),
             grid: Some("CN87".to_string()),
             name: Some("John".to_string()),
-            duration: None,
-            source_record: QsoRecord::default(),
+            source_record: QsoRecord {
+                comment: Some("Portable activation".to_string()),
+                ..Default::default()
+            },
         };
         assert!(qso.matches_search("40m"));
         assert!(qso.matches_search("cw"));
         assert!(qso.matches_search("united"));
         assert!(qso.matches_search("cn87"));
         assert!(qso.matches_search("john"));
+        assert!(qso.matches_search("portable"));
         assert!(qso.matches_search("12:00"));
     }
 
@@ -564,7 +571,6 @@ mod tests {
             country: None,
             grid: None,
             name: None,
-            duration: None,
             source_record: QsoRecord::default(),
         };
         assert!(!qso.matches_search("united"));

--- a/src/rust/qsoripper-tui/src/grpc.rs
+++ b/src/rust/qsoripper-tui/src/grpc.rs
@@ -5,7 +5,6 @@ use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use tonic::transport::{Channel, Endpoint};
 
 use qsoripper_core::domain::band::{band_from_adif, band_to_adif};
-use qsoripper_core::domain::duration::format_qso_duration;
 use qsoripper_core::domain::mode::{mode_from_adif, mode_to_adif};
 use qsoripper_core::proto::qsoripper::domain::{Band, LookupState, Mode, RstReport};
 use qsoripper_core::proto::qsoripper::services::{
@@ -159,7 +158,6 @@ pub(crate) async fn list_recent_qsos(
             country: qso.worked_country.clone(),
             grid: qso.worked_grid.clone(),
             name: qso.worked_operator_name.clone(),
-            duration: format_qso_duration(&qso),
             source_record: qso,
         });
     }

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -1149,7 +1149,6 @@ mod tests {
             country: None,
             grid: None,
             name: None,
-            duration: None,
             source_record: QsoRecord {
                 local_id: id.to_string(),
                 worked_callsign: callsign.to_string(),
@@ -1720,7 +1719,6 @@ mod tests {
             country: None,
             grid: None,
             name: Some("John".to_string()),
-            duration: None,
             source_record: QsoRecord {
                 local_id: "q1".to_string(),
                 worked_callsign: "K7ABC".to_string(),
@@ -1777,7 +1775,6 @@ mod tests {
             country: Some("United States".to_string()),
             grid: Some("FN31pr".to_string()),
             name: Some("Hiram".to_string()),
-            duration: None,
             source_record: QsoRecord {
                 local_id: "adv1".to_string(),
                 worked_callsign: "W1AW".to_string(),

--- a/src/rust/qsoripper-tui/src/ui/mod.rs
+++ b/src/rust/qsoripper-tui/src/ui/mod.rs
@@ -117,7 +117,6 @@ mod tests {
             country: Some("United States".to_string()),
             grid: Some("CN87".to_string()),
             name: Some("John Smith".to_string()),
-            duration: None,
             source_record: QsoRecord {
                 local_id: id.to_string(),
                 worked_callsign: callsign.to_string(),

--- a/src/rust/qsoripper-tui/src/ui/recent_qsos.rs
+++ b/src/rust/qsoripper-tui/src/ui/recent_qsos.rs
@@ -101,9 +101,9 @@ fn render_table(app: &App, filtered: &[&crate::app::RecentQso], frame: &mut Fram
         "Mode",
         "RST\u{2191}",
         "RST\u{2193}",
-        "Dur",
         "Country",
         "Grid",
+        "Comment",
     ]
     .iter()
     .map(|h| {
@@ -133,9 +133,9 @@ fn render_table(app: &App, filtered: &[&crate::app::RecentQso], frame: &mut Fram
             Cell::from(qso.mode.as_str()),
             Cell::from(qso.rst_sent.as_str()),
             Cell::from(qso.rst_rcvd.as_str()),
-            Cell::from(qso.duration.as_deref().unwrap_or("")),
             Cell::from(qso.country.as_deref().unwrap_or("")),
             Cell::from(qso.grid.as_deref().unwrap_or("")),
+            Cell::from(qso.source_record.comment.as_deref().unwrap_or("")),
         ])
         .style(row_style)
         .height(1)
@@ -148,9 +148,9 @@ fn render_table(app: &App, filtered: &[&crate::app::RecentQso], frame: &mut Fram
         Constraint::Length(6),
         Constraint::Length(5),
         Constraint::Length(5),
-        Constraint::Length(9),
-        Constraint::Fill(1),
+        Constraint::Length(14),
         Constraint::Length(7),
+        Constraint::Fill(1),
     ];
 
     let highlight_style = if app.qso_list_focused {


### PR DESCRIPTION
## Summary
- show QSO comments in the TUI recent QSO list
- remove the TUI recent QSO duration column
- keep the Avalonia grid unchanged because it already exposes Comment

## Validation
- cargo test -p qsoripper-tui
- cargo fmt --check