### PR TITLE
Add CAT hub daemon checkbox to launcher TUI

### DIFF
--- a/docs/integrations/cathub-setup.md
+++ b/docs/integrations/cathub-setup.md
@@ -92,13 +92,21 @@ Stop the hub with Ctrl+C in its window, or:
 ### Cold-start workflow (build + launch everything)
 
 For a clean start after logon, build all artifacts and then launch the hub together with the
-engines and UIs from one command:
+engines and UIs from the launcher TUI:
 
-    .\build.ps1                  # publishes qsoripper-cathub alongside the engines/UIs
-    .\launcher.ps1 -WithCatHub   # starts the CAT hub first, then the launcher TUI
+    .\build.ps1        # publishes qsoripper-cathub alongside the engines/UIs
+    .\launcher.ps1     # opens the launcher TUI
 
-`-WithCatHub` brings the radio daemon up in its own window (reading the unified `config.toml`)
-before the launcher starts engines and UIs, so everything connects to the hub's rigctld face.
+In the launcher, the first column ("Services") lists the **CAT hub daemon (rigctld :4532)**
+above the engines. Check it with `Space`, then press `Enter`. The launcher starts the hub
+first, waits for its rigctld face on `127.0.0.1:4532`, and only then starts the selected
+engines and UIs so everything connects to the hub. If the hub fails to come up the launcher
+aborts the rest of the launch; check `.\scripts\Get-CatHubLog.ps1 -Follow` for the cause. The
+hub reads the unified `config.toml` when it has a `[cat_hub]` table, otherwise the repo sample
+`config\cathub.toml`. Your selection (including the hub) is remembered for next time.
+
+`.\scripts\Start-CatHub.ps1` remains available as a manual, foreground helper for running the
+hub on its own (for example with `-DryRun` to validate config).
 
 ## 5. Point each application at the hub
 

--- a/launcher.ps1
+++ b/launcher.ps1
@@ -21,16 +21,12 @@
 
 .EXAMPLE
     .\launcher.ps1 -- --help
-
-.EXAMPLE
-    .\launcher.ps1 -WithCatHub
 #>
 
 [CmdletBinding()]
 param(
     [switch]$Dev,
     [switch]$Rebuild,
-    [switch]$WithCatHub,
     [Parameter(ValueFromRemainingArguments = $true)]
     [string[]]$Forward
 )
@@ -40,20 +36,6 @@ $ErrorActionPreference = 'Stop'
 $rustRoot = Join-Path $PSScriptRoot 'src\rust'
 if (-not (Test-Path -LiteralPath $rustRoot)) {
     throw "Rust workspace not found at $rustRoot"
-}
-
-# Bring up the CAT hub daemon first so it owns the radio and the engines/UIs can connect to
-# its rigctld-compatible face. It runs in its own console window and reads the unified config.
-if ($WithCatHub) {
-    $startCatHub = Join-Path $PSScriptRoot 'scripts\Start-CatHub.ps1'
-    if (-not (Test-Path -LiteralPath $startCatHub)) {
-        throw "Start-CatHub.ps1 not found at $startCatHub"
-    }
-    $catHubArgs = @('-NoLogo', '-NoExit', '-File', $startCatHub)
-    if ($Dev) { $catHubArgs += '-DebugBuild' }
-    Write-Host "Starting CAT hub daemon in a new window..." -ForegroundColor Cyan
-    Start-Process pwsh -ArgumentList $catHubArgs -WorkingDirectory $PSScriptRoot
-    Start-Sleep -Seconds 2
 }
 
 $profileDir = if ($Dev) { 'debug' } else { 'release' }

--- a/src/rust/qsoripper-launcher/src/catalog.rs
+++ b/src/rust/qsoripper-launcher/src/catalog.rs
@@ -10,6 +10,9 @@ pub(crate) type ComponentId = &'static str;
 /// Whether a component is an engine (acts as a gRPC server) or a UI client.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ComponentKind {
+    /// Background daemon/service that must be up before engines connect
+    /// (e.g. the CAT hub that owns the radio serial port).
+    Daemon,
     /// Engine that exposes a gRPC endpoint on a known TCP port.
     Engine,
     /// UI client that connects to one of the running engines.
@@ -22,7 +25,8 @@ pub(crate) struct ComponentSpec {
     pub id: ComponentId,
     pub display_name: &'static str,
     pub kind: ComponentKind,
-    /// `Some(port)` for engines that listen on a canonical 127.0.0.1 port.
+    /// Canonical 127.0.0.1 readiness port: an engine's gRPC port, or a
+    /// daemon's primary listening port. `None` for UIs and portless services.
     pub engine_port: Option<u16>,
     /// `true` if the UI honors `QSORIPPER_ENGINE` / `QSORIPPER_ENDPOINT` envs
     /// to pick an engine. Used to decide whether to show a binding picker.
@@ -61,6 +65,7 @@ impl ArtifactSpec {
     }
 }
 
+pub(crate) const DAEMON_CATHUB: ComponentId = "cathub";
 pub(crate) const ENGINE_RUST: ComponentId = "rust-engine";
 pub(crate) const ENGINE_DOTNET: ComponentId = "dotnet-engine";
 pub(crate) const UI_GUI: ComponentId = "gui";
@@ -72,6 +77,18 @@ pub(crate) const UI_WIN32: ComponentId = "win32";
 /// Static list of every component the launcher manages.
 pub(crate) fn catalog() -> Vec<ComponentSpec> {
     vec![
+        ComponentSpec {
+            id: DAEMON_CATHUB,
+            display_name: "CAT hub daemon (rigctld :4532)",
+            kind: ComponentKind::Daemon,
+            engine_port: Some(4532),
+            engine_bindable: false,
+            wants_console: false,
+            artifact: ArtifactSpec {
+                publish_subdir: "qsoripper-cathub",
+                executable_stem: "qsoripper-cathub",
+            },
+        },
         ComponentSpec {
             id: ENGINE_RUST,
             display_name: "Rust engine (qsoripper-server)",
@@ -196,5 +213,23 @@ mod tests {
         sorted.sort_unstable();
         sorted.dedup();
         assert_eq!(sorted.len(), ids.len(), "duplicate component id in catalog");
+    }
+
+    #[test]
+    fn cathub_daemon_is_in_catalog() {
+        let spec = find(DAEMON_CATHUB).expect("cathub daemon in catalog");
+        assert_eq!(spec.kind, ComponentKind::Daemon);
+        assert_eq!(spec.engine_port, Some(4532));
+        assert!(!spec.engine_bindable);
+        assert!(!spec.wants_console);
+        assert_eq!(spec.artifact.publish_subdir, "qsoripper-cathub");
+        assert_eq!(spec.artifact.executable_stem, "qsoripper-cathub");
+    }
+
+    #[test]
+    fn cathub_is_not_an_engine_endpoint() {
+        // The daemon carries a port for readiness probing, but must never be
+        // offered as a gRPC engine endpoint a UI can bind to.
+        assert!(engine_endpoint(DAEMON_CATHUB).is_none());
     }
 }

--- a/src/rust/qsoripper-launcher/src/config.rs
+++ b/src/rust/qsoripper-launcher/src/config.rs
@@ -54,6 +54,17 @@ fn extract_selection(doc: &DocumentMut) -> Selection {
         return sel;
     };
 
+    if let Some(daemons) = launcher.get("daemons").and_then(Item::as_array) {
+        let mut out = Vec::new();
+        for v in daemons {
+            if let Some(s) = v.as_str() {
+                if let Some(id) = resolve_known_id(s, ComponentKind::Daemon) {
+                    out.push(id);
+                }
+            }
+        }
+        sel.daemons = out;
+    }
     if let Some(engines) = launcher.get("engines").and_then(Item::as_array) {
         let mut out = Vec::new();
         for v in engines {
@@ -121,6 +132,12 @@ pub(crate) fn save(path: &Path, selection: &Selection) -> Result<()> {
         .as_table_mut()
         .context("[launcher] is not a table")?;
 
+    let mut daemons = Array::new();
+    for id in &selection.daemons {
+        daemons.push(*id);
+    }
+    launcher.insert("daemons", value(daemons));
+
     let mut engines = Array::new();
     for id in &selection.engines {
         engines.push(*id);
@@ -163,7 +180,7 @@ pub(crate) fn save(path: &Path, selection: &Selection) -> Result<()> {
 )]
 mod tests {
     use super::*;
-    use crate::catalog::{ENGINE_DOTNET, ENGINE_RUST, UI_DEBUGHOST, UI_GUI};
+    use crate::catalog::{DAEMON_CATHUB, ENGINE_DOTNET, ENGINE_RUST, UI_DEBUGHOST, UI_GUI};
     use tempfile::tempdir;
 
     #[test]
@@ -216,6 +233,17 @@ mod tests {
         let sel = load(&p).unwrap();
         assert_eq!(sel.bindings.get(&UI_GUI), Some(&ENGINE_DOTNET));
         assert_eq!(sel.bindings.get(&UI_DEBUGHOST), Some(&ENGINE_DOTNET));
+    }
+
+    #[test]
+    fn round_trips_selected_daemons() {
+        let dir = tempdir().unwrap();
+        let p = dir.path().join("config.toml");
+        let mut sel = Selection::default_preset();
+        sel.daemons = vec![DAEMON_CATHUB];
+        save(&p, &sel).unwrap();
+        let reloaded = load(&p).unwrap();
+        assert_eq!(reloaded.daemons, vec![DAEMON_CATHUB]);
     }
 
     #[test]

--- a/src/rust/qsoripper-launcher/src/main.rs
+++ b/src/rust/qsoripper-launcher/src/main.rs
@@ -55,7 +55,7 @@ fn main() -> Result<()> {
         None => config::default_shared_config_path()?,
     };
     let selection = config::load(&config_path)?;
-    let mut app = ui::AppState::new(selection, config_path, artifact_root);
+    let mut app = ui::AppState::new(selection, config_path, artifact_root, repo_root);
     ui::run(&mut app)
 }
 

--- a/src/rust/qsoripper-launcher/src/model.rs
+++ b/src/rust/qsoripper-launcher/src/model.rs
@@ -3,12 +3,16 @@
 use std::collections::BTreeMap;
 
 #[cfg(test)]
+use crate::catalog::DAEMON_CATHUB;
+#[cfg(test)]
 use crate::catalog::ENGINE_DOTNET;
 use crate::catalog::{catalog, ComponentId, ComponentKind, ENGINE_RUST, UI_DEBUGHOST, UI_GUI};
 
 /// User-editable launcher selection.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Selection {
+    /// Background daemons (e.g. the CAT hub) the user wants started first.
+    pub daemons: Vec<ComponentId>,
     /// Engines the user wants started.
     pub engines: Vec<ComponentId>,
     /// UIs the user wants started.
@@ -19,15 +23,22 @@ pub(crate) struct Selection {
 
 impl Selection {
     /// Default selection: Rust engine + Avalonia GUI + `DebugHost`, both bound to Rust.
+    /// Daemons stay off by default so the launcher never grabs the radio serial
+    /// port on machines without one attached.
     pub(crate) fn default_preset() -> Self {
         let mut bindings = BTreeMap::new();
         bindings.insert(UI_GUI, ENGINE_RUST);
         bindings.insert(UI_DEBUGHOST, ENGINE_RUST);
         Self {
+            daemons: Vec::new(),
             engines: vec![ENGINE_RUST],
             uis: vec![UI_GUI, UI_DEBUGHOST],
             bindings,
         }
+    }
+
+    pub(crate) fn daemon_selected(&self, id: ComponentId) -> bool {
+        self.daemons.contains(&id)
     }
 
     pub(crate) fn engine_selected(&self, id: ComponentId) -> bool {
@@ -38,14 +49,15 @@ impl Selection {
         self.uis.contains(&id)
     }
 
-    /// Toggle membership of `id` in either the engines or UIs list, depending
-    /// on the component kind. UIs that get unchecked keep their binding so it
-    /// is restored if the user toggles them back on.
+    /// Toggle membership of `id` in the daemons, engines, or UIs list,
+    /// depending on the component kind. UIs that get unchecked keep their
+    /// binding so it is restored if the user toggles them back on.
     pub(crate) fn toggle(&mut self, id: ComponentId) {
         let Some(spec) = catalog().into_iter().find(|c| c.id == id) else {
             return;
         };
         let list = match spec.kind {
+            ComponentKind::Daemon => &mut self.daemons,
             ComponentKind::Engine => &mut self.engines,
             ComponentKind::Ui => &mut self.uis,
         };
@@ -126,6 +138,25 @@ mod tests {
         assert!(sel.engine_selected(ENGINE_DOTNET));
         sel.toggle(ENGINE_DOTNET);
         assert!(!sel.engine_selected(ENGINE_DOTNET));
+    }
+
+    #[test]
+    fn toggle_routes_daemon_into_daemons_list() {
+        let mut sel = Selection::default_preset();
+        assert!(sel.daemons.is_empty());
+        sel.toggle(DAEMON_CATHUB);
+        assert!(sel.daemon_selected(DAEMON_CATHUB));
+        assert!(!sel.engine_selected(DAEMON_CATHUB));
+        sel.toggle(DAEMON_CATHUB);
+        assert!(!sel.daemon_selected(DAEMON_CATHUB));
+    }
+
+    #[test]
+    fn set_binding_rejects_daemon_as_engine_target() {
+        let mut sel = Selection::default_preset();
+        // The CAT hub daemon must never be selectable as a UI's engine.
+        sel.set_binding(UI_GUI, DAEMON_CATHUB);
+        assert_eq!(sel.bindings.get(&UI_GUI), Some(&ENGINE_RUST));
     }
 
     #[test]

--- a/src/rust/qsoripper-launcher/src/plan.rs
+++ b/src/rust/qsoripper-launcher/src/plan.rs
@@ -1,9 +1,10 @@
 //! Map a [`Selection`] onto concrete spawn arguments + env for each component.
 
 use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 
 use crate::catalog::{
-    engine_endpoint, find, ComponentSpec, ENGINE_DOTNET, ENGINE_RUST, UI_DEBUGHOST,
+    engine_endpoint, find, ComponentSpec, DAEMON_CATHUB, ENGINE_DOTNET, ENGINE_RUST, UI_DEBUGHOST,
 };
 use crate::model::Selection;
 
@@ -62,6 +63,50 @@ pub(crate) fn engine_plan(engine_id: &str) -> Option<LaunchPlan> {
         args: Vec::new(),
         env: Vec::new(),
     })
+}
+
+/// Build the launch plan for a background daemon. The CAT hub is passed an
+/// explicit `--config` so it reads the same file `Start-CatHub.ps1` would: the
+/// unified `config.toml` when it carries a top-level `[cat_hub]` table,
+/// otherwise the repo sample at `<repo_root>/config/cathub.toml`.
+pub(crate) fn daemon_plan(
+    daemon_id: &str,
+    unified_config_path: &Path,
+    repo_root: &Path,
+) -> Option<LaunchPlan> {
+    let spec = find(daemon_id)?;
+    let mut args: Vec<OsString> = Vec::new();
+    if daemon_id == DAEMON_CATHUB {
+        let config = resolve_cathub_config(unified_config_path, repo_root);
+        args.push("--config".into());
+        args.push(config.into_os_string());
+    }
+    Some(LaunchPlan {
+        spec,
+        args,
+        env: Vec::new(),
+    })
+}
+
+/// Choose the cathub config path. Uses the unified config only when it parses
+/// and exposes a top-level `cat_hub` table; any read/parse failure or a missing
+/// table falls back to the repo sample so a malformed unified file never makes
+/// the hub silently mis-parse it as a standalone cathub config.
+fn resolve_cathub_config(unified_config_path: &Path, repo_root: &Path) -> PathBuf {
+    if unified_has_cat_hub(unified_config_path) {
+        return unified_config_path.to_path_buf();
+    }
+    repo_root.join("config").join("cathub.toml")
+}
+
+fn unified_has_cat_hub(unified_config_path: &Path) -> bool {
+    let Ok(text) = std::fs::read_to_string(unified_config_path) else {
+        return false;
+    };
+    let Ok(doc) = text.parse::<toml_edit::DocumentMut>() else {
+        return false;
+    };
+    doc.get("cat_hub").is_some()
 }
 
 #[cfg(test)]
@@ -128,5 +173,61 @@ mod tests {
             strs,
             vec!["--urls".to_string(), "http://localhost:5082".to_string()]
         );
+    }
+
+    #[test]
+    fn daemon_plan_falls_back_to_repo_sample_without_cat_hub() {
+        let dir = tempfile::tempdir().unwrap();
+        let unified = dir.path().join("config.toml");
+        std::fs::write(&unified, "[launcher]\nengines = [\"rust-engine\"]\n").unwrap();
+        let repo_root = dir.path().join("repo");
+        let plan = daemon_plan(DAEMON_CATHUB, &unified, &repo_root).expect("plan");
+        let strs: Vec<String> = plan
+            .args
+            .into_iter()
+            .map(|a| a.into_string().unwrap())
+            .collect();
+        let expected = repo_root
+            .join("config")
+            .join("cathub.toml")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(strs, vec!["--config".to_string(), expected]);
+    }
+
+    #[test]
+    fn daemon_plan_uses_unified_config_when_it_has_cat_hub() {
+        let dir = tempfile::tempdir().unwrap();
+        let unified = dir.path().join("config.toml");
+        std::fs::write(&unified, "[cat_hub]\n[radio]\nport = \"COM3\"\n").unwrap();
+        let repo_root = dir.path().join("repo");
+        let plan = daemon_plan(DAEMON_CATHUB, &unified, &repo_root).expect("plan");
+        let strs: Vec<String> = plan
+            .args
+            .into_iter()
+            .map(|a| a.into_string().unwrap())
+            .collect();
+        let expected = unified.to_string_lossy().into_owned();
+        assert_eq!(strs, vec!["--config".to_string(), expected]);
+    }
+
+    #[test]
+    fn daemon_plan_falls_back_when_unified_config_is_invalid_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let unified = dir.path().join("config.toml");
+        std::fs::write(&unified, "this is = not valid = toml [[[").unwrap();
+        let repo_root = dir.path().join("repo");
+        let plan = daemon_plan(DAEMON_CATHUB, &unified, &repo_root).expect("plan");
+        let strs: Vec<String> = plan
+            .args
+            .into_iter()
+            .map(|a| a.into_string().unwrap())
+            .collect();
+        let expected = repo_root
+            .join("config")
+            .join("cathub.toml")
+            .to_string_lossy()
+            .into_owned();
+        assert_eq!(strs, vec!["--config".to_string(), expected]);
     }
 }

--- a/src/rust/qsoripper-launcher/src/ui.rs
+++ b/src/rust/qsoripper-launcher/src/ui.rs
@@ -20,7 +20,7 @@ use crate::catalog::{
 use crate::config;
 use crate::discovery::ArtifactRoot;
 use crate::model::Selection;
-use crate::plan::{engine_plan, ui_plan};
+use crate::plan::{daemon_plan, engine_plan, ui_plan};
 use crate::ports::{is_port_listening, wait_for_port};
 use crate::process::{open_url, spawn, stop_pid, ProcessRegistry};
 use crate::sync::{diff_rows, DialogState, DiffRow, Side, SyncDialog};
@@ -100,6 +100,7 @@ pub(crate) struct AppState {
     pub selection: Selection,
     pub config_path: PathBuf,
     pub artifact_root: ArtifactRoot,
+    repo_root: PathBuf,
     column: Column,
     cursor: BTreeMap<Column, usize>,
     statuses: BTreeMap<ComponentId, Status>,
@@ -115,6 +116,7 @@ impl AppState {
         selection: Selection,
         config_path: PathBuf,
         artifact_root: ArtifactRoot,
+        repo_root: PathBuf,
     ) -> Self {
         let mut cursor = BTreeMap::new();
         cursor.insert(Column::Engines, 0);
@@ -124,6 +126,7 @@ impl AppState {
             selection,
             config_path,
             artifact_root,
+            repo_root,
             column: Column::Engines,
             cursor,
             statuses: BTreeMap::new(),
@@ -192,10 +195,13 @@ impl AppState {
             .filter(|d| matches!(d.state, DialogState::Ready))
     }
 
-    fn engine_components() -> Vec<ComponentId> {
+    /// Components shown in the first column: daemons first (they start first),
+    /// then engines. The CAT hub lives here so it lists above the engines that
+    /// connect to it.
+    fn service_components() -> Vec<ComponentId> {
         catalog()
             .into_iter()
-            .filter(|c| c.kind == ComponentKind::Engine)
+            .filter(|c| matches!(c.kind, ComponentKind::Daemon | ComponentKind::Engine))
             .map(|c| c.id)
             .collect()
     }
@@ -220,7 +226,7 @@ impl AppState {
 
     fn current_list(&self) -> Vec<ComponentId> {
         match self.column {
-            Column::Engines => Self::engine_components(),
+            Column::Engines => Self::service_components(),
             Column::Uis => Self::ui_components(),
             Column::Bindings => self.bindable_uis_selected(),
         }
@@ -272,10 +278,60 @@ impl AppState {
         }
     }
 
-    /// Spawn every selected engine, wait for readiness, then spawn each
-    /// selected UI with the per-UI engine binding env vars.
+    /// Spawn every selected daemon, gating on its readiness port. Returns `false`
+    /// (with `last_message`/status set) if any daemon fails so the caller aborts
+    /// the rest of the launch.
+    fn launch_daemons(&mut self) -> bool {
+        for daemon_id in self.selection.daemons.clone() {
+            let Some(plan) = daemon_plan(daemon_id, &self.config_path, &self.repo_root) else {
+                continue;
+            };
+            let exe = plan.spec.artifact.executable_path(&self.artifact_root);
+            let port = plan.spec.engine_port.unwrap_or(0);
+            if port != 0 && is_port_listening(port, Duration::from_millis(200)) {
+                self.statuses
+                    .insert(daemon_id, Status::listening_external());
+                continue;
+            }
+            self.statuses.insert(daemon_id, Status::starting());
+            let arg_refs: Vec<&std::ffi::OsStr> = plan.args.iter().map(AsRef::as_ref).collect();
+            match spawn(&plan.spec, &exe, &arg_refs, &plan.env, &mut self.registry) {
+                Ok(p) => {
+                    if port != 0
+                        && !wait_for_port(port, Duration::from_secs(15), Duration::from_millis(300))
+                    {
+                        self.statuses.insert(
+                            daemon_id,
+                            Status::failed(&format!("never came up on 127.0.0.1:{port}")),
+                        );
+                        self.last_message = format!(
+                            "Aborted launch: {daemon_id} did not respond on 127.0.0.1:{port}. Check Get-CatHubLog.ps1."
+                        );
+                        return false;
+                    }
+                    self.statuses.insert(daemon_id, Status::running(p.pid));
+                }
+                Err(e) => {
+                    self.statuses
+                        .insert(daemon_id, Status::failed(&e.to_string()));
+                    self.last_message = format!("Aborted launch: failed to start {daemon_id}: {e}");
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// Spawn selected daemons, then engines (waiting for readiness on each),
+    /// then every selected UI with its per-UI engine binding env vars.
     fn launch_selected(&mut self) {
-        // Engines first.
+        // Daemons first: the CAT hub must own the radio and expose its rigctld
+        // face before any engine connects. Abort the launch if one fails.
+        if !self.launch_daemons() {
+            return;
+        }
+
+        // Engines next.
         for engine_id in self.selection.engines.clone() {
             let Some(plan) = engine_plan(engine_id) else {
                 continue;
@@ -435,7 +491,7 @@ fn render(frame: &mut ratatui::Frame, app: &AppState) {
         ])
         .areas(body_area);
 
-    render_column(frame, engines_area, app, Column::Engines, "Engines");
+    render_column(frame, engines_area, app, Column::Engines, "Services");
     render_column(frame, uis_area, app, Column::Uis, "UIs");
     render_column(frame, bindings_area, app, Column::Bindings, "Bindings");
 
@@ -621,7 +677,7 @@ fn render_column(
 ) {
     let active = app.column == column;
     let list_ids: Vec<ComponentId> = match column {
-        Column::Engines => AppState::engine_components(),
+        Column::Engines => AppState::service_components(),
         Column::Uis => AppState::ui_components(),
         Column::Bindings => app.bindable_uis_selected(),
     };
@@ -636,7 +692,11 @@ fn render_column(
                 .find(|c| c.id == *id)
                 .map_or(*id, |c| c.display_name);
             let checked = match column {
-                Column::Engines => app.selection.engine_selected(id),
+                // The Services column mixes daemons and engines; an id belongs
+                // to exactly one list, so a logical OR reflects either kind.
+                Column::Engines => {
+                    app.selection.engine_selected(id) || app.selection.daemon_selected(id)
+                }
                 Column::Uis => app.selection.ui_selected(id),
                 Column::Bindings => true,
             };


### PR DESCRIPTION
Replace the launcher.ps1 -WithCatHub switch with a first-class daemon
entry in the launcher TUI. The CAT hub (qsoripper-cathub) now appears as
the first row of the relabeled Services column. Selecting it starts the
hub first, waits for its rigctld face on 127.0.0.1:4532, and only then
launches the selected engines and UIs so everything connects through the
hub. A hub failure aborts the rest of the launch with a clear message.

Adds ComponentKind::Daemon, a daemons list in Selection (persisted to
launcher.daemons), config resolution that prefers the unified config.toml
when it has a [cat_hub] table and falls back to config/cathub.toml, and
regression tests guarding that the daemon is never treated as an engine
endpoint or binding target.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
