### PR TITLE
Add CAT Hub config editor to GUI Settings dialog

### DIFF
--- a/scripts/automation/avalonia-cathub-settings.json
+++ b/scripts/automation/avalonia-cathub-settings.json
@@ -1,0 +1,52 @@
+{
+  "inspectSurface": "Settings",
+  "window": {
+    "title": "Settings",
+    "x": 120,
+    "y": 80,
+    "width": 720,
+    "height": 900
+  },
+  "actions": [
+    {
+      "type": "wait",
+      "milliseconds": 600
+    },
+    {
+      "type": "click",
+      "automationId": "SettingsCatHubTab"
+    },
+    {
+      "type": "wait",
+      "milliseconds": 250
+    },
+    {
+      "type": "screenshot",
+      "path": "cathub-start.png"
+    },
+    {
+      "type": "click",
+      "automationId": "SettingsCatHubAddFaceButton"
+    },
+    {
+      "type": "wait",
+      "milliseconds": 150
+    },
+    {
+      "type": "click",
+      "automationId": "SettingsCatHubAddEndpointButton"
+    },
+    {
+      "type": "wait",
+      "milliseconds": 150
+    },
+    {
+      "type": "screenshot",
+      "path": "cathub-rows-added.png"
+    },
+    {
+      "type": "dump-tree",
+      "path": "cathub-tree.json"
+    }
+  ]
+}

--- a/src/dotnet/QsoRipper.Gui.Tests/SettingsViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/SettingsViewModelTests.cs
@@ -2,6 +2,7 @@ using QsoRipper.EngineSelection;
 using QsoRipper.Gui.Inspection;
 using QsoRipper.Gui.Services;
 using QsoRipper.Gui.ViewModels;
+using QsoRipper.Services;
 
 namespace QsoRipper.Gui.Tests;
 
@@ -156,5 +157,170 @@ public class SettingsViewModelTests
 
         Assert.Same(loopbackDevice, viewModel.SelectedRadioMonitorDevice);
         Assert.True(viewModel.ResolvedIsLoopback);
+    }
+
+    [Fact]
+    public async Task LoadAsyncPopulatesCatHubSectionFromStatus()
+    {
+        var client = new UxFixtureEngineClient(
+            new UxCaptureFixture
+            {
+                CatHubBackend = "ts590",
+                CatHubTransport = "serial",
+                CatHubPort = "COM3",
+                CatHubBaud = 115200,
+                CatHubFaceName = "omnirig",
+                CatHubFaceDialect = "ts2000",
+                CatHubEndpointName = "wsjtx",
+                CatHubEndpointBind = "127.0.0.1:4532"
+            });
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+
+        Assert.Equal("ts590", viewModel.CatHubBackend);
+        Assert.Equal("serial", viewModel.CatHubTransport);
+        Assert.Equal("COM3", viewModel.CatHubPort);
+        Assert.Equal("115200", viewModel.CatHubBaud);
+
+        var face = Assert.Single(viewModel.CatHubFaces);
+        Assert.Equal("omnirig", face.Name);
+        Assert.Equal("ts2000", face.Dialect);
+        Assert.True(face.PermRead);
+        Assert.True(face.PermWrite);
+        Assert.False(face.PermPtt);
+
+        var endpoint = Assert.Single(viewModel.CatHubEndpoints);
+        Assert.Equal("wsjtx", endpoint.Name);
+        Assert.Equal("127.0.0.1:4532", endpoint.Bind);
+        Assert.True(endpoint.PermRead);
+
+        // Loading must not look like an operator edit.
+        Assert.False(viewModel.IsCatHubDirty);
+        Assert.False(viewModel.ShowCatHubRewriteWarning);
+    }
+
+    [Fact]
+    public async Task SaveOmitsCatHubWhenSectionUntouched()
+    {
+        var client = new UxFixtureEngineClient(
+            new UxCaptureFixture
+            {
+                CatHubBackend = "ts590",
+                CatHubTransport = "serial",
+                CatHubPort = "COM3",
+                CatHubBaud = 115200,
+                CatHubEndpointName = "wsjtx",
+                CatHubEndpointBind = "127.0.0.1:4532"
+            });
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+        // Edit an unrelated section only.
+        viewModel.OperatorName = "Changed Operator";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        Assert.True(viewModel.DidSave);
+        Assert.NotNull(client.LastSaveSetupRequest);
+        // Omitted cat_hub means the engine preserves the section verbatim.
+        Assert.Null(client.LastSaveSetupRequest!.CatHub);
+    }
+
+    [Fact]
+    public async Task SaveEmitsCatHubWhenEdited()
+    {
+        var client = new UxFixtureEngineClient(
+            new UxCaptureFixture
+            {
+                CatHubBackend = "ts590",
+                CatHubTransport = "serial",
+                CatHubPort = "COM3",
+                CatHubBaud = 115200,
+                CatHubEndpointName = "wsjtx",
+                CatHubEndpointBind = "127.0.0.1:4532"
+            });
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+        viewModel.CatHubBaud = "57600";
+
+        Assert.True(viewModel.IsCatHubDirty);
+        Assert.True(viewModel.ShowCatHubRewriteWarning);
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        Assert.True(viewModel.DidSave);
+        var request = client.LastSaveSetupRequest;
+        Assert.NotNull(request!.CatHub);
+        Assert.Equal("ts590", request.CatHub.Radio.Backend);
+        Assert.Equal(57600u, request.CatHub.Radio.Baud);
+        var endpoint = Assert.Single(request.CatHub.HamlibNet);
+        Assert.Equal("wsjtx", endpoint.Name);
+        Assert.Contains(CatHubPermission.Read, endpoint.Perms);
+    }
+
+    [Fact]
+    public async Task SaveRejectsManagedCatHubWithoutEndpoints()
+    {
+        var client = new UxFixtureEngineClient(new UxCaptureFixture());
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+        viewModel.CatHubBackend = "ts590";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        Assert.False(viewModel.DidSave);
+        Assert.Equal(
+            "A managed CAT hub radio needs at least one face or network endpoint.",
+            viewModel.ErrorMessage);
+        Assert.Null(client.LastSaveSetupRequest);
+    }
+
+    [Fact]
+    public async Task SaveRejectsCatHubEndpointWithoutHostPortBind()
+    {
+        var client = new UxFixtureEngineClient(new UxCaptureFixture());
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+        viewModel.CatHubBackend = "ts590";
+        viewModel.AddCatHubEndpointCommand.Execute(null);
+        var endpoint = Assert.Single(viewModel.CatHubEndpoints);
+        endpoint.Name = "wsjtx";
+        endpoint.Bind = "localhost-no-port";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        Assert.False(viewModel.DidSave);
+        Assert.Contains("bind must be host:port", viewModel.ErrorMessage, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task CatHubCertifiedTriStateRoundTripsExplicitFalse()
+    {
+        var client = new UxFixtureEngineClient(
+            new UxCaptureFixture
+            {
+                CatHubBackend = "ts590",
+                CatHubEndpointName = "wsjtx",
+                CatHubEndpointBind = "127.0.0.1:4532"
+            });
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+        // Default (omit) on load.
+        Assert.Equal(0, viewModel.CatHubCertifiedIndex);
+
+        // Explicit "No" -> certified=false must round-trip, not be dropped.
+        viewModel.CatHubCertifiedIndex = 2;
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        Assert.True(viewModel.DidSave);
+        var radio = client.LastSaveSetupRequest!.CatHub.Radio;
+        Assert.True(radio.HasCertified);
+        Assert.False(radio.Certified);
     }
 }

--- a/src/dotnet/QsoRipper.Gui/Inspection/UxCaptureFixture.cs
+++ b/src/dotnet/QsoRipper.Gui/Inspection/UxCaptureFixture.cs
@@ -91,6 +91,22 @@ internal sealed record UxCaptureFixture
 
     public ulong? RigControlStaleThresholdMs { get; init; }
 
+    public string? CatHubBackend { get; init; }
+
+    public string? CatHubTransport { get; init; }
+
+    public string? CatHubPort { get; init; }
+
+    public uint? CatHubBaud { get; init; }
+
+    public string? CatHubFaceName { get; init; }
+
+    public string? CatHubFaceDialect { get; init; }
+
+    public string? CatHubEndpointName { get; init; }
+
+    public string? CatHubEndpointBind { get; init; }
+
     public bool IsSyncing { get; init; }
 
     public IReadOnlyList<UxCaptureQsoFixtureItem> RecentQsos { get; init; } = CreateDefaultRecentQsos();
@@ -198,6 +214,67 @@ internal sealed record UxCaptureFixture
         return settings;
     }
 
+    public CatHubSettings? BuildCatHubSettings()
+    {
+        var hasValues = !string.IsNullOrWhiteSpace(CatHubBackend)
+            || !string.IsNullOrWhiteSpace(CatHubTransport)
+            || !string.IsNullOrWhiteSpace(CatHubPort)
+            || CatHubBaud.HasValue
+            || !string.IsNullOrWhiteSpace(CatHubFaceName)
+            || !string.IsNullOrWhiteSpace(CatHubEndpointName);
+
+        if (!hasValues)
+        {
+            return null;
+        }
+
+        var settings = new CatHubSettings { Radio = new CatHubRadioSettings() };
+        if (!string.IsNullOrWhiteSpace(CatHubBackend))
+        {
+            settings.Radio.Backend = CatHubBackend;
+        }
+
+        if (!string.IsNullOrWhiteSpace(CatHubTransport))
+        {
+            settings.Radio.Transport = CatHubTransport;
+        }
+
+        if (!string.IsNullOrWhiteSpace(CatHubPort))
+        {
+            settings.Radio.Port = CatHubPort;
+        }
+
+        if (CatHubBaud.HasValue)
+        {
+            settings.Radio.Baud = CatHubBaud.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(CatHubFaceName))
+        {
+            var face = new CatHubSerialFace
+            {
+                Name = CatHubFaceName,
+                Transport = "COM11",
+                Dialect = string.IsNullOrWhiteSpace(CatHubFaceDialect) ? "ts590" : CatHubFaceDialect,
+            };
+            face.Perms.Add(CatHubPermission.Read);
+            face.Perms.Add(CatHubPermission.Write);
+            settings.Faces.Add(face);
+        }
+
+        if (!string.IsNullOrWhiteSpace(CatHubEndpointName))
+        {
+            var endpoint = new CatHubHamlibNetEndpoint
+            {
+                Name = CatHubEndpointName,
+                Bind = string.IsNullOrWhiteSpace(CatHubEndpointBind) ? "127.0.0.1:4532" : CatHubEndpointBind,
+            };
+            endpoint.Perms.Add(CatHubPermission.Read);
+            settings.HamlibNet.Add(endpoint);
+        }
+
+        return settings;
+    }
     public SyncConfig BuildSyncConfig() => new()
     {
         AutoSyncEnabled = AutoSyncEnabled,

--- a/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
@@ -21,6 +21,7 @@ internal sealed class UxFixtureEngineClient : IEngineClient
     private string _logFilePath;
     private string? _qrzXmlUsername;
     private RigControlSettings? _rigControl;
+    private CatHubSettings? _catHub;
     private DateTimeOffset? _lastSyncUtc;
     private bool _configFileExists;
     private bool _setupComplete;
@@ -43,6 +44,7 @@ internal sealed class UxFixtureEngineClient : IEngineClient
         _logFilePath = fixture.ActiveLogFilePath;
         _qrzXmlUsername = fixture.QrzXmlUsername;
         _rigControl = fixture.BuildRigControlSettings();
+        _catHub = fixture.BuildCatHubSettings();
         _lastSyncUtc = fixture.LastSyncUtc;
         _configFileExists = fixture.ConfigFileExists;
         _setupComplete = fixture.SetupComplete;
@@ -209,6 +211,11 @@ internal sealed class UxFixtureEngineClient : IEngineClient
             if (request.RigControl is not null)
             {
                 _rigControl = request.RigControl.Clone();
+            }
+
+            if (request.CatHub is not null)
+            {
+                _catHub = request.CatHub.Clone();
             }
 
             _configFileExists = true;
@@ -605,6 +612,11 @@ internal sealed class UxFixtureEngineClient : IEngineClient
         if (_rigControl is not null)
         {
             status.RigControl = _rigControl.Clone();
+        }
+
+        if (_catHub is not null)
+        {
+            status.CatHub = _catHub.Clone();
         }
 
         if (HasStationProfile())

--- a/src/dotnet/QsoRipper.Gui/ViewModels/CatHubEndpointRowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/CatHubEndpointRowViewModel.cs
@@ -1,0 +1,29 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace QsoRipper.Gui.ViewModels;
+
+/// <summary>
+/// One editable rigctld-compatible TCP endpoint row
+/// (<c>[[cat_hub.hamlib_net]]</c>) in the CAT Hub settings tab. Network-CAT
+/// applications (the engine, WSJT-X, Log4OM, ...) connect to the bind address.
+/// </summary>
+internal sealed partial class CatHubEndpointRowViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _name = string.Empty;
+
+    [ObservableProperty]
+    private string _bind = string.Empty;
+
+    [ObservableProperty]
+    private bool _permRead = true;
+
+    [ObservableProperty]
+    private bool _permWrite;
+
+    [ObservableProperty]
+    private bool _permPtt;
+
+    [ObservableProperty]
+    private bool _permConfigWrite;
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/CatHubFaceRowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/CatHubFaceRowViewModel.cs
@@ -1,0 +1,37 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace QsoRipper.Gui.ViewModels;
+
+/// <summary>
+/// One editable serial-face row (<c>[[cat_hub.face]]</c>) in the CAT Hub
+/// settings tab. A serial face is a com0com virtual pair the hub binds; the
+/// client application connects to the other port of the same pair.
+/// </summary>
+internal sealed partial class CatHubFaceRowViewModel : ObservableObject
+{
+    [ObservableProperty]
+    private string _name = string.Empty;
+
+    [ObservableProperty]
+    private string _transport = string.Empty;
+
+    [ObservableProperty]
+    private string _baud = string.Empty;
+
+    [ObservableProperty]
+    private string _dialect = "ts590";
+
+    public string[] DialectOptions { get; } = ["ts590", "ts2000"];
+
+    [ObservableProperty]
+    private bool _permRead = true;
+
+    [ObservableProperty]
+    private bool _permWrite;
+
+    [ObservableProperty]
+    private bool _permPtt;
+
+    [ObservableProperty]
+    private bool _permConfigWrite;
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
 using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
@@ -114,6 +116,69 @@ internal sealed partial class SettingsViewModel : ObservableObject
 
     [ObservableProperty]
     private string _rigControlStaleThresholdMs = string.Empty;
+
+    // CAT hub ([cat_hub]) — the engine owns this whole section. The editor below
+    // only emits it on save when the operator actually edits it (IsCatHubDirty),
+    // so an untouched section keeps its comments and unknown keys verbatim.
+    [ObservableProperty]
+    private string _catHubBackend = string.Empty;
+
+    [ObservableProperty]
+    private string _catHubModel = string.Empty;
+
+    [ObservableProperty]
+    private string _catHubTransport = string.Empty;
+
+    [ObservableProperty]
+    private string _catHubPort = string.Empty;
+
+    [ObservableProperty]
+    private string _catHubBaud = string.Empty;
+
+    [ObservableProperty]
+    private string _catHubHost = string.Empty;
+
+    [ObservableProperty]
+    private string _catHubTcpPort = string.Empty;
+
+    // Tri-state ComboBox index: 0 = daemon default (omit), 1 = yes, 2 = no.
+    [ObservableProperty]
+    private int _catHubCertifiedIndex;
+
+    [ObservableProperty]
+    private string _catHubReplyTimeoutMs = string.Empty;
+
+    [ObservableProperty]
+    private string _catHubPollBaselineMs = string.Empty;
+
+    [ObservableProperty]
+    private string _catHubPollHeartbeatMs = string.Empty;
+
+    [ObservableProperty]
+    private string _catHubPttMaxTxMs = string.Empty;
+
+    // Tri-state ComboBox index: 0 = daemon default (omit), 1 = on, 2 = off.
+    [ObservableProperty]
+    private int _catHubNativePushIndex;
+
+    private bool _hasPersistedCatHub;
+    private bool _catHubLoading;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowCatHubRewriteWarning))]
+    private bool _isCatHubDirty;
+
+    /// <summary>
+    /// True once the operator edits a CAT hub field for a section that already
+    /// exists on disk. Surfacing this warns that saving rewrites the whole
+    /// <c>[cat_hub]</c> section and drops comments / unknown keys.
+    /// </summary>
+    public bool ShowCatHubRewriteWarning => IsCatHubDirty && _hasPersistedCatHub;
+
+    public ObservableCollection<CatHubFaceRowViewModel> CatHubFaces { get; } = [];
+
+    public ObservableCollection<CatHubEndpointRowViewModel> CatHubEndpoints { get; } = [];
+
 
     [ObservableProperty]
     private string _persistenceDescription = "Where should QsoRipper store persisted logbook data?";
@@ -231,6 +296,97 @@ internal sealed partial class SettingsViewModel : ObservableObject
     public SettingsViewModel(IEngineClient engine)
     {
         _engine = engine;
+        CatHubFaces.CollectionChanged += OnCatHubCollectionChanged;
+        CatHubEndpoints.CollectionChanged += OnCatHubCollectionChanged;
+    }
+
+    private static readonly HashSet<string> CatHubScalarPropertyNames = new(StringComparer.Ordinal)
+    {
+        nameof(CatHubBackend),
+        nameof(CatHubModel),
+        nameof(CatHubTransport),
+        nameof(CatHubPort),
+        nameof(CatHubBaud),
+        nameof(CatHubHost),
+        nameof(CatHubTcpPort),
+        nameof(CatHubCertifiedIndex),
+        nameof(CatHubReplyTimeoutMs),
+        nameof(CatHubPollBaselineMs),
+        nameof(CatHubPollHeartbeatMs),
+        nameof(CatHubPttMaxTxMs),
+        nameof(CatHubNativePushIndex),
+    };
+
+    protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+    {
+        base.OnPropertyChanged(e);
+        if (e.PropertyName is not null && CatHubScalarPropertyNames.Contains(e.PropertyName))
+        {
+            MarkCatHubDirty();
+        }
+    }
+
+    private void MarkCatHubDirty()
+    {
+        if (_catHubLoading)
+        {
+            return;
+        }
+
+        IsCatHubDirty = true;
+    }
+
+    private void OnCatHubCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.OldItems is not null)
+        {
+            foreach (ObservableObject row in e.OldItems)
+            {
+                row.PropertyChanged -= OnCatHubRowChanged;
+            }
+        }
+
+        if (e.NewItems is not null)
+        {
+            foreach (ObservableObject row in e.NewItems)
+            {
+                row.PropertyChanged += OnCatHubRowChanged;
+            }
+        }
+
+        MarkCatHubDirty();
+    }
+
+    private void OnCatHubRowChanged(object? sender, PropertyChangedEventArgs e) => MarkCatHubDirty();
+
+    [RelayCommand]
+    private void AddCatHubFace()
+    {
+        CatHubFaces.Add(new CatHubFaceRowViewModel());
+    }
+
+    [RelayCommand]
+    private void RemoveCatHubFace(CatHubFaceRowViewModel? row)
+    {
+        if (row is not null)
+        {
+            CatHubFaces.Remove(row);
+        }
+    }
+
+    [RelayCommand]
+    private void AddCatHubEndpoint()
+    {
+        CatHubEndpoints.Add(new CatHubEndpointRowViewModel());
+    }
+
+    [RelayCommand]
+    private void RemoveCatHubEndpoint(CatHubEndpointRowViewModel? row)
+    {
+        if (row is not null)
+        {
+            CatHubEndpoints.Remove(row);
+        }
     }
 
     /// <summary>
@@ -369,6 +525,12 @@ internal sealed partial class SettingsViewModel : ObservableObject
                 return;
             }
 
+            if (IsCatHubDirty && !TryValidateCatHubInputs(out var catHubError))
+            {
+                ErrorMessage = catHubError;
+                return;
+            }
+
             var request = BuildSaveRequest();
             await _engine.SaveSetupAsync(request);
             DidSave = true;
@@ -406,10 +568,13 @@ internal sealed partial class SettingsViewModel : ObservableObject
     private void SelectRigSection() => SelectedSectionIndex = 4;
 
     [RelayCommand]
-    private void SelectNextSection() => SelectedSectionIndex = (SelectedSectionIndex + 1) % 5;
+    private void SelectCatHubSection() => SelectedSectionIndex = 5;
 
     [RelayCommand]
-    private void SelectPreviousSection() => SelectedSectionIndex = (SelectedSectionIndex + 4) % 5;
+    private void SelectNextSection() => SelectedSectionIndex = (SelectedSectionIndex + 1) % 6;
+
+    [RelayCommand]
+    private void SelectPreviousSection() => SelectedSectionIndex = (SelectedSectionIndex + 5) % 6;
 
     [RelayCommand]
     private async Task TestQrzXmlAsync()
@@ -532,6 +697,90 @@ internal sealed partial class SettingsViewModel : ObservableObject
 
         // Password and API key are never returned by the engine for security;
         // leave them empty so the user can re-enter if they want to change them.
+        ApplyCatHub(status.CatHub);
+    }
+
+    private void ApplyCatHub(CatHubSettings? catHub)
+    {
+        _catHubLoading = true;
+        try
+        {
+            foreach (var row in CatHubFaces)
+            {
+                row.PropertyChanged -= OnCatHubRowChanged;
+            }
+
+            foreach (var row in CatHubEndpoints)
+            {
+                row.PropertyChanged -= OnCatHubRowChanged;
+            }
+
+            CatHubFaces.Clear();
+            CatHubEndpoints.Clear();
+
+            _hasPersistedCatHub = catHub is not null;
+
+            var radio = catHub?.Radio;
+            CatHubBackend = radio is { HasBackend: true } ? radio.Backend : string.Empty;
+            CatHubModel = radio is { HasModel: true } ? radio.Model : string.Empty;
+            CatHubTransport = radio is { HasTransport: true } ? radio.Transport : string.Empty;
+            CatHubPort = radio is { HasPort: true } ? radio.Port : string.Empty;
+            CatHubBaud = radio is { HasBaud: true } ? radio.Baud.ToString(CultureInfo.InvariantCulture) : string.Empty;
+            CatHubHost = radio is { HasHost: true } ? radio.Host : string.Empty;
+            CatHubTcpPort = radio is { HasTcpPort: true } ? radio.TcpPort.ToString(CultureInfo.InvariantCulture) : string.Empty;
+            CatHubCertifiedIndex = radio is { HasCertified: true } ? (radio.Certified ? 1 : 2) : 0;
+            CatHubReplyTimeoutMs = radio is { HasReplyTimeoutMs: true }
+                ? radio.ReplyTimeoutMs.ToString(CultureInfo.InvariantCulture) : string.Empty;
+
+            var poll = catHub?.Poll;
+            CatHubPollBaselineMs = poll is { HasBaselineMs: true }
+                ? poll.BaselineMs.ToString(CultureInfo.InvariantCulture) : string.Empty;
+            CatHubPollHeartbeatMs = poll is { HasHeartbeatMs: true }
+                ? poll.HeartbeatMs.ToString(CultureInfo.InvariantCulture) : string.Empty;
+
+            var ptt = catHub?.Ptt;
+            CatHubPttMaxTxMs = ptt is { HasMaxTxMs: true }
+                ? ptt.MaxTxMs.ToString(CultureInfo.InvariantCulture) : string.Empty;
+
+            var events = catHub?.Events;
+            CatHubNativePushIndex = events is { HasNativePush: true } ? (events.NativePush ? 1 : 2) : 0;
+
+            if (catHub is not null)
+            {
+                foreach (var face in catHub.Faces)
+                {
+                    CatHubFaces.Add(new CatHubFaceRowViewModel
+                    {
+                        Name = face.Name,
+                        Transport = face.Transport,
+                        Baud = face.Baud != 0 ? face.Baud.ToString(CultureInfo.InvariantCulture) : string.Empty,
+                        Dialect = string.IsNullOrWhiteSpace(face.Dialect) ? "ts590" : face.Dialect,
+                        PermRead = face.Perms.Contains(CatHubPermission.Read),
+                        PermWrite = face.Perms.Contains(CatHubPermission.Write),
+                        PermPtt = face.Perms.Contains(CatHubPermission.Ptt),
+                        PermConfigWrite = face.Perms.Contains(CatHubPermission.ConfigWrite),
+                    });
+                }
+
+                foreach (var endpoint in catHub.HamlibNet)
+                {
+                    CatHubEndpoints.Add(new CatHubEndpointRowViewModel
+                    {
+                        Name = endpoint.Name,
+                        Bind = endpoint.Bind,
+                        PermRead = endpoint.Perms.Contains(CatHubPermission.Read),
+                        PermWrite = endpoint.Perms.Contains(CatHubPermission.Write),
+                        PermPtt = endpoint.Perms.Contains(CatHubPermission.Ptt),
+                        PermConfigWrite = endpoint.Perms.Contains(CatHubPermission.ConfigWrite),
+                    });
+                }
+            }
+        }
+        finally
+        {
+            _catHubLoading = false;
+            IsCatHubDirty = false;
+        }
     }
 
     private void ApplyStationProfile(StationProfile profile)
@@ -612,7 +861,111 @@ internal sealed partial class SettingsViewModel : ObservableObject
             request.RigControl = rigControl;
         }
 
+        if (IsCatHubDirty)
+        {
+            request.CatHub = BuildCatHubSettings();
+        }
+
         return request;
+    }
+
+    private CatHubSettings BuildCatHubSettings()
+    {
+        var settings = new CatHubSettings();
+
+        var radio = new CatHubRadioSettings();
+        SetOptionalString(CatHubBackend, value => radio.Backend = value.ToLowerInvariant());
+        SetOptionalString(CatHubModel, value => radio.Model = value);
+        SetOptionalString(CatHubTransport, value => radio.Transport = value.ToLowerInvariant());
+        SetOptionalString(CatHubPort, value => radio.Port = value);
+        SetUInt32Field(CatHubBaud, value => radio.Baud = value);
+        SetOptionalString(CatHubHost, value => radio.Host = value);
+        SetUInt32Field(CatHubTcpPort, value => radio.TcpPort = value);
+        if (CatHubCertifiedIndex != 0)
+        {
+            radio.Certified = CatHubCertifiedIndex == 1;
+        }
+
+        SetUInt64Field(CatHubReplyTimeoutMs, value => radio.ReplyTimeoutMs = value);
+        settings.Radio = radio;
+
+        if (!string.IsNullOrWhiteSpace(CatHubPollBaselineMs) || !string.IsNullOrWhiteSpace(CatHubPollHeartbeatMs))
+        {
+            var poll = new CatHubPollSettings();
+            SetUInt64Field(CatHubPollBaselineMs, value => poll.BaselineMs = value);
+            SetUInt64Field(CatHubPollHeartbeatMs, value => poll.HeartbeatMs = value);
+            settings.Poll = poll;
+        }
+
+        if (!string.IsNullOrWhiteSpace(CatHubPttMaxTxMs))
+        {
+            var ptt = new CatHubPttSettings();
+            SetUInt64Field(CatHubPttMaxTxMs, value => ptt.MaxTxMs = value);
+            settings.Ptt = ptt;
+        }
+
+        if (CatHubNativePushIndex != 0)
+        {
+            settings.Events = new CatHubEventSettings { NativePush = CatHubNativePushIndex == 1 };
+        }
+
+        foreach (var face in CatHubFaces)
+        {
+            var proto = new CatHubSerialFace
+            {
+                Name = face.Name.Trim(),
+                Transport = face.Transport.Trim(),
+                Dialect = string.IsNullOrWhiteSpace(face.Dialect) ? "ts590" : face.Dialect.Trim().ToLowerInvariant(),
+            };
+            if (uint.TryParse(face.Baud, CultureInfo.InvariantCulture, out var baud))
+            {
+                proto.Baud = baud;
+            }
+
+            AddPerms(proto.Perms, face.PermRead, face.PermWrite, face.PermPtt, face.PermConfigWrite);
+            settings.Faces.Add(proto);
+        }
+
+        foreach (var endpoint in CatHubEndpoints)
+        {
+            var proto = new CatHubHamlibNetEndpoint
+            {
+                Name = endpoint.Name.Trim(),
+                Bind = endpoint.Bind.Trim(),
+            };
+            AddPerms(proto.Perms, endpoint.PermRead, endpoint.PermWrite, endpoint.PermPtt, endpoint.PermConfigWrite);
+            settings.HamlibNet.Add(proto);
+        }
+
+        return settings;
+    }
+
+    private static void AddPerms(
+        Google.Protobuf.Collections.RepeatedField<CatHubPermission> perms,
+        bool read,
+        bool write,
+        bool ptt,
+        bool configWrite)
+    {
+        if (read)
+        {
+            perms.Add(CatHubPermission.Read);
+        }
+
+        if (write)
+        {
+            perms.Add(CatHubPermission.Write);
+        }
+
+        if (ptt)
+        {
+            perms.Add(CatHubPermission.Ptt);
+        }
+
+        if (configWrite)
+        {
+            perms.Add(CatHubPermission.ConfigWrite);
+        }
     }
 
     private RigControlSettings? BuildRigControlSettings()
@@ -682,6 +1035,108 @@ internal sealed partial class SettingsViewModel : ObservableObject
             1,
             "Rig control stale threshold",
             out validationError);
+    }
+
+    private bool TryValidateCatHubInputs(out string? validationError)
+    {
+        validationError = null;
+
+        var backend = CatHubBackend.Trim().ToLowerInvariant();
+        var managed = backend is not ("" or "loopback");
+        if (managed && backend is not ("ts590" or "rigctld"))
+        {
+            validationError = "CAT hub backend must be ts590, rigctld, or loopback.";
+            return false;
+        }
+
+        var transport = CatHubTransport.Trim().ToLowerInvariant();
+        if (transport.Length > 0 && transport is not ("serial" or "tcp"))
+        {
+            validationError = "CAT hub transport must be serial or tcp.";
+            return false;
+        }
+
+        if (managed && transport == "serial" && string.IsNullOrWhiteSpace(CatHubPort))
+        {
+            validationError = "CAT hub serial transport requires a port (e.g. COM3).";
+            return false;
+        }
+
+        if (!TryValidateUInt32Field(CatHubBaud, 1, 4_000_000, "CAT hub baud", out validationError))
+        {
+            return false;
+        }
+
+        if (!TryValidateUInt32Field(CatHubTcpPort, 1, 65_535, "CAT hub TCP port", out validationError))
+        {
+            return false;
+        }
+
+        if (!TryValidateUInt64Field(CatHubReplyTimeoutMs, 1, "CAT hub reply timeout", out validationError)
+            || !TryValidateUInt64Field(CatHubPollBaselineMs, 1, "CAT hub poll baseline", out validationError)
+            || !TryValidateUInt64Field(CatHubPollHeartbeatMs, 1, "CAT hub poll heartbeat", out validationError)
+            || !TryValidateUInt64Field(CatHubPttMaxTxMs, 1, "CAT hub PTT max TX", out validationError))
+        {
+            return false;
+        }
+
+        var names = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var face in CatHubFaces)
+        {
+            if (string.IsNullOrWhiteSpace(face.Name))
+            {
+                validationError = "Every CAT hub face needs a name.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(face.Transport))
+            {
+                validationError = $"CAT hub face '{face.Name}' needs a transport (path or host:port).";
+                return false;
+            }
+
+            var dialect = face.Dialect.Trim().ToLowerInvariant();
+            if (dialect is not ("ts590" or "ts2000"))
+            {
+                validationError = $"CAT hub face '{face.Name}' dialect must be ts590 or ts2000.";
+                return false;
+            }
+
+            if (!names.Add(face.Name.Trim()))
+            {
+                validationError = $"CAT hub endpoint name '{face.Name}' is used more than once.";
+                return false;
+            }
+        }
+
+        foreach (var endpoint in CatHubEndpoints)
+        {
+            if (string.IsNullOrWhiteSpace(endpoint.Name))
+            {
+                validationError = "Every CAT hub network endpoint needs a name.";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(endpoint.Bind) || !endpoint.Bind.Contains(':', StringComparison.Ordinal))
+            {
+                validationError = $"CAT hub endpoint '{endpoint.Name}' bind must be host:port (e.g. 127.0.0.1:4532).";
+                return false;
+            }
+
+            if (!names.Add(endpoint.Name.Trim()))
+            {
+                validationError = $"CAT hub endpoint name '{endpoint.Name}' is used more than once.";
+                return false;
+            }
+        }
+
+        if (managed && CatHubEndpoints.Count == 0 && CatHubFaces.Count == 0)
+        {
+            validationError = "A managed CAT hub radio needs at least one face or network endpoint.";
+            return false;
+        }
+
+        return true;
     }
 
     private static void SetOptionalString(string input, Action<string> setter)

--- a/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
@@ -57,7 +57,7 @@
                      TextWrapping="Wrap"
                      IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
           <TextBlock Classes="settingsSectionHint"
-                     Text="Sections: Ctrl+1 Station  Ctrl+2 Display  Ctrl+3 Storage  Ctrl+4 QRZ  Ctrl+5 Rig  Ctrl+Tab Next"
+                     Text="Sections: Ctrl+1 Station  Ctrl+2 Display  Ctrl+3 Storage  Ctrl+4 QRZ  Ctrl+5 Rig  Ctrl+6 CAT Hub  Ctrl+Tab Next"
                      IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNullOrEmpty}}" />
         </StackPanel>
 
@@ -505,6 +505,236 @@
                      PlaceholderText="5000" />
           </Grid>
         </StackPanel>
+      </TabItem>
+
+      <TabItem AutomationProperties.AutomationId="SettingsCatHubTab">
+        <TabItem.Header>
+          <StackPanel Spacing="1">
+            <TextBlock Text="CAT Hub" />
+            <TextBlock Classes="settingsTabShortcut" Text="Ctrl+6" />
+          </StackPanel>
+        </TabItem.Header>
+        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled"
+                      Padding="16">
+          <StackPanel Spacing="16">
+            <TextBlock Classes="settingsSectionHeader" Text="CAT Hub" />
+            <TextBlock Classes="settingsSectionHint"
+                       Text="The multi-client CAT hub owns the radio link and fans it out to every connected app (HDSDR, OmniRig, N1MM, WSJT-X, Log4OM, ARCP-590). These map to the [cat_hub] section of config.toml." />
+
+            <Border x:Name="SettingsCatHubRewriteWarning"
+                    AutomationProperties.AutomationId="SettingsCatHubRewriteWarning"
+                    IsVisible="{Binding ShowCatHubRewriteWarning}"
+                    Background="#332E1A"
+                    BorderBrush="#B8862B"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Padding="12,8">
+              <TextBlock TextWrapping="Wrap"
+                         Foreground="#E8C76B"
+                         Text="Saving rewrites the entire [cat_hub] section. Comments and any keys not shown here will be dropped." />
+            </Border>
+
+            <TextBlock Classes="settingsSectionHeader" FontSize="14" Text="Radio" />
+            <Grid ColumnDefinitions="120,*,120,*"
+                  RowDefinitions="Auto,Auto,Auto,Auto,Auto"
+                  ColumnSpacing="12"
+                  RowSpacing="6">
+              <TextBlock Grid.Row="0" Grid.Column="0" Text="Backend:" VerticalAlignment="Center" />
+              <TextBox x:Name="SettingsCatHubBackendBox"
+                       AutomationProperties.AutomationId="SettingsCatHubBackendBox"
+                       Grid.Row="0" Grid.Column="1"
+                       Text="{Binding CatHubBackend, Mode=TwoWay}"
+                       PlaceholderText="ts590 / rigctld / loopback" />
+
+              <TextBlock Grid.Row="0" Grid.Column="2" Text="Model:" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="SettingsCatHubModelBox"
+                       Grid.Row="0" Grid.Column="3"
+                       Text="{Binding CatHubModel, Mode=TwoWay}"
+                       PlaceholderText="optional rigctld model id" />
+
+              <TextBlock Grid.Row="1" Grid.Column="0" Text="Transport:" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="SettingsCatHubTransportBox"
+                       Grid.Row="1" Grid.Column="1"
+                       Text="{Binding CatHubTransport, Mode=TwoWay}"
+                       PlaceholderText="serial / tcp" />
+
+              <TextBlock Grid.Row="1" Grid.Column="2" Text="Port:" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="SettingsCatHubPortBox"
+                       Grid.Row="1" Grid.Column="3"
+                       Text="{Binding CatHubPort, Mode=TwoWay}"
+                       PlaceholderText="COM3" />
+
+              <TextBlock Grid.Row="2" Grid.Column="0" Text="Baud:" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="SettingsCatHubBaudBox"
+                       Grid.Row="2" Grid.Column="1"
+                       Text="{Binding CatHubBaud, Mode=TwoWay}"
+                       PlaceholderText="115200" />
+
+              <TextBlock Grid.Row="2" Grid.Column="2" Text="Host:" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="SettingsCatHubHostBox"
+                       Grid.Row="2" Grid.Column="3"
+                       Text="{Binding CatHubHost, Mode=TwoWay}"
+                       PlaceholderText="127.0.0.1 (tcp backend)" />
+
+              <TextBlock Grid.Row="3" Grid.Column="0" Text="TCP port:" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="SettingsCatHubTcpPortBox"
+                       Grid.Row="3" Grid.Column="1"
+                       Text="{Binding CatHubTcpPort, Mode=TwoWay}"
+                       PlaceholderText="4532 (rigctld backend)" />
+
+              <TextBlock Grid.Row="3" Grid.Column="2" Text="Certified:" VerticalAlignment="Center" />
+              <ComboBox AutomationProperties.AutomationId="SettingsCatHubCertifiedCombo"
+                        Grid.Row="3" Grid.Column="3"
+                        HorizontalAlignment="Stretch"
+                        SelectedIndex="{Binding CatHubCertifiedIndex, Mode=TwoWay}">
+                <ComboBoxItem Content="Default" />
+                <ComboBoxItem Content="Yes" />
+                <ComboBoxItem Content="No" />
+              </ComboBox>
+
+              <TextBlock Grid.Row="4" Grid.Column="0" Text="Reply timeout (ms):" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="SettingsCatHubReplyTimeoutBox"
+                       Grid.Row="4" Grid.Column="1"
+                       Text="{Binding CatHubReplyTimeoutMs, Mode=TwoWay}"
+                       PlaceholderText="700" />
+            </Grid>
+
+            <TextBlock Classes="settingsSectionHeader" FontSize="14" Text="Polling, PTT &amp; events" />
+            <Grid ColumnDefinitions="140,*,140,*"
+                  RowDefinitions="Auto,Auto"
+                  ColumnSpacing="12"
+                  RowSpacing="6">
+              <TextBlock Grid.Row="0" Grid.Column="0" Text="Poll baseline (ms):" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="SettingsCatHubPollBaselineBox"
+                       Grid.Row="0" Grid.Column="1"
+                       Text="{Binding CatHubPollBaselineMs, Mode=TwoWay}"
+                       PlaceholderText="250" />
+
+              <TextBlock Grid.Row="0" Grid.Column="2" Text="Poll heartbeat (ms):" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="SettingsCatHubPollHeartbeatBox"
+                       Grid.Row="0" Grid.Column="3"
+                       Text="{Binding CatHubPollHeartbeatMs, Mode=TwoWay}"
+                       PlaceholderText="1000" />
+
+              <TextBlock Grid.Row="1" Grid.Column="0" Text="PTT max TX (ms):" VerticalAlignment="Center" />
+              <TextBox AutomationProperties.AutomationId="SettingsCatHubPttMaxTxBox"
+                       Grid.Row="1" Grid.Column="1"
+                       Text="{Binding CatHubPttMaxTxMs, Mode=TwoWay}"
+                       PlaceholderText="180000" />
+
+              <TextBlock Grid.Row="1" Grid.Column="2" Text="Native push:" VerticalAlignment="Center" />
+              <ComboBox AutomationProperties.AutomationId="SettingsCatHubNativePushCombo"
+                        Grid.Row="1" Grid.Column="3"
+                        HorizontalAlignment="Stretch"
+                        SelectedIndex="{Binding CatHubNativePushIndex, Mode=TwoWay}">
+                <ComboBoxItem Content="Default" />
+                <ComboBoxItem Content="On" />
+                <ComboBoxItem Content="Off" />
+              </ComboBox>
+            </Grid>
+
+            <DockPanel>
+              <TextBlock DockPanel.Dock="Left"
+                         Classes="settingsSectionHeader" FontSize="14"
+                         VerticalAlignment="Center"
+                         Text="Serial faces" />
+              <Button DockPanel.Dock="Right"
+                      AutomationProperties.AutomationId="SettingsCatHubAddFaceButton"
+                      HorizontalAlignment="Right"
+                      Content="Add face"
+                      Command="{Binding AddCatHubFaceCommand}" />
+            </DockPanel>
+            <TextBlock Classes="settingsSectionHint"
+                       Text="Each face is a local serial endpoint (com0com pair) an app connects to. Transport is the COM path or host:port." />
+            <ItemsControl AutomationProperties.AutomationId="SettingsCatHubFacesList"
+                          ItemsSource="{Binding CatHubFaces}">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                          BorderThickness="1"
+                          CornerRadius="4"
+                          Padding="10"
+                          Margin="0,0,0,8">
+                    <StackPanel Spacing="6">
+                      <Grid ColumnDefinitions="80,*,70,90,70,90,Auto"
+                            ColumnSpacing="8">
+                        <TextBlock Grid.Column="0" Text="Name:" VerticalAlignment="Center" />
+                        <TextBox Grid.Column="1" Text="{Binding Name, Mode=TwoWay}" PlaceholderText="omnirig" />
+                        <TextBlock Grid.Column="2" Text="Baud:" VerticalAlignment="Center" />
+                        <TextBox Grid.Column="3" Text="{Binding Baud, Mode=TwoWay}" PlaceholderText="57600" />
+                        <TextBlock Grid.Column="4" Text="Dialect:" VerticalAlignment="Center" />
+                        <ComboBox Grid.Column="5"
+                                  HorizontalAlignment="Stretch"
+                                  ItemsSource="{Binding DialectOptions}"
+                                  SelectedItem="{Binding Dialect, Mode=TwoWay}" />
+                        <Button Grid.Column="6"
+                                Content="Remove"
+                                Command="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).RemoveCatHubFaceCommand}"
+                                CommandParameter="{Binding}" />
+                      </Grid>
+                      <Grid ColumnDefinitions="80,*" ColumnSpacing="8">
+                        <TextBlock Grid.Column="0" Text="Transport:" VerticalAlignment="Center" />
+                        <TextBox Grid.Column="1" Text="{Binding Transport, Mode=TwoWay}" PlaceholderText="COM11 or 127.0.0.1:7811" />
+                      </Grid>
+                      <StackPanel Orientation="Horizontal" Spacing="14">
+                        <CheckBox Content="Read" IsChecked="{Binding PermRead, Mode=TwoWay}" />
+                        <CheckBox Content="Write" IsChecked="{Binding PermWrite, Mode=TwoWay}" />
+                        <CheckBox Content="PTT" IsChecked="{Binding PermPtt, Mode=TwoWay}" />
+                        <CheckBox Content="Config write" IsChecked="{Binding PermConfigWrite, Mode=TwoWay}" />
+                      </StackPanel>
+                    </StackPanel>
+                  </Border>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+
+            <DockPanel>
+              <TextBlock DockPanel.Dock="Left"
+                         Classes="settingsSectionHeader" FontSize="14"
+                         VerticalAlignment="Center"
+                         Text="Network endpoints (Hamlib rigctld)" />
+              <Button DockPanel.Dock="Right"
+                      AutomationProperties.AutomationId="SettingsCatHubAddEndpointButton"
+                      HorizontalAlignment="Right"
+                      Content="Add endpoint"
+                      Command="{Binding AddCatHubEndpointCommand}" />
+            </DockPanel>
+            <TextBlock Classes="settingsSectionHint"
+                       Text="Each endpoint is a rigctld-compatible TCP server (host:port) for apps like WSJT-X, N1MM and Log4OM." />
+            <ItemsControl AutomationProperties.AutomationId="SettingsCatHubEndpointsList"
+                          ItemsSource="{Binding CatHubEndpoints}">
+              <ItemsControl.ItemTemplate>
+                <DataTemplate>
+                  <Border BorderBrush="{DynamicResource SystemControlForegroundBaseMediumLowBrush}"
+                          BorderThickness="1"
+                          CornerRadius="4"
+                          Padding="10"
+                          Margin="0,0,0,8">
+                    <StackPanel Spacing="6">
+                      <Grid ColumnDefinitions="80,*,80,*,Auto" ColumnSpacing="8">
+                        <TextBlock Grid.Column="0" Text="Name:" VerticalAlignment="Center" />
+                        <TextBox Grid.Column="1" Text="{Binding Name, Mode=TwoWay}" PlaceholderText="wsjtx" />
+                        <TextBlock Grid.Column="2" Text="Bind:" VerticalAlignment="Center" />
+                        <TextBox Grid.Column="3" Text="{Binding Bind, Mode=TwoWay}" PlaceholderText="127.0.0.1:4532" />
+                        <Button Grid.Column="4"
+                                Content="Remove"
+                                Command="{Binding $parent[ItemsControl].((vm:SettingsViewModel)DataContext).RemoveCatHubEndpointCommand}"
+                                CommandParameter="{Binding}" />
+                      </Grid>
+                      <StackPanel Orientation="Horizontal" Spacing="14">
+                        <CheckBox Content="Read" IsChecked="{Binding PermRead, Mode=TwoWay}" />
+                        <CheckBox Content="Write" IsChecked="{Binding PermWrite, Mode=TwoWay}" />
+                        <CheckBox Content="PTT" IsChecked="{Binding PermPtt, Mode=TwoWay}" />
+                        <CheckBox Content="Config write" IsChecked="{Binding PermConfigWrite, Mode=TwoWay}" />
+                      </StackPanel>
+                    </StackPanel>
+                  </Border>
+                </DataTemplate>
+              </ItemsControl.ItemTemplate>
+            </ItemsControl>
+          </StackPanel>
+        </ScrollViewer>
       </TabItem>
     </TabControl>
   </DockPanel>

--- a/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml.cs
@@ -102,6 +102,7 @@ internal sealed partial class SettingsView : Window
             2 => this.FindControl<Control>("SettingsAutoSyncCheckBox"),
             3 => this.FindControl<Control>("SettingsQrzXmlUsernameBox"),
             4 => this.FindControl<Control>("SettingsRigControlEnabledCheckBox"),
+            5 => this.FindControl<Control>("SettingsCatHubBackendBox"),
             _ => null
         };
 
@@ -147,6 +148,11 @@ internal sealed partial class SettingsView : Window
             case Key.D5:
             case Key.NumPad5:
                 vm.SelectRigSectionCommand.Execute(null);
+                e.Handled = true;
+                return true;
+            case Key.D6:
+            case Key.NumPad6:
+                vm.SelectCatHubSectionCommand.Execute(null);
                 e.Handled = true;
                 return true;
             case Key.Tab:


### PR DESCRIPTION
Adds a CAT Hub tab to the GUI Settings dialog so operators can edit the [cat_hub] section of config.toml from the UI instead of hand-editing the file. The tab covers the radio backend, polling, PTT, events, serial faces, and hamlib_net endpoints, with add/remove rows and per-face permission checkboxes.

Because every save rewrites the whole config.toml, the cat_hub section is only emitted when it has actually been edited (dirty-gated), so an unrelated Save never strips or rewrites it. A warning banner is shown before the first rewrite since unmodeled keys and comments in the section are dropped on full replacement. Optional booleans (certified, native push) use a tri-state of omit/true/false.

This stacks on PR #482, which introduces the CatHubSettings proto family and the engine SetupService persistence. The PR is based on that branch and will retarget to main once #482 merges.

Validation: dotnet format clean, GUI and tests build with 0 warnings, all 178 GUI tests pass (6 new CAT hub tests), and the tab was visually verified via drive-avalonia automation.