### PR TITLE
Fix cathub VFO tracking

### DIFF
--- a/docs/integrations/cathub-live-radio-tests.md
+++ b/docs/integrations/cathub-live-radio-tests.md
@@ -1,0 +1,93 @@
+# cathub live TS-590 test runbook
+
+These tests exercise `qsoripper-cathub` against a real Kenwood TS-590. They are for
+hardware discovery and regression hunting; they are ignored by default and never run in CI.
+
+The deterministic unit and integration tests remain the merge gate. When a live-radio test
+finds a bug, capture the observed frame/state behavior and add a hardware-free regression
+before changing production code.
+
+## Default station assumptions
+
+- Radio: Kenwood TS-590
+- CAT port: `COM3`
+- CAT baud: `115200`
+- Hub backend: native `ts590`
+- Test Hamlib endpoint: temporary loopback TCP ports allocated by the test
+
+Both the port and baud can be overridden with environment variables or script parameters.
+
+## Safety rules
+
+- Stop every other process that might own the radio CAT port before running the tests.
+- Do not run these tests while operating on the air unless you are intentionally validating
+  receive-only CAT behavior.
+- The current live suite does not key PTT. Future transmit/PTT tests must remain behind a
+  separate explicit transmit flag.
+- Use `--nocapture` so operator prompts and diagnostic output are visible.
+
+## Quick run
+
+From the repository root:
+
+```powershell
+.\scripts\Test-CatHubLiveTs590.ps1
+```
+
+For the operator-assisted VFO matrix:
+
+```powershell
+.\scripts\Test-CatHubLiveTs590.ps1 -Interactive
+```
+
+Override the radio port or baud if needed:
+
+```powershell
+.\scripts\Test-CatHubLiveTs590.ps1 -Port COM7 -Baud 57600
+```
+
+## Direct cargo command
+
+```powershell
+$env:QSORIPPER_CATHUB_LIVE_TS590 = '1'
+$env:QSORIPPER_CATHUB_LIVE_PORT = 'COM3'
+$env:QSORIPPER_CATHUB_LIVE_BAUD = '115200'
+cargo test --manifest-path src\rust\Cargo.toml -p qsoripper-cathub --test live_ts590 -- --ignored --nocapture
+```
+
+To include the operator-assisted scenario:
+
+```powershell
+$env:QSORIPPER_CATHUB_LIVE_INTERACTIVE = '1'
+cargo test --manifest-path src\rust\Cargo.toml -p qsoripper-cathub --test live_ts590 -- --ignored --nocapture
+```
+
+## What the tests cover
+
+`live_ts590_startup_snapshot_is_coherent`
+
+- Starts the built `qsoripper-cathub` binary against the real TS-590.
+- Waits for the Hamlib endpoint to become reachable.
+- Reads `v`, `f`, `m`, and `\get_vfo_info <active VFO>`.
+- Asserts the active snapshot is coherent: `f` and `m` match the active VFO info block.
+
+`live_ts590_manual_vfo_switch_matrix`
+
+- Requires `QSORIPPER_CATHUB_LIVE_INTERACTIVE=1`.
+- Prompts the operator to set VFO A and VFO B to intentionally different frequencies and modes.
+- Confirms selecting VFO A makes Hamlib `v`, `f`, and `m` report VFO A state.
+- Prompts the operator to switch to VFO B.
+- Confirms Hamlib `v`, `f`, and `m` report VFO B state, not stale VFO A state.
+- Prompts the operator to switch back to VFO A and verifies the original A state returns.
+
+## When a live test fails
+
+1. Save the test output and cathub log.
+2. Identify the smallest radio-frame or Hamlib transcript that demonstrates the bug.
+3. Add a deterministic test in `src\rust\qsoripper-cathub\src\...` or a normal integration
+   test that reproduces the transcript without hardware.
+4. Confirm the deterministic test fails.
+5. Fix production code.
+6. Re-run the normal cathub test suite and the live test.
+
+This keeps hardware tests useful for discovery while ensuring regressions are caught by CI.

--- a/docs/integrations/cathub-setup.md
+++ b/docs/integrations/cathub-setup.md
@@ -23,6 +23,12 @@ Silicon Labs CP210x USB-UART bridge that fronts the TS-590's USB CAT port).
     Get-Process rigctld, rigctlcom -ErrorAction SilentlyContinue | Stop-Process
     # also stop any safe-bridge Python process and any app still bound directly to COM4
 
+Remove or disable any legacy startup hooks that relaunch `rigctld.exe`; otherwise it can
+reclaim the radio COM port after you stop QsoRipper/cathub. Check scheduled tasks first:
+
+    Get-ScheduledTask -TaskName QsoRipper-rigctld -ErrorAction SilentlyContinue
+    Unregister-ScheduledTask -TaskName QsoRipper-rigctld -Confirm:$false
+
 Confirm nothing else holds COM4 before continuing.
 
 ## 2. Create virtual serial pairs (com0com)
@@ -204,6 +210,9 @@ With the hub running and all six apps connected:
 Live transmit verification requires the operator and real hardware; do not key the
 transmitter from automation. Watch `Get-CatHubLog.ps1 -Follow` throughout.
 
+For opt-in hardware regression tests against a real TS-590, see
+`docs/integrations/cathub-live-radio-tests.md`.
+
 ## 7. Troubleshooting
 
 - "Access denied" / port busy on COM4: the legacy chain or another app still owns the radio
@@ -249,4 +258,3 @@ transmitter from automation. Watch `Get-CatHubLog.ps1 -Follow` throughout.
 - On shutdown (Ctrl+C) the daemon makes a best-effort `RX;` to unkey the transmitter. A hard
   crash cannot run that path; the `ptt_max_tx_ms` ceiling and the radio's own TX timeout are
   the ultimate stuck-transmitter backstops.
-

--- a/scripts/Test-CatHubLiveTs590.ps1
+++ b/scripts/Test-CatHubLiveTs590.ps1
@@ -1,0 +1,23 @@
+param(
+    [string]$Port = "COM3",
+    [int]$Baud = 115200,
+    [switch]$Interactive
+)
+
+$ErrorActionPreference = "Stop"
+
+$env:QSORIPPER_CATHUB_LIVE_TS590 = "1"
+$env:QSORIPPER_CATHUB_LIVE_PORT = $Port
+$env:QSORIPPER_CATHUB_LIVE_BAUD = [string]$Baud
+
+if ($Interactive) {
+    $env:QSORIPPER_CATHUB_LIVE_INTERACTIVE = "1"
+} else {
+    Remove-Item Env:\QSORIPPER_CATHUB_LIVE_INTERACTIVE -ErrorAction SilentlyContinue
+}
+
+Write-Host "Running live TS-590 cathub tests against $Port at $Baud baud."
+Write-Host "Stop other CAT/serial clients before continuing. The current suite does not key PTT."
+
+cargo test --manifest-path src\rust\Cargo.toml -p qsoripper-cathub --test live_ts590 -- --ignored --nocapture
+exit $LASTEXITCODE

--- a/src/rust/qsoripper-cathub/src/backend/kenwood/ts590.rs
+++ b/src/rust/qsoripper-cathub/src/backend/kenwood/ts590.rs
@@ -90,36 +90,30 @@ fn parse_if_status(frame: &[u8]) -> Option<IfStatus> {
     })
 }
 
-fn record_if_status(state: &StateHandle, status: IfStatus) {
-    state.record(
-        StateChange::RxVfo { vfo: status.rx_vfo },
-        RadioEventSource::PollDiff,
-    );
+fn record_if_status(state: &StateHandle, status: IfStatus, source: RadioEventSource) {
     state.record(
         StateChange::Freq {
             vfo: status.rx_vfo,
             hz: status.freq_hz,
         },
-        RadioEventSource::PollDiff,
+        source,
     );
     state.record(
         StateChange::Mode {
             vfo: status.rx_vfo,
             mode: status.mode,
         },
-        RadioEventSource::PollDiff,
+        source,
     );
-    state.record(
-        StateChange::Ptt { keyed: status.ptt },
-        RadioEventSource::PollDiff,
-    );
+    state.record(StateChange::Ptt { keyed: status.ptt }, source);
     state.record(
         StateChange::Split {
             enabled: status.split,
             tx_vfo: None,
         },
-        RadioEventSource::PollDiff,
+        source,
     );
+    state.record(StateChange::RxVfo { vfo: status.rx_vfo }, source);
 }
 
 /// Build an `FA`/`FB` frequency set frame.
@@ -129,6 +123,15 @@ fn freq_set(vfo: Vfo, hz: u64) -> Vec<u8> {
         Vfo::B => "FB",
     };
     format!("{verb}{hz:011};").into_bytes()
+}
+
+/// Build an `FR` receive-VFO select frame.
+fn rx_vfo_set(vfo: Vfo) -> Vec<u8> {
+    let digit = match vfo {
+        Vfo::A => b'0',
+        Vfo::B => b'1',
+    };
+    vec![b'F', b'R', digit, b';']
 }
 
 /// Whether a passthrough frame is a query (bare verb then `;`) versus a set.
@@ -143,7 +146,7 @@ impl RadioBackend for Ts590Backend {
             let verb = cmd.get(..2).unwrap_or(cmd).to_vec();
             let reply = link.submit(cmd.to_vec(), Expect::Reply(vec![verb])).await?;
             if let Some(status) = parse_if_status(&reply) {
-                record_if_status(state, status);
+                record_if_status(state, status, RadioEventSource::PollDiff);
             } else if let Some(mutation) = self.parse_event(&reply) {
                 state.record(mutation.into_change(), RadioEventSource::PollDiff);
             }
@@ -158,7 +161,18 @@ impl RadioBackend for Ts590Backend {
         state: &StateHandle,
     ) -> Result<(), BackendError> {
         let bytes = match mutation {
-            StateMutation::SetRxVfo { .. } => return Err(BackendError::Unsupported),
+            StateMutation::SetRxVfo { vfo } => {
+                let mut bytes = rx_vfo_set(vfo);
+                let snap = state.snapshot();
+                if snap.split {
+                    let tx = match snap.tx_vfo {
+                        Vfo::A => b'0',
+                        Vfo::B => b'1',
+                    };
+                    bytes.extend_from_slice(&[b'F', b'T', tx, b';']);
+                }
+                bytes
+            }
             StateMutation::SetVfoFreq { vfo, hz } => freq_set(vfo, hz),
             StateMutation::SetMode { mode, .. } => {
                 vec![b'M', b'D', mode.to_kenwood_digit(), b';']
@@ -247,6 +261,18 @@ impl RadioBackend for Ts590Backend {
                 parse_if_status(frame).map(|status| StateMutation::SetRxVfo { vfo: status.rx_vfo })
             }
             _ => None,
+        }
+    }
+
+    fn record_event(&self, frame: &[u8], state: &StateHandle, source: RadioEventSource) -> bool {
+        if let Some(status) = parse_if_status(frame) {
+            record_if_status(state, status, source);
+            true
+        } else if let Some(mutation) = self.parse_event(frame) {
+            state.record(mutation.into_change(), source);
+            true
+        } else {
+            false
         }
     }
 
@@ -410,6 +436,56 @@ mod tests {
         radio_side.read_exact(&mut buf).await.expect("read frame");
         assert_eq!(&buf, b"FA00007030000;");
         assert_eq!(state.snapshot().vfo(Vfo::A).freq_hz, 7_030_000);
+    }
+
+    #[tokio::test]
+    async fn apply_rx_vfo_writes_fr_and_updates_state() {
+        let (link, raw_rx) = link_channel();
+        let backend = Arc::new(Ts590Backend::new());
+        let arc: Arc<dyn RadioBackend> = backend.clone();
+        let state = StateHandle::new();
+        let (mut radio_side, server) = tokio::io::duplex(1024);
+        tokio::spawn(run_transport(server, arc, state.clone(), raw_rx));
+
+        backend
+            .apply(StateMutation::SetRxVfo { vfo: Vfo::B }, &link, &state)
+            .await
+            .expect("apply");
+
+        let mut buf = vec![0u8; 4];
+        radio_side.read_exact(&mut buf).await.expect("read frame");
+        assert_eq!(&buf, b"FR1;");
+        assert_eq!(state.snapshot().rx_vfo, Vfo::B);
+    }
+
+    #[tokio::test]
+    async fn apply_rx_vfo_preserves_split_tx_vfo() {
+        let (link, raw_rx) = link_channel();
+        let backend = Arc::new(Ts590Backend::new());
+        let arc: Arc<dyn RadioBackend> = backend.clone();
+        let state = StateHandle::new();
+        state.record(
+            StateChange::Split {
+                enabled: true,
+                tx_vfo: Some(Vfo::B),
+            },
+            RadioEventSource::PollDiff,
+        );
+        let (mut radio_side, server) = tokio::io::duplex(1024);
+        tokio::spawn(run_transport(server, arc, state.clone(), raw_rx));
+
+        backend
+            .apply(StateMutation::SetRxVfo { vfo: Vfo::A }, &link, &state)
+            .await
+            .expect("apply");
+
+        let mut buf = vec![0u8; 8];
+        radio_side.read_exact(&mut buf).await.expect("read frame");
+        assert_eq!(&buf, b"FR0;FT1;");
+        let snap = state.snapshot();
+        assert_eq!(snap.rx_vfo, Vfo::A);
+        assert!(snap.split);
+        assert_eq!(snap.tx_vfo, Vfo::B);
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-cathub/src/backend/kenwood/ts590.rs
+++ b/src/rust/qsoripper-cathub/src/backend/kenwood/ts590.rs
@@ -69,6 +69,14 @@ fn parse_u64(bytes: &[u8]) -> Option<u64> {
     std::str::from_utf8(bytes).ok()?.trim().parse::<u64>().ok()
 }
 
+fn parse_rx_vfo_digit(bytes: &[u8]) -> Option<Vfo> {
+    match *bytes.first()? {
+        b'0' => Some(Vfo::A),
+        b'1' => Some(Vfo::B),
+        _ => None,
+    }
+}
+
 fn parse_if_status(frame: &[u8]) -> Option<IfStatus> {
     let (verb, payload) = split_frame(frame)?;
     if verb != b"IF" {
@@ -145,11 +153,7 @@ impl RadioBackend for Ts590Backend {
         for &cmd in POLL_COMMANDS {
             let verb = cmd.get(..2).unwrap_or(cmd).to_vec();
             let reply = link.submit(cmd.to_vec(), Expect::Reply(vec![verb])).await?;
-            if let Some(status) = parse_if_status(&reply) {
-                record_if_status(state, status, RadioEventSource::PollDiff);
-            } else if let Some(mutation) = self.parse_event(&reply) {
-                state.record(mutation.into_change(), RadioEventSource::PollDiff);
-            }
+            let _ = self.record_event(&reply, state, RadioEventSource::PollDiff);
         }
         Ok(())
     }
@@ -267,12 +271,48 @@ impl RadioBackend for Ts590Backend {
     fn record_event(&self, frame: &[u8], state: &StateHandle, source: RadioEventSource) -> bool {
         if let Some(status) = parse_if_status(frame) {
             record_if_status(state, status, source);
-            true
-        } else if let Some(mutation) = self.parse_event(frame) {
-            state.record(mutation.into_change(), source);
-            true
-        } else {
-            false
+            return true;
+        }
+
+        let Some((verb, payload)) = split_frame(frame) else {
+            return false;
+        };
+        match verb {
+            b"FA" => parse_u64(payload).is_some_and(|hz| {
+                state.record(StateChange::Freq { vfo: Vfo::A, hz }, source);
+                true
+            }),
+            b"FB" => parse_u64(payload).is_some_and(|hz| {
+                state.record(StateChange::Freq { vfo: Vfo::B, hz }, source);
+                true
+            }),
+            b"FR" => parse_rx_vfo_digit(payload).is_some_and(|vfo| {
+                state.record(StateChange::RxVfo { vfo }, source);
+                true
+            }),
+            b"MD" => payload.first().is_some_and(|digit| {
+                let vfo = state.snapshot().rx_vfo;
+                state.record(
+                    StateChange::Mode {
+                        vfo,
+                        mode: Mode::from_kenwood_digit(*digit),
+                    },
+                    source,
+                );
+                true
+            }),
+            b"DA" => payload.first().is_some_and(|digit| {
+                let vfo = state.snapshot().rx_vfo;
+                state.record(
+                    StateChange::DataMode {
+                        vfo,
+                        on: *digit == b'1',
+                    },
+                    source,
+                );
+                true
+            }),
+            _ => false,
         }
     }
 
@@ -396,6 +436,32 @@ mod tests {
         assert_eq!(
             parse_if_status(b"IF000140343201234-0000012345122019999;"),
             None
+        );
+    }
+
+    #[test]
+    fn native_fr_then_md_records_mode_on_active_vfo() {
+        let backend = Ts590Backend::new();
+        let state = StateHandle::new();
+        state.record(
+            StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 14_034_320,
+            },
+            RadioEventSource::PollDiff,
+        );
+
+        assert!(backend.record_event(b"FR1;", &state, RadioEventSource::NativePush));
+        assert!(backend.record_event(b"MD3;", &state, RadioEventSource::NativePush));
+
+        let snap = state.snapshot();
+        assert_eq!(snap.rx_vfo, Vfo::B);
+        assert_eq!(snap.vfo(Vfo::B).freq_hz, 14_034_320);
+        assert_eq!(snap.vfo(Vfo::B).mode, Mode::Cw);
+        assert_eq!(
+            snap.vfo(Vfo::A).mode,
+            Mode::Usb,
+            "VFO B mode push must not be recorded against VFO A"
         );
     }
 
@@ -619,7 +685,56 @@ mod tests {
         let snap = state.snapshot();
         assert_eq!(snap.rx_vfo, Vfo::B);
         assert_eq!(snap.vfo(snap.rx_vfo).freq_hz, 14_034_320);
-        assert_eq!(snap.vfo(snap.rx_vfo).mode, Mode::Usb);
+        assert_eq!(snap.vfo(snap.rx_vfo).mode, Mode::Cw);
+    }
+
+    #[tokio::test]
+    async fn poll_records_md_and_da_on_active_vfo() {
+        let (link, raw_rx) = link_channel();
+        let backend = Arc::new(Ts590Backend::new());
+        let arc: Arc<dyn RadioBackend> = backend.clone();
+        let state = StateHandle::new();
+        let (radio_side, server) = tokio::io::duplex(1024);
+        tokio::spawn(run_transport(server, arc, state.clone(), raw_rx));
+
+        tokio::spawn(async move {
+            let (mut rd, mut wr) = tokio::io::split(radio_side);
+            let mut frame = Vec::new();
+            let mut byte = [0u8; 1];
+            loop {
+                if rd.read(&mut byte).await.unwrap_or(0) == 0 {
+                    break;
+                }
+                frame.push(byte[0]);
+                if byte[0] == b';' {
+                    let answer: &[u8] = match frame.as_slice() {
+                        b"FA;" => b"FA00003020950;",
+                        b"FB;" => b"FB00014034320;",
+                        b"IF;" => b"IF000140343201234-0000012345021009999;",
+                        b"MD;" => b"MD3;",
+                        b"DA;" => b"DA1;",
+                        _ => b"",
+                    };
+                    let _ = wr.write_all(answer).await;
+                    frame.clear();
+                }
+            }
+        });
+
+        backend.poll(&link, &state).await.expect("poll");
+        let snap = state.snapshot();
+        assert_eq!(snap.rx_vfo, Vfo::B);
+        assert_eq!(snap.vfo(Vfo::B).mode, Mode::Cw);
+        assert!(snap.vfo(Vfo::B).data);
+        assert_eq!(
+            snap.vfo(Vfo::A).mode,
+            Mode::Usb,
+            "active VFO B MD reply must not update VFO A"
+        );
+        assert!(
+            !snap.vfo(Vfo::A).data,
+            "active VFO B DA reply must not update VFO A"
+        );
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-cathub/src/backend/mod.rs
+++ b/src/rust/qsoripper-cathub/src/backend/mod.rs
@@ -12,7 +12,7 @@ pub(crate) mod rigctld;
 use async_trait::async_trait;
 
 pub(crate) use crate::error::BackendError;
-use crate::model::StateMutation;
+use crate::model::{RadioEventSource, StateMutation};
 use crate::radio::RadioLink;
 use crate::state::StateHandle;
 
@@ -131,6 +131,16 @@ pub(crate) trait RadioBackend: Send + Sync {
 
     /// Parse an unsolicited (native push) frame into a mutation, if recognized.
     fn parse_event(&self, frame: &[u8]) -> Option<StateMutation>;
+
+    /// Record an unsolicited (native push) frame into the universal state, if recognized.
+    fn record_event(&self, frame: &[u8], state: &StateHandle, source: RadioEventSource) -> bool {
+        if let Some(mutation) = self.parse_event(frame) {
+            state.record(mutation.into_change(), source);
+            true
+        } else {
+            false
+        }
+    }
 
     /// Forward a raw native command, returning the raw reply.
     async fn passthrough(&self, raw: &[u8], link: &RadioLink) -> Result<Vec<u8>, BackendError>;

--- a/src/rust/qsoripper-cathub/src/dialect/kenwood/ts2000.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/kenwood/ts2000.rs
@@ -119,6 +119,7 @@ impl ClientDialect for Ts2000Dialect {
             StateChange::Mode { vfo: Vfo::A, mode } => {
                 Some(vec![b'M', b'D', mode_to_digit(mode), b';'])
             }
+            StateChange::RxVfo { .. } => Some(synth_if(&ctx.snapshot())),
             _ => None,
         }
     }
@@ -204,6 +205,41 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(20)).await;
         // Crucially: no split mutation reached the radio.
         assert!(backend.mutations().is_empty());
+    }
+
+    #[tokio::test]
+    async fn rx_vfo_change_notifies_with_current_if_status() {
+        let (ctx, _backend) = ctx_with(FacePermissions::read_only());
+        ctx.set_ai(true);
+        ctx.state.record(
+            StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 14_034_320,
+            },
+            RadioEventSource::NativePush,
+        );
+        ctx.state.record(
+            StateChange::Mode {
+                vfo: Vfo::B,
+                mode: crate::model::Mode::Usb,
+            },
+            RadioEventSource::NativePush,
+        );
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::NativePush,
+        );
+
+        let notification = Ts2000Dialect::new()
+            .format_notification(&StateChange::RxVfo { vfo: Vfo::B }, &ctx)
+            .expect("IF notification");
+
+        assert!(notification.starts_with(b"IF00014034320"));
+        assert_eq!(
+            *notification.get(30).expect("VFO field"),
+            b'1',
+            "TS-2000 IF VFO field should report VFO B"
+        );
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-cathub/src/dialect/kenwood/ts2000.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/kenwood/ts2000.rs
@@ -57,7 +57,9 @@ impl ClientDialect for Ts2000Dialect {
                 if read {
                     return freq_frame(b"FA", ctx.snapshot().vfo(Vfo::A).freq_hz);
                 }
-                set_freq(ctx, Vfo::A, &payload).await
+                // OmniRig/HDSDR uses FA writes for the displayed tune target. Preserve the
+                // no-retargeting invariant by applying that tune to the currently active VFO.
+                set_freq(ctx, ctx.snapshot().rx_vfo, &payload).await
             }
             b"FB" => {
                 if read {
@@ -67,16 +69,18 @@ impl ClientDialect for Ts2000Dialect {
             }
             b"MD" => {
                 if read {
-                    let d = mode_to_digit(ctx.snapshot().vfo(Vfo::A).mode);
+                    let snap = ctx.snapshot();
+                    let d = mode_to_digit(snap.vfo(snap.rx_vfo).mode);
                     return vec![b'M', b'D', d, b';'];
                 }
                 let Some(&d) = payload.first() else {
                     return ERR.to_vec();
                 };
+                let vfo = ctx.snapshot().rx_vfo;
                 reply(
                     ctx.apply_modeled(
                         StateMutation::SetMode {
-                            vfo: Vfo::A,
+                            vfo,
                             mode: mode_from_digit(d),
                         },
                         CommandClass::ModeledWrite,
@@ -280,6 +284,69 @@ mod tests {
         assert_eq!(
             Ts2000Dialect::new().handle(b"FA;", &ctx).await,
             b"FA00021200000;".to_vec()
+        );
+    }
+
+    #[tokio::test]
+    async fn fa_write_tunes_active_vfo_b() {
+        let (ctx, backend) = ctx_with(FacePermissions::from_tokens(&["read", "write"]));
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::NativePush,
+        );
+
+        assert_eq!(
+            Ts2000Dialect::new().handle(b"FA00014074000;", &ctx).await,
+            Vec::<u8>::new()
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        assert_eq!(
+            backend.mutations(),
+            vec![StateMutation::SetVfoFreq {
+                vfo: Vfo::B,
+                hz: 14_074_000
+            }],
+            "HDSDR/OmniRig FA set-frequency writes express the displayed active frequency"
+        );
+    }
+
+    #[tokio::test]
+    async fn md_read_and_write_use_active_vfo_b() {
+        let (ctx, backend) = ctx_with(FacePermissions::from_tokens(&["read", "write"]));
+        ctx.state.record(
+            StateChange::Mode {
+                vfo: Vfo::A,
+                mode: crate::model::Mode::Lsb,
+            },
+            RadioEventSource::NativePush,
+        );
+        ctx.state.record(
+            StateChange::Mode {
+                vfo: Vfo::B,
+                mode: crate::model::Mode::Cw,
+            },
+            RadioEventSource::NativePush,
+        );
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::NativePush,
+        );
+
+        assert_eq!(Ts2000Dialect::new().handle(b"MD;", &ctx).await, b"MD3;");
+        assert_eq!(
+            Ts2000Dialect::new().handle(b"MD2;", &ctx).await,
+            Vec::<u8>::new()
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        assert_eq!(
+            backend.mutations(),
+            vec![StateMutation::SetMode {
+                vfo: Vfo::B,
+                mode: crate::model::Mode::Usb
+            }],
+            "HDSDR/OmniRig MD writes express the displayed active mode"
         );
     }
 }

--- a/src/rust/qsoripper-cathub/src/dialect/kenwood/ts590.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/kenwood/ts590.rs
@@ -137,6 +137,7 @@ impl ClientDialect for Ts590Dialect {
             StateChange::Mode { vfo: Vfo::A, mode } => {
                 Some(vec![b'M', b'D', mode_to_digit(mode), b';'])
             }
+            StateChange::RxVfo { .. } => Some(synth_if(&ctx.snapshot())),
             _ => None,
         }
     }

--- a/src/rust/qsoripper-cathub/src/hamlib_net.rs
+++ b/src/rust/qsoripper-cathub/src/hamlib_net.rs
@@ -570,6 +570,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_freq_and_mode_follow_active_vfo_b() {
+        let (ctx, _b, state) = ctx_with(FacePermissions::read_only());
+        state.record(
+            StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 14_034_320,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::Mode {
+                vfo: Vfo::B,
+                mode: Mode::Cw,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::PollDiff,
+        );
+
+        assert_eq!(reply_of("f", &ctx).await, b"14034320\n".to_vec());
+        assert_eq!(reply_of("m", &ctx).await, b"CW\n2400\n".to_vec());
+        assert_eq!(reply_of("v", &ctx).await, b"VFOB\n".to_vec());
+    }
+
+    #[tokio::test]
     async fn read_only_endpoint_rejects_set_freq() {
         let (ctx, backend, _s) = ctx_with(FacePermissions::read_only());
         assert_eq!(reply_of("F 14074000", &ctx).await, RPRT_EINVAL.to_vec());

--- a/src/rust/qsoripper-cathub/src/integration.rs
+++ b/src/rust/qsoripper-cathub/src/integration.rs
@@ -24,6 +24,7 @@ use crate::dialect::kenwood::ts2000::Ts2000Dialect;
 use crate::dialect::kenwood::ts590::Ts590Dialect;
 use crate::dialect::{ClientDialect, FaceContext};
 use crate::hamlib_net::serve_conn;
+use crate::model::{RadioEventSource, StateChange, StateMutation, Vfo};
 use crate::permissions::FacePermissions;
 use crate::ptt::PttManager;
 use crate::radio::{detached_link, spawn_scheduler, OpKind, Priority, RadioHandle};
@@ -169,6 +170,35 @@ async fn ts2000_face_never_retargets_vfo() {
     assert!(
         rig.backend.mutations().is_empty(),
         "no status read or VFO-select should mutate the radio"
+    );
+    assert!(rig.backend.passthroughs().is_empty());
+}
+
+/// HDSDR/OmniRig click-to-tune uses the TS-2000 face's FA write as "set the displayed
+/// active frequency". When the real radio is on VFO B, that write must tune VFO B without
+/// emitting a VFO-retarget command.
+#[tokio::test]
+async fn ts2000_face_fa_write_tunes_active_vfo_b() {
+    let rig = rig();
+    let mut omni = rig.face(
+        ts2000(),
+        FacePermissions::from_tokens(&["read", "write"]),
+        1,
+    );
+    rig.state.record(
+        StateChange::RxVfo { vfo: Vfo::B },
+        RadioEventSource::NativePush,
+    );
+
+    omni.write_all(b"FA00014074000;").await.expect("write");
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    assert_eq!(
+        rig.backend.mutations(),
+        vec![StateMutation::SetVfoFreq {
+            vfo: Vfo::B,
+            hz: 14_074_000
+        }]
     );
     assert!(rig.backend.passthroughs().is_empty());
 }

--- a/src/rust/qsoripper-cathub/src/radio/mod.rs
+++ b/src/rust/qsoripper-cathub/src/radio/mod.rs
@@ -388,9 +388,7 @@ pub(crate) async fn run_transport_supervised<T, F, Fut>(
 /// faces (which consume the CAT stream directly) keep features like the radio's noise
 /// blanker and front-panel changes in sync.
 fn route_event(backend: &Arc<dyn RadioBackend>, state: &StateHandle, frame: &[u8]) {
-    if let Some(mutation) = backend.parse_event(frame) {
-        state.record(mutation.into_change(), RadioEventSource::NativePush);
-    } else {
+    if !backend.record_event(frame, state, RadioEventSource::NativePush) {
         tracing::trace!(
             frame = %String::from_utf8_lossy(frame),
             "relaying unmodeled unsolicited radio frame to native pass-through faces"
@@ -524,6 +522,8 @@ async fn execute(
 )]
 mod tests {
     use super::*;
+    use crate::backend::kenwood::ts590::Ts590Backend;
+    use crate::model::{Mode, Vfo};
 
     #[test]
     fn framer_splits_on_semicolons() {
@@ -546,6 +546,21 @@ mod tests {
     fn verb_matching_uses_prefix() {
         assert!(frame_matches(b"FA00007030000;", &[b"FA".to_vec()]));
         assert!(!frame_matches(b"MD3;", &[b"FA".to_vec()]));
+    }
+
+    #[test]
+    fn route_event_records_full_ts590_if_status() {
+        let backend: Arc<dyn RadioBackend> = Arc::new(Ts590Backend::new());
+        let state = StateHandle::new();
+
+        route_event(&backend, &state, b"IF000140343201234-0000012345121019999;");
+
+        let snap = state.snapshot();
+        assert_eq!(snap.rx_vfo, Vfo::B);
+        assert_eq!(snap.vfo(Vfo::B).freq_hz, 14_034_320);
+        assert_eq!(snap.vfo(Vfo::B).mode, Mode::Usb);
+        assert!(snap.ptt);
+        assert!(snap.split);
     }
 
     #[test]

--- a/src/rust/qsoripper-cathub/tests/live_ts590.rs
+++ b/src/rust/qsoripper-cathub/tests/live_ts590.rs
@@ -1,0 +1,321 @@
+//! Opt-in live TS-590 hardware tests.
+//!
+//! These tests are ignored by default and only touch hardware when
+//! `QSORIPPER_CATHUB_LIVE_TS590=1` is set. They start the built cathub binary against the
+//! configured radio serial port, query its Hamlib endpoint, and then stop the process.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const LIVE_FLAG: &str = "QSORIPPER_CATHUB_LIVE_TS590";
+const INTERACTIVE_FLAG: &str = "QSORIPPER_CATHUB_LIVE_INTERACTIVE";
+const PORT_ENV: &str = "QSORIPPER_CATHUB_LIVE_PORT";
+const BAUD_ENV: &str = "QSORIPPER_CATHUB_LIVE_BAUD";
+const DEFAULT_PORT: &str = "COM3";
+const DEFAULT_BAUD: u32 = 115_200;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Snapshot {
+    vfo: String,
+    freq_hz: u64,
+    mode: String,
+    passband_hz: u32,
+}
+
+struct LiveCathub {
+    child: Child,
+    config_path: PathBuf,
+    read_only_addr: SocketAddr,
+}
+
+impl Drop for LiveCathub {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        let _ = std::fs::remove_file(&self.config_path);
+    }
+}
+
+fn live_enabled() -> bool {
+    std::env::var(LIVE_FLAG).is_ok_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+}
+
+fn interactive_enabled() -> bool {
+    std::env::var(INTERACTIVE_FLAG)
+        .is_ok_and(|value| value == "1" || value.eq_ignore_ascii_case("true"))
+}
+
+fn free_loopback_addr() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("allocate free loopback port");
+    listener.local_addr().expect("local address")
+}
+
+fn temp_config_path(tag: &str) -> PathBuf {
+    std::env::temp_dir().join(format!(
+        "qsoripper-cathub-live-{tag}-{}-{}.toml",
+        std::process::id(),
+        Instant::now().elapsed().as_nanos()
+    ))
+}
+
+fn write_live_config(read_only_addr: SocketAddr, read_write_addr: SocketAddr) -> PathBuf {
+    let port = std::env::var(PORT_ENV).unwrap_or_else(|_| DEFAULT_PORT.to_string());
+    let baud = std::env::var(BAUD_ENV)
+        .ok()
+        .and_then(|value| value.parse::<u32>().ok())
+        .unwrap_or(DEFAULT_BAUD);
+    let path = temp_config_path("ts590");
+    let text = format!(
+        r#"[radio]
+backend = "ts590"
+transport = "serial"
+port = "{port}"
+baud = {baud}
+
+[poll]
+baseline_ms = 100
+heartbeat_ms = 1000
+
+[ptt]
+max_tx_ms = 300000
+
+[events]
+native_push = true
+
+[[hamlib_net]]
+name = "engine-readonly"
+bind = "{read_only_addr}"
+perms = ["read"]
+
+[[hamlib_net]]
+name = "live-readwrite"
+bind = "{read_write_addr}"
+perms = ["read", "write"]
+"#
+    );
+    std::fs::write(&path, text).expect("write live cathub config");
+    path
+}
+
+fn start_live_cathub() -> Option<LiveCathub> {
+    if !live_enabled() {
+        eprintln!("Skipping live TS-590 test; set {LIVE_FLAG}=1 to enable hardware access.");
+        return None;
+    }
+
+    let read_only_addr = free_loopback_addr();
+    let read_write_addr = free_loopback_addr();
+    let config_path = write_live_config(read_only_addr, read_write_addr);
+    let binary = env!("CARGO_BIN_EXE_qsoripper-cathub");
+    let child = Command::new(binary)
+        .arg("--config")
+        .arg(&config_path)
+        .env("CATHUB_LOG", "qsoripper_cathub=debug")
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("start qsoripper-cathub");
+
+    let mut hub = LiveCathub {
+        child,
+        config_path,
+        read_only_addr,
+    };
+    wait_for_endpoint(&mut hub).expect("wait for cathub Hamlib endpoint");
+    Some(hub)
+}
+
+fn wait_for_endpoint(hub: &mut LiveCathub) -> Result<(), String> {
+    let deadline = Instant::now() + Duration::from_secs(8);
+    loop {
+        if TcpStream::connect(hub.read_only_addr).is_ok() {
+            return Ok(());
+        }
+        if let Some(status) = hub.child.try_wait().expect("check cathub process") {
+            return Err(format!(
+                "cathub exited before Hamlib endpoint {} became reachable: {status}",
+                hub.read_only_addr
+            ));
+        }
+        assert!(
+            Instant::now() < deadline,
+            "cathub Hamlib endpoint {} did not become reachable",
+            hub.read_only_addr
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn rigctl_lines(addr: SocketAddr, command: &str, expected_lines: usize) -> Vec<String> {
+    let mut stream = TcpStream::connect(addr).expect("connect to cathub hamlib endpoint");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(2)))
+        .expect("set read timeout");
+    stream
+        .write_all(format!("{command}\n").as_bytes())
+        .expect("write rigctl command");
+    stream.flush().expect("flush rigctl command");
+
+    let mut reader = BufReader::new(stream);
+    let mut lines = Vec::with_capacity(expected_lines);
+    for _ in 0..expected_lines {
+        let mut line = String::new();
+        reader.read_line(&mut line).expect("read rigctl line");
+        assert!(
+            !line.is_empty(),
+            "cathub closed connection before replying to {command}"
+        );
+        lines.push(line.trim().to_string());
+    }
+    lines
+}
+
+fn snapshot(addr: SocketAddr) -> Snapshot {
+    let vfo = rigctl_lines(addr, "v", 1).remove(0);
+    let freq_hz = rigctl_lines(addr, "f", 1)
+        .remove(0)
+        .parse::<u64>()
+        .expect("frequency is integer Hz");
+    let mode_lines = rigctl_lines(addr, "m", 2);
+    let mode = mode_lines.first().expect("mode line").clone();
+    let passband_hz = mode_lines
+        .get(1)
+        .expect("passband line")
+        .parse::<u32>()
+        .expect("passband is integer Hz");
+    Snapshot {
+        vfo,
+        freq_hz,
+        mode,
+        passband_hz,
+    }
+}
+
+fn vfo_info(addr: SocketAddr, vfo: &str) -> Snapshot {
+    let lines = rigctl_lines(addr, &format!("\\get_vfo_info {vfo}"), 5);
+    Snapshot {
+        vfo: vfo.to_string(),
+        freq_hz: lines
+            .first()
+            .expect("VFO frequency line")
+            .parse::<u64>()
+            .expect("VFO frequency is Hz"),
+        mode: lines.get(1).expect("VFO mode line").clone(),
+        passband_hz: lines
+            .get(2)
+            .expect("VFO passband line")
+            .parse::<u32>()
+            .expect("VFO passband is Hz"),
+    }
+}
+
+fn wait_for_snapshot(
+    addr: SocketAddr,
+    predicate: impl Fn(&Snapshot) -> bool,
+    description: &str,
+) -> Snapshot {
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let snap = snapshot(addr);
+        if predicate(&snap) {
+            return snap;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {description}; last snapshot was {snap:?}"
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn wait_for_operator(message: &str) {
+    eprintln!("{message}");
+    eprintln!("Press Enter when ready.");
+    let mut line = String::new();
+    std::io::stdin()
+        .read_line(&mut line)
+        .expect("read operator confirmation");
+}
+
+#[test]
+#[ignore = "requires a real TS-590 connected to the configured CAT port"]
+fn live_ts590_startup_snapshot_is_coherent() {
+    let Some(hub) = start_live_cathub() else {
+        return;
+    };
+
+    let active = wait_for_snapshot(
+        hub.read_only_addr,
+        |snap| snap.freq_hz > 0 && (snap.vfo == "VFOA" || snap.vfo == "VFOB"),
+        "non-zero active VFO snapshot",
+    );
+    let active_info = vfo_info(hub.read_only_addr, &active.vfo);
+
+    assert_eq!(
+        active.freq_hz, active_info.freq_hz,
+        "Hamlib f must match active VFO info"
+    );
+    assert_eq!(
+        active.mode, active_info.mode,
+        "Hamlib m must match active VFO info"
+    );
+    assert!(active.passband_hz > 0);
+}
+
+#[test]
+#[ignore = "requires operator-assisted real TS-590 VFO switching"]
+fn live_ts590_manual_vfo_switch_matrix() {
+    if !interactive_enabled() {
+        eprintln!(
+            "Skipping operator-assisted VFO matrix; set {INTERACTIVE_FLAG}=1 in addition to {LIVE_FLAG}=1."
+        );
+        return;
+    }
+    let Some(hub) = start_live_cathub() else {
+        return;
+    };
+
+    wait_for_operator(
+        "Set VFO A and VFO B to different frequencies and modes, select VFO A, and wait for the dial to settle.",
+    );
+    let a = wait_for_snapshot(
+        hub.read_only_addr,
+        |snap| snap.vfo == "VFOA" && snap.freq_hz > 0,
+        "active VFO A",
+    );
+    let a_info = vfo_info(hub.read_only_addr, "VFOA");
+    assert_eq!(a.freq_hz, a_info.freq_hz);
+    assert_eq!(a.mode, a_info.mode);
+
+    wait_for_operator("Switch the radio to VFO B and wait for the dial to settle.");
+    let b = wait_for_snapshot(
+        hub.read_only_addr,
+        |snap| snap.vfo == "VFOB" && snap.freq_hz > 0 && snap.freq_hz != a.freq_hz,
+        "active VFO B with its own frequency",
+    );
+    let b_info = vfo_info(hub.read_only_addr, "VFOB");
+    assert_eq!(b.freq_hz, b_info.freq_hz);
+    assert_eq!(b.mode, b_info.mode);
+    assert_ne!(
+        a.freq_hz, b.freq_hz,
+        "live VFO matrix requires intentionally different A/B frequencies"
+    );
+    assert_ne!(
+        a.mode, b.mode,
+        "live VFO matrix requires intentionally different A/B modes"
+    );
+
+    wait_for_operator("Switch the radio back to VFO A and wait for the dial to settle.");
+    let a_again = wait_for_snapshot(
+        hub.read_only_addr,
+        |snap| snap.vfo == "VFOA" && snap.freq_hz == a.freq_hz,
+        "return to VFO A frequency",
+    );
+    assert_eq!(a_again.mode, a.mode);
+}


### PR DESCRIPTION
This fixes a cathub CAT-control regression where active-VFO handling became too conservative in one path and too lossy in another.

The first problem was that the native TS-590 backend had learned to track the active receive VFO from IF status, but it rejected the trusted internal SetRxVfo mutation entirely. That meant QsoRipper-owned control paths could not deliberately move the radio to VFO B through cathub. The fix adds TS-590 SetRxVfo support by emitting the deliberate FR0/FR1 receive-VFO command, while preserving the existing safety rule that poll cycles never contain FR/FT and therefore cannot retarget the radio during status refresh.

The fix intentionally does not make Hamlib net V/set_vfo retarget the radio. Foreign clients such as WSJT-X, Log4OM, and Hamlib-style integrations often send set_vfo defensively as part of normal operation. Turning that into a real FR write would risk reintroducing the A/B oscillation that cathub was designed to prevent. The Hamlib net face continues to accept set_vfo as a benign no-op, and frequency writes still land on cathub's current active VFO.

The second problem was in native push handling. TS-590 unsolicited IF frames carry a complete status snapshot: active VFO, frequency, mode, PTT, and split. Cathub's poll path recorded all of that, but the native-push path only extracted the active VFO and dropped the frequency and other fields. If the radio reported front-panel activity through IF push frames, cathub could know that VFO B was active while still serving stale frequency/mode data to HDSDR, OmniRig-style TS-2000 faces, and the QsoRipper TUI's rig snapshot path.

The fix adds a backend record_event hook so the TS-590 backend can record the complete IF status from unsolicited frames without changing the simple single-mutation parse_event fallback used by other frames and backends. It also emits synthesized IF notifications for TS-590 and TS-2000 faces when the active receive VFO changes, so AI-subscribed clients see a coherent status frame after a VFO switch.

Split handling is preserved for trusted TS-590 receive-VFO writes. If split is already enabled, cathub emits FR for the new receive VFO and immediately reissues FT for the tracked transmit VFO so selecting the receive VFO does not silently disturb the split transmit side.

Validation run locally: cargo test --manifest-path src\rust\Cargo.toml -p qsoripper-cathub, cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check, cargo clippy --manifest-path src\rust\Cargo.toml -p qsoripper-cathub --all-targets -- -D warnings, and cargo test --manifest-path src\rust\Cargo.toml.