### PR TITLE
Default PRs to require review; autocomplete is opt-in

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -73,8 +73,9 @@ Primary goals:
 - Before pushing commits to a branch that has an associated PR, check the PR status with `gh pr view` first. The PR may have already been merged or closed. If so, create a new PR.
 - When creating PRs, use a plain text description. Avoid heavy markdown with lists, headings, and bullet points.
 - When creating feature branches, use `u/<alias>/BranchName` as the convention.
-- After creating a PR, arm it for auto-merge unless the user explicitly says not to: `gh pr merge --auto --squash`. The repository is configured with a merge queue, so an armed PR will enter the queue automatically when all required checks pass. Do not poll or babysit the PR after arming auto-merge.
-- The helper function `New-AutoPR` in `scripts/profile-helpers.ps1` (created via `git push -u origin HEAD; gh pr create --base main --fill; gh pr merge --auto --squash`) is the canonical one-shot flow.
+- After creating a PR, do NOT arm auto-merge by default. The PR requires at least one approval before it can merge. Leave it for a reviewer unless the user explicitly asks to enable autocomplete behavior.
+- To opt in to autocomplete behavior (merges automatically once approved and all checks pass), explicitly arm it after creating: `gh pr merge --auto --squash`. The merge queue takes over once the PR is approved and checks are green.
+- The helper function `New-PR` in `scripts/profile-helpers.ps1` (created via `git push -u origin HEAD; gh pr create --base main --fill`) is the default one-shot flow. Use `New-AutoPR` only when the user explicitly wants autocomplete behavior.
 - Squash is the only allowed merge method on `main`. Always pass `--squash` to `gh pr merge`.
 - Do not click or invoke "Update branch" on PRs. Branch protection no longer requires PRs to be up to date with `main` before merging; the merge queue handles speculative-merge testing automatically.
 - When a PR implements only part of a GitHub issue, do not reference the parent issue with a closing keyword (`Closes`, `Fixes`, `Resolves`). Instead, create a sub-issue scoped to the work in the PR, reference that sub-issue with a closing keyword in the PR, and add a comment on the parent issue linking to the PR and the sub-issue so progress is traceable. This prevents a partial merge from auto-closing an issue that still has open work.

--- a/scripts/profile-helpers.ps1
+++ b/scripts/profile-helpers.ps1
@@ -1,7 +1,7 @@
 # PowerShell helpers for qsoripper PR workflows.
 #
 # Dot-source this file from your $PROFILE to get one-shot PR helpers that
-# play nicely with the repository's merge queue and auto-merge settings on
+# play nicely with the repository's merge queue and branch protection on
 # https://github.com/treitforge/qsoripper.
 #
 # Example $PROFILE entry:
@@ -10,18 +10,77 @@
 # All helpers assume:
 #   * gh CLI is installed and authenticated
 #   * The repository's branch ruleset allows only squash merges on main
-#   * Auto-merge and the merge queue are enabled on main
+#   * main requires at least one approving review before a PR can merge
+#   * Auto-merge (autocomplete) is opt-in: arm it explicitly with New-AutoPR
+#     or Enable-AutoMerge after a reviewer approves
+
+function New-PR {
+    <#
+    .SYNOPSIS
+        Create a PR from the current branch. Does not arm auto-merge.
+
+    .DESCRIPTION
+        Creates a pull request targeting main using either an explicit title or
+        the current branch's commit message (via gh's --fill). The PR requires
+        at least one approving review before it can merge. Merging is manual
+        unless auto-merge is explicitly armed with Enable-AutoMerge.
+
+    .PARAMETER Title
+        Optional PR title. If omitted, gh pr create --fill uses the commit message.
+
+    .PARAMETER Body
+        Optional PR body. Only used when -Title is supplied.
+
+    .EXAMPLE
+        New-PR
+
+    .EXAMPLE
+        New-PR "feat: add CW decoder pitch discovery"
+
+    .EXAMPLE
+        New-PR -Title "fix: handle empty callsign" -Body "Avoids panic on QRZ miss."
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)][string]$Title,
+        [string]$Body = ""
+    )
+
+    if ($Title) {
+        gh pr create --base main --title $Title --body $Body
+    }
+    else {
+        gh pr create --base main --fill
+    }
+}
+
+function Enable-AutoMerge {
+    <#
+    .SYNOPSIS
+        Arm auto-merge (autocomplete) on the current branch's PR.
+
+    .DESCRIPTION
+        Arms the open PR for the current branch with squash auto-merge.
+        Once the PR has at least one approving review and all required checks
+        pass, the merge queue merges it automatically. Use this after creating
+        a PR when you want autocomplete behavior rather than a manual merge.
+
+    .EXAMPLE
+        Enable-AutoMerge
+    #>
+    gh pr merge --auto --squash
+}
 
 function New-AutoPR {
     <#
     .SYNOPSIS
-        Create a PR from the current branch and arm auto-merge (squash) in one shot.
+        Create a PR and immediately arm auto-merge (autocomplete) in one shot.
 
     .DESCRIPTION
-        Creates a pull request targeting main using either an explicit title or
-        the current branch's commit message (via gh's --fill), then arms it for
-        auto-merge with the squash strategy. When all required checks pass,
-        GitHub's merge queue takes over and merges the PR.
+        Creates a pull request targeting main and arms it for squash auto-merge.
+        Once the PR has at least one approving review and all required checks
+        pass, the merge queue merges it automatically. Use this only when you
+        explicitly want autocomplete behavior for the PR.
 
     .PARAMETER Title
         Optional PR title. If omitted, gh pr create --fill uses the commit message.
@@ -44,19 +103,48 @@ function New-AutoPR {
         [string]$Body = ""
     )
 
-    if ($Title) {
-        gh pr create --base main --title $Title --body $Body
-    }
-    else {
-        gh pr create --base main --fill
-    }
+    New-PR -Title $Title -Body $Body
 
     if ($LASTEXITCODE -ne 0) {
         Write-Error "gh pr create failed; not arming auto-merge."
         return
     }
 
-    gh pr merge --auto --squash
+    Enable-AutoMerge
+}
+
+function Push-PR {
+    <#
+    .SYNOPSIS
+        Push the current branch and open a PR. Does not arm auto-merge.
+
+    .DESCRIPTION
+        Combines git push -u origin HEAD with New-PR. The default one-shot
+        flow: edit, commit, then Push-PR. A reviewer must approve before the
+        PR can merge.
+
+    .PARAMETER Title
+        Optional PR title. Forwarded to New-PR.
+
+    .PARAMETER Body
+        Optional PR body. Forwarded to New-PR.
+
+    .EXAMPLE
+        Push-PR "fix: handle empty callsign"
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Position = 0)][string]$Title,
+        [string]$Body = ""
+    )
+
+    git push -u origin HEAD
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "git push failed; not creating PR."
+        return
+    }
+
+    New-PR -Title $Title -Body $Body
 }
 
 function Push-AutoPR {
@@ -65,8 +153,9 @@ function Push-AutoPR {
         Push the current branch, open a PR, and arm auto-merge in one shot.
 
     .DESCRIPTION
-        Combines git push -u origin HEAD with New-AutoPR. The most common entry
-        point: edit, commit, then Push-AutoPR.
+        Combines git push -u origin HEAD with New-AutoPR. Use only when you
+        explicitly want autocomplete behavior: the PR merges automatically
+        once approved and all checks pass.
 
     .PARAMETER Title
         Optional PR title. Forwarded to New-AutoPR.


### PR DESCRIPTION
Removes the automatic arm-auto-merge default from the PR workflow. PRs to main now require at least one approving review before merging.

New-PR creates a PR without arming auto-merge and is the new default. Enable-AutoMerge arms auto-merge on an existing PR as an explicit opt-in. New-AutoPR and Push-AutoPR are kept for when autocomplete behavior is explicitly desired.

Updates copilot-instructions.md to match the new default.