### PR TITLE
Add TUI advanced QSO card editor

### DIFF
--- a/src/rust/qsoripper-tui/src/form.rs
+++ b/src/rust/qsoripper-tui/src/form.rs
@@ -22,75 +22,82 @@ const DEFAULT_BAND_IDX: usize = 5;
 /// Tabs available in the Advanced view.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AdvancedTab {
-    Main,
+    Core,
+    Signal,
+    Station,
     Contest,
-    Technical,
-    Awards,
+    Notes,
 }
 
 impl AdvancedTab {
     pub(crate) const ALL: &'static [AdvancedTab] = &[
-        AdvancedTab::Main,
+        AdvancedTab::Core,
+        AdvancedTab::Signal,
+        AdvancedTab::Station,
         AdvancedTab::Contest,
-        AdvancedTab::Technical,
-        AdvancedTab::Awards,
+        AdvancedTab::Notes,
     ];
 
     pub(crate) fn label(self) -> &'static str {
         match self {
-            AdvancedTab::Main => "Main",
+            AdvancedTab::Core => "Core",
+            AdvancedTab::Signal => "Signal",
+            AdvancedTab::Station => "Station",
             AdvancedTab::Contest => "Contest",
-            AdvancedTab::Technical => "Technical",
-            AdvancedTab::Awards => "Awards",
+            AdvancedTab::Notes => "Notes",
         }
     }
 
     pub(crate) fn next(self) -> Self {
         match self {
-            AdvancedTab::Main => AdvancedTab::Contest,
-            AdvancedTab::Contest => AdvancedTab::Technical,
-            AdvancedTab::Technical => AdvancedTab::Awards,
-            AdvancedTab::Awards => AdvancedTab::Main,
+            AdvancedTab::Core => AdvancedTab::Signal,
+            AdvancedTab::Signal => AdvancedTab::Station,
+            AdvancedTab::Station => AdvancedTab::Contest,
+            AdvancedTab::Contest => AdvancedTab::Notes,
+            AdvancedTab::Notes => AdvancedTab::Core,
         }
     }
 
     pub(crate) fn prev(self) -> Self {
         match self {
-            AdvancedTab::Main => AdvancedTab::Awards,
-            AdvancedTab::Contest => AdvancedTab::Main,
-            AdvancedTab::Technical => AdvancedTab::Contest,
-            AdvancedTab::Awards => AdvancedTab::Technical,
+            AdvancedTab::Core => AdvancedTab::Notes,
+            AdvancedTab::Signal => AdvancedTab::Core,
+            AdvancedTab::Station => AdvancedTab::Signal,
+            AdvancedTab::Contest => AdvancedTab::Station,
+            AdvancedTab::Notes => AdvancedTab::Contest,
         }
     }
 
     /// Return the static slice of fields belonging to this tab.
     pub(crate) fn fields(self) -> &'static [Field] {
         match self {
-            AdvancedTab::Main => ADV_MAIN_FIELDS,
+            AdvancedTab::Core => ADV_CORE_FIELDS,
+            AdvancedTab::Signal => ADV_SIGNAL_FIELDS,
+            AdvancedTab::Station => ADV_STATION_FIELDS,
             AdvancedTab::Contest => ADV_CONTEST_FIELDS,
-            AdvancedTab::Technical => ADV_TECHNICAL_FIELDS,
-            AdvancedTab::Awards => ADV_AWARDS_FIELDS,
+            AdvancedTab::Notes => ADV_NOTES_FIELDS,
         }
     }
 
     /// Return the digit character used as an Alt+digit shortcut for this tab.
     pub(crate) fn shortcut_digit(self) -> char {
         match self {
-            AdvancedTab::Main => '1',
-            AdvancedTab::Contest => '2',
-            AdvancedTab::Technical => '3',
-            AdvancedTab::Awards => '4',
+            AdvancedTab::Core => '1',
+            AdvancedTab::Signal => '2',
+            AdvancedTab::Station => '3',
+            AdvancedTab::Contest => '4',
+            AdvancedTab::Notes => '5',
         }
     }
 
     /// Return the first field of this tab — the focus target when switching to it.
     pub(crate) fn first_field(self) -> Field {
-        self.fields().first().cloned().unwrap_or(Field::Callsign)
+        self.fields().first().copied().unwrap_or(Field::Callsign)
     }
 }
 
 /// Focusable fields in the QSO entry form.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Field {
     /// Worked callsign.
     Callsign,
@@ -167,8 +174,8 @@ const FIELD_ORDER: &[Field] = &[
     Field::Qth,
 ];
 
-/// Fields for the Advanced "Main" tab — mirrors the basic form.
-const ADV_MAIN_FIELDS: &[Field] = &[
+/// Fields for the Advanced "Core" tab — identity and time/frequency basics.
+const ADV_CORE_FIELDS: &[Field] = &[
     Field::Callsign,
     Field::Band,
     Field::Mode,
@@ -176,18 +183,32 @@ const ADV_MAIN_FIELDS: &[Field] = &[
     Field::Date,
     Field::Time,
     Field::TimeOff,
-    Field::Qth,
-    Field::WorkedName,
+];
+
+/// Fields for the Advanced "Signal" tab.
+const ADV_SIGNAL_FIELDS: &[Field] = &[
     Field::RstSent,
     Field::RstRcvd,
-    Field::Comment,
-    Field::Notes,
+    Field::TxPower,
+    Field::Submode,
+    Field::PropMode,
+    Field::SatName,
+    Field::SatMode,
+];
+
+/// Fields for the Advanced "Station" tab.
+const ADV_STATION_FIELDS: &[Field] = &[
+    Field::Qth,
+    Field::WorkedName,
+    Field::WorkedState,
+    Field::WorkedCounty,
+    Field::Iota,
+    Field::ArrlSection,
+    Field::Skcc,
 ];
 
 /// Fields for the Advanced "Contest" tab.
 const ADV_CONTEST_FIELDS: &[Field] = &[
-    Field::TxPower,
-    Field::Submode,
     Field::ContestId,
     Field::SerialSent,
     Field::SerialRcvd,
@@ -195,17 +216,8 @@ const ADV_CONTEST_FIELDS: &[Field] = &[
     Field::ExchangeRcvd,
 ];
 
-/// Fields for the Advanced "Technical" tab.
-const ADV_TECHNICAL_FIELDS: &[Field] = &[Field::PropMode, Field::SatName, Field::SatMode];
-
-/// Fields for the Advanced "Awards" tab.
-const ADV_AWARDS_FIELDS: &[Field] = &[
-    Field::Iota,
-    Field::ArrlSection,
-    Field::WorkedState,
-    Field::WorkedCounty,
-    Field::Skcc,
-];
+/// Fields for the Advanced "Notes" tab.
+const ADV_NOTES_FIELDS: &[Field] = &[Field::Comment, Field::Notes];
 
 /// State of the QSO entry form (basic + advanced fields).
 #[derive(Clone)]
@@ -255,14 +267,14 @@ pub(crate) struct LogForm {
     pub(crate) exchange_sent: String,
     /// Full exchange received string.
     pub(crate) exchange_rcvd: String,
-    // Advanced — Technical tab
+    // Advanced — Signal tab
     /// Propagation mode (ADIF `PROP_MODE` value, e.g., "ES", "TEP", "SAT").
     pub(crate) prop_mode: String,
     /// Satellite name (e.g., "AO-7").
     pub(crate) sat_name: String,
     /// Satellite mode (e.g., "V/U").
     pub(crate) sat_mode: String,
-    // Advanced — Awards tab
+    // Advanced — Station tab
     /// IOTA designator (e.g., "EU-005").
     pub(crate) iota: String,
     /// ARRL section abbreviation (e.g., "WWA", "ENY").
@@ -290,7 +302,7 @@ impl LogForm {
         let mut form = Self {
             focused: Field::Callsign,
             field_selected: false,
-            advanced_tab: AdvancedTab::Main,
+            advanced_tab: AdvancedTab::Core,
             callsign: String::new(),
             band_idx: DEFAULT_BAND_IDX,
             mode_idx: 0,
@@ -332,7 +344,7 @@ impl LogForm {
             .unwrap_or(0);
         self.focused = FIELD_ORDER
             .get((idx + 1) % FIELD_ORDER.len())
-            .cloned()
+            .copied()
             .unwrap_or(Field::Callsign);
         self.field_selected = true;
     }
@@ -348,17 +360,18 @@ impl LogForm {
         } else {
             idx - 1
         };
-        self.focused = FIELD_ORDER.get(new_idx).cloned().unwrap_or(Field::Callsign);
+        self.focused = FIELD_ORDER.get(new_idx).copied().unwrap_or(Field::Callsign);
         self.field_selected = true;
     }
 
     /// Return the field list for the current advanced tab.
     pub(crate) fn current_advanced_fields(&self) -> &'static [Field] {
         match self.advanced_tab {
-            AdvancedTab::Main => ADV_MAIN_FIELDS,
+            AdvancedTab::Core => ADV_CORE_FIELDS,
+            AdvancedTab::Signal => ADV_SIGNAL_FIELDS,
+            AdvancedTab::Station => ADV_STATION_FIELDS,
             AdvancedTab::Contest => ADV_CONTEST_FIELDS,
-            AdvancedTab::Technical => ADV_TECHNICAL_FIELDS,
-            AdvancedTab::Awards => ADV_AWARDS_FIELDS,
+            AdvancedTab::Notes => ADV_NOTES_FIELDS,
         }
     }
 
@@ -368,7 +381,7 @@ impl LogForm {
         let idx = fields.iter().position(|f| f == &self.focused).unwrap_or(0);
         self.focused = fields
             .get((idx + 1) % fields.len())
-            .cloned()
+            .copied()
             .unwrap_or(Field::Callsign);
         self.field_selected = true;
     }
@@ -382,7 +395,7 @@ impl LogForm {
         } else {
             idx - 1
         };
-        self.focused = fields.get(new_idx).cloned().unwrap_or(Field::Callsign);
+        self.focused = fields.get(new_idx).copied().unwrap_or(Field::Callsign);
         self.field_selected = true;
     }
 
@@ -392,7 +405,7 @@ impl LogForm {
         self.focused = self
             .current_advanced_fields()
             .first()
-            .cloned()
+            .copied()
             .unwrap_or(Field::Callsign);
         self.field_selected = true;
     }
@@ -403,7 +416,7 @@ impl LogForm {
         self.focused = self
             .current_advanced_fields()
             .first()
-            .cloned()
+            .copied()
             .unwrap_or(Field::Callsign);
         self.field_selected = true;
     }
@@ -775,7 +788,7 @@ mod tests {
         ];
         for (field, _getter) in &fields_and_setters {
             let mut form = LogForm::new();
-            form.focused = field.clone();
+            form.focused = *field;
             assert!(
                 form.current_field_text_mut().is_some(),
                 "Field {field:?} should return Some"
@@ -843,72 +856,78 @@ mod tests {
 
     #[test]
     fn advanced_tab_shortcut_digits() {
-        assert_eq!(AdvancedTab::Main.shortcut_digit(), '1');
-        assert_eq!(AdvancedTab::Contest.shortcut_digit(), '2');
-        assert_eq!(AdvancedTab::Technical.shortcut_digit(), '3');
-        assert_eq!(AdvancedTab::Awards.shortcut_digit(), '4');
+        assert_eq!(AdvancedTab::Core.shortcut_digit(), '1');
+        assert_eq!(AdvancedTab::Signal.shortcut_digit(), '2');
+        assert_eq!(AdvancedTab::Station.shortcut_digit(), '3');
+        assert_eq!(AdvancedTab::Contest.shortcut_digit(), '4');
+        assert_eq!(AdvancedTab::Notes.shortcut_digit(), '5');
     }
 
     #[test]
     fn advanced_tab_first_fields() {
-        assert_eq!(AdvancedTab::Main.first_field(), Field::Callsign);
-        assert_eq!(AdvancedTab::Contest.first_field(), Field::TxPower);
-        assert_eq!(AdvancedTab::Technical.first_field(), Field::PropMode);
-        assert_eq!(AdvancedTab::Awards.first_field(), Field::Iota);
+        assert_eq!(AdvancedTab::Core.first_field(), Field::Callsign);
+        assert_eq!(AdvancedTab::Signal.first_field(), Field::RstSent);
+        assert_eq!(AdvancedTab::Station.first_field(), Field::Qth);
+        assert_eq!(AdvancedTab::Contest.first_field(), Field::ContestId);
+        assert_eq!(AdvancedTab::Notes.first_field(), Field::Comment);
     }
 
     #[test]
     fn advanced_tab_fields_consistent_with_adv_slices() {
-        assert_eq!(AdvancedTab::Main.fields(), ADV_MAIN_FIELDS);
+        assert_eq!(AdvancedTab::Core.fields(), ADV_CORE_FIELDS);
+        assert_eq!(AdvancedTab::Signal.fields(), ADV_SIGNAL_FIELDS);
+        assert_eq!(AdvancedTab::Station.fields(), ADV_STATION_FIELDS);
         assert_eq!(AdvancedTab::Contest.fields(), ADV_CONTEST_FIELDS);
-        assert_eq!(AdvancedTab::Technical.fields(), ADV_TECHNICAL_FIELDS);
-        assert_eq!(AdvancedTab::Awards.fields(), ADV_AWARDS_FIELDS);
+        assert_eq!(AdvancedTab::Notes.fields(), ADV_NOTES_FIELDS);
     }
 
     #[test]
     fn advanced_tab_labels() {
-        assert_eq!(AdvancedTab::Main.label(), "Main");
+        assert_eq!(AdvancedTab::Core.label(), "Core");
+        assert_eq!(AdvancedTab::Signal.label(), "Signal");
+        assert_eq!(AdvancedTab::Station.label(), "Station");
         assert_eq!(AdvancedTab::Contest.label(), "Contest");
-        assert_eq!(AdvancedTab::Technical.label(), "Technical");
-        assert_eq!(AdvancedTab::Awards.label(), "Awards");
+        assert_eq!(AdvancedTab::Notes.label(), "Notes");
     }
 
     #[test]
     fn advanced_tab_next_cycles_all() {
-        assert_eq!(AdvancedTab::Main.next(), AdvancedTab::Contest);
-        assert_eq!(AdvancedTab::Contest.next(), AdvancedTab::Technical);
-        assert_eq!(AdvancedTab::Technical.next(), AdvancedTab::Awards);
-        assert_eq!(AdvancedTab::Awards.next(), AdvancedTab::Main);
+        assert_eq!(AdvancedTab::Core.next(), AdvancedTab::Signal);
+        assert_eq!(AdvancedTab::Signal.next(), AdvancedTab::Station);
+        assert_eq!(AdvancedTab::Station.next(), AdvancedTab::Contest);
+        assert_eq!(AdvancedTab::Contest.next(), AdvancedTab::Notes);
+        assert_eq!(AdvancedTab::Notes.next(), AdvancedTab::Core);
     }
 
     #[test]
     fn advanced_tab_prev_cycles_all() {
-        assert_eq!(AdvancedTab::Main.prev(), AdvancedTab::Awards);
-        assert_eq!(AdvancedTab::Awards.prev(), AdvancedTab::Technical);
-        assert_eq!(AdvancedTab::Technical.prev(), AdvancedTab::Contest);
-        assert_eq!(AdvancedTab::Contest.prev(), AdvancedTab::Main);
+        assert_eq!(AdvancedTab::Core.prev(), AdvancedTab::Notes);
+        assert_eq!(AdvancedTab::Notes.prev(), AdvancedTab::Contest);
+        assert_eq!(AdvancedTab::Contest.prev(), AdvancedTab::Station);
+        assert_eq!(AdvancedTab::Station.prev(), AdvancedTab::Signal);
+        assert_eq!(AdvancedTab::Signal.prev(), AdvancedTab::Core);
     }
 
     #[test]
     fn all_advanced_tabs_count() {
-        assert_eq!(AdvancedTab::ALL.len(), 4);
+        assert_eq!(AdvancedTab::ALL.len(), 5);
     }
 
     #[test]
     fn next_advanced_tab_updates_focus() {
         let mut form = LogForm::new();
-        form.advanced_tab = AdvancedTab::Main;
+        form.advanced_tab = AdvancedTab::Core;
         form.next_advanced_tab();
-        assert_eq!(form.advanced_tab, AdvancedTab::Contest);
+        assert_eq!(form.advanced_tab, AdvancedTab::Signal);
         assert!(form.field_selected);
     }
 
     #[test]
     fn prev_advanced_tab_updates_focus() {
         let mut form = LogForm::new();
-        form.advanced_tab = AdvancedTab::Main;
+        form.advanced_tab = AdvancedTab::Core;
         form.prev_advanced_tab();
-        assert_eq!(form.advanced_tab, AdvancedTab::Awards);
+        assert_eq!(form.advanced_tab, AdvancedTab::Notes);
         assert!(form.field_selected);
     }
 
@@ -917,7 +936,7 @@ mod tests {
         let mut form = LogForm::new();
         form.advanced_tab = AdvancedTab::Contest;
         let count = ADV_CONTEST_FIELDS.len();
-        form.focused = ADV_CONTEST_FIELDS[0].clone();
+        form.focused = ADV_CONTEST_FIELDS[0];
         for _ in 0..count {
             form.next_advanced_field();
         }
@@ -927,20 +946,40 @@ mod tests {
     #[test]
     fn prev_advanced_field_from_first_wraps_to_last() {
         let mut form = LogForm::new();
-        form.advanced_tab = AdvancedTab::Technical;
+        form.advanced_tab = AdvancedTab::Signal;
         let fields = form.current_advanced_fields();
-        form.focused = fields[0].clone();
+        form.focused = fields[0];
         form.prev_advanced_field();
         assert_eq!(form.focused, *fields.last().unwrap());
     }
 
     #[test]
-    fn current_advanced_fields_main_tab() {
+    fn current_advanced_fields_core_tab() {
         let mut form = LogForm::new();
-        form.advanced_tab = AdvancedTab::Main;
+        form.advanced_tab = AdvancedTab::Core;
         let fields = form.current_advanced_fields();
         assert!(fields.contains(&Field::Callsign));
+        assert!(fields.contains(&Field::FrequencyMhz));
+    }
+
+    #[test]
+    fn current_advanced_fields_signal_tab() {
+        let mut form = LogForm::new();
+        form.advanced_tab = AdvancedTab::Signal;
+        let fields = form.current_advanced_fields();
+        assert!(fields.contains(&Field::RstSent));
+        assert!(fields.contains(&Field::PropMode));
+        assert!(fields.contains(&Field::TxPower));
+    }
+
+    #[test]
+    fn current_advanced_fields_station_tab() {
+        let mut form = LogForm::new();
+        form.advanced_tab = AdvancedTab::Station;
+        let fields = form.current_advanced_fields();
         assert!(fields.contains(&Field::WorkedName));
+        assert!(fields.contains(&Field::Iota));
+        assert!(fields.contains(&Field::Skcc));
     }
 
     #[test]
@@ -953,22 +992,12 @@ mod tests {
     }
 
     #[test]
-    fn current_advanced_fields_technical_tab() {
+    fn current_advanced_fields_notes_tab() {
         let mut form = LogForm::new();
-        form.advanced_tab = AdvancedTab::Technical;
+        form.advanced_tab = AdvancedTab::Notes;
         let fields = form.current_advanced_fields();
-        assert!(fields.contains(&Field::PropMode));
-        assert!(fields.contains(&Field::SatName));
-    }
-
-    #[test]
-    fn current_advanced_fields_awards_tab() {
-        let mut form = LogForm::new();
-        form.advanced_tab = AdvancedTab::Awards;
-        let fields = form.current_advanced_fields();
-        assert!(fields.contains(&Field::Iota));
-        assert!(fields.contains(&Field::ArrlSection));
-        assert!(fields.contains(&Field::Skcc));
+        assert!(fields.contains(&Field::Comment));
+        assert!(fields.contains(&Field::Notes));
     }
 
     #[test]

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -433,7 +433,7 @@ fn handle_key_with_channel(
             }
             app::View::LogEntry => {
                 app.view = app::View::Advanced;
-                app.form.advanced_tab = AdvancedTab::Main;
+                app.form.advanced_tab = AdvancedTab::Core;
                 app.form.focused = Field::Callsign;
                 app.form.field_selected = true;
             }
@@ -483,7 +483,7 @@ fn handle_key_with_channel(
         KeyCode::Left if app.form.is_cycle_field() => cycle_left(app),
         KeyCode::Right if app.form.is_cycle_field() => cycle_right(app),
         KeyCode::Backspace => {
-            let focused = app.form.focused.clone();
+            let focused = app.form.focused;
             if app.form.field_selected {
                 if let Some(text) = app.form.current_field_text_mut() {
                     text.clear();
@@ -712,7 +712,7 @@ fn spawn_purge_deleted_qsos(
 
 /// Handle a plain character key press — type-selects Band/Mode, or appends to text fields.
 fn handle_char_key(app: &mut App, c: char, lookup_tx: &watch::Sender<String>) {
-    let focused = app.form.focused.clone();
+    let focused = app.form.focused;
     match focused {
         Field::Band => app.form.type_select_band(c),
         Field::Mode => app.form.type_select_mode(c),
@@ -740,10 +740,11 @@ fn handle_char_key(app: &mut App, c: char, lookup_tx: &watch::Sender<String>) {
 
 fn digit_to_tab(ch: char) -> Option<AdvancedTab> {
     match ch {
-        '1' => Some(AdvancedTab::Main),
-        '2' => Some(AdvancedTab::Contest),
-        '3' => Some(AdvancedTab::Technical),
-        '4' => Some(AdvancedTab::Awards),
+        '1' => Some(AdvancedTab::Core),
+        '2' => Some(AdvancedTab::Signal),
+        '3' => Some(AdvancedTab::Station),
+        '4' => Some(AdvancedTab::Contest),
+        '5' => Some(AdvancedTab::Notes),
         _ => None,
     }
 }
@@ -762,7 +763,24 @@ fn jump_to_field(app: &mut App, ch: char) {
         switch_to_tab(app, tab);
         return;
     }
-    let (target, tab) = match ch.to_ascii_lowercase() {
+    if matches!(app.view, app::View::Advanced) && app.form.advanced_tab == AdvancedTab::Contest {
+        match ch.to_ascii_lowercase() {
+            'o' => {
+                app.form.focused = Field::ExchangeSent;
+                app.form.field_selected = true;
+                app.qso_list_focused = false;
+                return;
+            }
+            'n' => {
+                app.form.focused = Field::ExchangeRcvd;
+                app.form.field_selected = true;
+                app.qso_list_focused = false;
+                return;
+            }
+            _ => {}
+        }
+    }
+    let (target, mut tab) = match ch.to_ascii_lowercase() {
         'c' => (Field::Callsign, None),
         'b' => (Field::Band, None),
         'm' => (Field::Mode, None),
@@ -775,18 +793,63 @@ fn jump_to_field(app: &mut App, ch: char) {
         't' => (Field::Time, None),
         'e' => (Field::TimeOff, None),
         'q' => (Field::Qth, None),
-        'a' => (Field::WorkedName, Some(AdvancedTab::Main)),
-        'k' => (Field::Skcc, Some(AdvancedTab::Awards)),
-        'w' => (Field::TxPower, Some(AdvancedTab::Contest)),
-        'p' => (Field::PropMode, Some(AdvancedTab::Technical)),
+        'a' => (Field::WorkedName, Some(AdvancedTab::Station)),
+        'k' => (Field::Skcc, Some(AdvancedTab::Station)),
+        'w' => (Field::TxPower, Some(AdvancedTab::Signal)),
+        'p' => (Field::PropMode, Some(AdvancedTab::Signal)),
+        'u' => (Field::Submode, Some(AdvancedTab::Signal)),
+        'l' => (Field::SatName, Some(AdvancedTab::Signal)),
+        'v' => (Field::SatMode, Some(AdvancedTab::Signal)),
+        'i' => (Field::Iota, Some(AdvancedTab::Station)),
+        'h' => (Field::WorkedState, Some(AdvancedTab::Station)),
+        'y' => (Field::WorkedCounty, Some(AdvancedTab::Station)),
+        'x' => (Field::ArrlSection, Some(AdvancedTab::Station)),
+        'g' => (Field::ContestId, Some(AdvancedTab::Contest)),
+        'j' => (Field::SerialSent, Some(AdvancedTab::Contest)),
+        'z' => (Field::SerialRcvd, Some(AdvancedTab::Contest)),
         _ => return,
     };
+    if tab.is_none() && matches!(app.view, app::View::Advanced) {
+        tab = Some(advanced_tab_for_field(target));
+    }
     if let Some(tab) = tab {
         switch_to_tab(app, tab);
     }
     app.form.focused = target;
     app.form.field_selected = true;
     app.qso_list_focused = false;
+}
+
+fn advanced_tab_for_field(field: Field) -> AdvancedTab {
+    match field {
+        Field::Callsign
+        | Field::Band
+        | Field::Mode
+        | Field::FrequencyMhz
+        | Field::Date
+        | Field::Time
+        | Field::TimeOff => AdvancedTab::Core,
+        Field::RstSent
+        | Field::RstRcvd
+        | Field::TxPower
+        | Field::Submode
+        | Field::PropMode
+        | Field::SatName
+        | Field::SatMode => AdvancedTab::Signal,
+        Field::Qth
+        | Field::WorkedName
+        | Field::WorkedState
+        | Field::WorkedCounty
+        | Field::Iota
+        | Field::ArrlSection
+        | Field::Skcc => AdvancedTab::Station,
+        Field::ContestId
+        | Field::SerialSent
+        | Field::SerialRcvd
+        | Field::ExchangeSent
+        | Field::ExchangeRcvd => AdvancedTab::Contest,
+        Field::Comment | Field::Notes => AdvancedTab::Notes,
+    }
 }
 
 /// Load the QSO identified by `local_id` into the form for editing.
@@ -1346,6 +1409,7 @@ mod tests {
         assert!(matches!(app.view, View::LogEntry));
         jump_to_field(&mut app, 'a');
         assert_eq!(app.form.focused, Field::WorkedName);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Station);
         assert!(matches!(app.view, View::Advanced));
     }
 
@@ -1355,84 +1419,106 @@ mod tests {
         app.view = View::Advanced;
         jump_to_field(&mut app, 'a');
         assert_eq!(app.form.focused, Field::WorkedName);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Station);
         assert!(matches!(app.view, View::Advanced));
     }
 
     #[test]
     fn jump_to_field_unknown_char_does_nothing() {
         let mut app = make_app();
-        let original_focused = app.form.focused.clone();
-        jump_to_field(&mut app, 'z');
+        let original_focused = app.form.focused;
+        jump_to_field(&mut app, '?');
         assert_eq!(app.form.focused, original_focused);
     }
 
     #[test]
-    fn jump_to_tab_1_switches_to_main() {
+    fn jump_to_tab_1_switches_to_core() {
         let mut app = make_app();
         jump_to_field(&mut app, '1');
         assert!(matches!(app.view, View::Advanced));
-        assert_eq!(app.form.advanced_tab, AdvancedTab::Main);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Core);
         assert_eq!(app.form.focused, Field::Callsign);
         assert!(app.form.field_selected);
         assert!(!app.qso_list_focused);
     }
 
     #[test]
-    fn jump_to_tab_2_switches_to_contest() {
+    fn jump_to_tab_2_switches_to_signal() {
         let mut app = make_app();
         jump_to_field(&mut app, '2');
         assert!(matches!(app.view, View::Advanced));
-        assert_eq!(app.form.advanced_tab, AdvancedTab::Contest);
-        assert_eq!(app.form.focused, Field::TxPower);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Signal);
+        assert_eq!(app.form.focused, Field::RstSent);
         assert!(app.form.field_selected);
     }
 
     #[test]
-    fn jump_to_tab_3_switches_to_technical() {
+    fn jump_to_tab_3_switches_to_station() {
         let mut app = make_app();
         jump_to_field(&mut app, '3');
         assert!(matches!(app.view, View::Advanced));
-        assert_eq!(app.form.advanced_tab, AdvancedTab::Technical);
-        assert_eq!(app.form.focused, Field::PropMode);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Station);
+        assert_eq!(app.form.focused, Field::Qth);
         assert!(app.form.field_selected);
     }
 
     #[test]
-    fn jump_to_tab_4_switches_to_awards() {
+    fn jump_to_tab_4_switches_to_contest() {
         let mut app = make_app();
         jump_to_field(&mut app, '4');
         assert!(matches!(app.view, View::Advanced));
-        assert_eq!(app.form.advanced_tab, AdvancedTab::Awards);
-        assert_eq!(app.form.focused, Field::Iota);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Contest);
+        assert_eq!(app.form.focused, Field::ContestId);
         assert!(app.form.field_selected);
     }
 
     #[test]
-    fn jump_to_field_skcc_opens_awards_tab() {
+    fn jump_to_tab_5_switches_to_notes() {
+        let mut app = make_app();
+        jump_to_field(&mut app, '5');
+        assert!(matches!(app.view, View::Advanced));
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Notes);
+        assert_eq!(app.form.focused, Field::Comment);
+        assert!(app.form.field_selected);
+    }
+
+    #[test]
+    fn jump_to_field_exchange_uses_contest_context() {
+        let mut app = make_app();
+        app.view = View::Advanced;
+        app.form.advanced_tab = AdvancedTab::Contest;
+        jump_to_field(&mut app, 'o');
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Contest);
+        assert_eq!(app.form.focused, Field::ExchangeSent);
+        assert!(app.form.field_selected);
+    }
+
+    #[test]
+    fn jump_to_field_skcc_opens_station_tab() {
         let mut app = make_app();
         jump_to_field(&mut app, 'k');
         assert!(matches!(app.view, View::Advanced));
-        assert_eq!(app.form.advanced_tab, AdvancedTab::Awards);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Station);
         assert_eq!(app.form.focused, Field::Skcc);
         assert!(app.form.field_selected);
     }
 
     #[test]
-    fn jump_to_field_tx_power_opens_contest_tab() {
+    fn jump_to_field_tx_power_opens_signal_tab() {
         let mut app = make_app();
         jump_to_field(&mut app, 'w');
         assert!(matches!(app.view, View::Advanced));
-        assert_eq!(app.form.advanced_tab, AdvancedTab::Contest);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Signal);
         assert_eq!(app.form.focused, Field::TxPower);
         assert!(app.form.field_selected);
     }
 
     #[test]
-    fn jump_to_field_prop_mode_opens_technical_tab() {
+    fn jump_to_field_prop_mode_opens_signal_tab() {
         let mut app = make_app();
         jump_to_field(&mut app, 'p');
         assert!(matches!(app.view, View::Advanced));
-        assert_eq!(app.form.advanced_tab, AdvancedTab::Technical);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Signal);
         assert_eq!(app.form.focused, Field::PropMode);
         assert!(app.form.field_selected);
     }
@@ -2574,7 +2660,7 @@ mod tests {
         let mut app = make_app();
         app.view = View::Advanced;
         use crate::form::AdvancedTab;
-        assert_eq!(app.form.advanced_tab, AdvancedTab::Main);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Core);
         handle_key(
             &mut app,
             make_key(KeyCode::F(5)),
@@ -2583,7 +2669,7 @@ mod tests {
             &rig_tx,
             "",
         );
-        assert_eq!(app.form.advanced_tab, AdvancedTab::Contest);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Signal);
     }
 
     #[tokio::test]
@@ -2602,7 +2688,7 @@ mod tests {
             "",
         );
         use crate::form::AdvancedTab;
-        assert_eq!(app.form.advanced_tab, AdvancedTab::Awards);
+        assert_eq!(app.form.advanced_tab, AdvancedTab::Notes);
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-tui/src/ui/advanced_form.rs
+++ b/src/rust/qsoripper-tui/src/ui/advanced_form.rs
@@ -1,4 +1,4 @@
-//! Advanced QSO field entry form rendering — tabbed layout.
+//! Advanced QSO card editor rendering — compact, tabbed, keyboard-first layout.
 
 use ratatui::{
     layout::{Constraint, Layout, Rect},
@@ -9,43 +9,100 @@ use ratatui::{
 };
 
 use crate::app::App;
-use crate::form::{AdvancedTab, Field};
+use crate::form::{AdvancedTab, Field, LogForm};
 use crate::ui::log_form::styled_field;
 
-/// Render the advanced field entry form into `area`.
+const LABEL_WIDTH: usize = 13;
+
+struct FieldSpec {
+    field: Field,
+    key: char,
+    label: &'static str,
+}
+
+/// Render the advanced QSO card editor into `area`.
 pub(super) fn render(app: &App, frame: &mut Frame, area: Rect) {
+    let title = if app.editing_local_id.is_some() {
+        " QSO Card - Edit "
+    } else {
+        " QSO Card - New "
+    };
     let block = Block::bordered()
-        .title(" Advanced Fields  (F2/Esc return | Alt+1-4 tabs | F5/F6 cycle) ")
+        .title(title)
         .border_style(Style::default().fg(Color::Magenta));
 
     let inner = block.inner(area);
     frame.render_widget(block, area);
 
-    if inner.height < 3 {
+    if inner.height < 6 {
         return;
     }
 
     let layout = Layout::vertical([
-        Constraint::Length(1), // tab bar
-        Constraint::Length(1), // separator line
-        Constraint::Fill(1),   // field rows
+        Constraint::Length(2), // card summary
+        Constraint::Length(1), // section tabs
+        Constraint::Fill(1),   // selected section
+        Constraint::Length(1), // action hints
     ])
     .split(inner);
 
-    let tab_area = layout.first().copied().unwrap_or(inner);
-    let fields_area = layout.get(2).copied().unwrap_or(inner);
+    render_header(app, frame, layout.first().copied().unwrap_or(inner));
+    render_tab_bar(
+        frame,
+        layout.get(1).copied().unwrap_or(inner),
+        app.form.advanced_tab,
+    );
+    render_tab_content(
+        frame,
+        layout.get(2).copied().unwrap_or(inner),
+        &app.form,
+        app.form.advanced_tab,
+    );
+    render_footer(frame, layout.get(3).copied().unwrap_or(inner));
+}
 
-    render_tab_bar(frame, tab_area, app.form.advanced_tab);
-
-    let form = &app.form;
-    let wide = (inner.width as usize).saturating_sub(13).max(10);
-
-    match form.advanced_tab {
-        AdvancedTab::Main => render_main_tab(frame, fields_area, form, wide),
-        AdvancedTab::Contest => render_contest_tab(frame, fields_area, form, wide),
-        AdvancedTab::Technical => render_technical_tab(frame, fields_area, form, wide),
-        AdvancedTab::Awards => render_awards_tab(frame, fields_area, form, wide),
-    }
+fn render_header(app: &App, frame: &mut Frame, area: Rect) {
+    let call = if app.form.callsign.is_empty() {
+        "new contact"
+    } else {
+        app.form.callsign.as_str()
+    };
+    let mode = if app.editing_local_id.is_some() {
+        "Edit existing"
+    } else {
+        "New contact"
+    };
+    let subtitle = if app.editing_local_id.is_some() {
+        "F10 updates, Esc/F2 returns to normal entry"
+    } else {
+        "Advanced entry: grouped fields, low-churn tab switching"
+    };
+    frame.render_widget(
+        Paragraph::new(vec![
+            Line::from(vec![
+                Span::styled(
+                    call.to_string(),
+                    Style::default()
+                        .fg(Color::Yellow)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::raw("  "),
+                Span::styled(mode, Style::default().fg(Color::Black).bg(Color::DarkGray)),
+                Span::raw("  "),
+                Span::styled(
+                    app.form.band_str().to_string(),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::raw(" / "),
+                Span::styled(
+                    app.form.mode_str().to_string(),
+                    Style::default().fg(Color::Cyan),
+                ),
+            ]),
+            Line::from(Span::styled(subtitle, Style::default().fg(Color::DarkGray))),
+        ]),
+        area,
+    );
 }
 
 fn render_tab_bar(frame: &mut Frame, area: Rect, active: AdvancedTab) {
@@ -63,421 +120,352 @@ fn render_tab_bar(frame: &mut Frame, area: Rect, active: AdvancedTab) {
             spans.push(Span::styled(digit, base.add_modifier(Modifier::UNDERLINED)));
             spans.push(Span::styled(label_text, base));
         } else {
-            let base = Style::default().fg(Color::Magenta).bg(Color::Reset);
+            let base = Style::default().fg(Color::Magenta);
             spans.push(Span::styled(" ", base));
             spans.push(Span::styled(digit, base.add_modifier(Modifier::UNDERLINED)));
             spans.push(Span::styled(label_text, base));
         }
         spans.push(Span::raw(" "));
     }
+    spans.push(Span::styled(
+        "  Alt+1-5 / F5-F6",
+        Style::default().fg(Color::DarkGray),
+    ));
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
-#[expect(
-    clippy::too_many_lines,
-    reason = "renders seven content rows plus a hint line for the main tab"
-)]
-fn render_main_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, _wide: usize) {
-    if area.height == 0 {
+fn render_tab_content(frame: &mut Frame, area: Rect, form: &LogForm, tab: AdvancedTab) {
+    match tab {
+        AdvancedTab::Core => render_core_tab(frame, area, form),
+        AdvancedTab::Signal => render_signal_tab(frame, area, form),
+        AdvancedTab::Station => render_station_tab(frame, area, form),
+        AdvancedTab::Contest => render_contest_tab(frame, area, form),
+        AdvancedTab::Notes => render_notes_tab(frame, area, form),
+    }
+}
+
+fn render_core_tab(frame: &mut Frame, area: Rect, form: &LogForm) {
+    let cols = two_columns(area);
+    render_group(
+        frame,
+        cols[0],
+        " Contact ",
+        form,
+        &[
+            FieldSpec {
+                field: Field::Callsign,
+                key: 'C',
+                label: "Callsign",
+            },
+            FieldSpec {
+                field: Field::Band,
+                key: 'B',
+                label: "Band",
+            },
+            FieldSpec {
+                field: Field::Mode,
+                key: 'M',
+                label: "Mode",
+            },
+            FieldSpec {
+                field: Field::FrequencyMhz,
+                key: 'F',
+                label: "Freq MHz",
+            },
+        ],
+    );
+    render_group(
+        frame,
+        cols[1],
+        " UTC ",
+        form,
+        &[
+            FieldSpec {
+                field: Field::Date,
+                key: 'D',
+                label: "Date",
+            },
+            FieldSpec {
+                field: Field::Time,
+                key: 'T',
+                label: "Start",
+            },
+            FieldSpec {
+                field: Field::TimeOff,
+                key: 'E',
+                label: "End",
+            },
+        ],
+    );
+}
+
+fn render_signal_tab(frame: &mut Frame, area: Rect, form: &LogForm) {
+    let cols = two_columns(area);
+    render_group(
+        frame,
+        cols[0],
+        " Reports ",
+        form,
+        &[
+            FieldSpec {
+                field: Field::RstSent,
+                key: 'S',
+                label: "RST sent",
+            },
+            FieldSpec {
+                field: Field::RstRcvd,
+                key: 'R',
+                label: "RST rcvd",
+            },
+            FieldSpec {
+                field: Field::TxPower,
+                key: 'W',
+                label: "TX power",
+            },
+            FieldSpec {
+                field: Field::Submode,
+                key: 'U',
+                label: "Submode",
+            },
+        ],
+    );
+    render_group(
+        frame,
+        cols[1],
+        " Propagation ",
+        form,
+        &[
+            FieldSpec {
+                field: Field::PropMode,
+                key: 'P',
+                label: "Prop mode",
+            },
+            FieldSpec {
+                field: Field::SatName,
+                key: 'L',
+                label: "Satellite",
+            },
+            FieldSpec {
+                field: Field::SatMode,
+                key: 'V',
+                label: "Sat mode",
+            },
+        ],
+    );
+}
+
+fn render_station_tab(frame: &mut Frame, area: Rect, form: &LogForm) {
+    let cols = two_columns(area);
+    render_group(
+        frame,
+        cols[0],
+        " Worked station ",
+        form,
+        &[
+            FieldSpec {
+                field: Field::WorkedName,
+                key: 'A',
+                label: "Name",
+            },
+            FieldSpec {
+                field: Field::Qth,
+                key: 'Q',
+                label: "QTH",
+            },
+            FieldSpec {
+                field: Field::WorkedState,
+                key: 'H',
+                label: "State",
+            },
+            FieldSpec {
+                field: Field::WorkedCounty,
+                key: 'Y',
+                label: "County",
+            },
+        ],
+    );
+    render_group(
+        frame,
+        cols[1],
+        " Location / awards ",
+        form,
+        &[
+            FieldSpec {
+                field: Field::Iota,
+                key: 'I',
+                label: "IOTA",
+            },
+            FieldSpec {
+                field: Field::ArrlSection,
+                key: 'X',
+                label: "ARRL sec",
+            },
+            FieldSpec {
+                field: Field::Skcc,
+                key: 'K',
+                label: "SKCC",
+            },
+        ],
+    );
+}
+
+fn render_contest_tab(frame: &mut Frame, area: Rect, form: &LogForm) {
+    let cols = two_columns(area);
+    render_group(
+        frame,
+        cols[0],
+        " Contest ",
+        form,
+        &[
+            FieldSpec {
+                field: Field::ContestId,
+                key: 'G',
+                label: "Contest ID",
+            },
+            FieldSpec {
+                field: Field::SerialSent,
+                key: 'J',
+                label: "Serial sent",
+            },
+            FieldSpec {
+                field: Field::SerialRcvd,
+                key: 'Z',
+                label: "Serial rcvd",
+            },
+        ],
+    );
+    render_group(
+        frame,
+        cols[1],
+        " Exchange ",
+        form,
+        &[
+            FieldSpec {
+                field: Field::ExchangeSent,
+                key: 'O',
+                label: "Exch sent",
+            },
+            FieldSpec {
+                field: Field::ExchangeRcvd,
+                key: 'N',
+                label: "Exch rcvd",
+            },
+        ],
+    );
+}
+
+fn render_notes_tab(frame: &mut Frame, area: Rect, form: &LogForm) {
+    let cols = two_columns(area);
+    render_group(
+        frame,
+        cols[0],
+        " Comments ",
+        form,
+        &[FieldSpec {
+            field: Field::Comment,
+            key: 'O',
+            label: "Comment",
+        }],
+    );
+    render_group(
+        frame,
+        cols[1],
+        " Operator notes ",
+        form,
+        &[FieldSpec {
+            field: Field::Notes,
+            key: 'N',
+            label: "Notes",
+        }],
+    );
+}
+
+fn render_group(
+    frame: &mut Frame,
+    area: Rect,
+    title: &'static str,
+    form: &LogForm,
+    fields: &[FieldSpec],
+) {
+    let block = Block::bordered()
+        .title(title)
+        .border_style(Style::default().fg(Color::DarkGray));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    if inner.height == 0 {
         return;
     }
-    let rows = Layout::vertical([
-        Constraint::Length(1), // callsign / band / mode
-        Constraint::Length(1), // freq / date
-        Constraint::Length(1), // time / time-off
-        Constraint::Length(1), // qth / name
-        Constraint::Length(1), // rst sent / rst rcvd
-        Constraint::Length(1), // comment
-        Constraint::Length(1), // notes
-        Constraint::Fill(1),   // hint
-    ])
-    .split(area);
 
-    // Row 0: [C]allsign  [B]and  [M]ode
-    if let Some(row) = rows.first().copied() {
-        let cs_focused = form.focused == Field::Callsign;
-        let cs_selected = cs_focused && form.field_selected;
-        let band_focused = form.focused == Field::Band;
-        let mode_focused = form.focused == Field::Mode;
-        let cs_val = adv_field(&form.callsign, cs_focused, cs_selected, 12);
-        let band_val = cycle_adv(form.band_str(), band_focused);
-        let mode_val = cycle_adv(form.mode_str(), mode_focused);
-        let mut spans: Vec<Span<'static>> = Vec::new();
-        spans.extend(kl("", 'c', "allsign  "));
-        spans.push(styled_field(cs_val, cs_focused, cs_selected));
-        spans.push(Span::raw("  "));
-        spans.extend(kl("", 'b', "and "));
-        spans.push(Span::styled(
-            band_val,
-            Style::default()
-                .fg(if band_focused {
-                    Color::Yellow
-                } else {
-                    Color::Gray
-                })
-                .add_modifier(if band_focused {
-                    Modifier::BOLD
-                } else {
-                    Modifier::empty()
-                }),
-        ));
-        spans.push(Span::raw("  "));
-        spans.extend(kl("", 'm', "ode "));
-        spans.push(Span::styled(
-            mode_val,
-            Style::default()
-                .fg(if mode_focused {
-                    Color::Yellow
-                } else {
-                    Color::Gray
-                })
-                .add_modifier(if mode_focused {
-                    Modifier::BOLD
-                } else {
-                    Modifier::empty()
-                }),
-        ));
-        frame.render_widget(Paragraph::new(Line::from(spans)), row);
-    }
-
-    // Row 1: [F]req MHz (left half) | [D]ate (right half)
-    if let Some(row) = rows.get(1).copied() {
-        let cols =
-            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(row);
-        let ff = form.focused == Field::FrequencyMhz;
-        let fs = ff && form.field_selected;
-        let df = form.focused == Field::Date;
-        let ds = df && form.field_selected;
-        if let Some(&left) = cols.first() {
-            let fw = (left.width as usize).saturating_sub(10).max(5);
-            let fv = adv_field(&form.frequency_mhz, ff, fs, fw);
-            let mut s: Vec<Span<'static>> = Vec::new();
-            s.extend(kl("", 'f', "req MHz  "));
-            s.push(styled_field(fv, ff, fs));
-            frame.render_widget(Paragraph::new(Line::from(s)), left);
+    let constraints: Vec<Constraint> = fields.iter().map(|_| Constraint::Length(1)).collect();
+    let rows = Layout::vertical(constraints).split(inner);
+    for (idx, spec) in fields.iter().enumerate() {
+        if let Some(row) = rows.get(idx).copied() {
+            render_field(frame, row, form, spec);
         }
-        if let Some(&right) = cols.get(1) {
-            let dw = (right.width as usize).saturating_sub(10).max(5);
-            let dv = adv_field(&form.date, df, ds, dw);
-            let mut s: Vec<Span<'static>> = Vec::new();
-            s.extend(kl("", 'd', "ate      "));
-            s.push(styled_field(dv, df, ds));
-            frame.render_widget(Paragraph::new(Line::from(s)), right);
-        }
-    }
-
-    // Row 2: [T]ime (left half) | T[e]nd / time-off (right half)
-    if let Some(row) = rows.get(2).copied() {
-        let cols =
-            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(row);
-        let tf = form.focused == Field::Time;
-        let ts = tf && form.field_selected;
-        let ef = form.focused == Field::TimeOff;
-        let es = ef && form.field_selected;
-        if let Some(&left) = cols.first() {
-            let tw = (left.width as usize).saturating_sub(10).max(5);
-            let tv = adv_field(&form.time, tf, ts, tw);
-            let mut s: Vec<Span<'static>> = Vec::new();
-            s.extend(kl("", 't', "ime      "));
-            s.push(styled_field(tv, tf, ts));
-            frame.render_widget(Paragraph::new(Line::from(s)), left);
-        }
-        if let Some(&right) = cols.get(1) {
-            let ew = (right.width as usize).saturating_sub(10).max(5);
-            let ev = adv_field(&form.time_off, ef, es, ew);
-            let mut s: Vec<Span<'static>> = Vec::new();
-            s.extend(kl("T", 'e', "nd      "));
-            s.push(styled_field(ev, ef, es));
-            frame.render_widget(Paragraph::new(Line::from(s)), right);
-        }
-    }
-
-    // Row 3: [Q]th (left half) | N[a]me (right half)
-    if let Some(row) = rows.get(3).copied() {
-        let cols =
-            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(row);
-        let qf = form.focused == Field::Qth;
-        let qs = qf && form.field_selected;
-        let nf = form.focused == Field::WorkedName;
-        let ns = nf && form.field_selected;
-        if let Some(&left) = cols.first() {
-            let qw = (left.width as usize).saturating_sub(10).max(5);
-            let qv = adv_field(&form.qth, qf, qs, qw);
-            let mut s: Vec<Span<'static>> = Vec::new();
-            s.extend(kl("", 'q', "th       "));
-            s.push(styled_field(qv, qf, qs));
-            frame.render_widget(Paragraph::new(Line::from(s)), left);
-        }
-        if let Some(&right) = cols.get(1) {
-            let nw = (right.width as usize).saturating_sub(10).max(5);
-            let nv = adv_field(&form.worked_name, nf, ns, nw);
-            let mut s: Vec<Span<'static>> = Vec::new();
-            s.extend(kl("N", 'a', "me      "));
-            s.push(styled_field(nv, nf, ns));
-            frame.render_widget(Paragraph::new(Line::from(s)), right);
-        }
-    }
-
-    // Row 4: RST [S]ent (left half) | RST [R]cvd (right half)
-    if let Some(row) = rows.get(4).copied() {
-        let cols =
-            Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(row);
-        let sf = form.focused == Field::RstSent;
-        let ss = sf && form.field_selected;
-        let rf = form.focused == Field::RstRcvd;
-        let rs = rf && form.field_selected;
-        if let Some(&left) = cols.first() {
-            let sv = adv_field(&form.rst_sent, sf, ss, 5);
-            let mut s: Vec<Span<'static>> = Vec::new();
-            s.extend(kl("RST ", 's', "ent  "));
-            s.push(styled_field(sv, sf, ss));
-            frame.render_widget(Paragraph::new(Line::from(s)), left);
-        }
-        if let Some(&right) = cols.get(1) {
-            let rv = adv_field(&form.rst_rcvd, rf, rs, 5);
-            let mut s: Vec<Span<'static>> = Vec::new();
-            s.extend(kl("RST ", 'r', "cvd  "));
-            s.push(styled_field(rv, rf, rs));
-            frame.render_widget(Paragraph::new(Line::from(s)), right);
-        }
-    }
-
-    // Row 5: C[o]mment
-    if let Some(row) = rows.get(5).copied() {
-        let focused = form.focused == Field::Comment;
-        let selected = focused && form.field_selected;
-        let val = adv_field(
-            &form.comment,
-            focused,
-            selected,
-            (row.width as usize).saturating_sub(10).max(10),
-        );
-        let mut spans: Vec<Span<'static>> = Vec::new();
-        spans.extend(kl("C", 'o', "mment   "));
-        spans.push(styled_field(val, focused, selected));
-        frame.render_widget(Paragraph::new(Line::from(spans)), row);
-    }
-
-    // Row 6: [N]otes
-    if let Some(row) = rows.get(6).copied() {
-        let focused = form.focused == Field::Notes;
-        let selected = focused && form.field_selected;
-        let val = adv_field(
-            &form.notes,
-            focused,
-            selected,
-            (row.width as usize).saturating_sub(10).max(10),
-        );
-        let mut spans: Vec<Span<'static>> = Vec::new();
-        spans.extend(kl("", 'n', "otes     "));
-        spans.push(styled_field(val, focused, selected));
-        frame.render_widget(Paragraph::new(Line::from(spans)), row);
-    }
-
-    // Hint row
-    if let Some(row) = rows.get(7).copied() {
-        frame.render_widget(
-            Paragraph::new(Span::styled(
-                "Alt+key to jump  |  Alt+1-4 for tabs  |  Tab/ShiftTab to navigate",
-                Style::default().fg(Color::DarkGray),
-            )),
-            row,
-        );
     }
 }
 
-fn render_contest_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, wide: usize) {
-    let rows = Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Fill(1),
-    ])
-    .split(area);
+fn render_field(frame: &mut Frame, area: Rect, form: &LogForm, spec: &FieldSpec) {
+    let focused = form.focused == spec.field;
+    let selected = focused && form.field_selected;
+    let value_width = (area.width as usize).saturating_sub(LABEL_WIDTH + 2).max(5);
+    let value = if matches!(spec.field, Field::Band | Field::Mode) {
+        cycle_value(field_text(form, spec.field), focused)
+    } else {
+        adv_field(field_text(form, spec.field), focused, selected, value_width)
+    };
 
-    let short = 20_usize;
+    let mut spans = Vec::new();
+    spans.extend(shortcut_label(spec.key, spec.label));
+    spans.push(Span::raw(" "));
+    if matches!(spec.field, Field::Band | Field::Mode) {
+        spans.push(styled_cycle(value, focused));
+    } else {
+        spans.push(styled_field(value, focused, selected));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
 
-    if let Some(row) = rows.first().copied() {
-        let pf = form.focused == Field::TxPower;
-        let ps = pf && form.field_selected;
-        let sf = form.focused == Field::Submode;
-        let ss = sf && form.field_selected;
-        let pv = adv_field(&form.tx_power, pf, ps, short);
-        let sv = adv_field(&form.submode_override, sf, ss, short);
-        let mut row0_spans: Vec<Span<'static>> = Vec::new();
-        row0_spans.extend(kl("TX Po", 'w', "er "));
-        row0_spans.push(styled_field(pv, pf, ps));
-        row0_spans.push(Span::raw("   "));
-        row0_spans.push(label("Submode  "));
-        row0_spans.push(styled_field(sv, sf, ss));
-        frame.render_widget(Paragraph::new(Line::from(row0_spans)), row);
-    }
-    if let Some(row) = rows.get(1).copied() {
-        let focused = form.focused == Field::ContestId;
-        let selected = focused && form.field_selected;
-        let val = adv_field(&form.contest_id, focused, selected, wide);
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                label("Contest  "),
-                styled_field(val, focused, selected),
-            ])),
-            row,
-        );
-    }
-    if let Some(row) = rows.get(2).copied() {
-        let sf = form.focused == Field::SerialSent;
-        let ss = sf && form.field_selected;
-        let rf = form.focused == Field::SerialRcvd;
-        let rs = rf && form.field_selected;
-        let sv = adv_field(&form.serial_sent, sf, ss, short);
-        let rv = adv_field(&form.serial_rcvd, rf, rs, short);
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                label("Ser Sent "),
-                styled_field(sv, sf, ss),
-                Span::raw("   "),
-                label("Ser Rcvd "),
-                styled_field(rv, rf, rs),
-            ])),
-            row,
-        );
-    }
-    if let Some(row) = rows.get(3).copied() {
-        let focused = form.focused == Field::ExchangeSent;
-        let selected = focused && form.field_selected;
-        let val = adv_field(&form.exchange_sent, focused, selected, wide);
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                label("Exch Snt "),
-                styled_field(val, focused, selected),
-            ])),
-            row,
-        );
-    }
-    if let Some(row) = rows.get(4).copied() {
-        let focused = form.focused == Field::ExchangeRcvd;
-        let selected = focused && form.field_selected;
-        let val = adv_field(&form.exchange_rcvd, focused, selected, wide);
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                label("Exch Rcvd"),
-                styled_field(val, focused, selected),
-            ])),
-            row,
-        );
+fn field_text(form: &LogForm, field: Field) -> &str {
+    match field {
+        Field::Callsign => &form.callsign,
+        Field::Band => form.band_str(),
+        Field::Mode => form.mode_str(),
+        Field::RstSent => &form.rst_sent,
+        Field::RstRcvd => &form.rst_rcvd,
+        Field::Comment => &form.comment,
+        Field::Notes => &form.notes,
+        Field::FrequencyMhz => &form.frequency_mhz,
+        Field::Date => &form.date,
+        Field::Time => &form.time,
+        Field::TimeOff => &form.time_off,
+        Field::Qth => &form.qth,
+        Field::TxPower => &form.tx_power,
+        Field::Submode => &form.submode_override,
+        Field::ContestId => &form.contest_id,
+        Field::SerialSent => &form.serial_sent,
+        Field::SerialRcvd => &form.serial_rcvd,
+        Field::ExchangeSent => &form.exchange_sent,
+        Field::ExchangeRcvd => &form.exchange_rcvd,
+        Field::PropMode => &form.prop_mode,
+        Field::SatName => &form.sat_name,
+        Field::SatMode => &form.sat_mode,
+        Field::Iota => &form.iota,
+        Field::ArrlSection => &form.arrl_section,
+        Field::WorkedState => &form.worked_state,
+        Field::WorkedCounty => &form.worked_county,
+        Field::WorkedName => &form.worked_name,
+        Field::Skcc => &form.skcc,
     }
 }
 
-fn render_technical_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, wide: usize) {
-    let rows = Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Fill(1),
-    ])
-    .split(area);
-
-    if let Some(row) = rows.first().copied() {
-        let focused = form.focused == Field::PropMode;
-        let selected = focused && form.field_selected;
-        let val = adv_field(&form.prop_mode, focused, selected, wide);
-        let mut spans: Vec<Span<'static>> = Vec::new();
-        spans.extend(kl("", 'p', "rop Mode"));
-        spans.push(styled_field(val, focused, selected));
-        frame.render_widget(Paragraph::new(Line::from(spans)), row);
-    }
-    if let Some(row) = rows.get(1).copied() {
-        let focused = form.focused == Field::SatName;
-        let selected = focused && form.field_selected;
-        let val = adv_field(&form.sat_name, focused, selected, wide);
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                label("Sat Name "),
-                styled_field(val, focused, selected),
-            ])),
-            row,
-        );
-    }
-    if let Some(row) = rows.get(2).copied() {
-        let focused = form.focused == Field::SatMode;
-        let selected = focused && form.field_selected;
-        let val = adv_field(&form.sat_mode, focused, selected, wide);
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                label("Sat Mode "),
-                styled_field(val, focused, selected),
-            ])),
-            row,
-        );
-    }
-}
-
-fn render_awards_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, wide: usize) {
-    let rows = Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Length(1),
-        Constraint::Fill(1),
-    ])
-    .split(area);
-
-    let short = 20_usize;
-
-    if let Some(row) = rows.first().copied() {
-        let focused = form.focused == Field::Iota;
-        let selected = focused && form.field_selected;
-        let val = adv_field(&form.iota, focused, selected, short);
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                label("IOTA     "),
-                styled_field(val, focused, selected),
-            ])),
-            row,
-        );
-    }
-    if let Some(row) = rows.get(1).copied() {
-        let focused = form.focused == Field::ArrlSection;
-        let selected = focused && form.field_selected;
-        let val = adv_field(&form.arrl_section, focused, selected, short);
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                label("ARRL Sec "),
-                styled_field(val, focused, selected),
-            ])),
-            row,
-        );
-    }
-    if let Some(row) = rows.get(2).copied() {
-        let wf = form.focused == Field::WorkedState;
-        let ws = wf && form.field_selected;
-        let cf = form.focused == Field::WorkedCounty;
-        let cs = cf && form.field_selected;
-        let wv = adv_field(&form.worked_state, wf, ws, short);
-        let cv = adv_field(&form.worked_county, cf, cs, wide);
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                label("State    "),
-                styled_field(wv, wf, ws),
-                Span::raw("   "),
-                label("County   "),
-                styled_field(cv, cf, cs),
-            ])),
-            row,
-        );
-    }
-    if let Some(row) = rows.get(3).copied() {
-        let focused = form.focused == Field::Skcc;
-        let selected = focused && form.field_selected;
-        let val = adv_field(&form.skcc, focused, selected, short);
-        let mut spans: Vec<Span<'static>> = Vec::new();
-        spans.extend(kl("S", 'k', "CC     "));
-        spans.push(styled_field(val, focused, selected));
-        frame.render_widget(Paragraph::new(Line::from(spans)), row);
-    }
+fn two_columns(area: Rect) -> [Rect; 2] {
+    let cols =
+        Layout::horizontal([Constraint::Percentage(50), Constraint::Percentage(50)]).split(area);
+    [
+        cols.first().copied().unwrap_or(area),
+        cols.get(1).copied().unwrap_or(area),
+    ]
 }
 
 /// Format an advanced field value with a fixed display width and optional cursor.
@@ -503,30 +491,68 @@ fn adv_field(text: &str, focused: bool, selected: bool, width: usize) -> String 
     }
 }
 
-fn label(text: &str) -> Span<'static> {
-    Span::styled(text.to_string(), Style::default().fg(Color::Cyan))
-}
-
-/// Build a label with one underlined shortcut key character.
-///
-/// `prefix` appears before the key, `suffix` after it. The key renders in yellow+underlined;
-/// prefix and suffix render in cyan. All three together form the complete label.
-fn kl(prefix: &'static str, key: char, suffix: &'static str) -> [Span<'static>; 3] {
+fn shortcut_label(key: char, label: &'static str) -> [Span<'static>; 3] {
     let label_style = Style::default().fg(Color::Cyan);
     [
-        Span::styled(prefix, label_style),
         Span::styled(
             key.to_ascii_uppercase().to_string(),
             label_style.add_modifier(Modifier::UNDERLINED),
         ),
-        Span::styled(suffix, label_style),
+        Span::styled(" ", label_style),
+        Span::styled(
+            format!("{label:<width$}", width = LABEL_WIDTH - 2),
+            label_style,
+        ),
     ]
 }
 
-fn cycle_adv(text: &str, focused: bool) -> String {
+fn cycle_value(text: &str, focused: bool) -> String {
     if focused {
         format!("< {text} >")
     } else {
         format!("  {text}  ")
     }
+}
+
+fn styled_cycle(value: String, focused: bool) -> Span<'static> {
+    Span::styled(
+        value,
+        Style::default()
+            .fg(if focused { Color::Yellow } else { Color::Gray })
+            .add_modifier(if focused {
+                Modifier::BOLD
+            } else {
+                Modifier::empty()
+            }),
+    )
+}
+
+fn render_footer(frame: &mut Frame, area: Rect) {
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled(
+                " F2/Esc Return ",
+                Style::default().fg(Color::Black).bg(Color::DarkGray),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                " Tab/Shift+Tab Field ",
+                Style::default().fg(Color::Black).bg(Color::DarkGray),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                " Alt+key Jump ",
+                Style::default().fg(Color::Black).bg(Color::DarkGray),
+            ),
+            Span::raw("  "),
+            Span::styled(
+                " F10 Log/Save ",
+                Style::default()
+                    .fg(Color::Black)
+                    .bg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ])),
+        area,
+    );
 }

--- a/src/rust/qsoripper-tui/src/ui/help.rs
+++ b/src/rust/qsoripper-tui/src/ui/help.rs
@@ -49,6 +49,10 @@ pub(super) fn render(frame: &mut Frame, area: Rect) {
         "F2               ",
         "Toggle advanced fields (F2 or Esc to close)",
     ));
+    lines.push(binding(
+        "Alt+1..5 / F5/F6 ",
+        "Switch advanced card sections",
+    ));
     lines.push(binding("F10 / Alt+Enter  ", "Log the QSO"));
     lines.push(binding("F7               ", "Reset QSO start time to now"));
     lines.push(binding(

--- a/src/rust/qsoripper-tui/src/ui/mod.rs
+++ b/src/rust/qsoripper-tui/src/ui/mod.rs
@@ -10,7 +10,7 @@ mod lookup_panel;
 mod recent_qsos;
 
 use ratatui::{
-    layout::{Constraint, Layout},
+    layout::{Constraint, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Paragraph},
@@ -43,12 +43,18 @@ pub(crate) fn render_ui(app: &App, frame: &mut Frame) {
     header::render(app, frame, header_area);
     render_status_bar(app, frame, status_area);
     if matches!(app.view, View::Advanced) {
-        advanced_form::render(app, frame, form_area);
+        let advanced_area = Rect {
+            x: form_area.x,
+            y: form_area.y,
+            width: form_area.width,
+            height: footer_area.y.saturating_sub(form_area.y),
+        };
+        advanced_form::render(app, frame, advanced_area);
     } else {
         log_form::render(app, frame, form_area);
+        lookup_panel::render(app, frame, lookup_area);
+        recent_qsos::render(app, frame, recent_area);
     }
-    lookup_panel::render(app, frame, lookup_area);
-    recent_qsos::render(app, frame, recent_area);
     footer::render(frame, footer_area);
 
     if matches!(app.view, View::Help) {
@@ -142,11 +148,29 @@ mod tests {
     }
 
     #[test]
-    fn render_advanced_main_tab() {
+    fn render_advanced_core_tab() {
         let mut terminal = make_terminal();
         let mut app = make_app();
         app.view = View::Advanced;
-        app.form.advanced_tab = AdvancedTab::Main;
+        app.form.advanced_tab = AdvancedTab::Core;
+        terminal.draw(|f| super::render_ui(&app, f)).unwrap();
+    }
+
+    #[test]
+    fn render_advanced_signal_tab() {
+        let mut terminal = make_terminal();
+        let mut app = make_app();
+        app.view = View::Advanced;
+        app.form.advanced_tab = AdvancedTab::Signal;
+        terminal.draw(|f| super::render_ui(&app, f)).unwrap();
+    }
+
+    #[test]
+    fn render_advanced_station_tab() {
+        let mut terminal = make_terminal();
+        let mut app = make_app();
+        app.view = View::Advanced;
+        app.form.advanced_tab = AdvancedTab::Station;
         terminal.draw(|f| super::render_ui(&app, f)).unwrap();
     }
 
@@ -160,20 +184,11 @@ mod tests {
     }
 
     #[test]
-    fn render_advanced_technical_tab() {
+    fn render_advanced_notes_tab() {
         let mut terminal = make_terminal();
         let mut app = make_app();
         app.view = View::Advanced;
-        app.form.advanced_tab = AdvancedTab::Technical;
-        terminal.draw(|f| super::render_ui(&app, f)).unwrap();
-    }
-
-    #[test]
-    fn render_advanced_awards_tab() {
-        let mut terminal = make_terminal();
-        let mut app = make_app();
-        app.view = View::Advanced;
-        app.form.advanced_tab = AdvancedTab::Awards;
+        app.form.advanced_tab = AdvancedTab::Notes;
         terminal.draw(|f| super::render_ui(&app, f)).unwrap();
     }
 
@@ -305,7 +320,7 @@ mod tests {
         let mut terminal = make_terminal();
         let mut app = make_app();
         app.view = View::Advanced;
-        app.form.advanced_tab = AdvancedTab::Main;
+        app.form.advanced_tab = AdvancedTab::Core;
         app.form.field_selected = true;
         terminal.draw(|f| super::render_ui(&app, f)).unwrap();
     }


### PR DESCRIPTION
Summary:
- Replace the TUI advanced edit surface with a compact QSO card editor.
- Add Core, Signal, Station, Contest, and Notes sections with discoverable keyboard navigation.
- Keep the change scoped to the TUI advanced editor flow.

Validation:
- cargo test --manifest-path src\rust\Cargo.toml -p qsoripper-tui
- cargo clippy --manifest-path src\rust\Cargo.toml -p qsoripper-tui --all-targets -- -D warnings
- cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check