### PR TITLE
Add qsoripper-cathub phase 1: single-radio CAT hub skeleton

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "qsoripper-cathub",
     "qsoripper-core",
     "qsoripper-ffi",
     "qsoripper-server",
@@ -26,6 +27,16 @@ tonic = "0.12"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 uuid = { version = "1", features = ["v4"] }
 sqlite = { version = "0.37", features = ["bundled"] }
+async-trait = "0.1"
+thiserror = "2"
+serial2-tokio = "0.1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+clap = { version = "4", features = ["derive"] }
+bytes = "1"
 
 [workspace.lints.clippy]
 all = { level = "deny", priority = -1 }

--- a/src/rust/qsoripper-cathub/Cargo.toml
+++ b/src/rust/qsoripper-cathub/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "qsoripper-cathub"
+description = "Multi-client CAT hub daemon that owns the radio serial port and fans it out to multiple clients"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+name = "qsoripper_cathub"
+path = "src/lib.rs"
+
+[[bin]]
+name = "qsoripper-cathub"
+path = "src/main.rs"
+
+[dependencies]
+async-trait = { workspace = true }
+bytes = { workspace = true }
+clap = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "sync", "io-util", "time", "net", "signal"] }
+serial2-tokio = { workspace = true }
+toml = { workspace = true }
+tracing = { workspace = true }
+tracing-appender = { workspace = true }
+tracing-subscriber = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/src/rust/qsoripper-cathub/src/backend/kenwood/mod.rs
+++ b/src/rust/qsoripper-cathub/src/backend/kenwood/mod.rs
@@ -1,0 +1,7 @@
+//! Kenwood CAT backend family. The TS-590 is the first concrete model; other
+//! Kenwood radios share the command grammar and slot in via the same parsing
+//! and formatting helpers.
+
+pub(crate) mod ts590;
+
+pub(crate) use ts590::Ts590Backend;

--- a/src/rust/qsoripper-cathub/src/backend/kenwood/ts590.rs
+++ b/src/rust/qsoripper-cathub/src/backend/kenwood/ts590.rs
@@ -1,0 +1,257 @@
+//! Kenwood TS-590 backend. Maps universal [`StateMutation`]s to native CAT
+//! commands and parses Kenwood replies (`FA`, `FB`, `MD`) back into universal
+//! state. Phase 1 wires frequency, mode, and PTT to the wire.
+
+use async_trait::async_trait;
+
+use crate::backend::{RadioBackend, StateMutation};
+use crate::error::BackendError;
+use crate::model::{Mode, Vfo};
+use crate::radio::RadioHandle;
+use crate::state::StateHandle;
+
+/// Backend driving a Kenwood TS-590 over a serialized radio handle.
+pub(crate) struct Ts590Backend {
+    radio: RadioHandle,
+}
+
+impl Ts590Backend {
+    /// Construct a TS-590 backend over the given radio handle.
+    pub(crate) fn new(radio: RadioHandle) -> Self {
+        Self { radio }
+    }
+
+    fn freq_set_command(vfo: Vfo, hz: u64) -> Vec<u8> {
+        let verb = match vfo {
+            Vfo::A => "FA",
+            Vfo::B => "FB",
+        };
+        format!("{verb}{hz:011};").into_bytes()
+    }
+
+    fn freq_query_command(vfo: Vfo) -> Vec<u8> {
+        match vfo {
+            Vfo::A => b"FA;".to_vec(),
+            Vfo::B => b"FB;".to_vec(),
+        }
+    }
+}
+
+#[async_trait]
+impl RadioBackend for Ts590Backend {
+    async fn poll(&self, state: &StateHandle) -> Result<(), BackendError> {
+        let fa = self
+            .radio
+            .send(Self::freq_query_command(Vfo::A), true)
+            .await?;
+        if let Some(hz) = parse_freq(&fa, b"FA") {
+            state.set_frequency(Vfo::A, hz).await;
+        }
+        let fb = self
+            .radio
+            .send(Self::freq_query_command(Vfo::B), true)
+            .await?;
+        if let Some(hz) = parse_freq(&fb, b"FB") {
+            state.set_frequency(Vfo::B, hz).await;
+        }
+        let md = self.radio.send(b"MD;".to_vec(), true).await?;
+        if let Some(mode) = parse_mode(&md) {
+            state.set_mode(Vfo::A, mode).await;
+        }
+        Ok(())
+    }
+
+    async fn apply(
+        &self,
+        mutation: StateMutation,
+        state: &StateHandle,
+    ) -> Result<(), BackendError> {
+        match mutation {
+            StateMutation::Frequency { vfo, hz } => {
+                self.radio
+                    .send(Self::freq_set_command(vfo, hz), false)
+                    .await?;
+                state.set_frequency(vfo, hz).await;
+            }
+            StateMutation::Mode { vfo, mode } => {
+                let cmd = format!("MD{};", mode.to_kenwood_digit()).into_bytes();
+                self.radio.send(cmd, false).await?;
+                state.set_mode(vfo, mode).await;
+            }
+            StateMutation::Ptt { keyed } => {
+                let cmd = if keyed {
+                    b"TX;".to_vec()
+                } else {
+                    b"RX;".to_vec()
+                };
+                self.radio.send(cmd, false).await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn passthrough(&self, raw: &[u8]) -> Result<Vec<u8>, BackendError> {
+        self.radio.send(raw.to_vec(), is_query(raw)).await
+    }
+}
+
+/// Whether a raw command is a query (expects a reply): a verb followed only by
+/// the terminator, with no parameter payload.
+fn is_query(raw: &[u8]) -> bool {
+    let trimmed = raw.strip_suffix(b";").unwrap_or(raw);
+    !trimmed.is_empty() && trimmed.iter().all(u8::is_ascii_alphabetic)
+}
+
+/// Parse a Kenwood frequency frame (`FA`/`FB` + 11 digits + `;`).
+fn parse_freq(frame: &[u8], verb: &[u8]) -> Option<u64> {
+    let body = frame.strip_prefix(verb)?;
+    let digits = body.strip_suffix(b";")?;
+    if digits.len() != 11 || !digits.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    std::str::from_utf8(digits).ok()?.parse::<u64>().ok()
+}
+
+/// Parse a Kenwood mode frame (`MD` + 1 digit + `;`).
+fn parse_mode(frame: &[u8]) -> Option<Mode> {
+    let body = frame.strip_prefix(b"MD")?;
+    let digits = body.strip_suffix(b";")?;
+    let &[digit] = digits else {
+        return None;
+    };
+    Mode::from_kenwood_digit(digit as char)
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use crate::radio::{self, run_radio_task};
+    use std::time::Duration;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    fn backend_with_fake() -> (Ts590Backend, tokio::io::DuplexStream) {
+        let (handle, inbox) = radio::channel(8);
+        let (client, radio_side) = tokio::io::duplex(1024);
+        tokio::spawn(run_radio_task(
+            radio_side,
+            inbox,
+            Duration::from_millis(200),
+        ));
+        (Ts590Backend::new(handle), client)
+    }
+
+    #[test]
+    fn parse_freq_reads_eleven_digits() {
+        assert_eq!(parse_freq(b"FA00014074000;", b"FA"), Some(14_074_000));
+        assert_eq!(parse_freq(b"FB00007030000;", b"FB"), Some(7_030_000));
+        assert_eq!(parse_freq(b"FA0001407400;", b"FA"), None);
+        assert_eq!(parse_freq(b"MD2;", b"FA"), None);
+    }
+
+    #[test]
+    fn parse_mode_reads_single_digit() {
+        assert_eq!(parse_mode(b"MD2;"), Some(Mode::Usb));
+        assert_eq!(parse_mode(b"MD3;"), Some(Mode::Cw));
+        assert_eq!(parse_mode(b"MD;"), None);
+    }
+
+    #[test]
+    fn is_query_distinguishes_reads_from_writes() {
+        assert!(is_query(b"FA;"));
+        assert!(is_query(b"MD;"));
+        assert!(!is_query(b"FA00014074000;"));
+        assert!(!is_query(b"MD2;"));
+    }
+
+    #[test]
+    fn freq_set_command_zero_pads() {
+        assert_eq!(
+            Ts590Backend::freq_set_command(Vfo::A, 14_074_000),
+            b"FA00014074000;".to_vec()
+        );
+        assert_eq!(
+            Ts590Backend::freq_set_command(Vfo::B, 7_030_000),
+            b"FB00007030000;".to_vec()
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_freq_writes_native_command_and_records_state() {
+        let (backend, mut fake) = backend_with_fake();
+        let reader = tokio::spawn(async move {
+            let mut got = vec![0u8; 14];
+            fake.read_exact(&mut got).await.expect("read set");
+            assert_eq!(&got, b"FA00021074000;");
+        });
+        let (handle, _inbox) = StateHandle::new(16);
+        backend
+            .apply(
+                StateMutation::Frequency {
+                    vfo: Vfo::A,
+                    hz: 21_074_000,
+                },
+                &handle,
+            )
+            .await
+            .expect("apply");
+        assert_eq!(handle.snapshot().await.freq_a, 21_074_000);
+        reader.await.expect("reader");
+    }
+
+    #[tokio::test]
+    async fn poll_parses_replies_into_state() {
+        let (backend, mut fake) = backend_with_fake();
+        let responder = tokio::spawn(async move {
+            let mut buf = vec![0u8; 3];
+            fake.read_exact(&mut buf).await.expect("FA?");
+            assert_eq!(&buf, b"FA;");
+            fake.write_all(b"FA00014074000;").await.expect("FA reply");
+            let mut buf = vec![0u8; 3];
+            fake.read_exact(&mut buf).await.expect("FB?");
+            assert_eq!(&buf, b"FB;");
+            fake.write_all(b"FB00007030000;").await.expect("FB reply");
+            let mut buf = vec![0u8; 3];
+            fake.read_exact(&mut buf).await.expect("MD?");
+            assert_eq!(&buf, b"MD;");
+            fake.write_all(b"MD3;").await.expect("MD reply");
+        });
+        let (handle, _inbox) = StateHandle::new(16);
+        backend.poll(&handle).await.expect("poll");
+        let snap = handle.snapshot().await;
+        assert_eq!(snap.freq_a, 14_074_000);
+        assert_eq!(snap.freq_b, 7_030_000);
+        assert_eq!(snap.mode_a, Mode::Cw);
+        responder.await.expect("responder");
+    }
+
+    #[tokio::test]
+    async fn ptt_keys_the_transmitter() {
+        let (backend, mut fake) = backend_with_fake();
+        let reader = tokio::spawn(async move {
+            let mut buf = vec![0u8; 3];
+            fake.read_exact(&mut buf).await.expect("TX");
+            assert_eq!(&buf, b"TX;");
+        });
+        let (handle, _inbox) = StateHandle::new(16);
+        backend
+            .apply(StateMutation::Ptt { keyed: true }, &handle)
+            .await
+            .expect("apply ptt");
+        reader.await.expect("reader");
+    }
+
+    #[tokio::test]
+    async fn passthrough_query_returns_reply() {
+        let (backend, mut fake) = backend_with_fake();
+        let responder = tokio::spawn(async move {
+            let mut buf = vec![0u8; 3];
+            fake.read_exact(&mut buf).await.expect("PS?");
+            assert_eq!(&buf, b"PS;");
+            fake.write_all(b"PS1;").await.expect("PS reply");
+        });
+        let reply = backend.passthrough(b"PS;").await.expect("passthrough");
+        assert_eq!(reply, b"PS1;".to_vec());
+        responder.await.expect("responder");
+    }
+}

--- a/src/rust/qsoripper-cathub/src/backend/loopback.rs
+++ b/src/rust/qsoripper-cathub/src/backend/loopback.rs
@@ -1,0 +1,162 @@
+//! In-memory backend used by tests and `--dry-run`. Records every mutation and
+//! passthrough, reflects mutations into the universal state, and serves canned
+//! poll data without touching hardware.
+
+#[cfg(test)]
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+
+use crate::backend::{RadioBackend, StateMutation};
+use crate::error::BackendError;
+use crate::model::{Mode, Vfo};
+use crate::state::StateHandle;
+
+/// A canned poll snapshot the loopback backend reports.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CannedPoll {
+    /// VFO A frequency in Hz.
+    pub(crate) freq_a: u64,
+    /// VFO B frequency in Hz.
+    pub(crate) freq_b: u64,
+    /// VFO A mode.
+    pub(crate) mode_a: Mode,
+    /// VFO B mode.
+    pub(crate) mode_b: Mode,
+}
+
+impl Default for CannedPoll {
+    fn default() -> Self {
+        Self {
+            freq_a: 14_074_000,
+            freq_b: 14_074_000,
+            mode_a: Mode::Usb,
+            mode_b: Mode::Usb,
+        }
+    }
+}
+
+/// Backend that records interactions instead of driving a radio.
+pub(crate) struct LoopbackBackend {
+    canned: CannedPoll,
+    #[cfg(test)]
+    mutations: Mutex<Vec<StateMutation>>,
+    #[cfg(test)]
+    passthroughs: Mutex<Vec<Vec<u8>>>,
+}
+
+impl LoopbackBackend {
+    /// Create a loopback backend with default canned poll data.
+    pub(crate) fn new() -> Self {
+        Self {
+            canned: CannedPoll::default(),
+            #[cfg(test)]
+            mutations: Mutex::new(Vec::new()),
+            #[cfg(test)]
+            passthroughs: Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Snapshot of mutations recorded so far (test introspection only).
+    #[cfg(test)]
+    pub(crate) fn recorded_mutations(&self) -> Vec<StateMutation> {
+        self.mutations.lock().map(|g| g.clone()).unwrap_or_default()
+    }
+
+    /// Snapshot of passthrough payloads recorded so far (test introspection only).
+    #[cfg(test)]
+    pub(crate) fn recorded_passthroughs(&self) -> Vec<Vec<u8>> {
+        self.passthroughs
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    fn record_mutation(&self, mutation: StateMutation) {
+        if let Ok(mut guard) = self.mutations.lock() {
+            guard.push(mutation);
+        }
+    }
+
+    #[cfg(not(test))]
+    #[allow(clippy::unused_self)]
+    fn record_mutation(&self, _mutation: StateMutation) {}
+}
+
+#[async_trait]
+impl RadioBackend for LoopbackBackend {
+    async fn poll(&self, state: &StateHandle) -> Result<(), BackendError> {
+        state.set_frequency(Vfo::A, self.canned.freq_a).await;
+        state.set_frequency(Vfo::B, self.canned.freq_b).await;
+        state.set_mode(Vfo::A, self.canned.mode_a).await;
+        state.set_mode(Vfo::B, self.canned.mode_b).await;
+        Ok(())
+    }
+
+    async fn apply(
+        &self,
+        mutation: StateMutation,
+        state: &StateHandle,
+    ) -> Result<(), BackendError> {
+        self.record_mutation(mutation);
+        match mutation {
+            StateMutation::Frequency { vfo, hz } => state.set_frequency(vfo, hz).await,
+            StateMutation::Mode { vfo, mode } => state.set_mode(vfo, mode).await,
+            StateMutation::Ptt { .. } => {}
+        }
+        Ok(())
+    }
+
+    async fn passthrough(&self, raw: &[u8]) -> Result<Vec<u8>, BackendError> {
+        #[cfg(test)]
+        {
+            if let Ok(mut guard) = self.passthroughs.lock() {
+                guard.push(raw.to_vec());
+            }
+        }
+        #[cfg(not(test))]
+        let _ = raw;
+        Ok(Vec::new())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn poll_populates_state_from_canned_data() {
+        let (handle, _inbox) = StateHandle::new(16);
+        let backend = LoopbackBackend::new();
+        backend.poll(&handle).await.expect("poll");
+        assert_eq!(handle.snapshot().await.freq_a, 14_074_000);
+    }
+
+    #[tokio::test]
+    async fn apply_records_and_reflects_mutation() {
+        let (handle, _inbox) = StateHandle::new(16);
+        let backend = LoopbackBackend::new();
+        backend
+            .apply(
+                StateMutation::Mode {
+                    vfo: Vfo::A,
+                    mode: Mode::Cw,
+                },
+                &handle,
+            )
+            .await
+            .expect("apply");
+        assert_eq!(handle.snapshot().await.mode_a, Mode::Cw);
+        assert_eq!(backend.recorded_mutations().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn passthrough_records_raw_bytes() {
+        let backend = LoopbackBackend::new();
+        let reply = backend.passthrough(b"FA;").await.expect("passthrough");
+        assert!(reply.is_empty());
+        assert_eq!(backend.recorded_passthroughs(), vec![b"FA;".to_vec()]);
+    }
+}

--- a/src/rust/qsoripper-cathub/src/backend/mod.rs
+++ b/src/rust/qsoripper-cathub/src/backend/mod.rs
@@ -1,0 +1,51 @@
+//! Radio backend abstraction: the seam that lets the hub drive different radio
+//! families (Kenwood, Icom CI-V, Yaesu) behind one trait.
+
+pub(crate) mod kenwood;
+pub(crate) mod loopback;
+
+use async_trait::async_trait;
+
+use crate::error::BackendError;
+use crate::model::{Mode, Vfo};
+use crate::state::StateHandle;
+
+/// A single normalized change to apply to the radio.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StateMutation {
+    /// Set a VFO frequency in Hz.
+    Frequency {
+        /// Target VFO.
+        vfo: Vfo,
+        /// Frequency in Hz.
+        hz: u64,
+    },
+    /// Set a VFO mode.
+    Mode {
+        /// Target VFO.
+        vfo: Vfo,
+        /// Mode to set.
+        mode: Mode,
+    },
+    /// Key or unkey the transmitter.
+    Ptt {
+        /// Whether the transmitter should be keyed.
+        keyed: bool,
+    },
+}
+
+/// A radio family backend. Implementations own the native command vocabulary
+/// and the mapping to and from universal [`StateMutation`]s and [`StateHandle`].
+#[async_trait]
+pub(crate) trait RadioBackend: Send + Sync {
+    /// Refresh the universal state by polling the radio.
+    async fn poll(&self, state: &StateHandle) -> Result<(), BackendError>;
+
+    /// Apply a mutation to the radio and reflect it into the universal state.
+    async fn apply(&self, mutation: StateMutation, state: &StateHandle)
+        -> Result<(), BackendError>;
+
+    /// Pass a raw native command straight through to the radio and return the
+    /// raw reply bytes (possibly empty for no-reply commands).
+    async fn passthrough(&self, raw: &[u8]) -> Result<Vec<u8>, BackendError>;
+}

--- a/src/rust/qsoripper-cathub/src/config.rs
+++ b/src/rust/qsoripper-cathub/src/config.rs
@@ -1,0 +1,350 @@
+//! Configuration schema and loading. The hub is configured from a TOML file
+//! describing the radio, the baseline poll cadence, and one or more client
+//! faces. Phase 1 supports serial faces; the Hamlib net section lands later.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::dialect::Permissions;
+use crate::error::ConfigError;
+
+/// Top-level daemon configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct Config {
+    /// Radio transport settings.
+    pub(crate) radio: RadioConfig,
+    /// Baseline polling settings.
+    #[serde(default)]
+    pub(crate) poll: PollConfig,
+    /// Client faces.
+    #[serde(default, rename = "face")]
+    pub(crate) faces: Vec<FaceConfig>,
+}
+
+/// Which radio backend family to drive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum BackendKind {
+    /// Kenwood TS-590.
+    Ts590,
+    /// In-memory loopback backend (testing and `--dry-run`).
+    Loopback,
+}
+
+/// Which client dialect a face speaks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum DialectKind {
+    /// Native Kenwood TS-590.
+    Ts590,
+}
+
+/// Radio transport configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct RadioConfig {
+    /// Serial port path (for example `COM3` or `/dev/ttyUSB0`).
+    pub(crate) port: String,
+    /// Serial baud rate.
+    #[serde(default = "default_baud")]
+    pub(crate) baud: u32,
+    /// Backend family.
+    pub(crate) backend: BackendKind,
+    /// Per-command reply timeout in milliseconds.
+    #[serde(default = "default_reply_timeout_ms")]
+    pub(crate) reply_timeout_ms: u64,
+}
+
+/// Baseline polling configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct PollConfig {
+    /// Baseline poll interval in milliseconds.
+    #[serde(default = "default_baseline_ms")]
+    pub(crate) baseline_ms: u64,
+}
+
+impl Default for PollConfig {
+    fn default() -> Self {
+        Self {
+            baseline_ms: default_baseline_ms(),
+        }
+    }
+}
+
+/// One client face.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct FaceConfig {
+    /// Face name (used in logs and as PTT owner identity).
+    pub(crate) name: String,
+    /// Serial port path the client connects to.
+    pub(crate) port: String,
+    /// Serial baud rate.
+    #[serde(default = "default_baud")]
+    pub(crate) baud: u32,
+    /// Dialect this face speaks.
+    pub(crate) dialect: DialectKind,
+    /// Whether the face may change frequency/mode/split.
+    #[serde(default = "default_true")]
+    pub(crate) allow_write: bool,
+    /// Whether the face may key PTT.
+    #[serde(default)]
+    pub(crate) allow_ptt: bool,
+    /// Whether the face may send raw passthrough commands.
+    #[serde(default = "default_true")]
+    pub(crate) allow_passthrough: bool,
+}
+
+impl FaceConfig {
+    /// Permissions derived from this face configuration.
+    pub(crate) fn permissions(&self) -> Permissions {
+        Permissions {
+            allow_write: self.allow_write,
+            allow_ptt: self.allow_ptt,
+            allow_passthrough: self.allow_passthrough,
+        }
+    }
+}
+
+impl Config {
+    /// Load and parse configuration from a TOML file.
+    pub(crate) fn load(path: &Path) -> Result<Self, ConfigError> {
+        let text = std::fs::read_to_string(path).map_err(|source| ConfigError::Read {
+            path: path.display().to_string(),
+            source,
+        })?;
+        Self::parse(&text)
+    }
+
+    /// Parse configuration from a TOML string.
+    pub(crate) fn parse(text: &str) -> Result<Self, ConfigError> {
+        toml::from_str(text).map_err(|e| ConfigError::Parse(e.to_string()))
+    }
+
+    /// Validate semantic constraints not expressible in the schema.
+    pub(crate) fn validate(&self) -> Result<(), ConfigError> {
+        if self.radio.port.trim().is_empty() {
+            return Err(ConfigError::Invalid(
+                "radio.port must not be empty".to_string(),
+            ));
+        }
+        if self.radio.reply_timeout_ms == 0 {
+            return Err(ConfigError::Invalid(
+                "radio.reply_timeout_ms must be greater than zero".to_string(),
+            ));
+        }
+        if self.poll.baseline_ms == 0 {
+            return Err(ConfigError::Invalid(
+                "poll.baseline_ms must be greater than zero".to_string(),
+            ));
+        }
+        for face in &self.faces {
+            if face.name.trim().is_empty() {
+                return Err(ConfigError::Invalid(
+                    "face.name must not be empty".to_string(),
+                ));
+            }
+            if face.port.trim().is_empty() {
+                return Err(ConfigError::Invalid(format!(
+                    "face '{}' port must not be empty",
+                    face.name
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Render a human-readable summary of the resolved configuration.
+    pub(crate) fn describe(&self) -> String {
+        let mut out = String::new();
+        let _ = writeln!(
+            out,
+            "radio: port={} baud={} backend={:?} reply_timeout_ms={}",
+            self.radio.port, self.radio.baud, self.radio.backend, self.radio.reply_timeout_ms
+        );
+        let _ = writeln!(out, "poll: baseline_ms={}", self.poll.baseline_ms);
+        if self.faces.is_empty() {
+            let _ = writeln!(out, "faces: (none)");
+        }
+        for face in &self.faces {
+            let _ = writeln!(
+                out,
+                "face: name={} port={} baud={} dialect={:?} write={} ptt={} passthrough={}",
+                face.name,
+                face.port,
+                face.baud,
+                face.dialect,
+                face.allow_write,
+                face.allow_ptt,
+                face.allow_passthrough
+            );
+        }
+        out
+    }
+}
+
+/// Resolve the default configuration file path from the environment.
+pub(crate) fn default_config_path() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("APPDATA") {
+        return Some(Path::new(&dir).join("qsoripper").join("cathub.toml"));
+    }
+    if let Some(dir) = std::env::var_os("XDG_CONFIG_HOME") {
+        return Some(Path::new(&dir).join("qsoripper").join("cathub.toml"));
+    }
+    if let Some(dir) = std::env::var_os("HOME") {
+        return Some(
+            Path::new(&dir)
+                .join(".config")
+                .join("qsoripper")
+                .join("cathub.toml"),
+        );
+    }
+    None
+}
+
+fn default_baud() -> u32 {
+    115_200
+}
+
+fn default_reply_timeout_ms() -> u64 {
+    250
+}
+
+fn default_baseline_ms() -> u64 {
+    500
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+[radio]
+port = "COM3"
+baud = 115200
+backend = "ts590"
+reply_timeout_ms = 200
+
+[poll]
+baseline_ms = 400
+
+[[face]]
+name = "n1mm"
+port = "COM11"
+dialect = "ts590"
+allow_ptt = true
+"#;
+
+    #[test]
+    fn parses_full_config() {
+        let config = Config::parse(SAMPLE).expect("parse");
+        assert_eq!(config.radio.port, "COM3");
+        assert_eq!(config.radio.backend, BackendKind::Ts590);
+        assert_eq!(config.radio.reply_timeout_ms, 200);
+        assert_eq!(config.poll.baseline_ms, 400);
+        assert_eq!(config.faces.len(), 1);
+        let face = &config.faces[0];
+        assert_eq!(face.name, "n1mm");
+        assert_eq!(face.baud, 115_200);
+        assert!(face.allow_ptt);
+        assert!(face.allow_write);
+        assert!(face.allow_passthrough);
+        config.validate().expect("valid");
+    }
+
+    #[test]
+    fn defaults_apply_when_omitted() {
+        let config = Config::parse(
+            r#"
+[radio]
+port = "/dev/ttyUSB0"
+backend = "loopback"
+"#,
+        )
+        .expect("parse");
+        assert_eq!(config.radio.baud, 115_200);
+        assert_eq!(config.radio.reply_timeout_ms, 250);
+        assert_eq!(config.poll.baseline_ms, 500);
+        assert!(config.faces.is_empty());
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let err = Config::parse(
+            r#"
+[radio]
+port = "COM3"
+backend = "ts590"
+bogus = true
+"#,
+        )
+        .expect_err("should reject unknown field");
+        assert!(matches!(err, ConfigError::Parse(_)));
+    }
+
+    #[test]
+    fn empty_port_is_invalid() {
+        let config = Config::parse(
+            r#"
+[radio]
+port = "  "
+backend = "ts590"
+"#,
+        )
+        .expect("parse");
+        assert!(matches!(config.validate(), Err(ConfigError::Invalid(_))));
+    }
+
+    #[test]
+    fn zero_timeout_is_invalid() {
+        let config = Config::parse(
+            r#"
+[radio]
+port = "COM3"
+backend = "ts590"
+reply_timeout_ms = 0
+"#,
+        )
+        .expect("parse");
+        assert!(matches!(config.validate(), Err(ConfigError::Invalid(_))));
+    }
+
+    #[test]
+    fn permissions_round_trip_from_face() {
+        let config = Config::parse(SAMPLE).expect("parse");
+        let perms = config.faces[0].permissions();
+        assert!(perms.allow_ptt);
+        assert!(perms.allow_write);
+        assert!(perms.allow_passthrough);
+    }
+
+    #[test]
+    fn describe_lists_radio_and_faces() {
+        let config = Config::parse(SAMPLE).expect("parse");
+        let described = config.describe();
+        assert!(described.contains("port=COM3"));
+        assert!(described.contains("name=n1mm"));
+    }
+
+    #[test]
+    fn describe_handles_no_faces() {
+        let config = Config::parse(
+            r#"
+[radio]
+port = "COM3"
+backend = "ts590"
+"#,
+        )
+        .expect("parse");
+        assert!(config.describe().contains("faces: (none)"));
+    }
+}

--- a/src/rust/qsoripper-cathub/src/dialect/kenwood/mod.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/kenwood/mod.rs
@@ -1,0 +1,6 @@
+//! Kenwood client dialects. The TS-590 dialect serves native Kenwood clients
+//! such as N1MM.
+
+pub(crate) mod ts590;
+
+pub(crate) use ts590::Ts590Dialect;

--- a/src/rust/qsoripper-cathub/src/dialect/kenwood/ts590.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/kenwood/ts590.rs
@@ -1,0 +1,277 @@
+//! TS-590 client dialect. Serves native Kenwood clients such as N1MM: status
+//! reads are answered from cached universal state, writes become universal
+//! mutations, PTT is permission-gated, and anything unmodeled passes through to
+//! the radio.
+
+use async_trait::async_trait;
+
+use crate::backend::StateMutation;
+use crate::dialect::{ClientDialect, FaceContext};
+use crate::model::{Mode, Vfo};
+use crate::state::{StateChange, StateHandle};
+
+/// Native Kenwood TS-590 dialect.
+pub(crate) struct Ts590Dialect;
+
+impl Ts590Dialect {
+    /// Construct the TS-590 dialect.
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    async fn read_reply(verb: &[u8], state: &StateHandle) -> Option<Vec<u8>> {
+        let snap = state.snapshot().await;
+        match verb {
+            b"FA" => Some(format_freq(b"FA", snap.freq(Vfo::A))),
+            b"FB" => Some(format_freq(b"FB", snap.freq(Vfo::B))),
+            b"MD" => Some(format_mode(snap.mode(snap.rx_vfo))),
+            _ => None,
+        }
+    }
+
+    async fn apply_write(verb: &[u8], payload: &[u8], ctx: &FaceContext) {
+        if !ctx.permissions().allow_write {
+            tracing::warn!(face = ctx.name(), "dropping write: face is read-only");
+            return;
+        }
+        let mutation =
+            match verb {
+                b"FA" => parse_freq_payload(payload)
+                    .map(|hz| StateMutation::Frequency { vfo: Vfo::A, hz }),
+                b"FB" => parse_freq_payload(payload)
+                    .map(|hz| StateMutation::Frequency { vfo: Vfo::B, hz }),
+                b"MD" => parse_mode_payload(payload)
+                    .map(|mode| StateMutation::Mode { vfo: Vfo::A, mode }),
+                _ => None,
+            };
+        if let Some(mutation) = mutation {
+            if let Err(error) = ctx.state().apply_mutation(mutation).await {
+                tracing::warn!(face = ctx.name(), %error, "write failed");
+            }
+        }
+    }
+
+    async fn route_ptt(keyed: bool, ctx: &FaceContext) {
+        if !ctx.permissions().allow_ptt {
+            tracing::warn!(face = ctx.name(), keyed, "dropping PTT: face may not key");
+            return;
+        }
+        if let Err(error) = ctx
+            .state()
+            .apply_mutation(StateMutation::Ptt { keyed })
+            .await
+        {
+            tracing::warn!(face = ctx.name(), keyed, %error, "PTT routing failed");
+        }
+    }
+}
+
+#[async_trait]
+impl ClientDialect for Ts590Dialect {
+    async fn handle(&self, request: &[u8], ctx: &FaceContext) -> Vec<u8> {
+        let Some((verb, payload)) = split_command(request) else {
+            return Vec::new();
+        };
+
+        match verb.as_slice() {
+            b"FA" | b"FB" | b"MD" if payload.is_empty() => Self::read_reply(&verb, ctx.state())
+                .await
+                .unwrap_or_default(),
+            b"FA" | b"FB" | b"MD" => {
+                Self::apply_write(&verb, &payload, ctx).await;
+                Vec::new()
+            }
+            b"TX" => {
+                Self::route_ptt(true, ctx).await;
+                Vec::new()
+            }
+            b"RX" => {
+                Self::route_ptt(false, ctx).await;
+                Vec::new()
+            }
+            b"AI" if payload.is_empty() => {
+                let level = u8::from(ctx.ai_enabled());
+                format!("AI{level};").into_bytes()
+            }
+            b"AI" => {
+                let enabled = payload.first().is_some_and(|&b| b != b'0');
+                ctx.set_ai_enabled(enabled);
+                Vec::new()
+            }
+            _ => {
+                if ctx.permissions().allow_passthrough {
+                    ctx.backend().passthrough(request).await.unwrap_or_default()
+                } else {
+                    tracing::warn!(face = ctx.name(), "dropping passthrough: not permitted");
+                    Vec::new()
+                }
+            }
+        }
+    }
+
+    fn format_notification(&self, change: &StateChange, ctx: &FaceContext) -> Option<Vec<u8>> {
+        if !ctx.ai_enabled() {
+            return None;
+        }
+        match change {
+            StateChange::Frequency { vfo: Vfo::A, hz } => Some(format_freq(b"FA", *hz)),
+            StateChange::Frequency { vfo: Vfo::B, hz } => Some(format_freq(b"FB", *hz)),
+            StateChange::Mode { vfo: Vfo::A, mode } => Some(format_mode(*mode)),
+            StateChange::Mode { vfo: Vfo::B, .. } => None,
+        }
+    }
+}
+
+fn format_freq(verb: &[u8], hz: u64) -> Vec<u8> {
+    let mut out = verb.to_vec();
+    out.extend_from_slice(format!("{hz:011};").as_bytes());
+    out
+}
+
+fn format_mode(mode: Mode) -> Vec<u8> {
+    format!("MD{};", mode.to_kenwood_digit()).into_bytes()
+}
+
+/// Split a terminated command into its alphabetic verb and remaining payload.
+fn split_command(request: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
+    let body = request.strip_suffix(b";").unwrap_or(request);
+    if body.is_empty() {
+        return None;
+    }
+    let verb_len = body.iter().take_while(|b| b.is_ascii_alphabetic()).count();
+    if verb_len == 0 {
+        return None;
+    }
+    let (verb, payload) = body.split_at(verb_len);
+    Some((verb.to_vec(), payload.to_vec()))
+}
+
+fn parse_freq_payload(payload: &[u8]) -> Option<u64> {
+    if payload.len() != 11 || !payload.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    std::str::from_utf8(payload).ok()?.parse::<u64>().ok()
+}
+
+fn parse_mode_payload(payload: &[u8]) -> Option<Mode> {
+    let &[digit] = payload else {
+        return None;
+    };
+    Mode::from_kenwood_digit(digit as char)
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::unused_async
+)]
+mod tests {
+    use super::*;
+    use crate::backend::loopback::LoopbackBackend;
+    use crate::dialect::Permissions;
+    use crate::state::run_mutation_dispatcher;
+    use std::sync::Arc;
+
+    fn wired(
+        permissions: Permissions,
+    ) -> (
+        Ts590Dialect,
+        FaceContext,
+        Arc<LoopbackBackend>,
+        tokio::task::JoinHandle<()>,
+    ) {
+        let (state, inbox) = StateHandle::new(16);
+        let backend = Arc::new(LoopbackBackend::new());
+        let dispatcher = tokio::spawn(run_mutation_dispatcher(
+            inbox,
+            backend.clone(),
+            state.clone(),
+        ));
+        let ctx = FaceContext::new("test", permissions, state, backend.clone());
+        (Ts590Dialect::new(), ctx, backend, dispatcher)
+    }
+
+    #[tokio::test]
+    async fn read_serves_cached_frequency() {
+        let (dialect, ctx, _backend, dispatcher) = wired(Permissions::default());
+        ctx.state().set_frequency(Vfo::A, 14_074_000).await;
+        let reply = dialect.handle(b"FA;", &ctx).await;
+        assert_eq!(reply, b"FA00014074000;".to_vec());
+        dispatcher.abort();
+    }
+
+    #[tokio::test]
+    async fn write_applies_mutation_through_backend() {
+        let (dialect, ctx, backend, dispatcher) = wired(Permissions::default());
+        let reply = dialect.handle(b"FA00021074000;", &ctx).await;
+        assert!(reply.is_empty());
+        assert_eq!(ctx.state().snapshot().await.freq_a, 21_074_000);
+        assert_eq!(backend.recorded_mutations().len(), 1);
+        dispatcher.abort();
+    }
+
+    #[tokio::test]
+    async fn ptt_dropped_without_permission() {
+        let permissions = Permissions {
+            allow_ptt: false,
+            ..Permissions::default()
+        };
+        let (dialect, ctx, backend, dispatcher) = wired(permissions);
+        let reply = dialect.handle(b"TX;", &ctx).await;
+        assert!(reply.is_empty());
+        assert!(backend.recorded_mutations().is_empty());
+        dispatcher.abort();
+    }
+
+    #[tokio::test]
+    async fn ptt_routed_with_permission() {
+        let permissions = Permissions {
+            allow_ptt: true,
+            ..Permissions::default()
+        };
+        let (dialect, ctx, backend, dispatcher) = wired(permissions);
+        dialect.handle(b"TX;", &ctx).await;
+        assert_eq!(
+            backend.recorded_mutations(),
+            vec![StateMutation::Ptt { keyed: true }]
+        );
+        dispatcher.abort();
+    }
+
+    #[tokio::test]
+    async fn unmodeled_command_passes_through() {
+        let (dialect, ctx, backend, dispatcher) = wired(Permissions::default());
+        let reply = dialect.handle(b"PS;", &ctx).await;
+        assert!(reply.is_empty());
+        assert_eq!(backend.recorded_passthroughs(), vec![b"PS;".to_vec()]);
+        dispatcher.abort();
+    }
+
+    #[tokio::test]
+    async fn ai_toggle_round_trips() {
+        let (dialect, ctx, _backend, dispatcher) = wired(Permissions::default());
+        assert_eq!(dialect.handle(b"AI;", &ctx).await, b"AI0;".to_vec());
+        dialect.handle(b"AI1;", &ctx).await;
+        assert!(ctx.ai_enabled());
+        assert_eq!(dialect.handle(b"AI;", &ctx).await, b"AI1;".to_vec());
+        dispatcher.abort();
+    }
+
+    #[tokio::test]
+    async fn notification_only_when_ai_enabled() {
+        let (dialect, ctx, _backend, dispatcher) = wired(Permissions::default());
+        let change = StateChange::Frequency {
+            vfo: Vfo::A,
+            hz: 14_074_000,
+        };
+        assert!(dialect.format_notification(&change, &ctx).is_none());
+        ctx.set_ai_enabled(true);
+        assert_eq!(
+            dialect.format_notification(&change, &ctx),
+            Some(b"FA00014074000;".to_vec())
+        );
+        dispatcher.abort();
+    }
+}

--- a/src/rust/qsoripper-cathub/src/dialect/mod.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/mod.rs
@@ -1,0 +1,110 @@
+//! Client dialect abstraction: the seam that lets one universal state serve
+//! many client CAT vocabularies (native Kenwood for N1MM, TS-2000 emulation for
+//! `OmniRig`, Hamlib net for the engine).
+
+pub(crate) mod kenwood;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::backend::RadioBackend;
+use crate::state::{StateChange, StateHandle};
+
+/// What a face is allowed to do, enforced before any radio write.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Permissions {
+    /// Whether the face may change frequency/mode/split.
+    pub(crate) allow_write: bool,
+    /// Whether the face may key PTT.
+    pub(crate) allow_ptt: bool,
+    /// Whether the face may send raw passthrough commands.
+    pub(crate) allow_passthrough: bool,
+}
+
+impl Default for Permissions {
+    fn default() -> Self {
+        Self {
+            allow_write: true,
+            allow_ptt: false,
+            allow_passthrough: true,
+        }
+    }
+}
+
+/// Per-face runtime context handed to a dialect on every request.
+#[derive(Clone)]
+pub(crate) struct FaceContext {
+    /// Face name, used in logs and as the PTT owner identity.
+    name: String,
+    /// What this face is permitted to do.
+    permissions: Permissions,
+    /// Shared universal state for reads and modeled writes.
+    state: StateHandle,
+    /// Active backend for raw passthrough commands.
+    backend: Arc<dyn RadioBackend>,
+    /// Whether this face has auto-information fan-out enabled.
+    ai_enabled: Arc<AtomicBool>,
+}
+
+impl FaceContext {
+    /// Build a face context.
+    pub(crate) fn new(
+        name: impl Into<String>,
+        permissions: Permissions,
+        state: StateHandle,
+        backend: Arc<dyn RadioBackend>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            permissions,
+            state,
+            backend,
+            ai_enabled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// Face name.
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Face permissions.
+    pub(crate) fn permissions(&self) -> Permissions {
+        self.permissions
+    }
+
+    /// Shared universal state.
+    pub(crate) fn state(&self) -> &StateHandle {
+        &self.state
+    }
+
+    /// Active backend.
+    pub(crate) fn backend(&self) -> &Arc<dyn RadioBackend> {
+        &self.backend
+    }
+
+    /// Whether auto-information fan-out is enabled for this face.
+    pub(crate) fn ai_enabled(&self) -> bool {
+        self.ai_enabled.load(Ordering::Relaxed)
+    }
+
+    /// Enable or disable auto-information fan-out for this face.
+    pub(crate) fn set_ai_enabled(&self, enabled: bool) {
+        self.ai_enabled.store(enabled, Ordering::Relaxed);
+    }
+}
+
+/// A client CAT dialect. Implementations translate between a client's command
+/// vocabulary and the universal state plus backend.
+#[async_trait]
+pub(crate) trait ClientDialect: Send + Sync {
+    /// Handle one client request frame, returning the bytes to write back to
+    /// the client (empty when the command produces no reply).
+    async fn handle(&self, request: &[u8], ctx: &FaceContext) -> Vec<u8>;
+
+    /// Format a universal state change as an unsolicited frame for an
+    /// AI-subscribed client, or `None` if the dialect does not surface it.
+    fn format_notification(&self, change: &StateChange, ctx: &FaceContext) -> Option<Vec<u8>>;
+}

--- a/src/rust/qsoripper-cathub/src/error.rs
+++ b/src/rust/qsoripper-cathub/src/error.rs
@@ -1,0 +1,81 @@
+//! Typed error surfaces for the CAT hub.
+
+use std::io;
+
+use thiserror::Error;
+
+/// Errors raised while loading or validating configuration.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// The configuration file could not be read.
+    #[error("failed to read config file '{path}': {source}")]
+    Read {
+        /// Path that failed to load.
+        path: String,
+        /// Underlying I/O error.
+        source: io::Error,
+    },
+    /// The configuration file was not valid TOML or failed schema parsing.
+    #[error("failed to parse config: {0}")]
+    Parse(String),
+    /// The configuration parsed but was semantically invalid.
+    #[error("invalid configuration: {0}")]
+    Invalid(String),
+}
+
+/// Errors raised by a radio backend.
+#[derive(Debug, Error)]
+pub enum BackendError {
+    /// The radio transport failed (I/O, disconnect).
+    #[error("radio transport error: {0}")]
+    Transport(String),
+    /// A command timed out waiting for a reply.
+    #[error("radio command timed out: {0}")]
+    Timeout(String),
+    /// A reply could not be parsed.
+    #[error("failed to parse radio reply: {0}")]
+    Parse(String),
+    /// The backend does not support the requested operation.
+    #[error("operation not supported by backend: {0}")]
+    Unsupported(String),
+}
+
+/// Errors raised while running a client face.
+#[derive(Debug, Error)]
+pub enum FaceError {
+    /// The face's serial or network endpoint could not be bound.
+    #[error("failed to bind face '{name}' to '{endpoint}': {message}")]
+    Bind {
+        /// Face name from configuration.
+        name: String,
+        /// Endpoint that failed to bind.
+        endpoint: String,
+        /// Description of the bind failure.
+        message: String,
+    },
+    /// An I/O error occurred while serving the face.
+    #[error("face '{name}' I/O error: {source}")]
+    Io {
+        /// Face name from configuration.
+        name: String,
+        /// Underlying I/O error.
+        source: io::Error,
+    },
+}
+
+/// Top-level error type for the daemon.
+#[derive(Debug, Error)]
+pub enum CatHubError {
+    /// Configuration failed to load or validate.
+    #[error(transparent)]
+    Config(#[from] ConfigError),
+    /// A backend failed fatally during startup.
+    #[error(transparent)]
+    Backend(#[from] BackendError),
+    /// A face failed fatally during startup.
+    #[error(transparent)]
+    Face(#[from] FaceError),
+    /// A generic I/O failure during startup or shutdown.
+    #[error("I/O error: {0}")]
+    Io(#[from] io::Error),
+}

--- a/src/rust/qsoripper-cathub/src/lib.rs
+++ b/src/rust/qsoripper-cathub/src/lib.rs
@@ -1,0 +1,153 @@
+//! `qsoripper-cathub`: a multi-client CAT hub that owns the radio's serial port
+//! and fans it out to multiple logging, panadapter, and engine clients.
+//!
+//! This crate is built as a library plus a thin binary so integration tests and
+//! the engine can drive the hub in-process. The public surface is intentionally
+//! minimal; the daemon internals are crate-private.
+
+#![forbid(unsafe_code)]
+
+mod backend;
+mod config;
+mod dialect;
+mod error;
+mod model;
+mod poller;
+mod radio;
+mod serial_face;
+mod state;
+
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::time::Duration;
+
+use clap::Parser;
+
+use crate::backend::kenwood::Ts590Backend;
+use crate::backend::loopback::LoopbackBackend;
+use crate::backend::{RadioBackend, StateMutation};
+use crate::config::{BackendKind, Config, DialectKind};
+use crate::dialect::kenwood::Ts590Dialect;
+use crate::dialect::{ClientDialect, FaceContext};
+use crate::error::{BackendError, ConfigError};
+use crate::poller::run_poller;
+use crate::radio::run_radio_task;
+use crate::state::{run_mutation_dispatcher, StateHandle};
+
+pub use error::CatHubError;
+
+/// Command-line arguments for the CAT hub daemon.
+#[derive(Debug, Parser)]
+#[command(
+    name = "qsoripper-cathub",
+    about = "Multi-client CAT hub for shared radio control"
+)]
+pub struct Cli {
+    /// Path to the TOML configuration file. Defaults to the per-user config path.
+    #[arg(long)]
+    pub config: Option<PathBuf>,
+    /// Path to a log file. When omitted, logs go to stderr.
+    #[arg(long)]
+    pub log: Option<PathBuf>,
+    /// Load and validate the configuration, print it, and exit.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
+/// Run the daemon to completion using the given command-line arguments.
+///
+/// # Errors
+///
+/// Returns a [`CatHubError`] if configuration fails to load or validate, if the
+/// radio transport cannot be opened, or if a face fails to bind.
+pub async fn run(cli: Cli) -> Result<(), CatHubError> {
+    let config_path = cli
+        .config
+        .or_else(config::default_config_path)
+        .ok_or_else(|| {
+            ConfigError::Invalid("no configuration path resolved; pass --config".to_string())
+        })?;
+    let config = Config::load(&config_path)?;
+    config.validate()?;
+
+    if cli.dry_run {
+        print!("{}", config.describe());
+        return Ok(());
+    }
+
+    run_daemon(config).await
+}
+
+async fn run_daemon(config: Config) -> Result<(), CatHubError> {
+    let (state, inbox) = StateHandle::new(256);
+    let reply_timeout = Duration::from_millis(config.radio.reply_timeout_ms);
+
+    let backend: Arc<dyn RadioBackend> = match config.radio.backend {
+        BackendKind::Ts590 => {
+            let (radio, inbox) = radio::channel(64);
+            let port = serial2_tokio::SerialPort::open(&config.radio.port, config.radio.baud)
+                .map_err(|e| {
+                    BackendError::Transport(format!(
+                        "opening radio port {}: {e}",
+                        config.radio.port
+                    ))
+                })?;
+            tokio::spawn(run_radio_task(port, inbox, reply_timeout));
+            // Disable the radio's auto-information so unsolicited frames can't
+            // desynchronize the polled request/reply stream.
+            if let Err(error) = radio.send(b"AI0;".to_vec(), false).await {
+                tracing::warn!(%error, "failed to disable radio auto-information");
+            }
+            Arc::new(Ts590Backend::new(radio))
+        }
+        BackendKind::Loopback => Arc::new(LoopbackBackend::new()),
+    };
+
+    tokio::spawn(run_mutation_dispatcher(
+        inbox,
+        backend.clone(),
+        state.clone(),
+    ));
+    tokio::spawn(run_poller(
+        backend.clone(),
+        state.clone(),
+        Duration::from_millis(config.poll.baseline_ms),
+    ));
+
+    // Prime the cache with one poll so early client reads see real radio state
+    // instead of defaults. Best-effort: the baseline poller retries on failure.
+    if let Err(error) = backend.poll(&state).await {
+        tracing::warn!(%error, "initial poll failed; serving defaults until next poll");
+    }
+
+    for face in &config.faces {
+        let ctx = FaceContext::new(
+            face.name.clone(),
+            face.permissions(),
+            state.clone(),
+            backend.clone(),
+        );
+        let dialect: Arc<dyn ClientDialect> = match face.dialect {
+            DialectKind::Ts590 => Arc::new(Ts590Dialect::new()),
+        };
+        let port = serial_face::open_serial(&face.name, &face.port, face.baud)?;
+        let name = face.name.clone();
+        let changes = state.subscribe();
+        tokio::spawn(async move {
+            if let Err(error) = serial_face::run_face(port, dialect, ctx, changes).await {
+                tracing::error!(%error, face = %name, "face stopped");
+            }
+        });
+    }
+
+    tracing::info!("cathub running; press Ctrl+C to stop");
+    tokio::signal::ctrl_c().await?;
+    tracing::info!("shutdown requested; releasing PTT");
+    let release = state.apply_mutation(StateMutation::Ptt { keyed: false });
+    match tokio::time::timeout(Duration::from_millis(500), release).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => tracing::warn!(%error, "failed to release PTT on shutdown"),
+        Err(_) => tracing::warn!("timed out releasing PTT on shutdown"),
+    }
+    Ok(())
+}

--- a/src/rust/qsoripper-cathub/src/main.rs
+++ b/src/rust/qsoripper-cathub/src/main.rs
@@ -1,0 +1,25 @@
+//! Thin binary entry point for the CAT hub daemon: initialize logging, parse
+//! arguments, and run the daemon until shutdown.
+
+use clap::Parser as _;
+use qsoripper_cathub::{run, Cli};
+use tracing_subscriber::EnvFilter;
+
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .with_writer(std::io::stderr)
+        .init();
+
+    let cli = Cli::parse();
+    match run(cli).await {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(error) => {
+            tracing::error!(%error, "cathub failed");
+            std::process::ExitCode::FAILURE
+        }
+    }
+}

--- a/src/rust/qsoripper-cathub/src/model.rs
+++ b/src/rust/qsoripper-cathub/src/model.rs
@@ -1,0 +1,112 @@
+//! Core domain enums shared across the hub: VFO selection and operating mode.
+
+use std::fmt;
+
+/// Identifies one of the radio's two VFOs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum Vfo {
+    /// VFO A.
+    A,
+    /// VFO B.
+    B,
+}
+
+impl fmt::Display for Vfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Vfo::A => f.write_str("A"),
+            Vfo::B => f.write_str("B"),
+        }
+    }
+}
+
+/// Operating mode, normalized across radio families.
+///
+/// The numeric encoding mirrors the Kenwood `MD` command digits so the TS-590
+/// backend maps modes with a simple table while remaining a backend-independent
+/// universal value for dialects.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum Mode {
+    /// Lower sideband.
+    Lsb,
+    /// Upper sideband.
+    Usb,
+    /// CW (normal).
+    Cw,
+    /// FM.
+    Fm,
+    /// AM.
+    Am,
+    /// FSK / RTTY.
+    Fsk,
+    /// CW reverse.
+    CwR,
+    /// FSK reverse.
+    FskR,
+}
+
+impl Mode {
+    /// Render the mode as its Kenwood `MD` digit.
+    pub(crate) fn to_kenwood_digit(self) -> char {
+        match self {
+            Mode::Lsb => '1',
+            Mode::Usb => '2',
+            Mode::Cw => '3',
+            Mode::Fm => '4',
+            Mode::Am => '5',
+            Mode::Fsk => '6',
+            Mode::CwR => '7',
+            Mode::FskR => '9',
+        }
+    }
+
+    /// Parse a Kenwood `MD` digit into a mode.
+    pub(crate) fn from_kenwood_digit(digit: char) -> Option<Self> {
+        match digit {
+            '1' => Some(Mode::Lsb),
+            '2' => Some(Mode::Usb),
+            '3' => Some(Mode::Cw),
+            '4' => Some(Mode::Fm),
+            '5' => Some(Mode::Am),
+            '6' => Some(Mode::Fsk),
+            '7' => Some(Mode::CwR),
+            '9' => Some(Mode::FskR),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kenwood_mode_digits_round_trip() {
+        for mode in [
+            Mode::Lsb,
+            Mode::Usb,
+            Mode::Cw,
+            Mode::Fm,
+            Mode::Am,
+            Mode::Fsk,
+            Mode::CwR,
+            Mode::FskR,
+        ] {
+            let digit = mode.to_kenwood_digit();
+            assert_eq!(Mode::from_kenwood_digit(digit), Some(mode));
+        }
+    }
+
+    #[test]
+    fn unknown_kenwood_digit_is_none() {
+        assert_eq!(Mode::from_kenwood_digit('0'), None);
+        assert_eq!(Mode::from_kenwood_digit('8'), None);
+    }
+
+    #[test]
+    fn vfo_display_renders_letter() {
+        assert_eq!(Vfo::A.to_string(), "A");
+        assert_eq!(Vfo::B.to_string(), "B");
+    }
+}

--- a/src/rust/qsoripper-cathub/src/poller.rs
+++ b/src/rust/qsoripper-cathub/src/poller.rs
@@ -1,0 +1,45 @@
+//! Baseline poll task. Drives the active backend to refresh universal state on
+//! a fixed cadence so client reads can be served from cache between polls.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::backend::RadioBackend;
+use crate::state::StateHandle;
+
+/// Run the baseline poller until cancelled, refreshing state every `interval`.
+pub(crate) async fn run_poller(
+    backend: Arc<dyn RadioBackend>,
+    state: StateHandle,
+    interval: Duration,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        ticker.tick().await;
+        if let Err(error) = backend.poll(&state).await {
+            tracing::warn!(%error, "baseline poll failed");
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use crate::backend::loopback::LoopbackBackend;
+
+    #[tokio::test]
+    async fn poller_refreshes_state() {
+        let (state, _inbox) = StateHandle::new(16);
+        let backend: Arc<dyn RadioBackend> = Arc::new(LoopbackBackend::new());
+        let task = tokio::spawn(run_poller(
+            backend,
+            state.clone(),
+            Duration::from_millis(10),
+        ));
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert_eq!(state.snapshot().await.freq_a, 14_074_000);
+        task.abort();
+    }
+}

--- a/src/rust/qsoripper-cathub/src/radio.rs
+++ b/src/rust/qsoripper-cathub/src/radio.rs
@@ -1,0 +1,186 @@
+//! The radio task: the single owner of the serial transport. All radio access
+//! is serialized through its command inbox so no two clients ever interleave
+//! bytes on the wire. The task is generic over the transport so tests drive it
+//! with an in-memory `tokio::io::duplex` pipe instead of a real port.
+
+use std::time::Duration;
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::{mpsc, oneshot};
+
+use crate::error::BackendError;
+
+/// Kenwood-family command/reply terminator.
+const TERMINATOR: u8 = b';';
+
+/// One serialized radio command and its reply slot.
+pub(crate) struct RadioCommand {
+    /// Raw bytes to write to the radio (already terminated).
+    pub(crate) bytes: Vec<u8>,
+    /// Whether to wait for and return a reply frame.
+    pub(crate) expect_reply: bool,
+    /// Where to deliver the reply (or error).
+    pub(crate) reply: oneshot::Sender<Result<Vec<u8>, BackendError>>,
+}
+
+/// Cloneable handle used by backends to submit commands to the radio task.
+#[derive(Clone)]
+pub(crate) struct RadioHandle {
+    tx: mpsc::Sender<RadioCommand>,
+}
+
+impl RadioHandle {
+    /// Submit a command, optionally waiting for a terminated reply frame.
+    pub(crate) async fn send(
+        &self,
+        bytes: Vec<u8>,
+        expect_reply: bool,
+    ) -> Result<Vec<u8>, BackendError> {
+        let (reply, rx) = oneshot::channel();
+        self.tx
+            .send(RadioCommand {
+                bytes,
+                expect_reply,
+                reply,
+            })
+            .await
+            .map_err(|_| BackendError::Transport("radio task stopped".to_string()))?;
+        rx.await
+            .map_err(|_| BackendError::Transport("radio task dropped reply".to_string()))?
+    }
+}
+
+/// Create a radio command channel, returning the client handle and the inbox
+/// receiver to hand to [`run_radio_task`].
+pub(crate) fn channel(capacity: usize) -> (RadioHandle, mpsc::Receiver<RadioCommand>) {
+    let (tx, rx) = mpsc::channel(capacity);
+    (RadioHandle { tx }, rx)
+}
+
+/// Run the radio task over the given transport until the inbox is closed.
+///
+/// Commands are serviced strictly in order. For commands that expect a reply,
+/// bytes are read until the Kenwood terminator or the per-command timeout.
+pub(crate) async fn run_radio_task<T>(
+    mut transport: T,
+    mut inbox: mpsc::Receiver<RadioCommand>,
+    reply_timeout: Duration,
+) where
+    T: AsyncRead + AsyncWrite + Unpin,
+{
+    while let Some(command) = inbox.recv().await {
+        let result = service_command(&mut transport, &command, reply_timeout).await;
+        let _ = command.reply.send(result);
+    }
+}
+
+async fn service_command<T>(
+    transport: &mut T,
+    command: &RadioCommand,
+    reply_timeout: Duration,
+) -> Result<Vec<u8>, BackendError>
+where
+    T: AsyncRead + AsyncWrite + Unpin,
+{
+    transport
+        .write_all(&command.bytes)
+        .await
+        .map_err(|e| BackendError::Transport(e.to_string()))?;
+    transport
+        .flush()
+        .await
+        .map_err(|e| BackendError::Transport(e.to_string()))?;
+
+    if !command.expect_reply {
+        return Ok(Vec::new());
+    }
+
+    match tokio::time::timeout(reply_timeout, read_frame(transport)).await {
+        Ok(result) => result,
+        Err(_) => Err(BackendError::Timeout(format!(
+            "no reply within {reply_timeout:?}"
+        ))),
+    }
+}
+
+async fn read_frame<T>(transport: &mut T) -> Result<Vec<u8>, BackendError>
+where
+    T: AsyncRead + Unpin,
+{
+    let mut frame = Vec::new();
+    loop {
+        let byte = transport
+            .read_u8()
+            .await
+            .map_err(|e| BackendError::Transport(e.to_string()))?;
+        frame.push(byte);
+        if byte == TERMINATOR {
+            return Ok(frame);
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::unused_async
+)]
+mod tests {
+    use super::*;
+
+    async fn spawn_with_fake() -> (RadioHandle, tokio::io::DuplexStream) {
+        let (handle, inbox) = channel(8);
+        let (client_side, radio_side) = tokio::io::duplex(1024);
+        tokio::spawn(run_radio_task(
+            radio_side,
+            inbox,
+            Duration::from_millis(200),
+        ));
+        (handle, client_side)
+    }
+
+    #[tokio::test]
+    async fn command_with_reply_reads_until_terminator() {
+        let (handle, mut fake) = spawn_with_fake().await;
+        let writer = tokio::spawn(async move {
+            let mut got = vec![0u8; 3];
+            fake.read_exact(&mut got).await.expect("read request");
+            assert_eq!(&got, b"FA;");
+            fake.write_all(b"FA00014074000;")
+                .await
+                .expect("write reply");
+            fake.flush().await.expect("flush");
+        });
+        let reply = handle.send(b"FA;".to_vec(), true).await.expect("reply");
+        assert_eq!(reply, b"FA00014074000;".to_vec());
+        writer.await.expect("writer task");
+    }
+
+    #[tokio::test]
+    async fn command_without_reply_returns_empty() {
+        let (handle, mut fake) = spawn_with_fake().await;
+        let reader = tokio::spawn(async move {
+            let mut got = vec![0u8; 14];
+            fake.read_exact(&mut got).await.expect("read request");
+            assert_eq!(&got, b"FA00021074000;");
+        });
+        let reply = handle
+            .send(b"FA00021074000;".to_vec(), false)
+            .await
+            .expect("ok");
+        assert!(reply.is_empty());
+        reader.await.expect("reader task");
+    }
+
+    #[tokio::test]
+    async fn missing_reply_times_out() {
+        let (handle, _fake) = spawn_with_fake().await;
+        let err = handle
+            .send(b"FA;".to_vec(), true)
+            .await
+            .expect_err("timeout");
+        assert!(matches!(err, BackendError::Timeout(_)));
+    }
+}

--- a/src/rust/qsoripper-cathub/src/serial_face.rs
+++ b/src/rust/qsoripper-cathub/src/serial_face.rs
@@ -1,0 +1,201 @@
+//! A serial face: one virtual COM port (or in-memory transport) bound to a
+//! client dialect. Reads client commands, frames them on the Kenwood
+//! terminator, dispatches them to the dialect, writes replies, and pushes
+//! auto-information notifications when the face has AI enabled.
+
+use std::sync::Arc;
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::sync::broadcast;
+use tokio::sync::broadcast::error::RecvError;
+
+use crate::dialect::{ClientDialect, FaceContext};
+use crate::error::FaceError;
+use crate::state::StateChange;
+
+/// Kenwood command terminator used for framing.
+const TERMINATOR: u8 = b';';
+
+/// Open a virtual serial port for a face.
+pub(crate) fn open_serial(
+    name: &str,
+    port: &str,
+    baud: u32,
+) -> Result<serial2_tokio::SerialPort, FaceError> {
+    serial2_tokio::SerialPort::open(port, baud).map_err(|error| FaceError::Bind {
+        name: name.to_string(),
+        endpoint: port.to_string(),
+        message: error.to_string(),
+    })
+}
+
+/// Drive one face over the given transport until the client disconnects.
+///
+/// `changes` is the caller-provided change subscription; subscribing before the
+/// task is spawned guarantees no state change is missed between spawn and the
+/// first poll of the receiver.
+pub(crate) async fn run_face<T>(
+    mut transport: T,
+    dialect: Arc<dyn ClientDialect>,
+    ctx: FaceContext,
+    mut changes: broadcast::Receiver<StateChange>,
+) -> Result<(), FaceError>
+where
+    T: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut pending = Vec::new();
+    let mut chunk = [0u8; 256];
+
+    loop {
+        tokio::select! {
+            read = transport.read(&mut chunk) => {
+                let n = read.map_err(|source| FaceError::Io {
+                    name: ctx.name().to_string(),
+                    source,
+                })?;
+                if n == 0 {
+                    return Ok(());
+                }
+                if let Some(slice) = chunk.get(..n) {
+                    pending.extend_from_slice(slice);
+                }
+                drain_frames(&mut transport, &mut pending, dialect.as_ref(), &ctx).await?;
+            }
+            change = changes.recv() => {
+                match change {
+                    Ok(change) => {
+                        if let Some(frame) = dialect.format_notification(&change, &ctx) {
+                            write_all(&mut transport, &frame, &ctx).await?;
+                        }
+                    }
+                    Err(RecvError::Lagged(_)) => {}
+                    Err(RecvError::Closed) => return Ok(()),
+                }
+            }
+        }
+    }
+}
+
+async fn drain_frames<T>(
+    transport: &mut T,
+    pending: &mut Vec<u8>,
+    dialect: &dyn ClientDialect,
+    ctx: &FaceContext,
+) -> Result<(), FaceError>
+where
+    T: AsyncWrite + Unpin,
+{
+    while let Some(pos) = pending.iter().position(|&b| b == TERMINATOR) {
+        let frame: Vec<u8> = pending.drain(..=pos).collect();
+        let reply = dialect.handle(&frame, ctx).await;
+        if !reply.is_empty() {
+            write_all(transport, &reply, ctx).await?;
+        }
+    }
+    Ok(())
+}
+
+async fn write_all<T>(transport: &mut T, bytes: &[u8], ctx: &FaceContext) -> Result<(), FaceError>
+where
+    T: AsyncWrite + Unpin,
+{
+    transport
+        .write_all(bytes)
+        .await
+        .map_err(|source| FaceError::Io {
+            name: ctx.name().to_string(),
+            source,
+        })?;
+    transport.flush().await.map_err(|source| FaceError::Io {
+        name: ctx.name().to_string(),
+        source,
+    })
+}
+
+#[cfg(test)]
+#[allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::unused_async
+)]
+mod tests {
+    use super::*;
+    use crate::backend::loopback::LoopbackBackend;
+    use crate::dialect::kenwood::Ts590Dialect;
+    use crate::dialect::Permissions;
+    use crate::model::Vfo;
+    use crate::state::{run_mutation_dispatcher, StateHandle};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn face_answers_read_and_applies_write() {
+        let (state, inbox) = StateHandle::new(16);
+        let backend = Arc::new(LoopbackBackend::new());
+        let dispatcher = tokio::spawn(run_mutation_dispatcher(
+            inbox,
+            backend.clone(),
+            state.clone(),
+        ));
+        state.set_frequency(Vfo::A, 14_074_000).await;
+
+        let ctx = FaceContext::new(
+            "n1mm",
+            Permissions::default(),
+            state.clone(),
+            backend.clone(),
+        );
+        let dialect: Arc<dyn ClientDialect> = Arc::new(Ts590Dialect::new());
+        let (mut client, face_side) = tokio::io::duplex(1024);
+        let changes = state.subscribe();
+        let face = tokio::spawn(run_face(face_side, dialect, ctx, changes));
+
+        client.write_all(b"FA;").await.expect("write read cmd");
+        let mut reply = vec![0u8; 14];
+        client.read_exact(&mut reply).await.expect("read reply");
+        assert_eq!(&reply, b"FA00014074000;");
+
+        client
+            .write_all(b"FA00021074000;")
+            .await
+            .expect("write set cmd");
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        assert_eq!(state.snapshot().await.freq_a, 21_074_000);
+
+        drop(client);
+        face.await.expect("face task").expect("face ok");
+        dispatcher.abort();
+    }
+
+    #[tokio::test]
+    async fn ai_subscribed_face_receives_notifications() {
+        let (state, inbox) = StateHandle::new(16);
+        let backend = Arc::new(LoopbackBackend::new());
+        let dispatcher = tokio::spawn(run_mutation_dispatcher(
+            inbox,
+            backend.clone(),
+            state.clone(),
+        ));
+
+        let ctx = FaceContext::new(
+            "n1mm",
+            Permissions::default(),
+            state.clone(),
+            backend.clone(),
+        );
+        ctx.set_ai_enabled(true);
+        let dialect: Arc<dyn ClientDialect> = Arc::new(Ts590Dialect::new());
+        let (mut client, face_side) = tokio::io::duplex(1024);
+        let changes = state.subscribe();
+        let face = tokio::spawn(run_face(face_side, dialect, ctx, changes));
+
+        state.set_frequency(Vfo::A, 18_100_000).await;
+        let mut reply = vec![0u8; 14];
+        client.read_exact(&mut reply).await.expect("notification");
+        assert_eq!(&reply, b"FA00018100000;");
+
+        drop(client);
+        face.await.expect("face task").expect("face ok");
+        dispatcher.abort();
+    }
+}

--- a/src/rust/qsoripper-cathub/src/state.rs
+++ b/src/rust/qsoripper-cathub/src/state.rs
@@ -1,0 +1,236 @@
+//! Universal in-memory rig state, the mutation dispatch channel, and the
+//! change-notification broadcast.
+//!
+//! Every path that observes or changes the radio goes through this layer:
+//! backends populate it, dialects read and mutate it, and the poller refreshes
+//! it. Faces subscribe to [`StateHandle::subscribe`] to push updates to
+//! auto-information clients.
+
+use std::sync::Arc;
+
+use tokio::sync::{broadcast, mpsc, oneshot, RwLock};
+
+use crate::backend::{RadioBackend, StateMutation};
+use crate::error::BackendError;
+use crate::model::{Mode, Vfo};
+
+/// A change to one universal-state field, broadcast to faces for AI fan-out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StateChange {
+    /// A VFO frequency changed.
+    Frequency {
+        /// Affected VFO.
+        vfo: Vfo,
+        /// New frequency in Hz.
+        hz: u64,
+    },
+    /// A VFO mode changed.
+    Mode {
+        /// Affected VFO.
+        vfo: Vfo,
+        /// New mode.
+        mode: Mode,
+    },
+}
+
+/// The universal rig state snapshot.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RigState {
+    /// VFO A frequency in Hz.
+    pub(crate) freq_a: u64,
+    /// VFO B frequency in Hz.
+    pub(crate) freq_b: u64,
+    /// VFO A mode.
+    pub(crate) mode_a: Mode,
+    /// VFO B mode.
+    pub(crate) mode_b: Mode,
+    /// Active receive VFO.
+    pub(crate) rx_vfo: Vfo,
+}
+
+impl Default for RigState {
+    fn default() -> Self {
+        Self {
+            freq_a: 0,
+            freq_b: 0,
+            mode_a: Mode::Usb,
+            mode_b: Mode::Usb,
+            rx_vfo: Vfo::A,
+        }
+    }
+}
+
+impl RigState {
+    /// Frequency for the given VFO.
+    pub(crate) fn freq(&self, vfo: Vfo) -> u64 {
+        match vfo {
+            Vfo::A => self.freq_a,
+            Vfo::B => self.freq_b,
+        }
+    }
+
+    /// Mode for the given VFO.
+    pub(crate) fn mode(&self, vfo: Vfo) -> Mode {
+        match vfo {
+            Vfo::A => self.mode_a,
+            Vfo::B => self.mode_b,
+        }
+    }
+}
+
+/// A request to mutate the radio, carried over the dispatch channel.
+struct MutationRequest {
+    mutation: StateMutation,
+    reply: oneshot::Sender<Result<(), BackendError>>,
+}
+
+/// Opaque wrapper around the mutation receiver so the channel payload stays
+/// private while the receiver can be handed to the dispatcher.
+pub(crate) struct MutationInbox {
+    rx: mpsc::Receiver<MutationRequest>,
+}
+
+/// Shared, cloneable handle to the universal rig state.
+#[derive(Clone)]
+pub(crate) struct StateHandle {
+    inner: Arc<RwLock<RigState>>,
+    changes: broadcast::Sender<StateChange>,
+    mutations: mpsc::Sender<MutationRequest>,
+}
+
+impl StateHandle {
+    /// Create a state handle plus the receiver half of the mutation channel.
+    ///
+    /// The caller runs [`run_mutation_dispatcher`] with the returned inbox and
+    /// the active backend to service [`StateHandle::apply_mutation`] calls.
+    pub(crate) fn new(broadcast_capacity: usize) -> (Self, MutationInbox) {
+        let (changes, _) = broadcast::channel(broadcast_capacity);
+        let (mutations, rx) = mpsc::channel(64);
+        let handle = Self {
+            inner: Arc::new(RwLock::new(RigState::default())),
+            changes,
+            mutations,
+        };
+        (handle, MutationInbox { rx })
+    }
+
+    /// Subscribe to the change-notification broadcast.
+    pub(crate) fn subscribe(&self) -> broadcast::Receiver<StateChange> {
+        self.changes.subscribe()
+    }
+
+    /// Take a snapshot of the current state.
+    pub(crate) async fn snapshot(&self) -> RigState {
+        *self.inner.read().await
+    }
+
+    fn broadcast(&self, change: StateChange) {
+        // A send error only means there are no subscribers, which is fine.
+        let _ = self.changes.send(change);
+    }
+
+    /// Set a VFO frequency and broadcast the change.
+    pub(crate) async fn set_frequency(&self, vfo: Vfo, hz: u64) {
+        {
+            let mut state = self.inner.write().await;
+            match vfo {
+                Vfo::A => state.freq_a = hz,
+                Vfo::B => state.freq_b = hz,
+            }
+        }
+        self.broadcast(StateChange::Frequency { vfo, hz });
+    }
+
+    /// Set a VFO mode and broadcast the change.
+    pub(crate) async fn set_mode(&self, vfo: Vfo, mode: Mode) {
+        {
+            let mut state = self.inner.write().await;
+            match vfo {
+                Vfo::A => state.mode_a = mode,
+                Vfo::B => state.mode_b = mode,
+            }
+        }
+        self.broadcast(StateChange::Mode { vfo, mode });
+    }
+
+    /// Submit a mutation for the backend to apply, awaiting the result.
+    pub(crate) async fn apply_mutation(&self, mutation: StateMutation) -> Result<(), BackendError> {
+        let (reply, rx) = oneshot::channel();
+        self.mutations
+            .send(MutationRequest { mutation, reply })
+            .await
+            .map_err(|_| BackendError::Transport("mutation dispatcher stopped".to_string()))?;
+        rx.await
+            .map_err(|_| BackendError::Transport("mutation dispatcher dropped reply".to_string()))?
+    }
+}
+
+/// Run the mutation dispatcher: pull mutation requests and apply them through
+/// the backend, which updates the shared state on success.
+pub(crate) async fn run_mutation_dispatcher(
+    mut inbox: MutationInbox,
+    backend: Arc<dyn RadioBackend>,
+    state: StateHandle,
+) {
+    while let Some(request) = inbox.rx.recv().await {
+        let result = backend.apply(request.mutation, &state).await;
+        let _ = request.reply.send(result);
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use crate::backend::loopback::LoopbackBackend;
+
+    #[tokio::test]
+    async fn set_frequency_updates_snapshot() {
+        let (handle, _inbox) = StateHandle::new(16);
+        handle.set_frequency(Vfo::A, 14_074_000).await;
+        assert_eq!(handle.snapshot().await.freq_a, 14_074_000);
+    }
+
+    #[tokio::test]
+    async fn set_mode_updates_snapshot() {
+        let (handle, _inbox) = StateHandle::new(16);
+        handle.set_mode(Vfo::B, Mode::Cw).await;
+        assert_eq!(handle.snapshot().await.mode_b, Mode::Cw);
+    }
+
+    #[tokio::test]
+    async fn subscribers_receive_changes() {
+        let (handle, _inbox) = StateHandle::new(16);
+        let mut rx = handle.subscribe();
+        handle.set_mode(Vfo::A, Mode::Cw).await;
+        let change = rx.recv().await.expect("a change");
+        assert_eq!(
+            change,
+            StateChange::Mode {
+                vfo: Vfo::A,
+                mode: Mode::Cw
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_mutation_round_trips_through_backend() {
+        let (handle, inbox) = StateHandle::new(16);
+        let backend = Arc::new(LoopbackBackend::new());
+        let dispatcher = tokio::spawn(run_mutation_dispatcher(
+            inbox,
+            backend.clone(),
+            handle.clone(),
+        ));
+        handle
+            .apply_mutation(StateMutation::Frequency {
+                vfo: Vfo::A,
+                hz: 21_074_000,
+            })
+            .await
+            .expect("mutation applied");
+        assert_eq!(handle.snapshot().await.freq_a, 21_074_000);
+        assert_eq!(backend.recorded_mutations().len(), 1);
+        dispatcher.abort();
+    }
+}

--- a/src/rust/qsoripper-cathub/tests/cli.rs
+++ b/src/rust/qsoripper-cathub/tests/cli.rs
@@ -1,0 +1,90 @@
+//! Integration coverage for the public CLI entry point: configuration
+//! resolution, the dry-run path, and load/parse error surfaces.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::path::PathBuf;
+
+use qsoripper_cathub::{run, Cli};
+
+fn temp_config(contents: &str) -> PathBuf {
+    let unique = format!(
+        "cathub-test-{}-{}.toml",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time after epoch")
+            .as_nanos()
+    );
+    let path = std::env::temp_dir().join(unique);
+    std::fs::write(&path, contents).expect("write temp config");
+    path
+}
+
+#[tokio::test]
+async fn dry_run_validates_and_returns_ok() {
+    let path = temp_config(
+        r#"
+[radio]
+port = "COM3"
+backend = "loopback"
+
+[[face]]
+name = "n1mm"
+port = "COM11"
+dialect = "ts590"
+"#,
+    );
+    let cli = Cli {
+        config: Some(path.clone()),
+        log: None,
+        dry_run: true,
+    };
+    let result = run(cli).await;
+    std::fs::remove_file(&path).ok();
+    assert!(result.is_ok(), "dry-run should succeed: {result:?}");
+}
+
+#[tokio::test]
+async fn missing_config_file_is_an_error() {
+    let path = std::env::temp_dir().join("cathub-missing-config-should-not-exist.toml");
+    std::fs::remove_file(&path).ok();
+    let cli = Cli {
+        config: Some(path),
+        log: None,
+        dry_run: true,
+    };
+    assert!(run(cli).await.is_err());
+}
+
+#[tokio::test]
+async fn invalid_config_is_an_error() {
+    let path = temp_config("this is not valid [[ toml");
+    let cli = Cli {
+        config: Some(path.clone()),
+        log: None,
+        dry_run: true,
+    };
+    let result = run(cli).await;
+    std::fs::remove_file(&path).ok();
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn invalid_semantics_are_rejected() {
+    let path = temp_config(
+        r#"
+[radio]
+port = "  "
+backend = "loopback"
+"#,
+    );
+    let cli = Cli {
+        config: Some(path.clone()),
+        log: None,
+        dry_run: true,
+    };
+    let result = run(cli).await;
+    std::fs::remove_file(&path).ok();
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Phase 1 of the qsoripper-cathub multi-client CAT hub described in docs/design/cathub-multi-client-cat-hub.md (design merged in #467 and #468). This delivers the single-radio vertical slice: a new lib+bin crate where one tokio task owns the TS-590 serial port, a universal RigState is driven by a baseline poller, and an N1MM-facing native Kenwood dialect is served over one serial face. A LoopbackBackend plus tokio::io::duplex fakes make every code path testable without hardware. Adds a TOML config loader with a --dry-run validate-and-exit mode and thiserror typed errors.

The serial transport uses serial2-tokio (BSD-2-Clause) rather than tokio-serial, because tokio-serial pulls in serialport under MPL-2.0 which the permissive-only cargo deny policy forbids. Startup sends AI0 to disable radio auto-information so unsolicited frames cannot desynchronize the polled request/reply stream, primes the cache with an initial poll, and bounds the shutdown PTT release with a timeout.

Validation: cargo fmt, clippy -D warnings, 43 tests, cargo deny, and the workspace coverage gate all pass. OmniRig TS-2000 dialect, the Hamlib net face, coalesced polling, and PTT ownership land in later phases.