### PR TITLE
Fix HDSDR active VFO readback

### DIFF
--- a/src/rust/qsoripper-cathub/src/dialect/kenwood/ts2000.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/kenwood/ts2000.rs
@@ -55,7 +55,8 @@ impl ClientDialect for Ts2000Dialect {
             b"IF" if read => synth_if(&ctx.snapshot()),
             b"FA" => {
                 if read {
-                    return freq_frame(b"FA", ctx.snapshot().vfo(Vfo::A).freq_hz);
+                    let snap = ctx.snapshot();
+                    return freq_frame(b"FA", snap.vfo(snap.rx_vfo).freq_hz);
                 }
                 // OmniRig/HDSDR uses FA writes for the displayed tune target. Preserve the
                 // no-retargeting invariant by applying that tune to the currently active VFO.
@@ -118,9 +119,11 @@ impl ClientDialect for Ts2000Dialect {
             return None;
         }
         match *change {
-            StateChange::Freq { vfo: Vfo::A, hz } => Some(freq_frame(b"FA", hz)),
+            StateChange::Freq { vfo, hz } if vfo == ctx.snapshot().rx_vfo => {
+                Some(freq_frame(b"FA", hz))
+            }
             StateChange::Freq { vfo: Vfo::B, hz } => Some(freq_frame(b"FB", hz)),
-            StateChange::Mode { vfo: Vfo::A, mode } => {
+            StateChange::Mode { vfo, mode } if vfo == ctx.snapshot().rx_vfo => {
                 Some(vec![b'M', b'D', mode_to_digit(mode), b';'])
             }
             StateChange::RxVfo { .. } => Some(synth_if(&ctx.snapshot())),
@@ -309,6 +312,57 @@ mod tests {
             }],
             "HDSDR/OmniRig FA set-frequency writes express the displayed active frequency"
         );
+    }
+
+    #[tokio::test]
+    async fn fa_read_reports_active_vfo_b_frequency() {
+        let (ctx, _backend) = ctx_with(FacePermissions::read_only());
+        ctx.state.record(
+            StateChange::Freq {
+                vfo: Vfo::A,
+                hz: 14_062_820,
+            },
+            RadioEventSource::NativePush,
+        );
+        ctx.state.record(
+            StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 14_074_000,
+            },
+            RadioEventSource::NativePush,
+        );
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::NativePush,
+        );
+
+        assert_eq!(
+            Ts2000Dialect::new().handle(b"FA;", &ctx).await,
+            b"FA00014074000;".to_vec(),
+            "HDSDR/OmniRig FA reads track the displayed active frequency"
+        );
+    }
+
+    #[tokio::test]
+    async fn active_vfo_b_frequency_notifies_as_fa() {
+        let (ctx, _backend) = ctx_with(FacePermissions::read_only());
+        ctx.set_ai(true);
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::NativePush,
+        );
+
+        let notification = Ts2000Dialect::new()
+            .format_notification(
+                &StateChange::Freq {
+                    vfo: Vfo::B,
+                    hz: 14_074_000,
+                },
+                &ctx,
+            )
+            .expect("active VFO B frequency notification");
+
+        assert_eq!(notification, b"FA00014074000;".to_vec());
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-cathub/src/integration.rs
+++ b/src/rust/qsoripper-cathub/src/integration.rs
@@ -203,6 +203,39 @@ async fn ts2000_face_fa_write_tunes_active_vfo_b() {
     assert!(rig.backend.passthroughs().is_empty());
 }
 
+/// HDSDR/OmniRig polls `IF;`, `FA;`, and `FB;`. On active VFO B, `FA;` must report the
+/// displayed active frequency, not stale inactive VFO A, because HDSDR treats FA as its main
+/// panadapter frequency.
+#[tokio::test]
+async fn ts2000_face_fa_read_reports_active_vfo_b() {
+    let rig = rig();
+    let mut omni = rig.face(ts2000(), FacePermissions::read_only(), 1);
+    rig.state.record(
+        StateChange::Freq {
+            vfo: Vfo::A,
+            hz: 14_062_820,
+        },
+        RadioEventSource::NativePush,
+    );
+    rig.state.record(
+        StateChange::Freq {
+            vfo: Vfo::B,
+            hz: 14_074_000,
+        },
+        RadioEventSource::NativePush,
+    );
+    rig.state.record(
+        StateChange::RxVfo { vfo: Vfo::B },
+        RadioEventSource::NativePush,
+    );
+
+    assert!(request(&mut omni, b"IF;")
+        .await
+        .starts_with(b"IF00014074000"));
+    assert_eq!(request(&mut omni, b"FA;").await, b"FA00014074000;");
+    assert_eq!(request(&mut omni, b"FB;").await, b"FB00014074000;");
+}
+
 /// A simulated front-panel change (a poll-diff from the backend's truth) fans out to every
 /// auto-info-subscribed face without any client having polled.
 #[tokio::test]


### PR DESCRIPTION
This fixes the remaining HDSDR/OmniRig CAT issue after PR #491.

The live trace showed HDSDR polling the TS-2000 face with IF, FA, and FB. When the radio was on VFO B, cathub correctly reported VFO B in IF, but FA still returned the inactive VFO A frequency. HDSDR appears to use FA as the displayed panadapter frequency for the TS-2000 profile, so it continued to see stale VFO A even though cathub state was correct.

The TS-2000 translator now treats FA reads, FA writes, MD reads, and MD writes as active/displayed VFO operations. FB still reports VFO B, and FR/FT writes remain rejected so the no-retargeting anti-oscillation invariant is preserved.

Validation run locally:

cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check
cargo test --manifest-path src\rust\Cargo.toml
cargo clippy --manifest-path src\rust\Cargo.toml --all-targets -- -D warnings

I also restarted cathub with trace logging on the live TS-590 station and verified that the fixed build replies to HDSDR polling on active VFO B with IF and FA both carrying the active VFO B frequency. The fixed release cathub binary has been published locally and is currently running against the station config.