### PR TITLE
Clarify Win32 advanced callsign labels

### DIFF
--- a/src/c/qsoripper-win32/src/main.c
+++ b/src/c/qsoripper-win32/src/main.c
@@ -160,6 +160,22 @@ static const char *FIELD_LABELS[] = {
     "Updated", "Extra ADIF"
 };
 
+static const char *AdvancedFieldLabel(enum Field f)
+{
+    switch (f) {
+    case FIELD_CALLSIGN:
+        return "Worked Call";
+    case FIELD_WORKED_OPERATOR_CALLSIGN:
+        return "Operator Call";
+    case FIELD_SNAPSHOT_STATION_CALLSIGN:
+        return "Profile Stn Call";
+    case FIELD_SNAPSHOT_OPERATOR_CALLSIGN:
+        return "Profile Op Call";
+    default:
+        return FIELD_LABELS[f];
+    }
+}
+
 static const int FIELD_MAX_LEN[] = {
     30, 0, 0,  /* callsign, band(cycle), mode(cycle) */
     6,  6,      /* rst sent, rst rcvd */
@@ -2830,6 +2846,12 @@ int qsr_test_advanced_tab_field_count(int tab)
     return ADV_TAB_COUNTS[tab];
 }
 
+const char *qsr_test_advanced_field_label(enum Field f)
+{
+    if (f < 0 || f >= FIELD_COUNT) return NULL;
+    return AdvancedFieldLabel(f);
+}
+
 int qsr_test_get_advanced_tab(void)
 {
     return g_state.advanced_tab;
@@ -2916,7 +2938,7 @@ static void DrawAdvancedEditorField(HDC hdc, enum Field f, int x, int y,
     int box_w = field_chars * cw + 6;
     int box_h = ch + 4;
 
-    DrawLabelWithHotkey(hdc, x, y + 3, CLR_LABEL, FIELD_LABELS[f],
+    DrawLabelWithHotkey(hdc, x, y + 3, CLR_LABEL, AdvancedFieldLabel(f),
                         FieldHotkey(f), cw, ch);
     if (f == FIELD_BAND) {
         DrawCycleField(hdc, field_x, y, field_chars, BANDS[g_state.band_idx],

--- a/src/c/qsoripper-win32/tests/win32_issue_regressions.c
+++ b/src/c/qsoripper-win32/tests/win32_issue_regressions.c
@@ -71,6 +71,7 @@ int qsr_test_qso_duration_seconds(const char *time_on, const char *time_off);
 int qsr_test_advanced_tab_for_field(enum Field field);
 const char *qsr_test_advanced_tab_name(int tab);
 int qsr_test_advanced_tab_field_count(int tab);
+const char *qsr_test_advanced_field_label(enum Field field);
 int qsr_test_get_advanced_tab(void);
 void qsr_test_set_advanced_tab(int tab);
 void qsr_test_cycle_advanced_tab(int delta);
@@ -449,6 +450,10 @@ static int test_win32_advanced_editor_uses_card_pages(void)
         return fail("core QSO fields are not grouped on the Core card page");
     }
 
+    if (strcmp(qsr_test_advanced_field_label(FIELD_CALLSIGN), "Worked Call") != 0) {
+        return fail("Core page does not label the primary callsign as the worked callsign");
+    }
+
     if (qsr_test_advanced_tab_for_field(FIELD_WORKED_OPERATOR_CALLSIGN) != 1 ||
         qsr_test_advanced_tab_for_field(FIELD_WORKED_NAME) != 1 ||
         qsr_test_advanced_tab_for_field(FIELD_WORKED_GRID) != 1 ||
@@ -460,6 +465,10 @@ static int test_win32_advanced_editor_uses_card_pages(void)
         qsr_test_advanced_tab_for_field(FIELD_WORKED_COUNTY) != 1 ||
         qsr_test_advanced_tab_for_field(FIELD_SKCC) != 1) {
         return fail("lookup fields are not grouped on the Lookup card page");
+    }
+
+    if (strcmp(qsr_test_advanced_field_label(FIELD_WORKED_OPERATOR_CALLSIGN), "Operator Call") != 0) {
+        return fail("Lookup page still labels the operator callsign like the worked callsign");
     }
 
     if (qsr_test_advanced_tab_for_field(FIELD_QSL_SENT_STATUS) != 2 ||


### PR DESCRIPTION
Clarifies the Win32 advanced card labels so the Core page shows the primary QSO callsign as Worked Call and the Lookup page shows the enrichment operator callsign as Operator Call. This keeps the Avalonia field split but makes the distinction clear in the compact Win32 layout.