### PR TITLE
Improve TUI field editing

### DIFF
--- a/src/rust/qsoripper-tui/src/app.rs
+++ b/src/rust/qsoripper-tui/src/app.rs
@@ -199,12 +199,12 @@ pub(crate) struct App {
     pub(crate) endpoint: String,
     /// When the current QSO started — used for the live duration display.
     ///
-    /// Reset by F7, by Ctrl+L (form clear), and after each QSO is successfully logged or updated.
+    /// Reset by F7, by Esc (form clear), and after each QSO is successfully logged or updated.
     pub(crate) qso_started_at: Instant,
     /// Set when the debounce fires and the duration timer is actively counting.
     ///
     /// Starts `false`; becomes `true` once a callsign has been stable for ~1.5 s.
-    /// Cleared on form reset, Ctrl+L, and after log/update.
+    /// Cleared on form reset, Esc, and after log/update.
     pub(crate) qso_timer_active: bool,
     /// Reachability of the gRPC engine — updated by a periodic background probe.
     pub(crate) engine_status: EngineStatus,

--- a/src/rust/qsoripper-tui/src/app.rs
+++ b/src/rust/qsoripper-tui/src/app.rs
@@ -199,12 +199,12 @@ pub(crate) struct App {
     pub(crate) endpoint: String,
     /// When the current QSO started — used for the live duration display.
     ///
-    /// Reset by F7, by Esc (form clear), and after each QSO is successfully logged or updated.
+    /// Reset by F7, by Ctrl+L (form clear), and after each QSO is successfully logged or updated.
     pub(crate) qso_started_at: Instant,
     /// Set when the debounce fires and the duration timer is actively counting.
     ///
     /// Starts `false`; becomes `true` once a callsign has been stable for ~1.5 s.
-    /// Cleared on form reset, Esc, and after log/update.
+    /// Cleared on form reset, Ctrl+L, and after log/update.
     pub(crate) qso_timer_active: bool,
     /// Reachability of the gRPC engine — updated by a periodic background probe.
     pub(crate) engine_status: EngineStatus,

--- a/src/rust/qsoripper-tui/src/form.rs
+++ b/src/rust/qsoripper-tui/src/form.rs
@@ -214,6 +214,8 @@ pub(crate) struct LogForm {
     pub(crate) focused: Field,
     /// When `true`, the focused field's text is fully selected; typing replaces it.
     pub(crate) field_selected: bool,
+    /// Cursor position within the focused text field, measured in Unicode scalar values.
+    pub(crate) field_cursor: usize,
     /// Active tab in the Advanced view.
     pub(crate) advanced_tab: AdvancedTab,
     /// Worked callsign text.
@@ -290,6 +292,7 @@ impl LogForm {
         let mut form = Self {
             focused: Field::Callsign,
             field_selected: false,
+            field_cursor: 0,
             advanced_tab: AdvancedTab::Main,
             callsign: String::new(),
             band_idx: DEFAULT_BAND_IDX,
@@ -335,6 +338,7 @@ impl LogForm {
             .cloned()
             .unwrap_or(Field::Callsign);
         self.field_selected = true;
+        self.field_cursor = self.focused_text_len();
     }
 
     /// Move focus to the previous basic field, wrapping around, and select its text.
@@ -350,6 +354,7 @@ impl LogForm {
         };
         self.focused = FIELD_ORDER.get(new_idx).cloned().unwrap_or(Field::Callsign);
         self.field_selected = true;
+        self.field_cursor = self.focused_text_len();
     }
 
     /// Return the field list for the current advanced tab.
@@ -371,6 +376,7 @@ impl LogForm {
             .cloned()
             .unwrap_or(Field::Callsign);
         self.field_selected = true;
+        self.field_cursor = self.focused_text_len();
     }
 
     /// Move focus to the previous field in the current advanced tab, and select its text.
@@ -384,6 +390,7 @@ impl LogForm {
         };
         self.focused = fields.get(new_idx).cloned().unwrap_or(Field::Callsign);
         self.field_selected = true;
+        self.field_cursor = self.focused_text_len();
     }
 
     /// Switch to the next advanced tab and focus its first field.
@@ -395,6 +402,7 @@ impl LogForm {
             .cloned()
             .unwrap_or(Field::Callsign);
         self.field_selected = true;
+        self.field_cursor = self.focused_text_len();
     }
 
     /// Switch to the previous advanced tab and focus its first field.
@@ -406,6 +414,7 @@ impl LogForm {
             .cloned()
             .unwrap_or(Field::Callsign);
         self.field_selected = true;
+        self.field_cursor = self.focused_text_len();
     }
 
     /// Update frequency and RST defaults after the band changes.
@@ -458,6 +467,155 @@ impl LogForm {
             Field::Skcc => Some(&mut self.skcc),
             Field::Band | Field::Mode => None,
         }
+    }
+
+    /// Return the focused field's text buffer.
+    ///
+    /// Returns `None` for cycle-only fields (`Band`, `Mode`).
+    pub(crate) fn current_field_text(&self) -> Option<&str> {
+        match self.focused {
+            Field::Callsign => Some(&self.callsign),
+            Field::FrequencyMhz => Some(&self.frequency_mhz),
+            Field::Date => Some(&self.date),
+            Field::Time => Some(&self.time),
+            Field::TimeOff => Some(&self.time_off),
+            Field::Qth => Some(&self.qth),
+            Field::RstSent => Some(&self.rst_sent),
+            Field::RstRcvd => Some(&self.rst_rcvd),
+            Field::Comment => Some(&self.comment),
+            Field::Notes => Some(&self.notes),
+            Field::TxPower => Some(&self.tx_power),
+            Field::Submode => Some(&self.submode_override),
+            Field::ContestId => Some(&self.contest_id),
+            Field::SerialSent => Some(&self.serial_sent),
+            Field::SerialRcvd => Some(&self.serial_rcvd),
+            Field::ExchangeSent => Some(&self.exchange_sent),
+            Field::ExchangeRcvd => Some(&self.exchange_rcvd),
+            Field::PropMode => Some(&self.prop_mode),
+            Field::SatName => Some(&self.sat_name),
+            Field::SatMode => Some(&self.sat_mode),
+            Field::Iota => Some(&self.iota),
+            Field::ArrlSection => Some(&self.arrl_section),
+            Field::WorkedState => Some(&self.worked_state),
+            Field::WorkedCounty => Some(&self.worked_county),
+            Field::WorkedName => Some(&self.worked_name),
+            Field::Skcc => Some(&self.skcc),
+            Field::Band | Field::Mode => None,
+        }
+    }
+
+    /// Move the focused text field cursor one character left, clamping at the start.
+    pub(crate) fn move_cursor_left(&mut self) {
+        if self.current_field_text().is_none() {
+            return;
+        }
+        if self.field_selected {
+            self.field_cursor = 0;
+        } else {
+            self.field_cursor = self.field_cursor.saturating_sub(1);
+        }
+        self.field_selected = false;
+    }
+
+    /// Move the focused text field cursor one character right, clamping at the end.
+    pub(crate) fn move_cursor_right(&mut self) {
+        let len = self.focused_text_len();
+        if self.current_field_text().is_none() {
+            return;
+        }
+        if self.field_selected {
+            self.field_cursor = len;
+        } else {
+            self.field_cursor = (self.field_cursor + 1).min(len);
+        }
+        self.field_selected = false;
+    }
+
+    /// Move the focused text field cursor to the beginning.
+    pub(crate) fn move_cursor_home(&mut self) {
+        if self.current_field_text().is_some() {
+            self.field_cursor = 0;
+            self.field_selected = false;
+        }
+    }
+
+    /// Move the focused text field cursor to the end.
+    pub(crate) fn move_cursor_end(&mut self) {
+        if self.current_field_text().is_some() {
+            self.field_cursor = self.focused_text_len();
+            self.field_selected = false;
+        }
+    }
+
+    /// Insert a character at the focused text field cursor.
+    pub(crate) fn insert_char_at_cursor(&mut self, ch: char) {
+        if self.field_selected {
+            if let Some(text) = self.current_field_text_mut() {
+                text.clear();
+            }
+            self.field_cursor = 0;
+            self.field_selected = false;
+        }
+        let cursor = self.field_cursor;
+        if let Some(text) = self.current_field_text_mut() {
+            insert_char(text, cursor, ch);
+        }
+        self.field_cursor = (cursor + 1).min(self.focused_text_len());
+    }
+
+    /// Delete the character before the focused text field cursor.
+    pub(crate) fn backspace_at_cursor(&mut self) {
+        if self.field_selected {
+            if let Some(text) = self.current_field_text_mut() {
+                text.clear();
+            }
+            self.field_cursor = 0;
+            self.field_selected = false;
+            return;
+        }
+        if self.field_cursor == 0 {
+            return;
+        }
+        let cursor = self.field_cursor;
+        if let Some(text) = self.current_field_text_mut() {
+            delete_char_before(text, cursor);
+        }
+        self.field_cursor = cursor.saturating_sub(1).min(self.focused_text_len());
+    }
+
+    /// Delete the character at the focused text field cursor.
+    pub(crate) fn delete_at_cursor(&mut self) {
+        if self.field_selected {
+            if let Some(text) = self.current_field_text_mut() {
+                text.clear();
+            }
+            self.field_cursor = 0;
+            self.field_selected = false;
+            return;
+        }
+        let cursor = self.field_cursor;
+        if cursor >= self.focused_text_len() {
+            return;
+        }
+        if let Some(text) = self.current_field_text_mut() {
+            delete_char_at(text, cursor);
+        }
+        self.field_cursor = cursor.min(self.focused_text_len());
+    }
+
+    /// Clear the focused text field and leave the rest of the QSO intact.
+    pub(crate) fn clear_focused_text_field(&mut self) {
+        if let Some(text) = self.current_field_text_mut() {
+            text.clear();
+            self.field_cursor = 0;
+            self.field_selected = false;
+        }
+    }
+
+    /// Return the focused text field length in Unicode scalar values.
+    pub(crate) fn focused_text_len(&self) -> usize {
+        self.current_field_text()
+            .map_or(0, |text| text.chars().count())
     }
 
     /// Current band name from the [`BANDS`] slice.
@@ -526,6 +684,35 @@ fn default_rst_for_mode(mode_idx: usize) -> &'static str {
         "SSB" | "AM" | "FM" => "59",
         _ => "599",
     }
+}
+
+fn insert_char(text: &mut String, cursor: usize, ch: char) {
+    let byte_idx = byte_index_for_cursor(text, cursor);
+    text.insert(byte_idx, ch);
+}
+
+fn delete_char_before(text: &mut String, cursor: usize) {
+    if cursor == 0 {
+        return;
+    }
+    let start = byte_index_for_cursor(text, cursor - 1);
+    let end = byte_index_for_cursor(text, cursor);
+    text.replace_range(start..end, "");
+}
+
+fn delete_char_at(text: &mut String, cursor: usize) {
+    let start = byte_index_for_cursor(text, cursor);
+    let end = byte_index_for_cursor(text, cursor + 1);
+    if start < end {
+        text.replace_range(start..end, "");
+    }
+}
+
+fn byte_index_for_cursor(text: &str, cursor: usize) -> usize {
+    text.char_indices()
+        .map(|(idx, _)| idx)
+        .nth(cursor)
+        .unwrap_or(text.len())
 }
 
 #[cfg(test)]
@@ -790,6 +977,153 @@ mod tests {
         assert!(form.current_field_text_mut().is_none());
         form.focused = Field::Mode;
         assert!(form.current_field_text_mut().is_none());
+    }
+
+    #[test]
+    fn cursor_left_and_right_clamp_to_text_boundaries() {
+        let mut form = LogForm::new();
+        form.focused = Field::Comment;
+        form.comment = "abc".to_string();
+        form.field_cursor = 1;
+
+        form.move_cursor_left();
+        assert_eq!(form.field_cursor, 0);
+        form.move_cursor_left();
+        assert_eq!(form.field_cursor, 0);
+
+        form.move_cursor_right();
+        assert_eq!(form.field_cursor, 1);
+        form.move_cursor_right();
+        form.move_cursor_right();
+        form.move_cursor_right();
+        assert_eq!(form.field_cursor, 3);
+    }
+
+    #[test]
+    fn cursor_home_and_end_move_to_boundaries() {
+        let mut form = LogForm::new();
+        form.focused = Field::Comment;
+        form.comment = "abc".to_string();
+        form.field_cursor = 1;
+
+        form.move_cursor_end();
+        assert_eq!(form.field_cursor, 3);
+
+        form.move_cursor_home();
+        assert_eq!(form.field_cursor, 0);
+    }
+
+    #[test]
+    fn cursor_left_and_right_clear_selection_predictably() {
+        let mut form = LogForm::new();
+        form.focused = Field::Comment;
+        form.comment = "abc".to_string();
+        form.field_selected = true;
+        form.field_cursor = 3;
+
+        form.move_cursor_left();
+        assert!(!form.field_selected);
+        assert_eq!(form.field_cursor, 0);
+
+        form.field_selected = true;
+        form.move_cursor_right();
+        assert!(!form.field_selected);
+        assert_eq!(form.field_cursor, 3);
+    }
+
+    #[test]
+    fn insert_char_at_cursor_inserts_without_appending() {
+        let mut form = LogForm::new();
+        form.focused = Field::Comment;
+        form.comment = "ac".to_string();
+        form.field_cursor = 1;
+
+        form.insert_char_at_cursor('b');
+
+        assert_eq!(form.comment, "abc");
+        assert_eq!(form.field_cursor, 2);
+    }
+
+    #[test]
+    fn insert_char_with_selected_field_replaces_text() {
+        let mut form = LogForm::new();
+        form.focused = Field::Comment;
+        form.comment = "old".to_string();
+        form.field_selected = true;
+        form.field_cursor = 3;
+
+        form.insert_char_at_cursor('n');
+
+        assert_eq!(form.comment, "n");
+        assert_eq!(form.field_cursor, 1);
+        assert!(!form.field_selected);
+    }
+
+    #[test]
+    fn backspace_at_cursor_deletes_previous_character() {
+        let mut form = LogForm::new();
+        form.focused = Field::Comment;
+        form.comment = "abc".to_string();
+        form.field_cursor = 2;
+
+        form.backspace_at_cursor();
+
+        assert_eq!(form.comment, "ac");
+        assert_eq!(form.field_cursor, 1);
+    }
+
+    #[test]
+    fn backspace_at_start_does_nothing() {
+        let mut form = LogForm::new();
+        form.focused = Field::Comment;
+        form.comment = "abc".to_string();
+        form.field_cursor = 0;
+
+        form.backspace_at_cursor();
+
+        assert_eq!(form.comment, "abc");
+        assert_eq!(form.field_cursor, 0);
+    }
+
+    #[test]
+    fn delete_at_cursor_deletes_current_character() {
+        let mut form = LogForm::new();
+        form.focused = Field::Comment;
+        form.comment = "abc".to_string();
+        form.field_cursor = 1;
+
+        form.delete_at_cursor();
+
+        assert_eq!(form.comment, "ac");
+        assert_eq!(form.field_cursor, 1);
+    }
+
+    #[test]
+    fn delete_at_end_does_nothing() {
+        let mut form = LogForm::new();
+        form.focused = Field::Comment;
+        form.comment = "abc".to_string();
+        form.field_cursor = 3;
+
+        form.delete_at_cursor();
+
+        assert_eq!(form.comment, "abc");
+        assert_eq!(form.field_cursor, 3);
+    }
+
+    #[test]
+    fn clear_focused_text_field_only_clears_active_field() {
+        let mut form = LogForm::new();
+        form.focused = Field::Comment;
+        form.callsign = "K7ABC".to_string();
+        form.comment = "clear me".to_string();
+        form.field_cursor = form.comment.chars().count();
+
+        form.clear_focused_text_field();
+
+        assert_eq!(form.callsign, "K7ABC");
+        assert!(form.comment.is_empty());
+        assert_eq!(form.field_cursor, 0);
     }
 
     #[test]

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -378,6 +378,14 @@ fn handle_key_with_channel(
         return;
     }
 
+    if matches!(key.code, KeyCode::Char('l' | 'L')) && key.modifiers.contains(KeyModifiers::CONTROL)
+    {
+        clear_current_qso(app);
+        let _ = lookup_tx.send(app.form.callsign.clone());
+        app.set_status("Current QSO cleared");
+        return;
+    }
+
     // F8 toggles rig control from any state.
     if matches!(key.code, KeyCode::F(8)) {
         app.toggle_rig_control();
@@ -561,6 +569,18 @@ fn handle_search_key(app: &mut App, key: crossterm::event::KeyEvent) {
     }
 }
 
+fn clear_current_qso(app: &mut App) {
+    let band_idx = app.form.band_idx;
+    let mode_idx = app.form.mode_idx;
+    app.form = LogForm::new();
+    app.form.band_idx = band_idx;
+    app.form.mode_idx = mode_idx;
+    app.form.on_band_change();
+    app.lookup_result = None;
+    app.editing_local_id = None;
+    app.reset_timer();
+}
+
 /// Navigate the QSO list with keyboard (active when `app.qso_list_focused` is true).
 fn handle_qso_list_key(
     app: &mut App,
@@ -586,6 +606,7 @@ fn handle_qso_list_key(
                 _ => 0,
             });
         }
+
         KeyCode::Down => {
             app.qso_selected = Some(match app.qso_selected {
                 Some(i) => (i + 1).min(max),
@@ -2348,6 +2369,35 @@ mod tests {
         assert!(matches!(app.view, View::Advanced));
         assert!(app.form.comment.is_empty());
         assert_eq!(app.form.callsign, "K7ABC");
+    }
+
+    #[tokio::test]
+    async fn handle_key_ctrl_l_clears_current_qso() {
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let (lookup_tx, lookup_rx) = make_watch();
+        let (rig_tx, _rig_rx) = make_rig_watch();
+        let mut app = make_app();
+        app.form.callsign = "K7ABC".to_string();
+        app.form.comment = "clear me".to_string();
+        app.form.band_idx = 5;
+        app.form.mode_idx = 1;
+        app.editing_local_id = Some("q1".to_string());
+        app.qso_timer_active = true;
+        handle_key(
+            &mut app,
+            make_key_with_mod(KeyCode::Char('l'), KeyModifiers::CONTROL),
+            &tx,
+            &lookup_tx,
+            &rig_tx,
+            "",
+        );
+        assert!(app.form.callsign.is_empty());
+        assert!(app.form.comment.is_empty());
+        assert_eq!(app.form.band_idx, 5);
+        assert_eq!(app.form.mode_idx, 1);
+        assert_eq!(app.editing_local_id, None);
+        assert!(!app.qso_timer_active);
+        assert_eq!(lookup_rx.borrow().as_str(), "");
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -378,14 +378,6 @@ fn handle_key_with_channel(
         return;
     }
 
-    if matches!(key.code, KeyCode::Char('l' | 'L')) && key.modifiers.contains(KeyModifiers::CONTROL)
-    {
-        clear_current_qso(app);
-        let _ = lookup_tx.send(app.form.callsign.clone());
-        app.set_status("Current QSO cleared");
-        return;
-    }
-
     // F8 toggles rig control from any state.
     if matches!(key.code, KeyCode::F(8)) {
         app.toggle_rig_control();
@@ -477,15 +469,15 @@ fn handle_key_with_channel(
         KeyCode::End => app.form.move_cursor_end(),
         KeyCode::Esc => match app.view {
             app::View::Advanced | app::View::LogEntry => {
-                let focused = app.form.focused.clone();
-                app.form.clear_focused_text_field();
-                if focused == Field::Callsign {
-                    let _ = lookup_tx.send(app.form.callsign.clone());
-                    app.lookup_result = None;
-                }
+                clear_current_qso(app);
+                let _ = lookup_tx.send(app.form.callsign.clone());
+                app.set_status("Current QSO cleared");
             }
             app::View::Help | app::View::ConfirmDeleteQso | app::View::ConfirmPurge => {}
         },
+        KeyCode::Backspace | KeyCode::Delete if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            clear_focused_field(app, lookup_tx);
+        }
         KeyCode::Left if app.form.is_cycle_field() => cycle_left(app),
         KeyCode::Right if app.form.is_cycle_field() => cycle_right(app),
         KeyCode::Left => app.form.move_cursor_left(),
@@ -511,6 +503,27 @@ fn handle_key_with_channel(
         }
         KeyCode::Char(c) => handle_char_key(app, c, lookup_tx),
         _ => {}
+    }
+}
+
+fn clear_current_qso(app: &mut App) {
+    let band_idx = app.form.band_idx;
+    let mode_idx = app.form.mode_idx;
+    app.form = LogForm::new();
+    app.form.band_idx = band_idx;
+    app.form.mode_idx = mode_idx;
+    app.form.on_band_change();
+    app.lookup_result = None;
+    app.editing_local_id = None;
+    app.reset_timer();
+}
+
+fn clear_focused_field(app: &mut App, lookup_tx: &watch::Sender<String>) {
+    let focused = app.form.focused.clone();
+    app.form.clear_focused_text_field();
+    if focused == Field::Callsign {
+        let _ = lookup_tx.send(app.form.callsign.clone());
+        app.lookup_result = None;
     }
 }
 
@@ -567,18 +580,6 @@ fn handle_search_key(app: &mut App, key: crossterm::event::KeyEvent) {
         }
         _ => {}
     }
-}
-
-fn clear_current_qso(app: &mut App) {
-    let band_idx = app.form.band_idx;
-    let mode_idx = app.form.mode_idx;
-    app.form = LogForm::new();
-    app.form.band_idx = band_idx;
-    app.form.mode_idx = mode_idx;
-    app.form.on_band_change();
-    app.lookup_result = None;
-    app.editing_local_id = None;
-    app.reset_timer();
 }
 
 /// Navigate the QSO list with keyboard (active when `app.qso_list_focused` is true).
@@ -2326,15 +2327,16 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_key_esc_clears_only_focused_field_in_log_entry() {
+    async fn handle_key_esc_clears_current_qso_in_log_entry() {
         let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
-        let (lookup_tx, _lookup_rx) = make_watch();
+        let (lookup_tx, lookup_rx) = make_watch();
         let (rig_tx, _rig_rx) = make_rig_watch();
         let mut app = make_app();
         app.form.callsign = "K7ABC".to_string();
-        app.form.comment = "keep this".to_string();
+        app.form.comment = "clear this".to_string();
         app.form.focused = Field::Callsign;
         app.editing_local_id = Some("q1".to_string());
+        app.qso_timer_active = true;
         handle_key(
             &mut app,
             make_key(KeyCode::Esc),
@@ -2344,12 +2346,14 @@ mod tests {
             "",
         );
         assert!(app.form.callsign.is_empty());
-        assert_eq!(app.form.comment, "keep this");
-        assert_eq!(app.editing_local_id, Some("q1".to_string()));
+        assert!(app.form.comment.is_empty());
+        assert_eq!(app.editing_local_id, None);
+        assert!(!app.qso_timer_active);
+        assert_eq!(lookup_rx.borrow().as_str(), "");
     }
 
     #[tokio::test]
-    async fn handle_key_esc_in_advanced_clears_focused_field() {
+    async fn handle_key_esc_in_advanced_clears_current_qso() {
         let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
         let (lookup_tx, _lookup_rx) = make_watch();
         let (rig_tx, _rig_rx) = make_rig_watch();
@@ -2368,35 +2372,36 @@ mod tests {
         );
         assert!(matches!(app.view, View::Advanced));
         assert!(app.form.comment.is_empty());
-        assert_eq!(app.form.callsign, "K7ABC");
+        assert!(app.form.callsign.is_empty());
     }
 
     #[tokio::test]
-    async fn handle_key_ctrl_l_clears_current_qso() {
+    async fn handle_key_ctrl_backspace_clears_only_focused_field() {
         let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
         let (lookup_tx, lookup_rx) = make_watch();
         let (rig_tx, _rig_rx) = make_rig_watch();
         let mut app = make_app();
         app.form.callsign = "K7ABC".to_string();
-        app.form.comment = "clear me".to_string();
+        app.form.comment = "keep this".to_string();
+        app.form.focused = Field::Callsign;
         app.form.band_idx = 5;
         app.form.mode_idx = 1;
         app.editing_local_id = Some("q1".to_string());
         app.qso_timer_active = true;
         handle_key(
             &mut app,
-            make_key_with_mod(KeyCode::Char('l'), KeyModifiers::CONTROL),
+            make_key_with_mod(KeyCode::Backspace, KeyModifiers::CONTROL),
             &tx,
             &lookup_tx,
             &rig_tx,
             "",
         );
         assert!(app.form.callsign.is_empty());
-        assert!(app.form.comment.is_empty());
+        assert_eq!(app.form.comment, "keep this");
         assert_eq!(app.form.band_idx, 5);
         assert_eq!(app.form.mode_idx, 1);
-        assert_eq!(app.editing_local_id, None);
-        assert!(!app.qso_timer_active);
+        assert_eq!(app.editing_local_id, Some("q1".to_string()));
+        assert!(app.qso_timer_active);
         assert_eq!(lookup_rx.borrow().as_str(), "");
     }
 

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -430,12 +430,14 @@ fn handle_key_with_channel(
                 app.view = app::View::LogEntry;
                 app.form.focused = Field::Callsign;
                 app.form.field_selected = false;
+                app.form.field_cursor = app.form.focused_text_len();
             }
             app::View::LogEntry => {
                 app.view = app::View::Advanced;
                 app.form.advanced_tab = AdvancedTab::Main;
                 app.form.focused = Field::Callsign;
                 app.form.field_selected = true;
+                app.form.field_cursor = app.form.focused_text_len();
             }
             app::View::Help | app::View::ConfirmDeleteQso | app::View::ConfirmPurge => {}
         },
@@ -463,35 +465,34 @@ fn handle_key_with_channel(
         KeyCode::Enter if key.modifiers.contains(KeyModifiers::ALT) => {
             spawn_log_qso(app, event_tx, channel);
         }
-        KeyCode::End => {
-            app.form.field_selected = false;
-        }
+        KeyCode::Home => app.form.move_cursor_home(),
+        KeyCode::End => app.form.move_cursor_end(),
         KeyCode::Esc => match app.view {
-            app::View::Advanced => {
-                app.view = app::View::LogEntry;
-                app.form.focused = Field::Callsign;
-                app.form.field_selected = false;
-            }
-            app::View::LogEntry => {
-                app.form = LogForm::new();
-                app.lookup_result = None;
-                app.editing_local_id = None;
-                app.reset_timer();
+            app::View::Advanced | app::View::LogEntry => {
+                let focused = app.form.focused.clone();
+                app.form.clear_focused_text_field();
+                if focused == Field::Callsign {
+                    let _ = lookup_tx.send(app.form.callsign.clone());
+                    app.lookup_result = None;
+                }
             }
             app::View::Help | app::View::ConfirmDeleteQso | app::View::ConfirmPurge => {}
         },
         KeyCode::Left if app.form.is_cycle_field() => cycle_left(app),
         KeyCode::Right if app.form.is_cycle_field() => cycle_right(app),
+        KeyCode::Left => app.form.move_cursor_left(),
+        KeyCode::Right => app.form.move_cursor_right(),
         KeyCode::Backspace => {
             let focused = app.form.focused.clone();
-            if app.form.field_selected {
-                if let Some(text) = app.form.current_field_text_mut() {
-                    text.clear();
-                }
-                app.form.field_selected = false;
-            } else if let Some(text) = app.form.current_field_text_mut() {
-                text.pop();
+            app.form.backspace_at_cursor();
+            if focused == Field::Callsign {
+                let callsign = app.form.callsign.clone();
+                let _ = lookup_tx.send(callsign);
             }
+        }
+        KeyCode::Delete => {
+            let focused = app.form.focused.clone();
+            app.form.delete_at_cursor();
             if focused == Field::Callsign {
                 let callsign = app.form.callsign.clone();
                 let _ = lookup_tx.send(callsign);
@@ -717,19 +718,12 @@ fn handle_char_key(app: &mut App, c: char, lookup_tx: &watch::Sender<String>) {
         Field::Band => app.form.type_select_band(c),
         Field::Mode => app.form.type_select_mode(c),
         _ => {
-            if app.form.field_selected {
-                if let Some(text) = app.form.current_field_text_mut() {
-                    text.clear();
-                }
-                app.form.field_selected = false;
-            }
-            if let Some(text) = app.form.current_field_text_mut() {
-                if focused == Field::Callsign {
-                    text.push(c.to_ascii_uppercase());
-                } else {
-                    text.push(c);
-                }
-            }
+            let ch = if focused == Field::Callsign {
+                c.to_ascii_uppercase()
+            } else {
+                c
+            };
+            app.form.insert_char_at_cursor(ch);
             if focused == Field::Callsign {
                 let callsign = app.form.callsign.clone();
                 let _ = lookup_tx.send(callsign);
@@ -753,6 +747,7 @@ fn switch_to_tab(app: &mut App, tab: AdvancedTab) {
     app.form.advanced_tab = tab;
     app.form.focused = tab.first_field();
     app.form.field_selected = true;
+    app.form.field_cursor = app.form.focused_text_len();
     app.qso_list_focused = false;
 }
 
@@ -786,6 +781,7 @@ fn jump_to_field(app: &mut App, ch: char) {
     }
     app.form.focused = target;
     app.form.field_selected = true;
+    app.form.field_cursor = app.form.focused_text_len();
     app.qso_list_focused = false;
 }
 
@@ -883,6 +879,7 @@ fn load_qso_into_form(app: &mut App, local_id: &str, lookup_tx: &watch::Sender<S
 
     app.form.focused = Field::Callsign;
     app.form.field_selected = true;
+    app.form.field_cursor = app.form.focused_text_len();
     app.qso_list_focused = false;
     app.qso_selected = None;
     app.editing_local_id = Some(local_id.to_string());
@@ -2308,12 +2305,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn handle_key_esc_clears_form_in_log_entry() {
+    async fn handle_key_esc_clears_only_focused_field_in_log_entry() {
         let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
         let (lookup_tx, _lookup_rx) = make_watch();
         let (rig_tx, _rig_rx) = make_rig_watch();
         let mut app = make_app();
         app.form.callsign = "K7ABC".to_string();
+        app.form.comment = "keep this".to_string();
+        app.form.focused = Field::Callsign;
+        app.editing_local_id = Some("q1".to_string());
         handle_key(
             &mut app,
             make_key(KeyCode::Esc),
@@ -2323,15 +2323,20 @@ mod tests {
             "",
         );
         assert!(app.form.callsign.is_empty());
+        assert_eq!(app.form.comment, "keep this");
+        assert_eq!(app.editing_local_id, Some("q1".to_string()));
     }
 
     #[tokio::test]
-    async fn handle_key_esc_in_advanced_returns_to_log_entry() {
+    async fn handle_key_esc_in_advanced_clears_focused_field() {
         let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
         let (lookup_tx, _lookup_rx) = make_watch();
         let (rig_tx, _rig_rx) = make_rig_watch();
         let mut app = make_app();
         app.view = View::Advanced;
+        app.form.focused = Field::Comment;
+        app.form.comment = "clear me".to_string();
+        app.form.callsign = "K7ABC".to_string();
         handle_key(
             &mut app,
             make_key(KeyCode::Esc),
@@ -2340,7 +2345,9 @@ mod tests {
             &rig_tx,
             "",
         );
-        assert!(matches!(app.view, View::LogEntry));
+        assert!(matches!(app.view, View::Advanced));
+        assert!(app.form.comment.is_empty());
+        assert_eq!(app.form.callsign, "K7ABC");
     }
 
     #[tokio::test]
@@ -2359,6 +2366,27 @@ mod tests {
             "",
         );
         assert!(!app.form.field_selected);
+        assert_eq!(app.form.field_cursor, app.form.focused_text_len());
+    }
+
+    #[tokio::test]
+    async fn handle_key_home_moves_text_cursor_to_start() {
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let (lookup_tx, _lookup_rx) = make_watch();
+        let (rig_tx, _rig_rx) = make_rig_watch();
+        let mut app = make_app();
+        app.form.focused = Field::Comment;
+        app.form.comment = "abc".to_string();
+        app.form.field_cursor = 3;
+        handle_key(
+            &mut app,
+            make_key(KeyCode::Home),
+            &tx,
+            &lookup_tx,
+            &rig_tx,
+            "",
+        );
+        assert_eq!(app.form.field_cursor, 0);
     }
 
     #[tokio::test]
@@ -2434,6 +2462,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_key_left_moves_text_cursor() {
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let (lookup_tx, _lookup_rx) = make_watch();
+        let (rig_tx, _rig_rx) = make_rig_watch();
+        let mut app = make_app();
+        app.form.focused = Field::Comment;
+        app.form.comment = "abc".to_string();
+        app.form.field_cursor = 2;
+        handle_key(
+            &mut app,
+            make_key(KeyCode::Left),
+            &tx,
+            &lookup_tx,
+            &rig_tx,
+            "",
+        );
+        assert_eq!(app.form.field_cursor, 1);
+    }
+
+    #[tokio::test]
+    async fn handle_key_right_moves_text_cursor() {
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let (lookup_tx, _lookup_rx) = make_watch();
+        let (rig_tx, _rig_rx) = make_rig_watch();
+        let mut app = make_app();
+        app.form.focused = Field::Comment;
+        app.form.comment = "abc".to_string();
+        app.form.field_cursor = 1;
+        handle_key(
+            &mut app,
+            make_key(KeyCode::Right),
+            &tx,
+            &lookup_tx,
+            &rig_tx,
+            "",
+        );
+        assert_eq!(app.form.field_cursor, 2);
+    }
+
+    #[tokio::test]
     async fn handle_key_char_appends_to_callsign_uppercase() {
         let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
         let (lookup_tx, _lookup_rx) = make_watch();
@@ -2470,6 +2538,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn handle_key_char_inserts_at_text_cursor() {
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let (lookup_tx, _lookup_rx) = make_watch();
+        let (rig_tx, _rig_rx) = make_rig_watch();
+        let mut app = make_app();
+        app.form.focused = Field::Comment;
+        app.form.comment = "ac".to_string();
+        app.form.field_cursor = 1;
+        handle_key(
+            &mut app,
+            make_key(KeyCode::Char('b')),
+            &tx,
+            &lookup_tx,
+            &rig_tx,
+            "",
+        );
+        assert_eq!(app.form.comment, "abc");
+        assert_eq!(app.form.field_cursor, 2);
+    }
+
+    #[tokio::test]
     async fn handle_key_char_with_field_selected_clears_first() {
         let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
         let (lookup_tx, _lookup_rx) = make_watch();
@@ -2497,6 +2586,7 @@ mod tests {
         let mut app = make_app();
         app.form.focused = Field::Callsign;
         app.form.callsign = "K7A".to_string();
+        app.form.field_cursor = 3;
         handle_key(
             &mut app,
             make_key(KeyCode::Backspace),
@@ -2506,6 +2596,27 @@ mod tests {
             "",
         );
         assert_eq!(app.form.callsign, "K7");
+    }
+
+    #[tokio::test]
+    async fn handle_key_delete_removes_char_at_cursor() {
+        let (tx, _rx) = mpsc::unbounded_channel::<AppEvent>();
+        let (lookup_tx, _lookup_rx) = make_watch();
+        let (rig_tx, _rig_rx) = make_rig_watch();
+        let mut app = make_app();
+        app.form.focused = Field::Comment;
+        app.form.comment = "abc".to_string();
+        app.form.field_cursor = 1;
+        handle_key(
+            &mut app,
+            make_key(KeyCode::Delete),
+            &tx,
+            &lookup_tx,
+            &rig_tx,
+            "",
+        );
+        assert_eq!(app.form.comment, "ac");
+        assert_eq!(app.form.field_cursor, 1);
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-tui/src/ui/advanced_form.rs
+++ b/src/rust/qsoripper-tui/src/ui/advanced_form.rs
@@ -15,7 +15,7 @@ use crate::ui::log_form::styled_field;
 /// Render the advanced field entry form into `area`.
 pub(super) fn render(app: &App, frame: &mut Frame, area: Rect) {
     let block = Block::bordered()
-        .title(" Advanced Fields  (F2/Esc return | Alt+1-4 tabs | F5/F6 cycle) ")
+        .title(" Advanced Fields  (F2 return | Esc clear field | Alt+1-4 tabs | F5/F6 cycle) ")
         .border_style(Style::default().fg(Color::Magenta));
 
     let inner = block.inner(area);
@@ -99,7 +99,13 @@ fn render_main_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, _
         let cs_selected = cs_focused && form.field_selected;
         let band_focused = form.focused == Field::Band;
         let mode_focused = form.focused == Field::Mode;
-        let cs_val = adv_field(&form.callsign, cs_focused, cs_selected, 12);
+        let cs_val = adv_field(
+            &form.callsign,
+            cs_focused,
+            cs_selected,
+            form.field_cursor,
+            12,
+        );
         let band_val = cycle_adv(form.band_str(), band_focused);
         let mode_val = cycle_adv(form.mode_str(), mode_focused);
         let mut spans: Vec<Span<'static>> = Vec::new();
@@ -150,7 +156,7 @@ fn render_main_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, _
         let ds = df && form.field_selected;
         if let Some(&left) = cols.first() {
             let fw = (left.width as usize).saturating_sub(10).max(5);
-            let fv = adv_field(&form.frequency_mhz, ff, fs, fw);
+            let fv = adv_field(&form.frequency_mhz, ff, fs, form.field_cursor, fw);
             let mut s: Vec<Span<'static>> = Vec::new();
             s.extend(kl("", 'f', "req MHz  "));
             s.push(styled_field(fv, ff, fs));
@@ -158,7 +164,7 @@ fn render_main_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, _
         }
         if let Some(&right) = cols.get(1) {
             let dw = (right.width as usize).saturating_sub(10).max(5);
-            let dv = adv_field(&form.date, df, ds, dw);
+            let dv = adv_field(&form.date, df, ds, form.field_cursor, dw);
             let mut s: Vec<Span<'static>> = Vec::new();
             s.extend(kl("", 'd', "ate      "));
             s.push(styled_field(dv, df, ds));
@@ -176,7 +182,7 @@ fn render_main_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, _
         let es = ef && form.field_selected;
         if let Some(&left) = cols.first() {
             let tw = (left.width as usize).saturating_sub(10).max(5);
-            let tv = adv_field(&form.time, tf, ts, tw);
+            let tv = adv_field(&form.time, tf, ts, form.field_cursor, tw);
             let mut s: Vec<Span<'static>> = Vec::new();
             s.extend(kl("", 't', "ime      "));
             s.push(styled_field(tv, tf, ts));
@@ -184,7 +190,7 @@ fn render_main_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, _
         }
         if let Some(&right) = cols.get(1) {
             let ew = (right.width as usize).saturating_sub(10).max(5);
-            let ev = adv_field(&form.time_off, ef, es, ew);
+            let ev = adv_field(&form.time_off, ef, es, form.field_cursor, ew);
             let mut s: Vec<Span<'static>> = Vec::new();
             s.extend(kl("T", 'e', "nd      "));
             s.push(styled_field(ev, ef, es));
@@ -202,7 +208,7 @@ fn render_main_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, _
         let ns = nf && form.field_selected;
         if let Some(&left) = cols.first() {
             let qw = (left.width as usize).saturating_sub(10).max(5);
-            let qv = adv_field(&form.qth, qf, qs, qw);
+            let qv = adv_field(&form.qth, qf, qs, form.field_cursor, qw);
             let mut s: Vec<Span<'static>> = Vec::new();
             s.extend(kl("", 'q', "th       "));
             s.push(styled_field(qv, qf, qs));
@@ -210,7 +216,7 @@ fn render_main_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, _
         }
         if let Some(&right) = cols.get(1) {
             let nw = (right.width as usize).saturating_sub(10).max(5);
-            let nv = adv_field(&form.worked_name, nf, ns, nw);
+            let nv = adv_field(&form.worked_name, nf, ns, form.field_cursor, nw);
             let mut s: Vec<Span<'static>> = Vec::new();
             s.extend(kl("N", 'a', "me      "));
             s.push(styled_field(nv, nf, ns));
@@ -227,14 +233,14 @@ fn render_main_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, _
         let rf = form.focused == Field::RstRcvd;
         let rs = rf && form.field_selected;
         if let Some(&left) = cols.first() {
-            let sv = adv_field(&form.rst_sent, sf, ss, 5);
+            let sv = adv_field(&form.rst_sent, sf, ss, form.field_cursor, 5);
             let mut s: Vec<Span<'static>> = Vec::new();
             s.extend(kl("RST ", 's', "ent  "));
             s.push(styled_field(sv, sf, ss));
             frame.render_widget(Paragraph::new(Line::from(s)), left);
         }
         if let Some(&right) = cols.get(1) {
-            let rv = adv_field(&form.rst_rcvd, rf, rs, 5);
+            let rv = adv_field(&form.rst_rcvd, rf, rs, form.field_cursor, 5);
             let mut s: Vec<Span<'static>> = Vec::new();
             s.extend(kl("RST ", 'r', "cvd  "));
             s.push(styled_field(rv, rf, rs));
@@ -250,6 +256,7 @@ fn render_main_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, _
             &form.comment,
             focused,
             selected,
+            form.field_cursor,
             (row.width as usize).saturating_sub(10).max(10),
         );
         let mut spans: Vec<Span<'static>> = Vec::new();
@@ -266,6 +273,7 @@ fn render_main_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm, _
             &form.notes,
             focused,
             selected,
+            form.field_cursor,
             (row.width as usize).saturating_sub(10).max(10),
         );
         let mut spans: Vec<Span<'static>> = Vec::new();
@@ -304,8 +312,8 @@ fn render_contest_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm
         let ps = pf && form.field_selected;
         let sf = form.focused == Field::Submode;
         let ss = sf && form.field_selected;
-        let pv = adv_field(&form.tx_power, pf, ps, short);
-        let sv = adv_field(&form.submode_override, sf, ss, short);
+        let pv = adv_field(&form.tx_power, pf, ps, form.field_cursor, short);
+        let sv = adv_field(&form.submode_override, sf, ss, form.field_cursor, short);
         let mut row0_spans: Vec<Span<'static>> = Vec::new();
         row0_spans.extend(kl("TX Po", 'w', "er "));
         row0_spans.push(styled_field(pv, pf, ps));
@@ -317,7 +325,7 @@ fn render_contest_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm
     if let Some(row) = rows.get(1).copied() {
         let focused = form.focused == Field::ContestId;
         let selected = focused && form.field_selected;
-        let val = adv_field(&form.contest_id, focused, selected, wide);
+        let val = adv_field(&form.contest_id, focused, selected, form.field_cursor, wide);
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 label("Contest  "),
@@ -331,8 +339,8 @@ fn render_contest_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm
         let ss = sf && form.field_selected;
         let rf = form.focused == Field::SerialRcvd;
         let rs = rf && form.field_selected;
-        let sv = adv_field(&form.serial_sent, sf, ss, short);
-        let rv = adv_field(&form.serial_rcvd, rf, rs, short);
+        let sv = adv_field(&form.serial_sent, sf, ss, form.field_cursor, short);
+        let rv = adv_field(&form.serial_rcvd, rf, rs, form.field_cursor, short);
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 label("Ser Sent "),
@@ -347,7 +355,13 @@ fn render_contest_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm
     if let Some(row) = rows.get(3).copied() {
         let focused = form.focused == Field::ExchangeSent;
         let selected = focused && form.field_selected;
-        let val = adv_field(&form.exchange_sent, focused, selected, wide);
+        let val = adv_field(
+            &form.exchange_sent,
+            focused,
+            selected,
+            form.field_cursor,
+            wide,
+        );
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 label("Exch Snt "),
@@ -359,7 +373,13 @@ fn render_contest_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm
     if let Some(row) = rows.get(4).copied() {
         let focused = form.focused == Field::ExchangeRcvd;
         let selected = focused && form.field_selected;
-        let val = adv_field(&form.exchange_rcvd, focused, selected, wide);
+        let val = adv_field(
+            &form.exchange_rcvd,
+            focused,
+            selected,
+            form.field_cursor,
+            wide,
+        );
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 label("Exch Rcvd"),
@@ -382,7 +402,7 @@ fn render_technical_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogFo
     if let Some(row) = rows.first().copied() {
         let focused = form.focused == Field::PropMode;
         let selected = focused && form.field_selected;
-        let val = adv_field(&form.prop_mode, focused, selected, wide);
+        let val = adv_field(&form.prop_mode, focused, selected, form.field_cursor, wide);
         let mut spans: Vec<Span<'static>> = Vec::new();
         spans.extend(kl("", 'p', "rop Mode"));
         spans.push(styled_field(val, focused, selected));
@@ -391,7 +411,7 @@ fn render_technical_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogFo
     if let Some(row) = rows.get(1).copied() {
         let focused = form.focused == Field::SatName;
         let selected = focused && form.field_selected;
-        let val = adv_field(&form.sat_name, focused, selected, wide);
+        let val = adv_field(&form.sat_name, focused, selected, form.field_cursor, wide);
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 label("Sat Name "),
@@ -403,7 +423,7 @@ fn render_technical_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogFo
     if let Some(row) = rows.get(2).copied() {
         let focused = form.focused == Field::SatMode;
         let selected = focused && form.field_selected;
-        let val = adv_field(&form.sat_mode, focused, selected, wide);
+        let val = adv_field(&form.sat_mode, focused, selected, form.field_cursor, wide);
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 label("Sat Mode "),
@@ -430,7 +450,7 @@ fn render_awards_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm,
     if let Some(row) = rows.first().copied() {
         let focused = form.focused == Field::Iota;
         let selected = focused && form.field_selected;
-        let val = adv_field(&form.iota, focused, selected, short);
+        let val = adv_field(&form.iota, focused, selected, form.field_cursor, short);
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 label("IOTA     "),
@@ -442,7 +462,13 @@ fn render_awards_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm,
     if let Some(row) = rows.get(1).copied() {
         let focused = form.focused == Field::ArrlSection;
         let selected = focused && form.field_selected;
-        let val = adv_field(&form.arrl_section, focused, selected, short);
+        let val = adv_field(
+            &form.arrl_section,
+            focused,
+            selected,
+            form.field_cursor,
+            short,
+        );
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 label("ARRL Sec "),
@@ -456,8 +482,8 @@ fn render_awards_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm,
         let ws = wf && form.field_selected;
         let cf = form.focused == Field::WorkedCounty;
         let cs = cf && form.field_selected;
-        let wv = adv_field(&form.worked_state, wf, ws, short);
-        let cv = adv_field(&form.worked_county, cf, cs, wide);
+        let wv = adv_field(&form.worked_state, wf, ws, form.field_cursor, short);
+        let cv = adv_field(&form.worked_county, cf, cs, form.field_cursor, wide);
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 label("State    "),
@@ -472,7 +498,7 @@ fn render_awards_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm,
     if let Some(row) = rows.get(3).copied() {
         let focused = form.focused == Field::Skcc;
         let selected = focused && form.field_selected;
-        let val = adv_field(&form.skcc, focused, selected, short);
+        let val = adv_field(&form.skcc, focused, selected, form.field_cursor, short);
         let mut spans: Vec<Span<'static>> = Vec::new();
         spans.extend(kl("S", 'k', "CC     "));
         spans.push(styled_field(val, focused, selected));
@@ -481,7 +507,7 @@ fn render_awards_tab(frame: &mut Frame, area: Rect, form: &crate::form::LogForm,
 }
 
 /// Format an advanced field value with a fixed display width and optional cursor.
-fn adv_field(text: &str, focused: bool, selected: bool, width: usize) -> String {
+fn adv_field(text: &str, focused: bool, selected: bool, cursor: usize, width: usize) -> String {
     if selected {
         let len = text.chars().count();
         if len >= width {
@@ -490,17 +516,39 @@ fn adv_field(text: &str, focused: bool, selected: bool, width: usize) -> String 
             format!("{text:<width$}")
         }
     } else {
-        let mut s = text.to_string();
-        if focused {
-            s.push('|');
-        }
+        let s = if focused {
+            text_with_cursor(text, cursor)
+        } else {
+            text.to_string()
+        };
         let len = s.chars().count();
         if len > width {
-            s.chars().skip(len - width).collect()
+            let skip = if focused {
+                cursor.saturating_add(1).saturating_sub(width)
+            } else {
+                len - width
+            };
+            s.chars().skip(skip).take(width).collect()
         } else {
             format!("{s:<width$}")
         }
     }
+}
+
+fn text_with_cursor(text: &str, cursor: usize) -> String {
+    let len = text.chars().count();
+    let cursor = cursor.min(len);
+    let mut value = String::new();
+    for (idx, ch) in text.chars().enumerate() {
+        if idx == cursor {
+            value.push('|');
+        }
+        value.push(ch);
+    }
+    if cursor == len {
+        value.push('|');
+    }
+    value
 }
 
 fn label(text: &str) -> Span<'static> {

--- a/src/rust/qsoripper-tui/src/ui/advanced_form.rs
+++ b/src/rust/qsoripper-tui/src/ui/advanced_form.rs
@@ -15,7 +15,7 @@ use crate::ui::log_form::styled_field;
 /// Render the advanced field entry form into `area`.
 pub(super) fn render(app: &App, frame: &mut Frame, area: Rect) {
     let block = Block::bordered()
-        .title(" Advanced Fields  (F2 return | Esc clear field | Alt+1-4 tabs | F5/F6 cycle) ")
+        .title(" Advanced Fields  (F2 return | Esc clear QSO | Ctrl+Bksp clear field | Alt+1-4 tabs | F5/F6 cycle) ")
         .border_style(Style::default().fg(Color::Magenta));
 
     let inner = block.inner(area);

--- a/src/rust/qsoripper-tui/src/ui/footer.rs
+++ b/src/rust/qsoripper-tui/src/ui/footer.rs
@@ -20,8 +20,8 @@ pub(super) fn render(frame: &mut Frame, area: Rect) {
         ("F5/F6", "Adv tabs"),
         ("F8", "Rig ctrl"),
         ("F10", "Log QSO (Alt+Enter)"),
-        ("Esc", "Clear field"),
-        ("Ctrl+L", "Clear QSO"),
+        ("Esc", "Clear QSO"),
+        ("Ctrl+Bksp", "Clear field"),
         ("Ctrl+Q", "Quit"),
     ];
 

--- a/src/rust/qsoripper-tui/src/ui/footer.rs
+++ b/src/rust/qsoripper-tui/src/ui/footer.rs
@@ -20,7 +20,8 @@ pub(super) fn render(frame: &mut Frame, area: Rect) {
         ("F5/F6", "Adv tabs"),
         ("F8", "Rig ctrl"),
         ("F10", "Log QSO (Alt+Enter)"),
-        ("Esc", "Clear"),
+        ("Esc", "Clear field"),
+        ("Ctrl+L", "Clear QSO"),
         ("Ctrl+Q", "Quit"),
     ];
 

--- a/src/rust/qsoripper-tui/src/ui/help.rs
+++ b/src/rust/qsoripper-tui/src/ui/help.rs
@@ -55,8 +55,8 @@ pub(super) fn render(frame: &mut Frame, area: Rect) {
         "F8               ",
         "Toggle rig control (read freq/mode from radio)",
     ));
-    lines.push(binding("Esc              ", "Clear the focused field"));
-    lines.push(binding("Ctrl+L           ", "Clear the current QSO"));
+    lines.push(binding("Esc              ", "Clear the current QSO"));
+    lines.push(binding("Ctrl+Backspace   ", "Clear the focused field"));
     lines.push(binding("Ctrl+Q           ", "Quit"));
     lines.push(Line::raw(""));
 

--- a/src/rust/qsoripper-tui/src/ui/help.rs
+++ b/src/rust/qsoripper-tui/src/ui/help.rs
@@ -55,10 +55,8 @@ pub(super) fn render(frame: &mut Frame, area: Rect) {
         "F8               ",
         "Toggle rig control (read freq/mode from radio)",
     ));
-    lines.push(binding(
-        "Esc              ",
-        "Clear form (or close advanced view)",
-    ));
+    lines.push(binding("Esc              ", "Clear the focused field"));
+    lines.push(binding("Ctrl+L           ", "Clear the current QSO"));
     lines.push(binding("Ctrl+Q           ", "Quit"));
     lines.push(Line::raw(""));
 

--- a/src/rust/qsoripper-tui/src/ui/log_form.rs
+++ b/src/rust/qsoripper-tui/src/ui/log_form.rs
@@ -77,7 +77,13 @@ pub(super) fn render(app: &App, frame: &mut Frame, area: Rect) {
 fn render_callsign_row(frame: &mut Frame, area: Rect, form: &crate::form::LogForm) {
     let cs_focused = form.focused == Field::Callsign;
     let cs_selected = cs_focused && form.field_selected;
-    let cs_val = field_value(&form.callsign, cs_focused, cs_selected, CALLSIGN_WIDTH);
+    let cs_val = field_value(
+        &form.callsign,
+        cs_focused,
+        cs_selected,
+        form.field_cursor,
+        CALLSIGN_WIDTH,
+    );
     let mut spans: Vec<Span<'static>> = Vec::new();
     spans.extend(label_m("", 'C', "allsign "));
     spans.push(styled_field(cs_val, cs_focused, cs_selected));
@@ -103,8 +109,20 @@ fn render_rst_row(frame: &mut Frame, area: Rect, form: &crate::form::LogForm) {
     let sent_selected = sent_focused && form.field_selected;
     let rcvd_focused = form.focused == Field::RstRcvd;
     let rcvd_selected = rcvd_focused && form.field_selected;
-    let sent_val = field_value(&form.rst_sent, sent_focused, sent_selected, RST_WIDTH);
-    let rcvd_val = field_value(&form.rst_rcvd, rcvd_focused, rcvd_selected, RST_WIDTH);
+    let sent_val = field_value(
+        &form.rst_sent,
+        sent_focused,
+        sent_selected,
+        form.field_cursor,
+        RST_WIDTH,
+    );
+    let rcvd_val = field_value(
+        &form.rst_rcvd,
+        rcvd_focused,
+        rcvd_selected,
+        form.field_cursor,
+        RST_WIDTH,
+    );
     let mut spans: Vec<Span<'static>> = Vec::new();
     spans.extend(label_m("RST ", 'S', "nt "));
     spans.push(styled_field(sent_val, sent_focused, sent_selected));
@@ -120,7 +138,7 @@ fn render_comment_row(frame: &mut Frame, area: Rect, form: &crate::form::LogForm
     let width = (area.width as usize).saturating_sub(label_len + 2).max(10);
     let focused = form.focused == Field::Comment;
     let selected = focused && form.field_selected;
-    let val = field_value(&form.comment, focused, selected, width);
+    let val = field_value(&form.comment, focused, selected, form.field_cursor, width);
     let mut spans: Vec<Span<'static>> = Vec::new();
     spans.extend(label_m("C", 'o', "mment  "));
     spans.push(styled_field(val, focused, selected));
@@ -133,7 +151,7 @@ fn render_notes_row(frame: &mut Frame, area: Rect, form: &crate::form::LogForm) 
     let width = (area.width as usize).saturating_sub(label_len + 2).max(10);
     let focused = form.focused == Field::Notes;
     let selected = focused && form.field_selected;
-    let val = field_value(&form.notes, focused, selected, width);
+    let val = field_value(&form.notes, focused, selected, form.field_cursor, width);
     let mut spans: Vec<Span<'static>> = Vec::new();
     spans.extend(label_m("", 'N', "otes    "));
     spans.push(styled_field(val, focused, selected));
@@ -148,9 +166,27 @@ fn render_freq_row(frame: &mut Frame, area: Rect, form: &crate::form::LogForm) {
     let date_selected = date_focused && form.field_selected;
     let time_focused = form.focused == Field::Time;
     let time_selected = time_focused && form.field_selected;
-    let freq_val = field_value(&form.frequency_mhz, freq_focused, freq_selected, FREQ_WIDTH);
-    let date_val = field_value(&form.date, date_focused, date_selected, DATE_WIDTH);
-    let time_val = field_value(&form.time, time_focused, time_selected, TIME_WIDTH);
+    let freq_val = field_value(
+        &form.frequency_mhz,
+        freq_focused,
+        freq_selected,
+        form.field_cursor,
+        FREQ_WIDTH,
+    );
+    let date_val = field_value(
+        &form.date,
+        date_focused,
+        date_selected,
+        form.field_cursor,
+        DATE_WIDTH,
+    );
+    let time_val = field_value(
+        &form.time,
+        time_focused,
+        time_selected,
+        form.field_cursor,
+        TIME_WIDTH,
+    );
     let mut spans: Vec<Span<'static>> = Vec::new();
     spans.extend(label_m("", 'F', "req MHz "));
     spans.push(styled_field(freq_val, freq_focused, freq_selected));
@@ -208,7 +244,7 @@ fn render_hints_row(frame: &mut Frame, area: Rect) {
             ),
             Span::raw("  "),
             Span::styled(
-                " Esc Clear ",
+                " Esc Clear Field ",
                 Style::default().fg(Color::Black).bg(Color::DarkGray),
             ),
             Span::raw("  "),
@@ -245,7 +281,7 @@ fn label_m(before: &'static str, mnemonic: char, after: &'static str) -> [Span<'
 ///
 /// When `selected`, shows text padded to width without a cursor.
 /// When focused (not selected), appends `|` cursor and scrolls right when long.
-fn field_value(text: &str, focused: bool, selected: bool, width: usize) -> String {
+fn field_value(text: &str, focused: bool, selected: bool, cursor: usize, width: usize) -> String {
     if selected {
         let len = text.chars().count();
         if len >= width {
@@ -254,17 +290,38 @@ fn field_value(text: &str, focused: bool, selected: bool, width: usize) -> Strin
             format!("{text:<width$}")
         }
     } else {
-        let mut s = text.to_string();
-        if focused {
-            s.push('|');
-        }
+        let s = if focused {
+            text_with_cursor(text, cursor)
+        } else {
+            text.to_string()
+        };
         let len = s.chars().count();
         if len > width {
-            s.chars().skip(len - width).collect()
+            let skip = if focused {
+                cursor.saturating_add(1).saturating_sub(width)
+            } else {
+                len - width
+            };
+            s.chars().skip(skip).take(width).collect()
         } else {
             format!("{s:<width$}")
         }
     }
+}
+
+fn text_with_cursor(text: &str, cursor: usize) -> String {
+    let cursor = cursor.min(text.chars().count());
+    let mut value = String::new();
+    for (idx, ch) in text.chars().enumerate() {
+        if idx == cursor {
+            value.push('|');
+        }
+        value.push(ch);
+    }
+    if cursor == text.chars().count() {
+        value.push('|');
+    }
+    value
 }
 
 /// Format a cycle selector value with arrow hints.

--- a/src/rust/qsoripper-tui/src/ui/log_form.rs
+++ b/src/rust/qsoripper-tui/src/ui/log_form.rs
@@ -244,7 +244,7 @@ fn render_hints_row(frame: &mut Frame, area: Rect) {
             ),
             Span::raw("  "),
             Span::styled(
-                " Esc Clear Field ",
+                " Esc Clear QSO ",
                 Style::default().fg(Color::Black).bg(Color::DarkGray),
             ),
             Span::raw("  "),


### PR DESCRIPTION
## Summary
- Add cursor-aware editing for TUI text fields, including Home/End and Left/Right movement.
- Insert, backspace, and delete text at the cursor instead of only appending/removing from the end.
- Make Esc clear the active edit field without clearing the whole QSO.

## Validation
- cargo clippy --manifest-path src\\rust\\Cargo.toml -p qsoripper-tui --all-targets -- -D warnings
- cargo test --manifest-path src\\rust\\Cargo.toml -p qsoripper-tui
- cargo fmt --manifest-path src\\rust\\Cargo.toml --all -- --check