### PR TITLE
Reclaim engine port from stale published process on launch/restart

### DIFF
--- a/src/rust/qsoripper-launcher/src/ports.rs
+++ b/src/rust/qsoripper-launcher/src/ports.rs
@@ -24,6 +24,21 @@ pub(crate) fn wait_for_port(port: u16, total: Duration, per_attempt: Duration) -
     }
 }
 
+/// Poll until nothing is listening on `port` (the previous owner has fully
+/// released it) or `total` elapses. Returns `true` when the port is free.
+pub(crate) fn wait_for_port_release(port: u16, total: Duration) -> bool {
+    let deadline = Instant::now() + total;
+    loop {
+        if !is_port_listening(port, Duration::from_millis(100)) {
+            return true;
+        }
+        if Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(150));
+    }
+}
+
 #[cfg(test)]
 #[allow(
     clippy::expect_used,

--- a/src/rust/qsoripper-launcher/src/process.rs
+++ b/src/rust/qsoripper-launcher/src/process.rs
@@ -5,8 +5,10 @@ use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
+use std::time::UNIX_EPOCH;
+
 use anyhow::{bail, Context, Result};
-use sysinfo::{Pid, ProcessRefreshKind, Signal, System};
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, Signal, System, UpdateKind};
 
 use crate::catalog::{ComponentId, ComponentSpec};
 
@@ -320,6 +322,103 @@ pub(crate) fn stop_pid(pid: u32) -> bool {
         .unwrap_or_else(|| proc_handle.kill())
 }
 
+/// Decide whether a running process is a stale copy of the published binary at
+/// `target_exe`. "Stale" means: it is the same executable we manage (same
+/// directory and either the same file name or its side-lined
+/// `<name>.locked-*.old` variant left behind by a rebuild) AND it was started
+/// before the binary on disk was last built (`built_secs`, seconds since the
+/// Unix epoch). A process running a different executable, or one started after
+/// the current build, is never considered stale.
+#[expect(
+    clippy::case_sensitive_file_extension_comparisons,
+    reason = "comparing a known side-lined suffix, not a real file extension; casing is normalized on Windows and intentionally exact on Unix"
+)]
+fn is_stale_published_copy(
+    proc_exe: &Path,
+    proc_start_secs: u64,
+    target_exe: &Path,
+    built_secs: u64,
+) -> bool {
+    if proc_start_secs >= built_secs {
+        return false;
+    }
+    let (Some(proc_parent), Some(target_parent)) = (proc_exe.parent(), target_exe.parent()) else {
+        return false;
+    };
+    if canonical_or(proc_parent) != canonical_or(target_parent) {
+        return false;
+    }
+    let (Some(proc_name), Some(target_name)) = (proc_exe.file_name(), target_exe.file_name())
+    else {
+        return false;
+    };
+    if proc_name == target_name {
+        return true;
+    }
+    // A rebuild side-lines an in-use binary as "<name>.locked-<ts>.old" before
+    // dropping the fresh file at the original path; the still-running stale
+    // process keeps that side-lined image path.
+    let proc_name = proc_name.to_string_lossy();
+    let target_name = target_name.to_string_lossy();
+    if cfg!(windows) {
+        // Windows paths are case-insensitive and sysinfo may report different
+        // casing than the catalog-derived path.
+        if proc_name.eq_ignore_ascii_case(&target_name) {
+            return true;
+        }
+        let prefix = format!("{}.locked-", target_name.to_ascii_lowercase());
+        let lowered = proc_name.to_ascii_lowercase();
+        lowered.starts_with(&prefix) && lowered.ends_with(".old")
+    } else {
+        proc_name.starts_with(&format!("{target_name}.locked-")) && proc_name.ends_with(".old")
+    }
+}
+
+fn canonical_or(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Stop any process that is a stale copy of the published binary at `exe`
+/// (see [`is_stale_published_copy`]). This frees a held engine/daemon port so
+/// the next launch spawns fresh code instead of attaching to outdated code left
+/// running by an earlier launcher session or rebuild. Genuinely external
+/// engines (a different executable, or a build newer than what is on disk) are
+/// left untouched. Best-effort: returns the number of stale copies stopped, or
+/// `0` if the binary's build time cannot be read.
+pub(crate) fn reap_stale_published_copies(exe: &Path) -> usize {
+    let built_secs = match std::fs::metadata(exe).and_then(|m| m.modified()) {
+        Ok(modified) => match modified.duration_since(UNIX_EPOCH) {
+            Ok(delta) => delta.as_secs(),
+            Err(_) => return 0,
+        },
+        Err(_) => return 0,
+    };
+
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing().with_exe(UpdateKind::Always),
+    );
+
+    let mut stopped = 0usize;
+    for proc_handle in sys.processes().values() {
+        let Some(proc_exe) = proc_handle.exe() else {
+            continue;
+        };
+        if !is_stale_published_copy(proc_exe, proc_handle.start_time(), exe, built_secs) {
+            continue;
+        }
+        let killed = proc_handle
+            .kill_with(Signal::Term)
+            .unwrap_or_else(|| proc_handle.kill());
+        if killed {
+            stopped += 1;
+        }
+    }
+    stopped
+}
+
 #[cfg(test)]
 #[allow(
     clippy::expect_used,
@@ -397,5 +496,51 @@ mod tests {
         assert_eq!(reg.get(ENGINE_RUST).map(|p| p.pid), Some(1234));
         assert!(reg.remove(ENGINE_RUST).is_some());
         assert!(reg.get(ENGINE_RUST).is_none());
+    }
+
+    #[test]
+    fn stale_copy_matches_same_exe_started_before_build() {
+        let target = PathBuf::from("/publish/Release/qsoripper-server.exe");
+        // Started at t=100, binary built at t=200 -> stale.
+        assert!(is_stale_published_copy(&target, 100, &target, 200));
+    }
+
+    #[test]
+    fn fresh_copy_started_after_build_is_not_stale() {
+        let target = PathBuf::from("/publish/Release/qsoripper-server.exe");
+        // Started at t=300, binary built at t=200 -> current, keep it.
+        assert!(!is_stale_published_copy(&target, 300, &target, 200));
+        // Started exactly at the build second -> treat as current (keep).
+        assert!(!is_stale_published_copy(&target, 200, &target, 200));
+    }
+
+    #[test]
+    fn side_lined_locked_variant_in_same_dir_is_stale() {
+        let target = PathBuf::from("/publish/Release/qsoripper-server.exe");
+        let side_lined = PathBuf::from("/publish/Release/qsoripper-server.exe.locked-20260530.old");
+        assert!(is_stale_published_copy(&side_lined, 100, &target, 200));
+    }
+
+    #[test]
+    fn different_executable_is_never_stale() {
+        let target = PathBuf::from("/publish/Release/qsoripper-server.exe");
+        // Different file name in the same directory.
+        let other_name = PathBuf::from("/publish/Release/qsoripper-cathub.exe");
+        assert!(!is_stale_published_copy(&other_name, 100, &target, 200));
+        // Same file name but a different directory (e.g. a dev `cargo run`).
+        let other_dir = PathBuf::from("/debug/qsoripper-server.exe");
+        assert!(!is_stale_published_copy(&other_dir, 100, &target, 200));
+    }
+
+    #[test]
+    fn unrelated_locked_prefix_is_not_matched() {
+        let target = PathBuf::from("/publish/Release/qsoripper-server.exe");
+        // A file that merely starts with the same stem but is not the
+        // "<name>.locked-...old" side-lined form must not match.
+        let unrelated = PathBuf::from("/publish/Release/qsoripper-server.exe.bak");
+        assert!(!is_stale_published_copy(&unrelated, 100, &target, 200));
+        // The ".locked-" prefix without the ".old" suffix is also rejected.
+        let no_old = PathBuf::from("/publish/Release/qsoripper-server.exe.locked-20260530");
+        assert!(!is_stale_published_copy(&no_old, 100, &target, 200));
     }
 }

--- a/src/rust/qsoripper-launcher/src/ui.rs
+++ b/src/rust/qsoripper-launcher/src/ui.rs
@@ -21,8 +21,8 @@ use crate::config;
 use crate::discovery::ArtifactRoot;
 use crate::model::Selection;
 use crate::plan::{daemon_plan, engine_plan, ui_plan};
-use crate::ports::{is_port_listening, wait_for_port};
-use crate::process::{open_url, spawn, stop_pid, ProcessRegistry};
+use crate::ports::{is_port_listening, wait_for_port, wait_for_port_release};
+use crate::process::{open_url, reap_stale_published_copies, spawn, stop_pid, ProcessRegistry};
 use crate::sync::{diff_rows, DialogState, DiffRow, Side, SyncDialog};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -289,9 +289,18 @@ impl AppState {
             let exe = plan.spec.artifact.executable_path(&self.artifact_root);
             let port = plan.spec.engine_port.unwrap_or(0);
             if port != 0 && is_port_listening(port, Duration::from_millis(200)) {
-                self.statuses
-                    .insert(daemon_id, Status::listening_external());
-                continue;
+                // Something owns the port. If it is a stale copy of our own
+                // published binary left by an earlier session/rebuild, reclaim
+                // the port so the restart spawns fresh code; otherwise respect
+                // a genuinely external owner.
+                if reap_stale_published_copies(&exe) > 0 {
+                    wait_for_port_release(port, Duration::from_secs(3));
+                }
+                if is_port_listening(port, Duration::from_millis(200)) {
+                    self.statuses
+                        .insert(daemon_id, Status::listening_external());
+                    continue;
+                }
             }
             self.statuses.insert(daemon_id, Status::starting());
             let arg_refs: Vec<&std::ffi::OsStr> = plan.args.iter().map(AsRef::as_ref).collect();
@@ -339,9 +348,18 @@ impl AppState {
             let exe = plan.spec.artifact.executable_path(&self.artifact_root);
             let port = plan.spec.engine_port.unwrap_or(0);
             if port != 0 && is_port_listening(port, Duration::from_millis(200)) {
-                self.statuses
-                    .insert(engine_id, Status::listening_external());
-                continue;
+                // Something owns the port. If it is a stale copy of our own
+                // published binary left by an earlier session/rebuild, reclaim
+                // the port so the restart spawns fresh code; otherwise respect
+                // a genuinely external owner.
+                if reap_stale_published_copies(&exe) > 0 {
+                    wait_for_port_release(port, Duration::from_secs(3));
+                }
+                if is_port_listening(port, Duration::from_millis(200)) {
+                    self.statuses
+                        .insert(engine_id, Status::listening_external());
+                    continue;
+                }
             }
             self.statuses.insert(engine_id, Status::starting());
             let arg_refs: Vec<&std::ffi::OsStr> = plan.args.iter().map(AsRef::as_ref).collect();


### PR DESCRIPTION
The launcher TUI skipped spawning an engine/daemon whenever its port was
already listening, marking it listening_external. After launcher.ps1 -Rebuild
side-lines an in-use binary and drops fresh code at the same path, a
long-running engine from a prior session keeps serving outdated code on that
port, so the GUI/TUI silently attached to it (the CAT-hub-empty symptom).

When a port is occupied at launch/restart, the launcher now reaps any stale
copy of our own published binary holding it and waits for the port to free
before spawning fresh code. A stale copy is matched conservatively: same
publish directory, same file name (or its <name>.locked-*.old side-lined
variant), and a start time predating the on-disk binary's build time. Genuinely
external owners (a different executable, or a build newer than on disk) are
left untouched, and reaping only runs when the target port is actually
occupied. Windows name matching is case-insensitive.

Adds wait_for_port_release plus unit tests for the staleness predicate.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
