### PR TITLE
Complete Win32 advanced card parity

### DIFF
--- a/src/c/qsoripper-win32/include/qsoripper_ffi.h
+++ b/src/c/qsoripper-win32/include/qsoripper_ffi.h
@@ -72,6 +72,10 @@ typedef struct QsrLogQsoRequest {
    */
   uint8_t notes[256];
   /**
+   * Worked operator callsign (null-terminated).
+   */
+  uint8_t worked_operator_callsign[32];
+  /**
    * Operator name (null-terminated).
    */
   uint8_t worked_name[64];
@@ -159,6 +163,33 @@ typedef struct QsrLogQsoRequest {
    * SKCC membership number (null-terminated).
    */
   uint8_t skcc[16];
+  uint8_t qsl_sent_status[16];
+  uint8_t qsl_sent_date[16];
+  uint8_t qsl_rcvd_status[16];
+  uint8_t qsl_rcvd_date[16];
+  uint8_t lotw_sent[8];
+  uint8_t lotw_rcvd[8];
+  uint8_t eqsl_sent[8];
+  uint8_t eqsl_rcvd[8];
+  uint8_t qrz_log_id[32];
+  uint8_t qrz_book_id[32];
+  uint8_t snapshot_station_callsign[32];
+  uint8_t snapshot_operator_callsign[32];
+  uint8_t snapshot_profile[64];
+  uint8_t snapshot_operator_name[64];
+  uint8_t snapshot_grid[16];
+  uint8_t snapshot_country[64];
+  uint8_t snapshot_state[16];
+  uint8_t snapshot_county[32];
+  uint8_t snapshot_arrl_section[16];
+  uint8_t snapshot_dxcc[16];
+  uint8_t snapshot_cq_zone[16];
+  uint8_t snapshot_itu_zone[16];
+  uint8_t snapshot_latitude[24];
+  uint8_t snapshot_longitude[24];
+  uint8_t cw_rx_wpm[8];
+  uint8_t cw_transcript[256];
+  uint8_t extra_fields[256];
   /**
    * Time off date+time string "YYYY-MM-DD HH:MM" (null-terminated, empty = not set).
    */
@@ -241,6 +272,10 @@ typedef struct QsrQsoDetail {
    * Time off string "HH:MM" (null-terminated, empty = not set).
    */
   uint8_t time_off[16];
+  /**
+   * Worked operator callsign (null-terminated).
+   */
+  uint8_t worked_operator_callsign[32];
   /**
    * Worked name (null-terminated).
    */
@@ -329,6 +364,37 @@ typedef struct QsrQsoDetail {
    * SKCC membership number (null-terminated).
    */
   uint8_t skcc[16];
+  uint8_t station_callsign[32];
+  uint8_t qsl_sent_status[16];
+  uint8_t qsl_sent_date[16];
+  uint8_t qsl_rcvd_status[16];
+  uint8_t qsl_rcvd_date[16];
+  uint8_t lotw_sent[8];
+  uint8_t lotw_rcvd[8];
+  uint8_t eqsl_sent[8];
+  uint8_t eqsl_rcvd[8];
+  uint8_t qrz_log_id[32];
+  uint8_t qrz_book_id[32];
+  uint8_t snapshot_station_callsign[32];
+  uint8_t snapshot_operator_callsign[32];
+  uint8_t snapshot_profile[64];
+  uint8_t snapshot_operator_name[64];
+  uint8_t snapshot_grid[16];
+  uint8_t snapshot_country[64];
+  uint8_t snapshot_state[16];
+  uint8_t snapshot_county[32];
+  uint8_t snapshot_arrl_section[16];
+  uint8_t snapshot_dxcc[16];
+  uint8_t snapshot_cq_zone[16];
+  uint8_t snapshot_itu_zone[16];
+  uint8_t snapshot_latitude[24];
+  uint8_t snapshot_longitude[24];
+  uint8_t cw_rx_wpm[8];
+  uint8_t cw_transcript[256];
+  uint8_t sync_status[24];
+  uint8_t created_at[32];
+  uint8_t updated_at[32];
+  uint8_t extra_fields[256];
 } QsrQsoDetail;
 
 /**

--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -2942,7 +2942,7 @@ static int PaintAdvancedForm(HDC hdc, int y_start, int w)
     int ch = g_state.char_h;
     int row_h = ch + 8;
     int pad = cw * 2;
-    int label_w = cw * 13;
+    int label_w = cw * 16;
     int focused_form = !g_state.qso_list_focused && !g_state.search_focused;
     int tab = g_state.advanced_tab;
     int field_count, form_h, y, i, t;
@@ -2966,7 +2966,7 @@ static int PaintAdvancedForm(HDC hdc, int y_start, int w)
     }
 
     DrawText_A(hdc, pad, y_start + ch + 2, CLR_DARKGRAY,
-               "Ctrl+Tab or F5/F6 pages - Alt+1..7 jumps - F10 saves - Esc closes card");
+               "F5/F6 pages - Alt+1..7 jumps - F10 saves - Esc closes card");
 
     y = y_start + ch * 2 + 8;
 
@@ -3053,9 +3053,6 @@ static int PaintAdvancedForm(HDC hdc, int y_start, int w)
                        CLR_GRAY, line);
         }
 
-        y = card_y + card_h - ch - 6;
-        DrawText_A(hdc, card_x + cw * 2, y, CLR_GRAY,
-                   "Tab/Shift+Tab cycles fields; Ctrl+Tab/Ctrl+Shift+Tab cycles pages.");
     }
 
     return y_start + form_h;
@@ -3334,8 +3331,6 @@ static void PaintHelp(HDC hdc, int w, int h)
         "F4              Toggle search",
         "F7              Start QSO timer",
         "F8              Toggle rig control",
-        "Ctrl+Tab        Advanced page next",
-        "Ctrl+Shift+Tab  Advanced page previous",
         "F5 / F6         Advanced page next/previous",
         "Alt+1..7        Advanced page direct",
         "F10 / Alt+Enter Log QSO (or update)",

--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -101,7 +101,8 @@ enum Field {
     FIELD_COMMENT,  FIELD_NOTES,
     FIELD_FREQ,     FIELD_DATE, FIELD_TIME,
     /* Advanced fields */
-    FIELD_TIME_OFF, FIELD_QTH, FIELD_WORKED_NAME,
+    FIELD_TIME_OFF, FIELD_STATION_CALLSIGN, FIELD_QTH,
+    FIELD_WORKED_OPERATOR_CALLSIGN, FIELD_WORKED_NAME,
     FIELD_WORKED_GRID, FIELD_WORKED_COUNTRY, FIELD_WORKED_DXCC,
     FIELD_WORKED_CQ_ZONE, FIELD_WORKED_ITU_ZONE, FIELD_WORKED_CONTINENT,
     FIELD_TX_POWER, FIELD_SUBMODE, FIELD_CONTEST_ID,
@@ -110,6 +111,21 @@ enum Field {
     FIELD_PROP_MODE, FIELD_SAT_NAME, FIELD_SAT_MODE,
     FIELD_IOTA, FIELD_ARRL_SECTION, FIELD_WORKED_STATE, FIELD_WORKED_COUNTY,
     FIELD_SKCC,
+    FIELD_QSL_SENT_STATUS, FIELD_QSL_SENT_DATE,
+    FIELD_QSL_RCVD_STATUS, FIELD_QSL_RCVD_DATE,
+    FIELD_LOTW_SENT, FIELD_LOTW_RCVD,
+    FIELD_EQSL_SENT, FIELD_EQSL_RCVD,
+    FIELD_QRZ_LOG_ID, FIELD_QRZ_BOOK_ID,
+    FIELD_SNAPSHOT_STATION_CALLSIGN, FIELD_SNAPSHOT_OPERATOR_CALLSIGN,
+    FIELD_SNAPSHOT_PROFILE, FIELD_SNAPSHOT_OPERATOR_NAME,
+    FIELD_SNAPSHOT_GRID, FIELD_SNAPSHOT_COUNTRY,
+    FIELD_SNAPSHOT_STATE, FIELD_SNAPSHOT_COUNTY,
+    FIELD_SNAPSHOT_ARRL_SECTION, FIELD_SNAPSHOT_DXCC,
+    FIELD_SNAPSHOT_CQ_ZONE, FIELD_SNAPSHOT_ITU_ZONE,
+    FIELD_SNAPSHOT_LATITUDE, FIELD_SNAPSHOT_LONGITUDE,
+    FIELD_CW_RX_WPM, FIELD_CW_TRANSCRIPT,
+    FIELD_LOCAL_ID, FIELD_SYNC_STATUS, FIELD_CREATED_AT,
+    FIELD_UPDATED_AT, FIELD_EXTRA_FIELDS,
     FIELD_COUNT
 };
 
@@ -119,30 +135,55 @@ static const char *FIELD_LABELS[] = {
     "Comment",  "Notes",
     "Freq MHz", "Date", "Time",
     /* Advanced labels */
-    "Time Off", "QTH", "Name",
+    "Time Off", "Station Call", "QTH", "Worked Op Call", "Name",
     "Grid", "Country", "DXCC",
     "CQ Zone", "ITU Zone", "Continent",
     "TX Power", "Submode", "Contest ID",
     "Serial Sent", "Serial Rcvd",
     "Exch Sent", "Exch Rcvd",
     "Prop Mode", "Sat Name", "Sat Mode",
-    "IOTA", "ARRL Sect", "State", "County", "SKCC"
+    "IOTA", "ARRL Sect", "State", "County", "SKCC",
+    "QSL Sent", "QSL Sent Date",
+    "QSL Rcvd", "QSL Rcvd Date",
+    "LoTW Sent", "LoTW Rcvd",
+    "eQSL Sent", "eQSL Rcvd",
+    "QRZ Log ID", "QRZ Book ID",
+    "Station Call", "Operator Call",
+    "Profile", "Operator Name",
+    "Grid", "Country",
+    "State", "County",
+    "ARRL Sect", "DXCC",
+    "CQ Zone", "ITU Zone",
+    "Latitude", "Longitude",
+    "CW RX WPM", "CW Transcript",
+    "Local ID", "Sync Status", "Created",
+    "Updated", "Extra ADIF"
 };
 
 static const int FIELD_MAX_LEN[] = {
-    30, 0, 0,   /* callsign, band(cycle), mode(cycle) */
+    30, 0, 0,  /* callsign, band(cycle), mode(cycle) */
     6,  6,      /* rst sent, rst rcvd */
     250, 250,   /* comment, notes */
     14, 14, 14, /* freq, date, time */
     /* Advanced max lengths */
-    14, 60, 60,         /* time_off, qth, worked_name */
+    14, 30, 60, 30, 60, /* time_off, station callsign, qth, worked_operator, worked_name */
     14, 60, 14,         /* worked_grid, worked_country, worked_dxcc */
     14, 14, 8,          /* worked_cq_zone, worked_itu_zone, worked_continent */
     14, 14, 30,         /* tx_power, submode, contest_id */
     14, 14,             /* serial_sent, serial_rcvd */
     60, 60,             /* exchange_sent, exchange_rcvd */
     14, 30, 14,         /* prop_mode, sat_name, sat_mode */
-    14, 14, 14, 30, 16  /* iota, arrl_section, worked_state, worked_county, skcc */
+    14, 14, 14, 30, 16, /* iota, arrl_section, worked_state, worked_county, skcc */
+    14, 14, 14, 14,     /* qsl statuses and dates */
+    6, 6, 6, 6,         /* lotw/eqsl tri-state fields */
+    30, 30,             /* qrz ids */
+    30, 30,             /* station and operator callsigns */
+    60, 60,             /* station profile and operator name */
+    14, 60, 14, 30,     /* station grid, country, state, county */
+    14, 14, 14, 14,     /* station arrl, dxcc, cq, itu */
+    20, 20,             /* station latitude, longitude */
+    8, 250,             /* cw rx wpm, transcript */
+    63, 20, 24, 24, 250 /* local id, sync status, created, updated, extra fields */
 };
 
 /* ── Async lookup message structs ──────────────────────────────────────── */
@@ -213,6 +254,8 @@ typedef struct {
     char callsign[16];
 } QsoDeleteResult;
 
+static void LoadSelectedQso(void);
+
 /* ── Recent QSO record ─────────────────────────────────────────────────── */
 
 typedef struct {
@@ -246,6 +289,7 @@ typedef struct {
 
     /* Form field buffers */
     char callsign[32];
+    char station_callsign[32];
     char rst_sent[8];
     char rst_rcvd[8];
     char comment[256];
@@ -261,6 +305,7 @@ typedef struct {
     /* Advanced field buffers */
     char time_off[16];
     char qth[64];
+    char worked_operator_callsign[32];
     char worked_name[64];
     char worked_grid[16];
     char worked_country[64];
@@ -283,6 +328,37 @@ typedef struct {
     char worked_state[16];
     char worked_county[32];
     char skcc[16];
+    char qsl_sent_status[16];
+    char qsl_sent_date[16];
+    char qsl_rcvd_status[16];
+    char qsl_rcvd_date[16];
+    char lotw_sent[8];
+    char lotw_rcvd[8];
+    char eqsl_sent[8];
+    char eqsl_rcvd[8];
+    char qrz_log_id[32];
+    char qrz_book_id[32];
+    char snapshot_station_callsign[32];
+    char snapshot_operator_callsign[32];
+    char snapshot_profile[64];
+    char snapshot_operator_name[64];
+    char snapshot_grid[16];
+    char snapshot_country[64];
+    char snapshot_state[16];
+    char snapshot_county[32];
+    char snapshot_arrl_section[16];
+    char snapshot_dxcc[16];
+    char snapshot_cq_zone[16];
+    char snapshot_itu_zone[16];
+    char snapshot_latitude[24];
+    char snapshot_longitude[24];
+    char cw_rx_wpm[8];
+    char cw_transcript[256];
+    char metadata_local_id[64];
+    char sync_status[24];
+    char created_at[32];
+    char updated_at[32];
+    char extra_fields[256];
 
     /* Cursor positions per field */
     int cursor_pos[FIELD_COUNT];
@@ -913,6 +989,7 @@ static char *FieldBuffer(enum Field f)
 {
     switch (f) {
     case FIELD_CALLSIGN:      return g_state.callsign;
+    case FIELD_STATION_CALLSIGN:return g_state.station_callsign;
     case FIELD_RST_SENT:      return g_state.rst_sent;
     case FIELD_RST_RCVD:      return g_state.rst_rcvd;
     case FIELD_COMMENT:       return g_state.comment;
@@ -922,6 +999,7 @@ static char *FieldBuffer(enum Field f)
     case FIELD_TIME:          return g_state.time_str;
     case FIELD_TIME_OFF:      return g_state.time_off;
     case FIELD_QTH:           return g_state.qth;
+    case FIELD_WORKED_OPERATOR_CALLSIGN:return g_state.worked_operator_callsign;
     case FIELD_WORKED_NAME:   return g_state.worked_name;
     case FIELD_WORKED_GRID:   return g_state.worked_grid;
     case FIELD_WORKED_COUNTRY:return g_state.worked_country;
@@ -944,6 +1022,37 @@ static char *FieldBuffer(enum Field f)
     case FIELD_WORKED_STATE:  return g_state.worked_state;
     case FIELD_WORKED_COUNTY: return g_state.worked_county;
     case FIELD_SKCC:          return g_state.skcc;
+    case FIELD_QSL_SENT_STATUS:return g_state.qsl_sent_status;
+    case FIELD_QSL_SENT_DATE: return g_state.qsl_sent_date;
+    case FIELD_QSL_RCVD_STATUS:return g_state.qsl_rcvd_status;
+    case FIELD_QSL_RCVD_DATE: return g_state.qsl_rcvd_date;
+    case FIELD_LOTW_SENT:     return g_state.lotw_sent;
+    case FIELD_LOTW_RCVD:     return g_state.lotw_rcvd;
+    case FIELD_EQSL_SENT:     return g_state.eqsl_sent;
+    case FIELD_EQSL_RCVD:     return g_state.eqsl_rcvd;
+    case FIELD_QRZ_LOG_ID:    return g_state.qrz_log_id;
+    case FIELD_QRZ_BOOK_ID:   return g_state.qrz_book_id;
+    case FIELD_SNAPSHOT_STATION_CALLSIGN:return g_state.snapshot_station_callsign;
+    case FIELD_SNAPSHOT_OPERATOR_CALLSIGN:return g_state.snapshot_operator_callsign;
+    case FIELD_SNAPSHOT_PROFILE:return g_state.snapshot_profile;
+    case FIELD_SNAPSHOT_OPERATOR_NAME:return g_state.snapshot_operator_name;
+    case FIELD_SNAPSHOT_GRID:return g_state.snapshot_grid;
+    case FIELD_SNAPSHOT_COUNTRY:return g_state.snapshot_country;
+    case FIELD_SNAPSHOT_STATE:return g_state.snapshot_state;
+    case FIELD_SNAPSHOT_COUNTY:return g_state.snapshot_county;
+    case FIELD_SNAPSHOT_ARRL_SECTION:return g_state.snapshot_arrl_section;
+    case FIELD_SNAPSHOT_DXCC:return g_state.snapshot_dxcc;
+    case FIELD_SNAPSHOT_CQ_ZONE:return g_state.snapshot_cq_zone;
+    case FIELD_SNAPSHOT_ITU_ZONE:return g_state.snapshot_itu_zone;
+    case FIELD_SNAPSHOT_LATITUDE:return g_state.snapshot_latitude;
+    case FIELD_SNAPSHOT_LONGITUDE:return g_state.snapshot_longitude;
+    case FIELD_CW_RX_WPM:     return g_state.cw_rx_wpm;
+    case FIELD_CW_TRANSCRIPT: return g_state.cw_transcript;
+    case FIELD_LOCAL_ID:      return g_state.metadata_local_id;
+    case FIELD_SYNC_STATUS:   return g_state.sync_status;
+    case FIELD_CREATED_AT:    return g_state.created_at;
+    case FIELD_UPDATED_AT:    return g_state.updated_at;
+    case FIELD_EXTRA_FIELDS:  return g_state.extra_fields;
     default: return NULL; /* band/mode are cycle selectors, FIELD_COUNT sentinel */
     }
 }
@@ -1277,6 +1386,7 @@ static void fill_log_request(QsrLogQsoRequest *req)
 {
     memset(req, 0, sizeof(*req));
     safe_strcpy((char *)req->callsign, sizeof(req->callsign), g_state.callsign);
+    safe_strcpy((char *)req->station_callsign, sizeof(req->station_callsign), g_state.station_callsign);
     safe_strcpy((char *)req->band, sizeof(req->band), BANDS[g_state.band_idx]);
     safe_strcpy((char *)req->mode, sizeof(req->mode), MODES[g_state.mode_idx]);
 
@@ -1306,12 +1416,13 @@ static void fill_log_request(QsrLogQsoRequest *req)
 
     safe_strcpy((char *)req->comment,       sizeof(req->comment),       g_state.comment);
     safe_strcpy((char *)req->notes,          sizeof(req->notes),          g_state.notes);
+    safe_strcpy((char *)req->worked_operator_callsign, sizeof(req->worked_operator_callsign), g_state.worked_operator_callsign);
     safe_strcpy((char *)req->worked_name,    sizeof(req->worked_name),    g_state.worked_name);
     safe_strcpy((char *)req->worked_grid,    sizeof(req->worked_grid),    g_state.worked_grid);
     safe_strcpy((char *)req->worked_country, sizeof(req->worked_country), g_state.worked_country);
     safe_strcpy((char *)req->worked_dxcc,    sizeof(req->worked_dxcc),    g_state.worked_dxcc);
     safe_strcpy((char *)req->worked_cq_zone, sizeof(req->worked_cq_zone), g_state.worked_cq_zone);
-     safe_strcpy((char *)req->worked_itu_zone,sizeof(req->worked_itu_zone),g_state.worked_itu_zone);
+    safe_strcpy((char *)req->worked_itu_zone,sizeof(req->worked_itu_zone),g_state.worked_itu_zone);
     safe_strcpy((char *)req->worked_continent,sizeof(req->worked_continent),g_state.worked_continent);
     safe_strcpy((char *)req->tx_power,       sizeof(req->tx_power),       g_state.tx_power);
     safe_strcpy((char *)req->submode,        sizeof(req->submode),        g_state.submode);
@@ -1328,6 +1439,33 @@ static void fill_log_request(QsrLogQsoRequest *req)
     safe_strcpy((char *)req->worked_state,   sizeof(req->worked_state),   g_state.worked_state);
     safe_strcpy((char *)req->worked_county,  sizeof(req->worked_county),  g_state.worked_county);
     safe_strcpy((char *)req->skcc,           sizeof(req->skcc),           g_state.skcc);
+    safe_strcpy((char *)req->qsl_sent_status, sizeof(req->qsl_sent_status), g_state.qsl_sent_status);
+    safe_strcpy((char *)req->qsl_sent_date, sizeof(req->qsl_sent_date), g_state.qsl_sent_date);
+    safe_strcpy((char *)req->qsl_rcvd_status, sizeof(req->qsl_rcvd_status), g_state.qsl_rcvd_status);
+    safe_strcpy((char *)req->qsl_rcvd_date, sizeof(req->qsl_rcvd_date), g_state.qsl_rcvd_date);
+    safe_strcpy((char *)req->lotw_sent, sizeof(req->lotw_sent), g_state.lotw_sent);
+    safe_strcpy((char *)req->lotw_rcvd, sizeof(req->lotw_rcvd), g_state.lotw_rcvd);
+    safe_strcpy((char *)req->eqsl_sent, sizeof(req->eqsl_sent), g_state.eqsl_sent);
+    safe_strcpy((char *)req->eqsl_rcvd, sizeof(req->eqsl_rcvd), g_state.eqsl_rcvd);
+    safe_strcpy((char *)req->qrz_log_id, sizeof(req->qrz_log_id), g_state.qrz_log_id);
+    safe_strcpy((char *)req->qrz_book_id, sizeof(req->qrz_book_id), g_state.qrz_book_id);
+    safe_strcpy((char *)req->snapshot_station_callsign, sizeof(req->snapshot_station_callsign), g_state.snapshot_station_callsign);
+    safe_strcpy((char *)req->snapshot_operator_callsign, sizeof(req->snapshot_operator_callsign), g_state.snapshot_operator_callsign);
+    safe_strcpy((char *)req->snapshot_profile, sizeof(req->snapshot_profile), g_state.snapshot_profile);
+    safe_strcpy((char *)req->snapshot_operator_name, sizeof(req->snapshot_operator_name), g_state.snapshot_operator_name);
+    safe_strcpy((char *)req->snapshot_grid, sizeof(req->snapshot_grid), g_state.snapshot_grid);
+    safe_strcpy((char *)req->snapshot_country, sizeof(req->snapshot_country), g_state.snapshot_country);
+    safe_strcpy((char *)req->snapshot_state, sizeof(req->snapshot_state), g_state.snapshot_state);
+    safe_strcpy((char *)req->snapshot_county, sizeof(req->snapshot_county), g_state.snapshot_county);
+    safe_strcpy((char *)req->snapshot_arrl_section, sizeof(req->snapshot_arrl_section), g_state.snapshot_arrl_section);
+    safe_strcpy((char *)req->snapshot_dxcc, sizeof(req->snapshot_dxcc), g_state.snapshot_dxcc);
+    safe_strcpy((char *)req->snapshot_cq_zone, sizeof(req->snapshot_cq_zone), g_state.snapshot_cq_zone);
+    safe_strcpy((char *)req->snapshot_itu_zone, sizeof(req->snapshot_itu_zone), g_state.snapshot_itu_zone);
+    safe_strcpy((char *)req->snapshot_latitude, sizeof(req->snapshot_latitude), g_state.snapshot_latitude);
+    safe_strcpy((char *)req->snapshot_longitude, sizeof(req->snapshot_longitude), g_state.snapshot_longitude);
+    safe_strcpy((char *)req->cw_rx_wpm, sizeof(req->cw_rx_wpm), g_state.cw_rx_wpm);
+    safe_strcpy((char *)req->cw_transcript, sizeof(req->cw_transcript), g_state.cw_transcript);
+    safe_strcpy((char *)req->extra_fields, sizeof(req->extra_fields), g_state.extra_fields);
 
     if (g_state.time_off[0] && g_state.date[0]) {
         char off[64];
@@ -1974,6 +2112,7 @@ static void ApplyLoadedQsoDetail(const char *local_id, const QsrQsoDetail *detai
     ClearForm();
 
     safe_strcpy(g_state.callsign, sizeof(g_state.callsign), (const char *)detail->callsign);
+    safe_strcpy(g_state.station_callsign, sizeof(g_state.station_callsign), (const char *)detail->station_callsign);
 
     /* Match band to index */
     {
@@ -2014,16 +2153,17 @@ static void ApplyLoadedQsoDetail(const char *local_id, const QsrQsoDetail *detai
 
     safe_strcpy(g_state.comment,       sizeof(g_state.comment),       (const char *)detail->comment);
     safe_strcpy(g_state.notes,          sizeof(g_state.notes),          (const char *)detail->notes);
+    safe_strcpy(g_state.worked_operator_callsign, sizeof(g_state.worked_operator_callsign), (const char *)detail->worked_operator_callsign);
     safe_strcpy(g_state.worked_name,    sizeof(g_state.worked_name),    (const char *)detail->worked_name);
     safe_strcpy(g_state.worked_grid,    sizeof(g_state.worked_grid),    (const char *)detail->worked_grid);
     safe_strcpy(g_state.worked_country, sizeof(g_state.worked_country), (const char *)detail->worked_country);
     safe_strcpy(g_state.worked_dxcc,    sizeof(g_state.worked_dxcc),    (const char *)detail->worked_dxcc);
     safe_strcpy(g_state.worked_cq_zone, sizeof(g_state.worked_cq_zone), (const char *)detail->worked_cq_zone);
-      safe_strcpy(g_state.worked_itu_zone,sizeof(g_state.worked_itu_zone),(const char *)detail->worked_itu_zone);
-      safe_strcpy(g_state.worked_continent,sizeof(g_state.worked_continent),(const char *)detail->worked_continent);
+    safe_strcpy(g_state.worked_itu_zone,sizeof(g_state.worked_itu_zone),(const char *)detail->worked_itu_zone);
+    safe_strcpy(g_state.worked_continent,sizeof(g_state.worked_continent),(const char *)detail->worked_continent);
     safe_strcpy(g_state.tx_power,       sizeof(g_state.tx_power),       (const char *)detail->tx_power);
     safe_strcpy(g_state.submode,        sizeof(g_state.submode),        (const char *)detail->submode);
-      safe_strcpy(g_state.contest_id,     sizeof(g_state.contest_id),     (const char *)detail->contest_id);
+    safe_strcpy(g_state.contest_id,     sizeof(g_state.contest_id),     (const char *)detail->contest_id);
     safe_strcpy(g_state.serial_sent,    sizeof(g_state.serial_sent),    (const char *)detail->serial_sent);
     safe_strcpy(g_state.serial_rcvd,    sizeof(g_state.serial_rcvd),    (const char *)detail->serial_rcvd);
     safe_strcpy(g_state.exchange_sent,  sizeof(g_state.exchange_sent),  (const char *)detail->exchange_sent);
@@ -2036,6 +2176,37 @@ static void ApplyLoadedQsoDetail(const char *local_id, const QsrQsoDetail *detai
     safe_strcpy(g_state.worked_state,   sizeof(g_state.worked_state),   (const char *)detail->worked_state);
     safe_strcpy(g_state.worked_county,  sizeof(g_state.worked_county),  (const char *)detail->worked_county);
     safe_strcpy(g_state.skcc,           sizeof(g_state.skcc),           (const char *)detail->skcc);
+    safe_strcpy(g_state.qsl_sent_status, sizeof(g_state.qsl_sent_status), (const char *)detail->qsl_sent_status);
+    safe_strcpy(g_state.qsl_sent_date, sizeof(g_state.qsl_sent_date), (const char *)detail->qsl_sent_date);
+    safe_strcpy(g_state.qsl_rcvd_status, sizeof(g_state.qsl_rcvd_status), (const char *)detail->qsl_rcvd_status);
+    safe_strcpy(g_state.qsl_rcvd_date, sizeof(g_state.qsl_rcvd_date), (const char *)detail->qsl_rcvd_date);
+    safe_strcpy(g_state.lotw_sent, sizeof(g_state.lotw_sent), (const char *)detail->lotw_sent);
+    safe_strcpy(g_state.lotw_rcvd, sizeof(g_state.lotw_rcvd), (const char *)detail->lotw_rcvd);
+    safe_strcpy(g_state.eqsl_sent, sizeof(g_state.eqsl_sent), (const char *)detail->eqsl_sent);
+    safe_strcpy(g_state.eqsl_rcvd, sizeof(g_state.eqsl_rcvd), (const char *)detail->eqsl_rcvd);
+    safe_strcpy(g_state.qrz_log_id, sizeof(g_state.qrz_log_id), (const char *)detail->qrz_log_id);
+    safe_strcpy(g_state.qrz_book_id, sizeof(g_state.qrz_book_id), (const char *)detail->qrz_book_id);
+    safe_strcpy(g_state.snapshot_station_callsign, sizeof(g_state.snapshot_station_callsign), (const char *)detail->snapshot_station_callsign);
+    safe_strcpy(g_state.snapshot_operator_callsign, sizeof(g_state.snapshot_operator_callsign), (const char *)detail->snapshot_operator_callsign);
+    safe_strcpy(g_state.snapshot_profile, sizeof(g_state.snapshot_profile), (const char *)detail->snapshot_profile);
+    safe_strcpy(g_state.snapshot_operator_name, sizeof(g_state.snapshot_operator_name), (const char *)detail->snapshot_operator_name);
+    safe_strcpy(g_state.snapshot_grid, sizeof(g_state.snapshot_grid), (const char *)detail->snapshot_grid);
+    safe_strcpy(g_state.snapshot_country, sizeof(g_state.snapshot_country), (const char *)detail->snapshot_country);
+    safe_strcpy(g_state.snapshot_state, sizeof(g_state.snapshot_state), (const char *)detail->snapshot_state);
+    safe_strcpy(g_state.snapshot_county, sizeof(g_state.snapshot_county), (const char *)detail->snapshot_county);
+    safe_strcpy(g_state.snapshot_arrl_section, sizeof(g_state.snapshot_arrl_section), (const char *)detail->snapshot_arrl_section);
+    safe_strcpy(g_state.snapshot_dxcc, sizeof(g_state.snapshot_dxcc), (const char *)detail->snapshot_dxcc);
+    safe_strcpy(g_state.snapshot_cq_zone, sizeof(g_state.snapshot_cq_zone), (const char *)detail->snapshot_cq_zone);
+    safe_strcpy(g_state.snapshot_itu_zone, sizeof(g_state.snapshot_itu_zone), (const char *)detail->snapshot_itu_zone);
+    safe_strcpy(g_state.snapshot_latitude, sizeof(g_state.snapshot_latitude), (const char *)detail->snapshot_latitude);
+    safe_strcpy(g_state.snapshot_longitude, sizeof(g_state.snapshot_longitude), (const char *)detail->snapshot_longitude);
+    safe_strcpy(g_state.cw_rx_wpm, sizeof(g_state.cw_rx_wpm), (const char *)detail->cw_rx_wpm);
+    safe_strcpy(g_state.cw_transcript, sizeof(g_state.cw_transcript), (const char *)detail->cw_transcript);
+    safe_strcpy(g_state.metadata_local_id, sizeof(g_state.metadata_local_id), local_id);
+    safe_strcpy(g_state.sync_status, sizeof(g_state.sync_status), (const char *)detail->sync_status);
+    safe_strcpy(g_state.created_at, sizeof(g_state.created_at), (const char *)detail->created_at);
+    safe_strcpy(g_state.updated_at, sizeof(g_state.updated_at), (const char *)detail->updated_at);
+    safe_strcpy(g_state.extra_fields, sizeof(g_state.extra_fields), (const char *)detail->extra_fields);
 
     safe_strcpy(g_state.editing_local_id, sizeof(g_state.editing_local_id), local_id);
 
@@ -2491,12 +2662,12 @@ static int PaintLogForm(HDC hdc, int y_start, int w)
 static const enum Field ADV_TAB_CORE_FIELDS[] = {
     FIELD_CALLSIGN, FIELD_DATE, FIELD_TIME, FIELD_TIME_OFF,
     FIELD_BAND, FIELD_MODE, FIELD_FREQ, FIELD_RST_SENT,
-    FIELD_RST_RCVD, FIELD_TX_POWER, FIELD_SUBMODE,
+    FIELD_RST_RCVD, FIELD_STATION_CALLSIGN, FIELD_TX_POWER, FIELD_SUBMODE,
     FIELD_COMMENT, FIELD_NOTES
 };
 
 static const enum Field ADV_TAB_LOOKUP_FIELDS[] = {
-    FIELD_CALLSIGN, FIELD_WORKED_NAME,
+    FIELD_WORKED_OPERATOR_CALLSIGN, FIELD_WORKED_NAME,
     FIELD_WORKED_GRID, FIELD_WORKED_COUNTRY,
     FIELD_WORKED_DXCC, FIELD_WORKED_STATE,
     FIELD_WORKED_CQ_ZONE, FIELD_WORKED_ITU_ZONE,
@@ -2505,7 +2676,13 @@ static const enum Field ADV_TAB_LOOKUP_FIELDS[] = {
     FIELD_SKCC
 };
 
-static const enum Field ADV_TAB_QSL_FIELDS[] = { FIELD_CALLSIGN };
+static const enum Field ADV_TAB_QSL_FIELDS[] = {
+    FIELD_QSL_SENT_STATUS, FIELD_QSL_SENT_DATE,
+    FIELD_QSL_RCVD_STATUS, FIELD_QSL_RCVD_DATE,
+    FIELD_LOTW_SENT, FIELD_LOTW_RCVD,
+    FIELD_EQSL_SENT, FIELD_EQSL_RCVD,
+    FIELD_QRZ_LOG_ID, FIELD_QRZ_BOOK_ID
+};
 
 static const enum Field ADV_TAB_CONTEST_FIELDS[] = {
     FIELD_CONTEST_ID, FIELD_SERIAL_SENT, FIELD_SERIAL_RCVD,
@@ -2514,11 +2691,23 @@ static const enum Field ADV_TAB_CONTEST_FIELDS[] = {
 };
 
 static const enum Field ADV_TAB_STATION_FIELDS[] = {
-    FIELD_QTH
+    FIELD_SNAPSHOT_STATION_CALLSIGN, FIELD_SNAPSHOT_OPERATOR_CALLSIGN,
+    FIELD_SNAPSHOT_PROFILE, FIELD_SNAPSHOT_OPERATOR_NAME,
+    FIELD_SNAPSHOT_GRID, FIELD_SNAPSHOT_COUNTRY,
+    FIELD_SNAPSHOT_STATE, FIELD_SNAPSHOT_COUNTY,
+    FIELD_SNAPSHOT_ARRL_SECTION, FIELD_SNAPSHOT_DXCC,
+    FIELD_SNAPSHOT_CQ_ZONE, FIELD_SNAPSHOT_ITU_ZONE,
+    FIELD_SNAPSHOT_LATITUDE, FIELD_SNAPSHOT_LONGITUDE
 };
 
-static const enum Field ADV_TAB_TRANSCRIPT_FIELDS[] = { FIELD_CALLSIGN };
-static const enum Field ADV_TAB_METADATA_FIELDS[] = { FIELD_CALLSIGN };
+static const enum Field ADV_TAB_TRANSCRIPT_FIELDS[] = {
+    FIELD_CW_RX_WPM, FIELD_CW_TRANSCRIPT
+};
+
+static const enum Field ADV_TAB_METADATA_FIELDS[] = {
+    FIELD_LOCAL_ID, FIELD_SYNC_STATUS, FIELD_CREATED_AT,
+    FIELD_UPDATED_AT, FIELD_EXTRA_FIELDS
+};
 
 static const enum Field *ADV_TABS[] = {
     ADV_TAB_CORE_FIELDS, ADV_TAB_LOOKUP_FIELDS, ADV_TAB_QSL_FIELDS,
@@ -2529,11 +2718,11 @@ static const enum Field *ADV_TABS[] = {
 static const int ADV_TAB_COUNTS[] = {
     sizeof(ADV_TAB_CORE_FIELDS) / sizeof(ADV_TAB_CORE_FIELDS[0]),
     sizeof(ADV_TAB_LOOKUP_FIELDS) / sizeof(ADV_TAB_LOOKUP_FIELDS[0]),
-    0,
+    sizeof(ADV_TAB_QSL_FIELDS) / sizeof(ADV_TAB_QSL_FIELDS[0]),
     sizeof(ADV_TAB_CONTEST_FIELDS) / sizeof(ADV_TAB_CONTEST_FIELDS[0]),
     sizeof(ADV_TAB_STATION_FIELDS) / sizeof(ADV_TAB_STATION_FIELDS[0]),
-    0,
-    0
+    sizeof(ADV_TAB_TRANSCRIPT_FIELDS) / sizeof(ADV_TAB_TRANSCRIPT_FIELDS[0]),
+    sizeof(ADV_TAB_METADATA_FIELDS) / sizeof(ADV_TAB_METADATA_FIELDS[0])
 };
 
 static const char *ADV_TAB_NAMES[] = {
@@ -2543,11 +2732,11 @@ static const char *ADV_TAB_NAMES[] = {
 static const char *ADV_TAB_DESCRIPTIONS[] = {
     "Identity, UTC timing, band/mode, reports, comments and notes",
     "Worked operator lookup, location, DXCC, zone and award fields",
-    "QSL workflow fields are not editable here yet",
+    "QSL workflow, LoTW/eQSL status and QRZ log identifiers",
     "Contest identifiers, serial numbers, exchange text, propagation and satellite details",
-    "Station profile fields preserved from the engine plus logged QTH",
-    "CW transcript fields are preserved from the engine",
-    "Engine metadata and custom fields are preserved during edits"
+    "Station profile snapshot fields captured with the contact",
+    "CW decode speed and transcript text",
+    "Engine metadata and extra ADIF fields"
 };
 
 static const enum Field *AdvTabFields(int tab, int *count)
@@ -2573,6 +2762,39 @@ static int AdvTabForField(enum Field f)
         if (AdvTabFieldIndex(t, f) >= 0) return t;
     }
     return -1;
+}
+
+static void ToggleAdvancedView(HWND hwnd)
+{
+    if (!g_state.advanced_view && g_state.qso_list_focused &&
+        g_state.qso_selected >= 0 && g_state.qso_selected < g_state.recent_count) {
+        g_state.advanced_view = 1;
+        g_state.advanced_tab = ADV_TAB_CORE;
+        g_state.qso_list_focused = 0;
+        g_state.search_focused = 0;
+        LoadSelectedQso();
+        InvalidateRect(hwnd, NULL, FALSE);
+        return;
+    }
+
+    g_state.advanced_view = !g_state.advanced_view;
+    if (g_state.advanced_view) {
+        int field_tab = AdvTabForField(g_state.focused_field);
+        if (field_tab >= 0) {
+            g_state.advanced_tab = field_tab;
+        } else if (AdvTabFieldIndex(g_state.advanced_tab,
+                                    g_state.focused_field) < 0) {
+            int cnt;
+            const enum Field *flds = AdvTabFields(g_state.advanced_tab, &cnt);
+            SetFocusField(flds[0]);
+        }
+    } else {
+        if (g_state.focused_field > FIELD_TIME)
+            SetFocusField(FIELD_CALLSIGN);
+    }
+    g_state.qso_list_focused = 0;
+    g_state.search_focused = 0;
+    InvalidateRect(hwnd, NULL, FALSE);
 }
 
 static void SetAdvancedTab(int tab)
@@ -2622,6 +2844,21 @@ void qsr_test_cycle_advanced_tab(int delta)
 {
     CycleAdvancedTab(delta);
 }
+
+int qsr_test_advanced_view_enabled(void)
+{
+    return g_state.advanced_view;
+}
+
+void qsr_test_set_qso_list_focused(int focused)
+{
+    g_state.qso_list_focused = focused ? 1 : 0;
+}
+
+void qsr_test_toggle_advanced_view(void)
+{
+    ToggleAdvancedView(g_state.hwnd);
+}
 #endif
 
 static int CountAdvancedRows(const enum Field *fields, int count)
@@ -2629,12 +2866,14 @@ static int CountAdvancedRows(const enum Field *fields, int count)
     int rows = 0;
     int i;
     for (i = 0; i < count; ) {
-        if (fields[i] == FIELD_COMMENT || fields[i] == FIELD_NOTES) {
+        if (fields[i] == FIELD_COMMENT || fields[i] == FIELD_NOTES ||
+            fields[i] == FIELD_CW_TRANSCRIPT || fields[i] == FIELD_EXTRA_FIELDS) {
             rows++; i++;
         } else {
             rows++; i++;
             if (i < count && fields[i] != FIELD_COMMENT &&
-                fields[i] != FIELD_NOTES) {
+                fields[i] != FIELD_NOTES && fields[i] != FIELD_CW_TRANSCRIPT &&
+                fields[i] != FIELD_EXTRA_FIELDS) {
                 i++; /* paired into same row */
             }
         }
@@ -2768,7 +3007,8 @@ static int PaintAdvancedForm(HDC hdc, int y_start, int w)
 
         for (i = 0; i < field_count; ) {
             enum Field f1 = fields[i];
-            int full_w = (f1 == FIELD_COMMENT || f1 == FIELD_NOTES);
+            int full_w = (f1 == FIELD_COMMENT || f1 == FIELD_NOTES ||
+                          f1 == FIELD_CW_TRANSCRIPT || f1 == FIELD_EXTRA_FIELDS);
             int left_x = card_x + cw * 2;
 
             DrawAdvancedEditorField(hdc, f1, left_x, y, label_w,
@@ -2780,7 +3020,8 @@ static int PaintAdvancedForm(HDC hdc, int y_start, int w)
             /* Second field in same row (if first wasn't full-width) */
             if (!full_w && i < field_count) {
                 enum Field f2 = fields[i];
-                if (f2 != FIELD_COMMENT && f2 != FIELD_NOTES) {
+                if (f2 != FIELD_COMMENT && f2 != FIELD_NOTES &&
+                    f2 != FIELD_CW_TRANSCRIPT && f2 != FIELD_EXTRA_FIELDS) {
                     int col2_x = card_x + cw * 2 + col_w + cw * 4;
                     DrawAdvancedEditorField(hdc, f2, col2_x, y, label_w,
                                             field_w, focused_form, cw, ch);
@@ -3340,27 +3581,7 @@ static void OnKeyDown(HWND hwnd, WPARAM vk, LPARAM lp)
 
     /* F2: toggle advanced view */
     if (vk == VK_F2) {
-        g_state.advanced_view = !g_state.advanced_view;
-        if (g_state.advanced_view) {
-            /* Keep the operator's current basic field by opening its page. */
-            int field_tab = AdvTabForField(g_state.focused_field);
-            if (field_tab >= 0) {
-                g_state.advanced_tab = field_tab;
-            } else if (AdvTabFieldIndex(g_state.advanced_tab,
-                                        g_state.focused_field) < 0) {
-                int cnt;
-                const enum Field *flds =
-                    AdvTabFields(g_state.advanced_tab, &cnt);
-                SetFocusField(flds[0]);
-            }
-        } else {
-            /* Return to basic: ensure field is in basic range */
-            if (g_state.focused_field > FIELD_TIME)
-                SetFocusField(FIELD_CALLSIGN);
-        }
-        g_state.qso_list_focused = 0;
-        g_state.search_focused = 0;
-        InvalidateRect(hwnd, NULL, FALSE);
+        ToggleAdvancedView(hwnd);
         return;
     }
 

--- a/src/c/qsoripper-win32/tests/win32_issue_regressions.c
+++ b/src/c/qsoripper-win32/tests/win32_issue_regressions.c
@@ -18,7 +18,8 @@ enum Field {
     FIELD_RST_SENT, FIELD_RST_RCVD,
     FIELD_COMMENT, FIELD_NOTES,
     FIELD_FREQ, FIELD_DATE, FIELD_TIME,
-    FIELD_TIME_OFF, FIELD_QTH, FIELD_WORKED_NAME,
+    FIELD_TIME_OFF, FIELD_STATION_CALLSIGN, FIELD_QTH,
+    FIELD_WORKED_OPERATOR_CALLSIGN, FIELD_WORKED_NAME,
     FIELD_WORKED_GRID, FIELD_WORKED_COUNTRY, FIELD_WORKED_DXCC,
     FIELD_WORKED_CQ_ZONE, FIELD_WORKED_ITU_ZONE, FIELD_WORKED_CONTINENT,
     FIELD_TX_POWER, FIELD_SUBMODE, FIELD_CONTEST_ID,
@@ -27,6 +28,21 @@ enum Field {
     FIELD_PROP_MODE, FIELD_SAT_NAME, FIELD_SAT_MODE,
     FIELD_IOTA, FIELD_ARRL_SECTION, FIELD_WORKED_STATE, FIELD_WORKED_COUNTY,
     FIELD_SKCC,
+    FIELD_QSL_SENT_STATUS, FIELD_QSL_SENT_DATE,
+    FIELD_QSL_RCVD_STATUS, FIELD_QSL_RCVD_DATE,
+    FIELD_LOTW_SENT, FIELD_LOTW_RCVD,
+    FIELD_EQSL_SENT, FIELD_EQSL_RCVD,
+    FIELD_QRZ_LOG_ID, FIELD_QRZ_BOOK_ID,
+    FIELD_SNAPSHOT_STATION_CALLSIGN, FIELD_SNAPSHOT_OPERATOR_CALLSIGN,
+    FIELD_SNAPSHOT_PROFILE, FIELD_SNAPSHOT_OPERATOR_NAME,
+    FIELD_SNAPSHOT_GRID, FIELD_SNAPSHOT_COUNTRY,
+    FIELD_SNAPSHOT_STATE, FIELD_SNAPSHOT_COUNTY,
+    FIELD_SNAPSHOT_ARRL_SECTION, FIELD_SNAPSHOT_DXCC,
+    FIELD_SNAPSHOT_CQ_ZONE, FIELD_SNAPSHOT_ITU_ZONE,
+    FIELD_SNAPSHOT_LATITUDE, FIELD_SNAPSHOT_LONGITUDE,
+    FIELD_CW_RX_WPM, FIELD_CW_TRANSCRIPT,
+    FIELD_LOCAL_ID, FIELD_SYNC_STATUS, FIELD_CREATED_AT,
+    FIELD_UPDATED_AT, FIELD_EXTRA_FIELDS,
     FIELD_COUNT
 };
 
@@ -58,6 +74,9 @@ int qsr_test_advanced_tab_field_count(int tab);
 int qsr_test_get_advanced_tab(void);
 void qsr_test_set_advanced_tab(int tab);
 void qsr_test_cycle_advanced_tab(int delta);
+int qsr_test_advanced_view_enabled(void);
+void qsr_test_set_qso_list_focused(int focused);
+void qsr_test_toggle_advanced_view(void);
 
 static HANDLE g_log_entered = NULL;
 static HANDLE g_release_log = NULL;
@@ -425,11 +444,13 @@ static int test_win32_advanced_editor_uses_card_pages(void)
 
     if (qsr_test_advanced_tab_for_field(FIELD_RST_SENT) != 0 ||
         qsr_test_advanced_tab_for_field(FIELD_TX_POWER) != 0 ||
+        qsr_test_advanced_tab_for_field(FIELD_STATION_CALLSIGN) != 0 ||
         qsr_test_advanced_tab_for_field(FIELD_COMMENT) != 0) {
         return fail("core QSO fields are not grouped on the Core card page");
     }
 
-    if (qsr_test_advanced_tab_for_field(FIELD_WORKED_NAME) != 1 ||
+    if (qsr_test_advanced_tab_for_field(FIELD_WORKED_OPERATOR_CALLSIGN) != 1 ||
+        qsr_test_advanced_tab_for_field(FIELD_WORKED_NAME) != 1 ||
         qsr_test_advanced_tab_for_field(FIELD_WORKED_GRID) != 1 ||
         qsr_test_advanced_tab_for_field(FIELD_WORKED_COUNTRY) != 1 ||
         qsr_test_advanced_tab_for_field(FIELD_WORKED_DXCC) != 1 ||
@@ -441,14 +462,32 @@ static int test_win32_advanced_editor_uses_card_pages(void)
         return fail("lookup fields are not grouped on the Lookup card page");
     }
 
+    if (qsr_test_advanced_tab_for_field(FIELD_QSL_SENT_STATUS) != 2 ||
+        qsr_test_advanced_tab_for_field(FIELD_LOTW_SENT) != 2 ||
+        qsr_test_advanced_tab_for_field(FIELD_QRZ_LOG_ID) != 2) {
+        return fail("QSL fields are not grouped on the QSL card page");
+    }
+
     if (qsr_test_advanced_tab_for_field(FIELD_EXCHANGE_RCVD) != 3 ||
         qsr_test_advanced_tab_for_field(FIELD_CONTEST_ID) != 3 ||
         qsr_test_advanced_tab_for_field(FIELD_SAT_NAME) != 3) {
         return fail("contest fields are not grouped on the Contest card page");
     }
 
-    if (qsr_test_advanced_tab_for_field(FIELD_QTH) != 4) {
+    if (qsr_test_advanced_tab_for_field(FIELD_SNAPSHOT_GRID) != 4 ||
+        qsr_test_advanced_tab_for_field(FIELD_SNAPSHOT_OPERATOR_NAME) != 4 ||
+        qsr_test_advanced_tab_for_field(FIELD_SNAPSHOT_LATITUDE) != 4) {
         return fail("station fields are not grouped on the Station card page");
+    }
+
+    if (qsr_test_advanced_tab_for_field(FIELD_CW_RX_WPM) != 5 ||
+        qsr_test_advanced_tab_for_field(FIELD_CW_TRANSCRIPT) != 5) {
+        return fail("transcript fields are not grouped on the Transcript card page");
+    }
+
+    if (qsr_test_advanced_tab_for_field(FIELD_LOCAL_ID) != 6 ||
+        qsr_test_advanced_tab_for_field(FIELD_EXTRA_FIELDS) != 6) {
+        return fail("metadata fields are not grouped on the Metadata card page");
     }
 
     for (int tab = 0; tab < 7; tab++) {
@@ -457,10 +496,7 @@ static int test_win32_advanced_editor_uses_card_pages(void)
         }
     }
 
-    for (int tab = 0; tab < 5; tab++) {
-        if (tab == 2) {
-            continue;
-        }
+    for (int tab = 0; tab < 7; tab++) {
         if (qsr_test_advanced_tab_field_count(tab) <= 0) {
             return fail("advanced editor card page has no editable fields");
         }
@@ -497,6 +533,39 @@ static int test_win32_advanced_editor_cycles_card_pages(void)
     return 0;
 }
 
+static int test_win32_f2_loads_selected_qso_for_advanced_edit(void)
+{
+    qsr_test_reset_state();
+    qsr_test_set_selected_recent_qso("edit-1", "K1ABC");
+    qsr_test_set_qso_list_focused(1);
+    qsr_test_set_backend_ffi_get_delete_weather((struct QsrClient *)0x1, stub_get_qso, NULL, NULL);
+
+    g_load_entered = CreateEventW(NULL, TRUE, FALSE, NULL);
+    g_release_load = CreateEventW(NULL, TRUE, FALSE, NULL);
+    if (!g_load_entered || !g_release_load) {
+        return fail("failed to create F2 load test events");
+    }
+
+    qsr_test_toggle_advanced_view();
+
+    if (!qsr_test_advanced_view_enabled()) {
+        return fail("F2 did not open the advanced editor");
+    }
+
+    if (WaitForSingleObject(g_load_entered, 3000) != WAIT_OBJECT_0) {
+        return fail("F2 from the QSO list did not load the selected QSO");
+    }
+
+    SetEvent(g_release_load);
+    Sleep(50);
+    CloseHandle(g_load_entered);
+    CloseHandle(g_release_load);
+    g_load_entered = NULL;
+    g_release_load = NULL;
+
+    return 0;
+}
+
 int main(void)
 {
     int failures = 0;
@@ -510,6 +579,7 @@ int main(void)
     if (test_issue_329_qso_duration_uses_time_off() != 0) failures++;
     if (test_win32_advanced_editor_uses_card_pages() != 0) failures++;
     if (test_win32_advanced_editor_cycles_card_pages() != 0) failures++;
+    if (test_win32_f2_loads_selected_qso_for_advanced_edit() != 0) failures++;
     if (failures != 0) {
         fprintf(stderr, "FAIL: %d regression test(s) failed\n", failures);
         return 1;

--- a/src/rust/qsoripper-ffi/qsoripper_ffi.h
+++ b/src/rust/qsoripper-ffi/qsoripper_ffi.h
@@ -72,6 +72,10 @@ typedef struct QsrLogQsoRequest {
    */
   uint8_t notes[256];
   /**
+   * Worked operator callsign (null-terminated).
+   */
+  uint8_t worked_operator_callsign[32];
+  /**
    * Operator name (null-terminated).
    */
   uint8_t worked_name[64];
@@ -159,6 +163,33 @@ typedef struct QsrLogQsoRequest {
    * SKCC membership number (null-terminated).
    */
   uint8_t skcc[16];
+  uint8_t qsl_sent_status[16];
+  uint8_t qsl_sent_date[16];
+  uint8_t qsl_rcvd_status[16];
+  uint8_t qsl_rcvd_date[16];
+  uint8_t lotw_sent[8];
+  uint8_t lotw_rcvd[8];
+  uint8_t eqsl_sent[8];
+  uint8_t eqsl_rcvd[8];
+  uint8_t qrz_log_id[32];
+  uint8_t qrz_book_id[32];
+  uint8_t snapshot_station_callsign[32];
+  uint8_t snapshot_operator_callsign[32];
+  uint8_t snapshot_profile[64];
+  uint8_t snapshot_operator_name[64];
+  uint8_t snapshot_grid[16];
+  uint8_t snapshot_country[64];
+  uint8_t snapshot_state[16];
+  uint8_t snapshot_county[32];
+  uint8_t snapshot_arrl_section[16];
+  uint8_t snapshot_dxcc[16];
+  uint8_t snapshot_cq_zone[16];
+  uint8_t snapshot_itu_zone[16];
+  uint8_t snapshot_latitude[24];
+  uint8_t snapshot_longitude[24];
+  uint8_t cw_rx_wpm[8];
+  uint8_t cw_transcript[256];
+  uint8_t extra_fields[256];
   /**
    * Time off date+time string "YYYY-MM-DD HH:MM" (null-terminated, empty = not set).
    */
@@ -241,6 +272,10 @@ typedef struct QsrQsoDetail {
    * Time off string "HH:MM" (null-terminated, empty = not set).
    */
   uint8_t time_off[16];
+  /**
+   * Worked operator callsign (null-terminated).
+   */
+  uint8_t worked_operator_callsign[32];
   /**
    * Worked name (null-terminated).
    */
@@ -329,6 +364,37 @@ typedef struct QsrQsoDetail {
    * SKCC membership number (null-terminated).
    */
   uint8_t skcc[16];
+  uint8_t station_callsign[32];
+  uint8_t qsl_sent_status[16];
+  uint8_t qsl_sent_date[16];
+  uint8_t qsl_rcvd_status[16];
+  uint8_t qsl_rcvd_date[16];
+  uint8_t lotw_sent[8];
+  uint8_t lotw_rcvd[8];
+  uint8_t eqsl_sent[8];
+  uint8_t eqsl_rcvd[8];
+  uint8_t qrz_log_id[32];
+  uint8_t qrz_book_id[32];
+  uint8_t snapshot_station_callsign[32];
+  uint8_t snapshot_operator_callsign[32];
+  uint8_t snapshot_profile[64];
+  uint8_t snapshot_operator_name[64];
+  uint8_t snapshot_grid[16];
+  uint8_t snapshot_country[64];
+  uint8_t snapshot_state[16];
+  uint8_t snapshot_county[32];
+  uint8_t snapshot_arrl_section[16];
+  uint8_t snapshot_dxcc[16];
+  uint8_t snapshot_cq_zone[16];
+  uint8_t snapshot_itu_zone[16];
+  uint8_t snapshot_latitude[24];
+  uint8_t snapshot_longitude[24];
+  uint8_t cw_rx_wpm[8];
+  uint8_t cw_transcript[256];
+  uint8_t sync_status[24];
+  uint8_t created_at[32];
+  uint8_t updated_at[32];
+  uint8_t extra_fields[256];
 } QsrQsoDetail;
 
 /**

--- a/src/rust/qsoripper-ffi/src/client.rs
+++ b/src/rust/qsoripper-ffi/src/client.rs
@@ -12,6 +12,7 @@
 )]
 
 use std::ffi::CStr;
+use std::fmt::Write as _;
 use std::os::raw::c_char;
 use std::sync::Mutex;
 
@@ -20,7 +21,7 @@ use tonic::transport::Channel;
 use qsoripper_core::domain::band::{band_from_adif, band_to_adif};
 use qsoripper_core::domain::mode::{mode_from_adif, mode_to_adif};
 use qsoripper_core::proto::qsoripper::domain::{
-    Band, Mode, QsoRecord, RigConnectionStatus, RstReport,
+    Band, Mode, QslStatus, QsoRecord, RigConnectionStatus, RstReport, StationSnapshot, SyncStatus,
 };
 use qsoripper_core::proto::qsoripper::services::{
     logbook_service_client::LogbookServiceClient, lookup_service_client::LookupServiceClient,
@@ -423,6 +424,12 @@ fn build_qso_record(req: &QsrLogQsoRequest) -> Result<QsoRecord, String> {
         qso.worked_county = Some(s.to_string());
     });
     set_optional_str(&req.skcc, |s| qso.skcc = Some(s.to_string()));
+    set_optional_str(&req.worked_operator_callsign, |s| {
+        qso.worked_operator_callsign = Some(s.to_uppercase());
+    });
+    populate_qsl_fields(req, &mut qso)?;
+    populate_station_snapshot(req, &mut qso)?;
+    populate_transcript_and_extra_fields(req, &mut qso)?;
 
     let time_off = buf_to_str(&req.time_off);
     if !time_off.is_empty() {
@@ -449,6 +456,168 @@ fn set_optional_u32(buf: &[u8], field_name: &str, setter: impl FnOnce(u32)) -> R
             s.parse::<u32>()
                 .map_err(|_| format!("Invalid {field_name}: {s}"))?,
         );
+    }
+    Ok(())
+}
+
+fn set_optional_f64(buf: &[u8], field_name: &str, setter: impl FnOnce(f64)) -> Result<(), String> {
+    let s = buf_to_str(buf);
+    if !s.is_empty() {
+        setter(
+            s.parse::<f64>()
+                .map_err(|_| format!("Invalid {field_name}: {s}"))?,
+        );
+    }
+    Ok(())
+}
+
+fn parse_qsl_status(buf: &[u8], field_name: &str) -> Result<Option<QslStatus>, String> {
+    let s = buf_to_str(buf).trim().to_ascii_uppercase();
+    if s.is_empty() {
+        return Ok(None);
+    }
+    let status = match s.as_str() {
+        "N" | "NO" => QslStatus::No,
+        "Y" | "YES" => QslStatus::Yes,
+        "R" | "REQUESTED" => QslStatus::Requested,
+        "Q" | "QUEUED" => QslStatus::Queued,
+        "I" | "IGNORE" | "IGNORED" => QslStatus::Ignore,
+        "UNSPECIFIED" => QslStatus::Unspecified,
+        _ => return Err(format!("Invalid {field_name}: {s}")),
+    };
+    Ok(Some(status))
+}
+
+fn parse_optional_bool(buf: &[u8], field_name: &str) -> Result<Option<bool>, String> {
+    let s = buf_to_str(buf).trim().to_ascii_uppercase();
+    if s.is_empty() {
+        return Ok(None);
+    }
+    match s.as_str() {
+        "Y" | "YES" | "TRUE" | "1" => Ok(Some(true)),
+        "N" | "NO" | "FALSE" | "0" => Ok(Some(false)),
+        _ => Err(format!("Invalid {field_name}: {s}")),
+    }
+}
+
+fn parse_date(buf: &[u8], field_name: &str) -> Result<Option<prost_types::Timestamp>, String> {
+    let s = buf_to_str(buf);
+    if s.is_empty() {
+        return Ok(None);
+    }
+    parse_datetime(&format!("{s} 00:00"))
+        .map(Some)
+        .map_err(|e| format!("Invalid {field_name}: {e}"))
+}
+
+fn populate_qsl_fields(req: &QsrLogQsoRequest, qso: &mut QsoRecord) -> Result<(), String> {
+    if let Some(status) = parse_qsl_status(&req.qsl_sent_status, "QSL sent status")? {
+        qso.qsl_sent_status = status.into();
+    }
+    if let Some(status) = parse_qsl_status(&req.qsl_rcvd_status, "QSL received status")? {
+        qso.qsl_received_status = status.into();
+    }
+    qso.lotw_sent = parse_optional_bool(&req.lotw_sent, "LoTW sent")?;
+    qso.lotw_received = parse_optional_bool(&req.lotw_rcvd, "LoTW received")?;
+    qso.eqsl_sent = parse_optional_bool(&req.eqsl_sent, "eQSL sent")?;
+    qso.eqsl_received = parse_optional_bool(&req.eqsl_rcvd, "eQSL received")?;
+    qso.qsl_sent_date = parse_date(&req.qsl_sent_date, "QSL sent date")?;
+    qso.qsl_received_date = parse_date(&req.qsl_rcvd_date, "QSL received date")?;
+    set_optional_str(&req.qrz_log_id, |s| qso.qrz_logid = Some(s.to_string()));
+    set_optional_str(&req.qrz_book_id, |s| qso.qrz_bookid = Some(s.to_string()));
+    Ok(())
+}
+
+fn populate_station_snapshot(req: &QsrLogQsoRequest, qso: &mut QsoRecord) -> Result<(), String> {
+    let has_snapshot = [
+        &req.snapshot_station_callsign[..],
+        &req.snapshot_operator_callsign[..],
+        &req.snapshot_profile[..],
+        &req.snapshot_operator_name[..],
+        &req.snapshot_grid[..],
+        &req.snapshot_country[..],
+        &req.snapshot_state[..],
+        &req.snapshot_county[..],
+        &req.snapshot_arrl_section[..],
+        &req.snapshot_dxcc[..],
+        &req.snapshot_cq_zone[..],
+        &req.snapshot_itu_zone[..],
+        &req.snapshot_latitude[..],
+        &req.snapshot_longitude[..],
+    ]
+    .iter()
+    .any(|buf| !buf_to_str(buf).is_empty());
+    if !has_snapshot {
+        return Ok(());
+    }
+
+    let mut snapshot = StationSnapshot {
+        station_callsign: buf_to_str(&req.snapshot_station_callsign).to_uppercase(),
+        ..Default::default()
+    };
+    if snapshot.station_callsign.is_empty() {
+        snapshot.station_callsign = buf_to_str(&req.station_callsign).to_uppercase();
+    }
+    set_optional_str(&req.snapshot_operator_callsign, |s| {
+        snapshot.operator_callsign = Some(s.to_uppercase());
+    });
+    set_optional_str(&req.snapshot_profile, |s| {
+        snapshot.profile_name = Some(s.to_string());
+    });
+    set_optional_str(&req.snapshot_operator_name, |s| {
+        snapshot.operator_name = Some(s.to_string());
+    });
+    set_optional_str(&req.snapshot_grid, |s| {
+        snapshot.grid = Some(s.to_uppercase());
+    });
+    set_optional_str(&req.snapshot_country, |s| {
+        snapshot.country = Some(s.to_string());
+    });
+    set_optional_str(&req.snapshot_state, |s| {
+        snapshot.state = Some(s.to_string());
+    });
+    set_optional_str(&req.snapshot_county, |s| {
+        snapshot.county = Some(s.to_string());
+    });
+    set_optional_str(&req.snapshot_arrl_section, |s| {
+        snapshot.arrl_section = Some(s.to_uppercase());
+    });
+    set_optional_u32(&req.snapshot_dxcc, "station DXCC", |v| {
+        snapshot.dxcc = Some(v);
+    })?;
+    set_optional_u32(&req.snapshot_cq_zone, "station CQ zone", |v| {
+        snapshot.cq_zone = Some(v);
+    })?;
+    set_optional_u32(&req.snapshot_itu_zone, "station ITU zone", |v| {
+        snapshot.itu_zone = Some(v);
+    })?;
+    set_optional_f64(&req.snapshot_latitude, "station latitude", |v| {
+        snapshot.latitude = Some(v);
+    })?;
+    set_optional_f64(&req.snapshot_longitude, "station longitude", |v| {
+        snapshot.longitude = Some(v);
+    })?;
+    qso.station_snapshot = Some(snapshot);
+    Ok(())
+}
+
+fn populate_transcript_and_extra_fields(
+    req: &QsrLogQsoRequest,
+    qso: &mut QsoRecord,
+) -> Result<(), String> {
+    set_optional_u32(&req.cw_rx_wpm, "CW RX WPM", |v| {
+        qso.cw_decode_rx_wpm = Some(v);
+    })?;
+    set_optional_str(&req.cw_transcript, |s| {
+        qso.cw_decode_transcript = Some(s.to_string());
+    });
+    let extra = buf_to_str(&req.extra_fields);
+    for line in extra.lines().map(str::trim).filter(|line| !line.is_empty()) {
+        let Some((key, value)) = line.split_once('=') else {
+            return Err(format!("Invalid extra ADIF field: {line}"));
+        };
+        qso.extra_fields
+            .insert(key.trim().to_ascii_uppercase(), value.trim().to_string());
     }
     Ok(())
 }
@@ -662,6 +831,163 @@ fn format_rst(rst: &RstReport) -> String {
     }
 }
 
+fn timestamp_date(ts: &prost_types::Timestamp) -> String {
+    let (y, m, d, _, _) = timestamp_parts(ts);
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+fn timestamp_datetime(ts: &prost_types::Timestamp) -> String {
+    let (y, m, d, h, min) = timestamp_parts(ts);
+    format!("{y:04}-{m:02}-{d:02} {h:02}:{min:02}")
+}
+
+fn timestamp_parts(ts: &prost_types::Timestamp) -> (i64, i64, i64, i64, i64) {
+    let total_secs = ts.seconds;
+    let days = (total_secs / 86400) + 719_468;
+    let era = if days >= 0 { days } else { days - 146_096 } / 146_097;
+    let doe = days - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    let day_secs = total_secs.rem_euclid(86400);
+    let h = day_secs / 3600;
+    let min = (day_secs % 3600) / 60;
+    (y, m, d, h, min)
+}
+
+fn qsl_status_text(status: i32) -> &'static str {
+    match QslStatus::try_from(status).unwrap_or(QslStatus::Unspecified) {
+        QslStatus::No => "N",
+        QslStatus::Yes => "Y",
+        QslStatus::Requested => "R",
+        QslStatus::Queued => "Q",
+        QslStatus::Ignore => "I",
+        QslStatus::Unspecified => "",
+    }
+}
+
+fn optional_bool_text(value: Option<bool>) -> &'static str {
+    match value {
+        Some(true) => "Y",
+        Some(false) => "N",
+        None => "",
+    }
+}
+
+fn sync_status_text(status: i32) -> &'static str {
+    match SyncStatus::try_from(status).unwrap_or(SyncStatus::LocalOnly) {
+        SyncStatus::LocalOnly => "LocalOnly",
+        SyncStatus::Synced => "Synced",
+        SyncStatus::Modified => "Modified",
+        SyncStatus::Conflict => "Conflict",
+    }
+}
+
+fn populate_confirmation_detail(qso: &QsoRecord, out: &mut QsrQsoDetail) {
+    str_to_buf(
+        qsl_status_text(qso.qsl_sent_status),
+        &mut out.qsl_sent_status,
+    );
+    str_to_buf(
+        qsl_status_text(qso.qsl_received_status),
+        &mut out.qsl_rcvd_status,
+    );
+    str_to_buf(optional_bool_text(qso.lotw_sent), &mut out.lotw_sent);
+    str_to_buf(optional_bool_text(qso.lotw_received), &mut out.lotw_rcvd);
+    str_to_buf(optional_bool_text(qso.eqsl_sent), &mut out.eqsl_sent);
+    str_to_buf(optional_bool_text(qso.eqsl_received), &mut out.eqsl_rcvd);
+    if let Some(ts) = &qso.qsl_sent_date {
+        str_to_buf(&timestamp_date(ts), &mut out.qsl_sent_date);
+    }
+    if let Some(ts) = &qso.qsl_received_date {
+        str_to_buf(&timestamp_date(ts), &mut out.qsl_rcvd_date);
+    }
+    if let Some(v) = &qso.qrz_logid {
+        str_to_buf(v, &mut out.qrz_log_id);
+    }
+    if let Some(v) = &qso.qrz_bookid {
+        str_to_buf(v, &mut out.qrz_book_id);
+    }
+}
+
+fn populate_station_snapshot_detail(qso: &QsoRecord, out: &mut QsrQsoDetail) {
+    let Some(snapshot) = &qso.station_snapshot else {
+        return;
+    };
+    str_to_buf(
+        &snapshot.station_callsign,
+        &mut out.snapshot_station_callsign,
+    );
+    if let Some(v) = &snapshot.operator_callsign {
+        str_to_buf(v, &mut out.snapshot_operator_callsign);
+    }
+    if let Some(v) = &snapshot.profile_name {
+        str_to_buf(v, &mut out.snapshot_profile);
+    }
+    if let Some(v) = &snapshot.operator_name {
+        str_to_buf(v, &mut out.snapshot_operator_name);
+    }
+    if let Some(v) = &snapshot.grid {
+        str_to_buf(v, &mut out.snapshot_grid);
+    }
+    if let Some(v) = &snapshot.country {
+        str_to_buf(v, &mut out.snapshot_country);
+    }
+    if let Some(v) = &snapshot.state {
+        str_to_buf(v, &mut out.snapshot_state);
+    }
+    if let Some(v) = &snapshot.county {
+        str_to_buf(v, &mut out.snapshot_county);
+    }
+    if let Some(v) = &snapshot.arrl_section {
+        str_to_buf(v, &mut out.snapshot_arrl_section);
+    }
+    if let Some(v) = snapshot.dxcc {
+        str_to_buf(&v.to_string(), &mut out.snapshot_dxcc);
+    }
+    if let Some(v) = snapshot.cq_zone {
+        str_to_buf(&v.to_string(), &mut out.snapshot_cq_zone);
+    }
+    if let Some(v) = snapshot.itu_zone {
+        str_to_buf(&v.to_string(), &mut out.snapshot_itu_zone);
+    }
+    if let Some(v) = snapshot.latitude {
+        str_to_buf(&v.to_string(), &mut out.snapshot_latitude);
+    }
+    if let Some(v) = snapshot.longitude {
+        str_to_buf(&v.to_string(), &mut out.snapshot_longitude);
+    }
+}
+
+fn populate_transcript_metadata_detail(qso: &QsoRecord, out: &mut QsrQsoDetail) {
+    if let Some(v) = qso.cw_decode_rx_wpm {
+        str_to_buf(&v.to_string(), &mut out.cw_rx_wpm);
+    }
+    if let Some(v) = &qso.cw_decode_transcript {
+        str_to_buf(v, &mut out.cw_transcript);
+    }
+    str_to_buf(sync_status_text(qso.sync_status), &mut out.sync_status);
+    if let Some(ts) = &qso.created_at {
+        str_to_buf(&timestamp_datetime(ts), &mut out.created_at);
+    }
+    if let Some(ts) = &qso.updated_at {
+        str_to_buf(&timestamp_datetime(ts), &mut out.updated_at);
+    }
+    if !qso.extra_fields.is_empty() {
+        let mut text = String::new();
+        let mut entries: Vec<_> = qso.extra_fields.iter().collect();
+        entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+        for (key, value) in entries {
+            let _ = writeln!(&mut text, "{key}={value}");
+        }
+        str_to_buf(&text, &mut out.extra_fields);
+    }
+}
+
 fn populate_qso_optional_fields(qso: &QsoRecord, out: &mut QsrQsoDetail) {
     if let Some(v) = &qso.comment {
         str_to_buf(v, &mut out.comment);
@@ -671,6 +997,9 @@ fn populate_qso_optional_fields(qso: &QsoRecord, out: &mut QsrQsoDetail) {
     }
     if let Some(v) = &qso.worked_operator_name {
         str_to_buf(v, &mut out.worked_name);
+    }
+    if let Some(v) = &qso.worked_operator_callsign {
+        str_to_buf(v, &mut out.worked_operator_callsign);
     }
     if let Some(v) = &qso.worked_grid {
         str_to_buf(v, &mut out.worked_grid);
@@ -735,48 +1064,17 @@ fn populate_qso_optional_fields(qso: &QsoRecord, out: &mut QsrQsoDetail) {
     if let Some(v) = &qso.skcc {
         str_to_buf(v, &mut out.skcc);
     }
+    populate_confirmation_detail(qso, out);
+    populate_station_snapshot_detail(qso, out);
+    populate_transcript_metadata_detail(qso, out);
 }
 
 /// Populate a `QsrQsoDetail` from a proto `QsoRecord`.
 fn populate_qso_detail(qso: &QsoRecord, out: &mut QsrQsoDetail) {
-    *out = QsrQsoDetail {
-        callsign: [0; 32],
-        band: [0; 8],
-        mode: [0; 8],
-        date: [0; 16],
-        time: [0; 16],
-        freq_mhz: [0; 16],
-        rst_sent: [0; 8],
-        rst_rcvd: [0; 8],
-        comment: [0; 256],
-        notes: [0; 256],
-        local_id: [0; 64],
-        time_off: [0; 16],
-        worked_name: [0; 64],
-        worked_grid: [0; 16],
-        worked_country: [0; 64],
-        worked_dxcc: [0; 16],
-        worked_cq_zone: [0; 16],
-        worked_itu_zone: [0; 16],
-        worked_continent: [0; 8],
-        tx_power: [0; 16],
-        submode: [0; 16],
-        contest_id: [0; 32],
-        serial_sent: [0; 16],
-        serial_rcvd: [0; 16],
-        exchange_sent: [0; 64],
-        exchange_rcvd: [0; 64],
-        prop_mode: [0; 16],
-        sat_name: [0; 32],
-        sat_mode: [0; 16],
-        iota: [0; 16],
-        arrl_section: [0; 16],
-        worked_state: [0; 16],
-        worked_county: [0; 32],
-        skcc: [0; 16],
-    };
+    *out = QsrQsoDetail::default();
 
     str_to_buf(&qso.worked_callsign, &mut out.callsign);
+    str_to_buf(&qso.station_callsign, &mut out.station_callsign);
     str_to_buf(&qso.local_id, &mut out.local_id);
 
     let band = Band::try_from(qso.band).unwrap_or(Band::Unspecified);
@@ -956,7 +1254,7 @@ fn populate_rig_status(
 mod tests {
     use super::{buf_to_str, build_qso_record, parse_datetime, qso_to_summary};
     use crate::types::{str_to_buf, QsrLogQsoRequest, QsrRstReport};
-    use qsoripper_core::proto::qsoripper::domain::{QsoRecord, StationSnapshot};
+    use qsoripper_core::proto::qsoripper::domain::{QslStatus, QsoRecord, StationSnapshot};
 
     fn baseline_request() -> QsrLogQsoRequest {
         let mut req: QsrLogQsoRequest = unsafe { std::mem::zeroed() };
@@ -1000,6 +1298,44 @@ mod tests {
             qso.station_callsign.trim().is_empty(),
             "empty FFI station_callsign must round-trip as empty so the server fills it"
         );
+    }
+
+    #[test]
+    fn build_qso_record_populates_advanced_card_fields() {
+        let mut req = baseline_request();
+        str_to_buf("W1AW/OP", &mut req.worked_operator_callsign);
+        str_to_buf("Y", &mut req.qsl_sent_status);
+        str_to_buf("N", &mut req.lotw_sent);
+        str_to_buf("2025-01-16", &mut req.qsl_sent_date);
+        str_to_buf("123", &mut req.qrz_log_id);
+        str_to_buf("Home", &mut req.snapshot_profile);
+        str_to_buf("K7TST", &mut req.snapshot_station_callsign);
+        str_to_buf("CN87", &mut req.snapshot_grid);
+        str_to_buf("291", &mut req.snapshot_dxcc);
+        str_to_buf("34", &mut req.cw_rx_wpm);
+        str_to_buf("CQ TEST", &mut req.cw_transcript);
+        str_to_buf("APP_TEST=value", &mut req.extra_fields);
+
+        let qso = build_qso_record(&req).expect("advanced card fields should map");
+
+        assert_eq!(qso.worked_operator_callsign.as_deref(), Some("W1AW/OP"));
+        assert_eq!(qso.qsl_sent_status, QslStatus::Yes as i32);
+        assert_eq!(qso.lotw_sent, Some(false));
+        assert!(qso.qsl_sent_date.is_some());
+        assert_eq!(qso.qrz_logid.as_deref(), Some("123"));
+        assert_eq!(qso.cw_decode_rx_wpm, Some(34));
+        assert_eq!(qso.cw_decode_transcript.as_deref(), Some("CQ TEST"));
+        assert_eq!(
+            qso.extra_fields.get("APP_TEST").map(String::as_str),
+            Some("value")
+        );
+        let snapshot = qso
+            .station_snapshot
+            .expect("station snapshot should be present");
+        assert_eq!(snapshot.profile_name.as_deref(), Some("Home"));
+        assert_eq!(snapshot.station_callsign, "K7TST");
+        assert_eq!(snapshot.grid.as_deref(), Some("CN87"));
+        assert_eq!(snapshot.dxcc, Some(291));
     }
 
     #[test]

--- a/src/rust/qsoripper-ffi/src/types.rs
+++ b/src/rust/qsoripper-ffi/src/types.rs
@@ -40,6 +40,8 @@ pub struct QsrLogQsoRequest {
     pub comment: [u8; 256],
     /// Notes (null-terminated).
     pub notes: [u8; 256],
+    /// Worked operator callsign (null-terminated).
+    pub worked_operator_callsign: [u8; 32],
     /// Operator name (null-terminated).
     pub worked_name: [u8; 64],
     /// Worked grid square (null-terminated).
@@ -84,6 +86,60 @@ pub struct QsrLogQsoRequest {
     pub worked_county: [u8; 32],
     /// SKCC membership number (null-terminated).
     pub skcc: [u8; 16],
+    /// QSL sent status text (null-terminated).
+    pub qsl_sent_status: [u8; 16],
+    /// QSL sent date "YYYY-MM-DD" (null-terminated).
+    pub qsl_sent_date: [u8; 16],
+    /// QSL received status text (null-terminated).
+    pub qsl_rcvd_status: [u8; 16],
+    /// QSL received date "YYYY-MM-DD" (null-terminated).
+    pub qsl_rcvd_date: [u8; 16],
+    /// LoTW sent tri-state text (Y/N/blank, null-terminated).
+    pub lotw_sent: [u8; 8],
+    /// LoTW received tri-state text (Y/N/blank, null-terminated).
+    pub lotw_rcvd: [u8; 8],
+    /// eQSL sent tri-state text (Y/N/blank, null-terminated).
+    pub eqsl_sent: [u8; 8],
+    /// eQSL received tri-state text (Y/N/blank, null-terminated).
+    pub eqsl_rcvd: [u8; 8],
+    /// QRZ log identifier (null-terminated).
+    pub qrz_log_id: [u8; 32],
+    /// QRZ book identifier (null-terminated).
+    pub qrz_book_id: [u8; 32],
+    /// Station snapshot station callsign (null-terminated).
+    pub snapshot_station_callsign: [u8; 32],
+    /// Station snapshot operator callsign (null-terminated).
+    pub snapshot_operator_callsign: [u8; 32],
+    /// Station snapshot profile name (null-terminated).
+    pub snapshot_profile: [u8; 64],
+    /// Station snapshot operator name (null-terminated).
+    pub snapshot_operator_name: [u8; 64],
+    /// Station snapshot grid square (null-terminated).
+    pub snapshot_grid: [u8; 16],
+    /// Station snapshot country (null-terminated).
+    pub snapshot_country: [u8; 64],
+    /// Station snapshot state (null-terminated).
+    pub snapshot_state: [u8; 16],
+    /// Station snapshot county (null-terminated).
+    pub snapshot_county: [u8; 32],
+    /// Station snapshot ARRL section (null-terminated).
+    pub snapshot_arrl_section: [u8; 16],
+    /// Station snapshot DXCC as decimal text (null-terminated).
+    pub snapshot_dxcc: [u8; 16],
+    /// Station snapshot CQ zone as decimal text (null-terminated).
+    pub snapshot_cq_zone: [u8; 16],
+    /// Station snapshot ITU zone as decimal text (null-terminated).
+    pub snapshot_itu_zone: [u8; 16],
+    /// Station snapshot latitude as decimal text (null-terminated).
+    pub snapshot_latitude: [u8; 24],
+    /// Station snapshot longitude as decimal text (null-terminated).
+    pub snapshot_longitude: [u8; 24],
+    /// CW receive WPM as decimal text (null-terminated).
+    pub cw_rx_wpm: [u8; 8],
+    /// CW transcript text (null-terminated).
+    pub cw_transcript: [u8; 256],
+    /// Extra ADIF fields as newline-delimited KEY=value text (null-terminated).
+    pub extra_fields: [u8; 256],
     /// Time off date+time string "YYYY-MM-DD HH:MM" (null-terminated, empty = not set).
     pub time_off: [u8; 32],
 }
@@ -102,6 +158,13 @@ pub struct QsrUpdateQsoRequest {
     pub local_id: [u8; 64],
     /// Same payload as log request.
     pub qso: QsrLogQsoRequest,
+}
+
+impl Default for QsrQsoDetail {
+    fn default() -> Self {
+        // SAFETY: QsrQsoDetail only contains integer byte arrays, so all-zero is valid.
+        unsafe { std::mem::zeroed() }
+    }
 }
 
 /// Summary of a QSO for list display.
@@ -163,6 +226,8 @@ pub struct QsrQsoDetail {
     pub local_id: [u8; 64],
     /// Time off string "HH:MM" (null-terminated, empty = not set).
     pub time_off: [u8; 16],
+    /// Worked operator callsign (null-terminated).
+    pub worked_operator_callsign: [u8; 32],
     /// Worked name (null-terminated).
     pub worked_name: [u8; 64],
     /// Worked grid square (null-terminated).
@@ -207,6 +272,68 @@ pub struct QsrQsoDetail {
     pub worked_county: [u8; 32],
     /// SKCC membership number (null-terminated).
     pub skcc: [u8; 16],
+    /// Station callsign (null-terminated).
+    pub station_callsign: [u8; 32],
+    /// QSL sent status text (null-terminated).
+    pub qsl_sent_status: [u8; 16],
+    /// QSL sent date "YYYY-MM-DD" (null-terminated).
+    pub qsl_sent_date: [u8; 16],
+    /// QSL received status text (null-terminated).
+    pub qsl_rcvd_status: [u8; 16],
+    /// QSL received date "YYYY-MM-DD" (null-terminated).
+    pub qsl_rcvd_date: [u8; 16],
+    /// LoTW sent tri-state text (Y/N/blank, null-terminated).
+    pub lotw_sent: [u8; 8],
+    /// LoTW received tri-state text (Y/N/blank, null-terminated).
+    pub lotw_rcvd: [u8; 8],
+    /// eQSL sent tri-state text (Y/N/blank, null-terminated).
+    pub eqsl_sent: [u8; 8],
+    /// eQSL received tri-state text (Y/N/blank, null-terminated).
+    pub eqsl_rcvd: [u8; 8],
+    /// QRZ log identifier (null-terminated).
+    pub qrz_log_id: [u8; 32],
+    /// QRZ book identifier (null-terminated).
+    pub qrz_book_id: [u8; 32],
+    /// Station snapshot station callsign (null-terminated).
+    pub snapshot_station_callsign: [u8; 32],
+    /// Station snapshot operator callsign (null-terminated).
+    pub snapshot_operator_callsign: [u8; 32],
+    /// Station snapshot profile name (null-terminated).
+    pub snapshot_profile: [u8; 64],
+    /// Station snapshot operator name (null-terminated).
+    pub snapshot_operator_name: [u8; 64],
+    /// Station snapshot grid square (null-terminated).
+    pub snapshot_grid: [u8; 16],
+    /// Station snapshot country (null-terminated).
+    pub snapshot_country: [u8; 64],
+    /// Station snapshot state (null-terminated).
+    pub snapshot_state: [u8; 16],
+    /// Station snapshot county (null-terminated).
+    pub snapshot_county: [u8; 32],
+    /// Station snapshot ARRL section (null-terminated).
+    pub snapshot_arrl_section: [u8; 16],
+    /// Station snapshot DXCC as decimal text (null-terminated).
+    pub snapshot_dxcc: [u8; 16],
+    /// Station snapshot CQ zone as decimal text (null-terminated).
+    pub snapshot_cq_zone: [u8; 16],
+    /// Station snapshot ITU zone as decimal text (null-terminated).
+    pub snapshot_itu_zone: [u8; 16],
+    /// Station snapshot latitude as decimal text (null-terminated).
+    pub snapshot_latitude: [u8; 24],
+    /// Station snapshot longitude as decimal text (null-terminated).
+    pub snapshot_longitude: [u8; 24],
+    /// CW receive WPM as decimal text (null-terminated).
+    pub cw_rx_wpm: [u8; 8],
+    /// CW transcript text (null-terminated).
+    pub cw_transcript: [u8; 256],
+    /// Sync status text (null-terminated).
+    pub sync_status: [u8; 24],
+    /// Created timestamp text (null-terminated).
+    pub created_at: [u8; 32],
+    /// Updated timestamp text (null-terminated).
+    pub updated_at: [u8; 32],
+    /// Extra ADIF fields as newline-delimited KEY=value text (null-terminated).
+    pub extra_fields: [u8; 256],
 }
 
 /// Result from a callsign lookup.

--- a/src/rust/qsoripper-ffi/tests/integration.rs
+++ b/src/rust/qsoripper-ffi/tests/integration.rs
@@ -174,6 +174,18 @@ fn log_list_get_delete_round_trip() {
     };
     req.freq_khz = 14225;
     fill_buf(&mut req.comment, "FFI integration test");
+    fill_buf(&mut req.worked_operator_callsign, "W1AW/OP");
+    fill_buf(&mut req.qsl_sent_status, "Y");
+    fill_buf(&mut req.qsl_sent_date, "2025-01-16");
+    fill_buf(&mut req.lotw_sent, "N");
+    fill_buf(&mut req.qrz_log_id, "qrz-123");
+    fill_buf(&mut req.snapshot_profile, "Home");
+    fill_buf(&mut req.snapshot_station_callsign, "K7TST");
+    fill_buf(&mut req.snapshot_grid, "CN87");
+    fill_buf(&mut req.snapshot_dxcc, "291");
+    fill_buf(&mut req.cw_rx_wpm, "34");
+    fill_buf(&mut req.cw_transcript, "CQ TEST");
+    fill_buf(&mut req.extra_fields, "APP_TEST=value");
 
     let mut result: QsrLogQsoResult = unsafe { std::mem::zeroed() };
     let rc = unsafe { qsr_log_qso(client, &req, &mut result) };
@@ -205,6 +217,18 @@ fn log_list_get_delete_round_trip() {
     assert_eq!(buf_as_str(&detail.band), "20M");
     assert_eq!(buf_as_str(&detail.mode), "SSB");
     assert_eq!(buf_as_str(&detail.comment), "FFI integration test");
+    assert_eq!(buf_as_str(&detail.worked_operator_callsign), "W1AW/OP");
+    assert_eq!(buf_as_str(&detail.qsl_sent_status), "Y");
+    assert_eq!(buf_as_str(&detail.qsl_sent_date), "2025-01-16");
+    assert_eq!(buf_as_str(&detail.lotw_sent), "N");
+    assert_eq!(buf_as_str(&detail.qrz_log_id), "qrz-123");
+    assert_eq!(buf_as_str(&detail.snapshot_profile), "Home");
+    assert_eq!(buf_as_str(&detail.snapshot_station_callsign), "K7TST");
+    assert_eq!(buf_as_str(&detail.snapshot_grid), "CN87");
+    assert_eq!(buf_as_str(&detail.snapshot_dxcc), "291");
+    assert_eq!(buf_as_str(&detail.cw_rx_wpm), "34");
+    assert_eq!(buf_as_str(&detail.cw_transcript), "CQ TEST");
+    assert!(buf_as_str(&detail.extra_fields).contains("APP_TEST=value"));
 
     // 4. Delete the QSO
     let rc = unsafe { qsr_delete_qso(client, c_id.as_ptr()) };


### PR DESCRIPTION
This follow-up fills out the remaining Win32 advanced card pages to match the Avalonia editor more closely. It adds persisted QSL, station snapshot, transcript, metadata, and worked-operator fields through the Win32 FFI path, and fixes F2 from the focused QSO list so editing an existing row loads the selected QSO instead of opening a blank advanced form.