### PR TITLE
Fix advanced edit save failure handling and UpdateQso recovery

### DIFF
--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -918,6 +918,75 @@ public sealed class ManagedEngineStateTests : IDisposable
     }
 
     [Fact]
+    public void Update_qso_trims_local_id_before_lookup()
+    {
+        var state = CreateState();
+        EnsureStationConfigured(state);
+        var loggedResp = LogSampleQso(state, "W1AW");
+        var logged = state.GetQso(loggedResp.LocalId)!;
+
+        var updateResponse = state.UpdateQso(new UpdateQsoRequest
+        {
+            SyncToQrz = false,
+            Qso = new QsoRecord(logged)
+            {
+                LocalId = $"  {logged.LocalId}  ",
+                Comment = "Trimmed local id update",
+            },
+        });
+
+        Assert.True(updateResponse.Success);
+        var stored = state.GetQso(logged.LocalId);
+        Assert.NotNull(stored);
+        Assert.Equal("Trimmed local id update", stored!.Comment);
+    }
+
+    [Fact]
+    public void Update_qso_falls_back_to_unique_qrz_logid_when_local_id_misses()
+    {
+        var state = CreateState();
+        state.SaveSetup(new SaveSetupRequest
+        {
+            QrzLogbookApiKey = "test-api-key",
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87",
+            },
+        });
+        var loggedResp = state.LogQso(new LogQsoRequest
+        {
+            SyncToQrz = true,
+            Qso = new QsoRecord
+            {
+                WorkedCallsign = "W1AW",
+                Band = Band._20M,
+                Mode = Mode.Cw,
+                UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow),
+            },
+        });
+        var logged = state.GetQso(loggedResp.LocalId)!;
+        Assert.False(string.IsNullOrWhiteSpace(logged.QrzLogid));
+
+        var updateResponse = state.UpdateQso(new UpdateQsoRequest
+        {
+            SyncToQrz = false,
+            Qso = new QsoRecord(logged)
+            {
+                LocalId = "missing-local-id",
+                Comment = "Recovered via QRZ logid",
+            },
+        });
+
+        Assert.True(updateResponse.Success);
+        var stored = state.GetQso(logged.LocalId);
+        Assert.NotNull(stored);
+        Assert.Equal("Recovered via QRZ logid", stored!.Comment);
+    }
+
+    [Fact]
     public void Restore_clears_tombstone_and_pending_flag()
     {
         var state = CreateState();

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -529,15 +529,45 @@ internal sealed class ManagedEngineState
         lock (_gate)
         {
             var qso = request.Qso?.Clone() ?? throw new InvalidOperationException("qso is required.");
-            if (string.IsNullOrWhiteSpace(qso.LocalId))
+            var requestedLocalId = qso.LocalId?.Trim();
+            if (string.IsNullOrWhiteSpace(requestedLocalId))
             {
                 return new UpdateQsoResponse { Success = false, Error = "local_id is required." };
             }
+            qso.LocalId = requestedLocalId;
 
-            var existing = Sync(_storage.Logbook.GetQsoAsync(qso.LocalId));
+            var existing = Sync(_storage.Logbook.GetQsoAsync(requestedLocalId));
             if (existing is null)
             {
-                return new UpdateQsoResponse { Success = false, Error = $"QSO '{qso.LocalId}' was not found." };
+                if (!string.IsNullOrWhiteSpace(qso.QrzLogid))
+                {
+                    var matches = Sync(_storage.Logbook.ListQsosAsync(new QsoListQuery
+                    {
+                        DeletedFilter = Storage.DeletedRecordsFilter.All,
+                    }))
+                    .Where(candidate =>
+                        string.Equals(candidate.QrzLogid, qso.QrzLogid, StringComparison.OrdinalIgnoreCase))
+                    .ToArray();
+
+                    if (matches.Length == 1)
+                    {
+                        existing = matches[0];
+                        qso.LocalId = existing.LocalId;
+                    }
+                    else if (matches.Length > 1)
+                    {
+                        return new UpdateQsoResponse
+                        {
+                            Success = false,
+                            Error = $"QSO '{requestedLocalId}' was not found and QRZ logid '{qso.QrzLogid}' matched multiple local QSOs.",
+                        };
+                    }
+                }
+            }
+
+            if (existing is null)
+            {
+                return new UpdateQsoResponse { Success = false, Error = $"QSO '{requestedLocalId}' was not found." };
             }
             if (existing.DeletedAt is not null)
             {

--- a/src/dotnet/QsoRipper.Gui.Tests/FullQsoCardViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/FullQsoCardViewModelTests.cs
@@ -176,6 +176,43 @@ public sealed class FullQsoCardViewModelTests
     }
 
     [Fact]
+    public async Task SaveCommandKeepsCardOpenWhenUpdateFails()
+    {
+        var engine = new RecordingEngineClient
+        {
+            UpdateResponse = new UpdateQsoResponse
+            {
+                Success = false,
+                Error = "QSO 'qso-1' was not found.",
+            },
+        };
+        var existing = new QsoRecord
+        {
+            LocalId = "qso-1",
+            WorkedCallsign = "F6BCW",
+            StationCallsign = "K7RND",
+            UtcTimestamp = Timestamp.FromDateTimeOffset(new DateTimeOffset(2026, 5, 26, 4, 15, 0, TimeSpan.Zero)),
+            Band = Band._20M,
+            Mode = Mode.Cw,
+        };
+
+        var card = FullQsoCardViewModel.ForEdit(engine, existing);
+        var savedRaised = false;
+        var closeRaised = false;
+        card.Saved += (_, _) => savedRaised = true;
+        card.CloseRequested += (_, _) => closeRaised = true;
+        card.Comment = "Edited in advanced panel";
+
+        await card.SaveCommand.ExecuteAsync(null);
+
+        Assert.NotNull(engine.LastUpdatedQso);
+        Assert.Contains("Update failed", card.StatusText, StringComparison.Ordinal);
+        Assert.Contains("not found", card.StatusText, StringComparison.OrdinalIgnoreCase);
+        Assert.False(savedRaised);
+        Assert.False(closeRaised);
+    }
+
+    [Fact]
     public async Task OpenQsoCardCommandUsesSelectedGridQsoForEdit()
     {
         var engine = new RecordingEngineClient
@@ -478,6 +515,8 @@ public sealed class FullQsoCardViewModelTests
         public Dictionary<string, LookupResponse> LookupResponsesByCallsign { get; } =
             new(StringComparer.OrdinalIgnoreCase);
 
+        public UpdateQsoResponse UpdateResponse { get; init; } = new UpdateQsoResponse { Success = true };
+
         public Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default) =>
             Task.FromResult(new GetSetupWizardStateResponse());
 
@@ -509,7 +548,7 @@ public sealed class FullQsoCardViewModelTests
         public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default)
         {
             LastUpdatedQso = qso.Clone();
-            return Task.FromResult(new UpdateQsoResponse { Success = true });
+            return Task.FromResult(UpdateResponse);
         }
 
         public Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default) =>

--- a/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/FullQsoCardViewModel.cs
@@ -440,7 +440,15 @@ internal sealed partial class FullQsoCardViewModel : ObservableObject, IDisposab
         {
             if (IsEditingExisting)
             {
-                await _engine.UpdateQsoAsync(qso);
+                var response = await _engine.UpdateQsoAsync(qso);
+                if (!response.Success)
+                {
+                    StatusText = string.IsNullOrWhiteSpace(response.Error)
+                        ? $"Update failed for {qso.WorkedCallsign}."
+                        : $"Update failed: {response.Error}";
+                    return;
+                }
+
                 StatusText = $"Updated {qso.WorkedCallsign}.";
             }
             else


### PR DESCRIPTION
This fixes the advanced-card edit/save regression where failed UpdateQso responses were treated as success, and hardens the .NET engine update path to avoid false not-found misses.\n\nThe GUI now keeps the card open and surfaces update failures.\nThe engine now trims local_id before lookup and falls back to a unique qrz_logid match when local_id misses.\nAdded regression tests for both GUI and engine behavior.