### PR TITLE
cathub: single-VFO operating-VFO virtualization for N1MM SO1V

### DIFF
--- a/config/cathub.toml
+++ b/config/cathub.toml
@@ -70,14 +70,20 @@ dialect = "ts2000"
 perms = ["read", "write"]
 
 # N1MM Logger+ as a native TS-590.
+# N1MM in SO1V mode rejects VFO B ("You should not use VFO B when configured for SO1V"),
+# so present the operating VFO as VFO A. The hub mirrors reads/writes/notifications onto
+# whichever VFO the radio is actually on, so A/B switching tracks seamlessly.
 [[face]]
 name = "n1mm"
 transport = "COM20"      # N1MM binds COM21
 baud = 115200
 dialect = "ts590"
+single_vfo = true
 perms = ["read", "write", "ptt"]
 
 # ARCP-590 control panel: full faceplate control, including EX-menu (config_write).
+# ARCP-590 is a genuine dual-VFO faceplate: it must see the real VFO A/B, so leave
+# single_vfo off (the default).
 [[face]]
 name = "arcp590"
 transport = "COM30"      # ARCP-590 binds COM31

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -500,6 +500,16 @@ endpoint is the cathub daemon or a bare `rigctld`.
 - Operator setup: `docs/integrations/cathub-setup.md`.
 - Implementation: the `qsoripper-cathub` crate under `src/rust/`.
 
+Native `ts590` faces support an opt-in, per-face **single-VFO operating-VFO virtualization**
+policy (`single_vfo = true`). When enabled, the face never exposes the physical VFO letter:
+it always presents the operating (receive) VFO as VFO A, mirroring `FA`/`FB` reads and writes
+onto whichever VFO the radio is on, intercepting `FR`/`FT` VFO-select verbs, forcing the `IF;`
+active-VFO digit (P10) and split to `0`, and re-presenting an A/B switch by pushing the new
+operating VFO's `FA` + `MD` + `IF`. This makes single-VFO loggers — N1MM Logger+ in SO1V mode,
+which otherwise warns "You should not use VFO B when configured for SO1V" and freezes — track
+the radio seamlessly across A/B switches. It is **off by default** and must stay off for genuine
+dual-VFO faceplates such as ARCP-590. See design §8.4.2.
+
 The hub's Hamlib NET faces accept both the plain rigctld protocol (WSJT-X, N1MM, the engine)
 and Hamlib's **Extended Response Protocol** (ERP). An ERP request prefixes the command with a
 separator (`+` joins records with newlines; `;`, `|`, or `,` joins them on one line with that

--- a/docs/design/cathub-multi-client-cat-hub.md
+++ b/docs/design/cathub-multi-client-cat-hub.md
@@ -275,6 +275,21 @@ Downstream fan-out is identical regardless of source, so a station with a non-pu
 
 The auto-info command is virtualized per face, but for Kenwood `AI1` (post-command echo) and `AI2` (spontaneous updates) are not identical semantics (other vendors have analogous distinctions). v1 may collapse them to a single per-face push subscription; if it does, that limitation is documented and ARCP-590 and N1MM are tested specifically to confirm they tolerate the collapse before either is claimed as first-class. If a tested client depends on the distinction, the finer model is implemented for that dialect.
 
+### 8.4.2 Single-VFO operating-VFO virtualization
+
+Some loggers run as single-VFO controllers and actively reject the inactive VFO. N1MM Logger+ in **SO1V** mode is the canonical case: when the radio reports VFO B as the active receive VFO (Kenwood `IF;` field P10 = `1`), N1MM raises *"You should not use VFO B when configured for SO1V"* and **freezes its frequency display**, so an operator working on VFO B sees a stuck frequency even though the hub's cache is correct. Faithfully reporting P10 = `1` (§8.4 native active-VFO rule) is *correct* radio behavior, but it defeats the hub's goal of seamless A/B operation for this class of client.
+
+The fix is a per-face, opt-in **operating-VFO virtualization** policy (`single_vfo = true` on a `ts590` face). When enabled, the face never exposes the physical VFO letter; it always presents whichever VFO the radio is actually on (the operating / receive VFO) **as VFO A**:
+
+- **`IF;` reads** report P10 = `0` (VFO A) and split = `0`, carrying the operating VFO's frequency and mode. The 38-byte frame length is unchanged; only the active-VFO and split digits are rewritten.
+- **`FA;` reads** return the operating VFO's frequency; **`FA` writes** tune the operating VFO (so a "set VFO A" from the logger tunes physical VFO B when the rig is on B).
+- **`FB`** is mirrored onto the operating VFO rather than leaking physical VFO B, and split-on-B never reaches the face.
+- **`FR`/`FT`** (receive/transmit VFO select) are intercepted: reads return VFO A; a select write is swallowed (never forwarded to the radio), so the logger can never drive an A/B retarget.
+- **Notifications** are re-presented: an operating-VFO frequency change pushes `FA` (never `FB`) plus the synthesized operating `IF`; a mode change pushes `MD` + `IF`; and an **A→B (or B→A) switch re-presents the new operating VFO** by pushing its `FA` + `MD` + an `IF` with P10 = `0`, so the logger seamlessly retunes with no SO1V warning. Inactive-VFO churn is suppressed.
+- **Raw passthrough** frames are suppressed for a single-VFO face, since a verbatim native frame could leak a physical VFO-B verb.
+
+This policy is **opt-in per face and off by default**. It is enabled only for genuine single-VFO loggers (N1MM SO1V). Dual-VFO faceplates such as **ARCP-590 must leave it off** (`single_vfo = false`), because they legitimately control and display the real VFO A and VFO B. Split-aware clients are out of scope for this simplification: a single-VFO face always sees split = `0`. SO2V is an N1MM-side workaround, not a substitute for this hub-side virtualization.
+
 ### 8.5 PTT ownership and arbitration
 
 Multiple clients are now PTT-capable (N1MM CAT PTT, WSJT-X `T 1`, ARCP-590). The daemon arbitrates with a single-owner lease:

--- a/docs/integrations/cathub-setup.md
+++ b/docs/integrations/cathub-setup.md
@@ -125,7 +125,13 @@ hub on its own (for example with `-DryRun` to validate config).
 
 ### N1MM Logger+
 - Configurer > Hardware: radio `Kenwood`, port **COM21**, 115200, 8-N-1, no flow control.
-- The `n1mm` face is `dialect = "ts590"`, `perms = ["read", "write", "ptt"]`.
+- The `n1mm` face is `dialect = "ts590"`, `single_vfo = true`, `perms = ["read", "write", "ptt"]`.
+- **`single_vfo = true` is required for SO1V.** N1MM in single-VFO (SO1V) mode refuses VFO B
+  ("You should not use VFO B when configured for SO1V") and freezes its frequency display when
+  the radio is on VFO B. With `single_vfo = true` the hub presents whichever VFO the radio is
+  on as VFO A, so N1MM tracks the radio across A/B switches with no warning. If you run N1MM in
+  SO2V instead, you may set `single_vfo = false`; for SO1V leave it on (the shipped default for
+  this face). See design §8.4.2.
 
 ### ARCP-590
 - Set ARCP-590's COM port to **COM31**, 115200, 8-N-1.

--- a/src/rust/qsoripper-cathub/src/config.rs
+++ b/src/rust/qsoripper-cathub/src/config.rs
@@ -139,6 +139,16 @@ pub(crate) struct FaceConfig {
     /// Permission tokens (`read`, `write`, `ptt`, `config_write`).
     #[serde(default)]
     pub(crate) perms: Vec<String>,
+    /// Present the *operating* VFO as VFO A to this face (operating-VFO virtualization).
+    ///
+    /// Single-VFO loggers (notably N1MM Logger+ in SO1V) read the active VFO from the
+    /// Kenwood `IF;` answer and refuse to track VFO B ("You should not use VFO B when
+    /// configured for SO1V"). With `single_vfo = true` the hub always presents whichever
+    /// VFO the operator is actually using as VFO A, so the logger follows A/B switches
+    /// seamlessly with no warning. Leave this `false` for true dual-VFO control faces such
+    /// as ARCP-590, which must see and address real VFO A and B independently.
+    #[serde(default)]
+    pub(crate) single_vfo: bool,
 }
 
 impl FaceConfig {
@@ -317,8 +327,8 @@ impl Config {
         for face in &self.face {
             let _ = writeln!(
                 out,
-                "face: name={} transport={} baud={} dialect={} perms={:?}",
-                face.name, face.transport, face.baud, face.dialect, face.perms
+                "face: name={} transport={} baud={} dialect={} perms={:?} single_vfo={}",
+                face.name, face.transport, face.baud, face.dialect, face.perms, face.single_vfo
             );
         }
         for ep in &self.hamlib_net {
@@ -425,6 +435,7 @@ transport = "COM11"
 baud = 4800
 dialect = "ts590"
 perms = ["read", "write", "ptt"]
+single_vfo = true
 
 [[hamlib_net]]
 name = "engine"
@@ -440,6 +451,7 @@ perms = ["read"]
         assert_eq!(config.face.len(), 1);
         assert_eq!(config.hamlib_net.len(), 1);
         assert!(config.face[0].permissions().ptt);
+        assert!(config.face[0].single_vfo, "single_vfo parses as true");
         assert!(config.hamlib_net[0].permissions().read);
         assert!(!config.hamlib_net[0].permissions().write);
         assert_eq!(config.baseline_interval(), Duration::from_millis(200));
@@ -464,6 +476,10 @@ dialect = "ts590"
         assert_eq!(config.ptt.max_tx_ms, 300_000);
         assert!(config.events.native_push);
         assert_eq!(config.face[0].baud, 4_800);
+        assert!(
+            !config.face[0].single_vfo,
+            "single_vfo defaults to false (native dual-VFO presentation)"
+        );
     }
 
     #[test]

--- a/src/rust/qsoripper-cathub/src/dialect/kenwood/ts590.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/kenwood/ts590.rs
@@ -26,14 +26,26 @@ impl Ts590Dialect {
 }
 
 /// Synthesize a Kenwood `IF;` status answer (38 bytes) from the universal state.
-fn synth_if(snapshot: &Snapshot) -> Vec<u8> {
+///
+/// When `single_vfo` is true (operating-VFO virtualization) the operating VFO is always
+/// presented as VFO A with no split, so a single-VFO logger (N1MM SO1V) never sees VFO B
+/// in the P10 field and never warns about it.
+fn synth_if(snapshot: &Snapshot, single_vfo: bool) -> Vec<u8> {
     let freq = snapshot.vfo(snapshot.rx_vfo).freq_hz;
     let tx = u8::from(snapshot.ptt);
     let mode = mode_to_digit(snapshot.vfo(snapshot.rx_vfo).mode) - b'0';
-    let split = u8::from(snapshot.split);
-    let rx_vfo = match snapshot.rx_vfo {
-        Vfo::A => 0u8,
-        Vfo::B => 1u8,
+    let split = if single_vfo {
+        0
+    } else {
+        u8::from(snapshot.split)
+    };
+    let rx_vfo = if single_vfo {
+        0u8
+    } else {
+        match snapshot.rx_vfo {
+            Vfo::A => 0u8,
+            Vfo::B => 1u8,
+        }
     };
     format!("IF{freq:011}0000+0000000000{tx}{mode}{rx_vfo}0{split}0000;").into_bytes()
 }
@@ -45,19 +57,44 @@ impl ClientDialect for Ts590Dialect {
             return ERR.to_vec();
         };
         let read = payload.is_empty();
+        // In operating-VFO virtualization, every VFO-addressed read/write targets the
+        // operating (rx) VFO so the face only ever sees a single VFO presented as VFO A.
+        let single_vfo = ctx.single_vfo();
+        let op_vfo = ctx.snapshot().rx_vfo;
         match verb.as_slice() {
             b"FA" => {
+                let target = if single_vfo { op_vfo } else { Vfo::A };
                 if read {
-                    freq_frame(b"FA", ctx.snapshot().vfo(Vfo::A).freq_hz)
+                    freq_frame(b"FA", ctx.snapshot().vfo(target).freq_hz)
                 } else {
-                    set_freq(ctx, Vfo::A, &payload).await
+                    set_freq(ctx, target, &payload).await
                 }
             }
             b"FB" => {
+                // For a single-VFO face the "other" VFO is hidden: FB mirrors the operating
+                // VFO so no path exposes physical VFO B. Dual-VFO faces address real B.
+                let target = if single_vfo { op_vfo } else { Vfo::B };
                 if read {
-                    freq_frame(b"FB", ctx.snapshot().vfo(Vfo::B).freq_hz)
+                    freq_frame(b"FB", ctx.snapshot().vfo(target).freq_hz)
                 } else {
-                    set_freq(ctx, Vfo::B, &payload).await
+                    set_freq(ctx, target, &payload).await
+                }
+            }
+            // A single-VFO face must never see the receive/transmit VFO selectors expose
+            // VFO B (they would otherwise fall through to a raw passthrough). Present the
+            // operating VFO as VFO A and swallow attempts to select a VFO.
+            b"FR" if single_vfo => {
+                if read {
+                    b"FR0;".to_vec()
+                } else {
+                    Vec::new()
+                }
+            }
+            b"FT" if single_vfo => {
+                if read {
+                    b"FT0;".to_vec()
+                } else {
+                    Vec::new()
                 }
             }
             b"MD" => {
@@ -119,7 +156,7 @@ impl ClientDialect for Ts590Dialect {
             }
             b"ID" if read => b"ID021;".to_vec(),
             b"PS" if read => b"PS1;".to_vec(),
-            b"IF" if read => synth_if(&ctx.snapshot()),
+            b"IF" if read => synth_if(&ctx.snapshot(), single_vfo),
             // Any other native command is forwarded as a permission-gated passthrough.
             _ => {
                 let class = if read {
@@ -137,6 +174,9 @@ impl ClientDialect for Ts590Dialect {
             return None;
         }
         let snap = ctx.snapshot();
+        if ctx.single_vfo() {
+            return single_vfo_notification(change, &snap);
+        }
         match *change {
             StateChange::Freq { vfo, hz } => {
                 // Always emit the explicit per-VFO frame for VFO-specific trackers.
@@ -148,7 +188,7 @@ impl ClientDialect for Ts590Dialect {
                 // FB-only push made frequency updates silently stop whenever the rig was on
                 // VFO B. Appending `IF` makes VFO B behave exactly like VFO A.
                 if vfo == snap.rx_vfo {
-                    frame.extend_from_slice(&synth_if(&snap));
+                    frame.extend_from_slice(&synth_if(&snap, false));
                 }
                 Some(frame)
             }
@@ -156,15 +196,21 @@ impl ClientDialect for Ts590Dialect {
                 // `MD` reflects the active VFO on a real TS-590; emit it plus the operating
                 // `IF` so mode trackers follow the active VFO regardless of A/B.
                 let mut frame = vec![b'M', b'D', mode_to_digit(mode), b';'];
-                frame.extend_from_slice(&synth_if(&snap));
+                frame.extend_from_slice(&synth_if(&snap, false));
                 Some(frame)
             }
-            StateChange::RxVfo { .. } => Some(synth_if(&snap)),
+            StateChange::RxVfo { .. } => Some(synth_if(&snap, false)),
             _ => None,
         }
     }
 
     fn format_passthrough(&self, raw: &[u8], ctx: &FaceContext) -> Option<Vec<u8>> {
+        // A single-VFO face sees a curated, virtualized view: never relay the radio's raw
+        // CAT stream, which can carry FA/FB/FR/IF frames that would leak physical VFO B and
+        // break the "operating VFO is always VFO A" illusion.
+        if ctx.single_vfo() {
+            return None;
+        }
         // A certified-native client that enabled auto-information expects the radio's CAT
         // stream verbatim. Relaying unmodeled frames (NB/NR/AG/front-panel changes, ...)
         // keeps its client-side feature state machines in sync; without this, a client like
@@ -174,6 +220,35 @@ impl ClientDialect for Ts590Dialect {
         } else {
             None
         }
+    }
+}
+
+/// Build the operating-VFO-virtualized notification: the operating VFO is always presented
+/// as VFO A, inactive-VFO churn is suppressed, and an A/B switch re-presents the new
+/// operating VFO as VFO A (FA+MD+IF) so a single-VFO logger seamlessly retunes.
+fn single_vfo_notification(change: &StateChange, snap: &Snapshot) -> Option<Vec<u8>> {
+    match *change {
+        StateChange::Freq { vfo, hz } if vfo == snap.rx_vfo => {
+            let mut frame = freq_frame(b"FA", hz);
+            frame.extend_from_slice(&synth_if(snap, true));
+            Some(frame)
+        }
+        StateChange::Mode { vfo, mode } if vfo == snap.rx_vfo => {
+            let mut frame = vec![b'M', b'D', mode_to_digit(mode), b';'];
+            frame.extend_from_slice(&synth_if(snap, true));
+            Some(frame)
+        }
+        StateChange::RxVfo { .. } => {
+            // The operator pressed A/B: re-present the new operating VFO as VFO A so the
+            // logger retunes exactly as if VFO A had jumped to the new frequency and mode.
+            let op = snap.vfo(snap.rx_vfo);
+            let mut frame = freq_frame(b"FA", op.freq_hz);
+            frame.extend_from_slice(&[b'M', b'D', mode_to_digit(op.mode), b';']);
+            frame.extend_from_slice(&synth_if(snap, true));
+            Some(frame)
+        }
+        // Inactive-VFO frequency/mode churn is invisible to a single-VFO face.
+        _ => None,
     }
 }
 
@@ -223,6 +298,13 @@ mod tests {
         let radio = spawn_scheduler(arc, detached_link(), state.clone());
         let ptt = PttManager::new(Duration::from_secs(300));
         (FaceContext::new(5, perms, state, radio, ptt, caps), backend)
+    }
+
+    /// Like [`ctx_with`] but the face uses operating-VFO virtualization (single-VFO
+    /// presentation), as configured for N1MM SO1V.
+    fn single_vfo_ctx(perms: FacePermissions) -> (FaceContext, LoopbackBackend) {
+        let (ctx, backend) = ctx_with(perms);
+        (ctx.with_single_vfo(true), backend)
     }
 
     #[tokio::test]
@@ -312,7 +394,7 @@ mod tests {
         // per-VFO `FA` frame *and* the operating-status `IF` frame so clients that track the
         // operating frequency (N1MM, Log4OM-as-TS590) follow the change.
         let mut expected = b"FA00014074000;".to_vec();
-        expected.extend_from_slice(&synth_if(&ctx.snapshot()));
+        expected.extend_from_slice(&synth_if(&ctx.snapshot(), false));
         assert_eq!(note, Some(expected));
     }
 
@@ -346,7 +428,7 @@ mod tests {
                 &ctx,
             )
             .expect("active-VFO freq change must notify");
-        let synth = synth_if(&ctx.snapshot());
+        let synth = synth_if(&ctx.snapshot(), false);
         assert!(
             note.windows(synth.len()).any(|w| w == synth.as_slice()),
             "VFO B active-freq notification must include the operating IF frame; got {:?}",
@@ -467,5 +549,221 @@ mod tests {
         assert_eq!(reply, b"RM;".to_vec());
         tokio::time::sleep(Duration::from_millis(20)).await;
         assert_eq!(backend.passthroughs(), vec![b"RM;".to_vec()]);
+    }
+
+    // --- Operating-VFO virtualization (single_vfo) -----------------------------------
+
+    /// With the rig on VFO B, a single-VFO face must see the operating frequency presented
+    /// as VFO A: `IF;` reports P10 == '0' (not '1') so N1MM SO1V never warns, and the
+    /// frequency is VFO B's operating frequency.
+    #[tokio::test]
+    async fn single_vfo_if_presents_operating_vfo_b_as_vfo_a() {
+        let (ctx, _b) = single_vfo_ctx(FacePermissions::read_only());
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::PollDiff,
+        );
+        ctx.state.record(
+            StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 14_034_320,
+            },
+            RadioEventSource::PollDiff,
+        );
+        let reply = Ts590Dialect::new().handle(b"IF;", &ctx).await;
+        assert_eq!(reply.len(), 38);
+        // P10 (the active-VFO digit) is at index 30 in the 38-byte IF answer.
+        assert_eq!(reply[30], b'0', "operating VFO must be presented as VFO A");
+        assert!(
+            reply.windows(11).any(|w| w == b"00014034320"),
+            "IF must carry the operating (VFO B) frequency; got {}",
+            String::from_utf8_lossy(&reply)
+        );
+    }
+
+    /// A single-VFO face reads the operating VFO's frequency via `FA;`, even when the rig
+    /// is physically on VFO B.
+    #[tokio::test]
+    async fn single_vfo_fa_read_returns_operating_vfo_b_freq() {
+        let (ctx, _b) = single_vfo_ctx(FacePermissions::read_only());
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::PollDiff,
+        );
+        ctx.state.record(
+            StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 14_034_320,
+            },
+            RadioEventSource::PollDiff,
+        );
+        assert_eq!(
+            Ts590Dialect::new().handle(b"FA;", &ctx).await,
+            b"FA00014034320;".to_vec()
+        );
+    }
+
+    /// An `FA` write from a single-VFO face must tune the operating VFO (B), not VFO A.
+    #[tokio::test]
+    async fn single_vfo_fa_write_tunes_operating_vfo_b() {
+        let (ctx, backend) = single_vfo_ctx(FacePermissions::from_tokens(&["read", "write"]));
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::PollDiff,
+        );
+        assert_eq!(
+            Ts590Dialect::new().handle(b"FA00014050000;", &ctx).await,
+            Vec::<u8>::new()
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert_eq!(
+            backend.mutations(),
+            vec![StateMutation::SetVfoFreq {
+                vfo: Vfo::B,
+                hz: 14_050_000
+            }]
+        );
+    }
+
+    /// The receive-VFO selector never exposes VFO B to a single-VFO face: `FR;` reports
+    /// VFO A and a `FR1;` select is swallowed (not forwarded to the radio).
+    #[tokio::test]
+    async fn single_vfo_fr_is_virtualized_to_vfo_a() {
+        let (ctx, backend) = single_vfo_ctx(FacePermissions::from_tokens(&["read", "write"]));
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::PollDiff,
+        );
+        assert_eq!(
+            Ts590Dialect::new().handle(b"FR;", &ctx).await,
+            b"FR0;".to_vec()
+        );
+        assert_eq!(
+            Ts590Dialect::new().handle(b"FR1;", &ctx).await,
+            Vec::<u8>::new()
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            backend.passthroughs().is_empty(),
+            "FR must never reach the radio as a passthrough on a single-VFO face"
+        );
+    }
+
+    /// Switching the operating VFO (A->B) must re-present the new operating VFO as VFO A:
+    /// the push carries `FA`(new freq) + `MD`(new mode) + an `IF` with P10 == '0', so a
+    /// single-VFO logger seamlessly retunes with no SO1V warning.
+    #[tokio::test]
+    async fn single_vfo_rxvfo_switch_re_presents_operating_as_vfo_a() {
+        let (ctx, _b) = single_vfo_ctx(FacePermissions::read_only());
+        ctx.state.record(
+            StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 21_205_000,
+            },
+            RadioEventSource::PollDiff,
+        );
+        ctx.state.record(
+            StateChange::Mode {
+                vfo: Vfo::B,
+                mode: Mode::Cw,
+            },
+            RadioEventSource::PollDiff,
+        );
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::PollDiff,
+        );
+        ctx.set_ai(true);
+        let note = Ts590Dialect::new()
+            .format_notification(&StateChange::RxVfo { vfo: Vfo::B }, &ctx)
+            .expect("A/B switch must notify a single-VFO face");
+        assert!(
+            note.windows(b"FA00021205000;".len())
+                .any(|w| w == b"FA00021205000;"),
+            "switch must push the new operating frequency as FA; got {}",
+            String::from_utf8_lossy(&note)
+        );
+        assert!(
+            note.windows(4).any(|w| w == b"MD3;"),
+            "switch must push the new operating mode (CW=3); got {}",
+            String::from_utf8_lossy(&note)
+        );
+        // The trailing IF must present VFO A (P10 == '0'), never VFO B.
+        let if_pos = note
+            .windows(2)
+            .position(|w| w == b"IF")
+            .expect("notification must contain an IF frame");
+        assert_eq!(
+            note[if_pos + 30],
+            b'0',
+            "the operating VFO must be presented as VFO A in the IF frame"
+        );
+    }
+
+    /// An active-VFO (B) frequency change pushes `FA` (not `FB`) plus an `IF` presenting
+    /// VFO A, so N1MM SO1V tracks the change. Inactive-VFO churn is suppressed.
+    #[tokio::test]
+    async fn single_vfo_active_freq_change_pushes_fa_as_vfo_a() {
+        let (ctx, _b) = single_vfo_ctx(FacePermissions::read_only());
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::PollDiff,
+        );
+        ctx.state.record(
+            StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 14_034_320,
+            },
+            RadioEventSource::PollDiff,
+        );
+        ctx.set_ai(true);
+        let note = Ts590Dialect::new()
+            .format_notification(
+                &StateChange::Freq {
+                    vfo: Vfo::B,
+                    hz: 14_034_320,
+                },
+                &ctx,
+            )
+            .expect("active-VFO freq change must notify");
+        assert!(
+            note.starts_with(b"FA00014034320;"),
+            "active VFO-B change must be presented as an FA frame; got {}",
+            String::from_utf8_lossy(&note)
+        );
+        assert!(
+            !note.windows(2).any(|w| w == b"FB"),
+            "a single-VFO face must never receive an FB frame; got {}",
+            String::from_utf8_lossy(&note)
+        );
+        let if_pos = note.windows(2).position(|w| w == b"IF").expect("IF frame");
+        assert_eq!(note[if_pos + 30], b'0', "IF must present VFO A");
+    }
+
+    /// A frequency change on the *inactive* VFO is invisible to a single-VFO face.
+    #[tokio::test]
+    async fn single_vfo_inactive_freq_change_is_suppressed() {
+        let (ctx, _b) = single_vfo_ctx(FacePermissions::read_only());
+        // Operating on VFO A; a change on VFO B must not be pushed.
+        ctx.set_ai(true);
+        let note = Ts590Dialect::new().format_notification(
+            &StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 7_000_000,
+            },
+            &ctx,
+        );
+        assert_eq!(note, None);
+    }
+
+    /// A single-VFO face never receives raw passthrough frames (which could leak VFO B).
+    #[tokio::test]
+    async fn single_vfo_suppresses_raw_passthrough() {
+        let (ctx, _b) = single_vfo_ctx(FacePermissions::read_only());
+        ctx.set_ai(true);
+        assert_eq!(
+            Ts590Dialect::new().format_passthrough(b"FB00014000000;", &ctx),
+            None
+        );
     }
 }

--- a/src/rust/qsoripper-cathub/src/dialect/mod.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/mod.rs
@@ -56,6 +56,10 @@ pub(crate) struct FaceContext {
     pub(crate) ptt: PttManager,
     /// This face's virtualized auto-information flag (never reaches the radio).
     ai: Arc<AtomicBool>,
+    /// When true, present the *operating* VFO as VFO A to this face (operating-VFO
+    /// virtualization). Set from `[[face]] single_vfo` for single-VFO loggers such as
+    /// N1MM SO1V; left false for true dual-VFO control faces such as ARCP-590.
+    single_vfo: bool,
 }
 
 impl FaceContext {
@@ -76,7 +80,16 @@ impl FaceContext {
             radio,
             ptt,
             ai: Arc::new(AtomicBool::new(false)),
+            single_vfo: false,
         }
+    }
+
+    /// Enable operating-VFO virtualization for this face (builder style so existing
+    /// call sites are unaffected). When enabled, the face always sees the operating VFO
+    /// presented as VFO A. Returns `self` for chaining.
+    pub(crate) fn with_single_vfo(mut self, single_vfo: bool) -> Self {
+        self.single_vfo = single_vfo;
+        self
     }
 
     /// A consistent point-in-time view of the radio.
@@ -171,6 +184,12 @@ impl FaceContext {
         self.ai.load(Ordering::SeqCst)
     }
 
+    /// Whether this face uses operating-VFO virtualization (operating VFO presented as
+    /// VFO A). True for single-VFO loggers (N1MM SO1V); false for dual-VFO faces.
+    pub(crate) fn single_vfo(&self) -> bool {
+        self.single_vfo
+    }
+
     /// A clone of this context for a new connection: same shared state/radio/ptt and
     /// permissions, but a distinct face id and a fresh (off) auto-information flag.
     pub(crate) fn clone_with_face(&self, face_id: u64) -> FaceContext {
@@ -182,6 +201,8 @@ impl FaceContext {
             radio: self.radio.clone(),
             ptt: self.ptt.clone(),
             ai: Arc::new(AtomicBool::new(false)),
+            // A new connection to the same face keeps that face's VFO-presentation policy.
+            single_vfo: self.single_vfo,
         }
     }
 

--- a/src/rust/qsoripper-cathub/src/integration.rs
+++ b/src/rust/qsoripper-cathub/src/integration.rs
@@ -75,6 +75,27 @@ impl Rig {
         tokio::spawn(run_face(server, dialect, ctx, b';'));
         client
     }
+
+    /// A single-VFO face (e.g. N1MM in SO1V) that virtualizes the operating VFO as VFO A.
+    fn single_vfo_face(
+        &self,
+        dialect: Arc<dyn ClientDialect>,
+        perms: FacePermissions,
+        id: u64,
+    ) -> DuplexStream {
+        let ctx = FaceContext::new(
+            id,
+            perms,
+            self.state.clone(),
+            self.radio.clone(),
+            self.ptt.clone(),
+            self.caps.clone(),
+        )
+        .with_single_vfo(true);
+        let (client, server) = tokio::io::duplex(1024);
+        tokio::spawn(run_face(server, dialect, ctx, b';'));
+        client
+    }
 }
 
 fn ts590() -> Arc<dyn ClientDialect> {
@@ -258,6 +279,79 @@ async fn front_panel_change_fans_out_to_all_subscribed_faces() {
 
     assert_eq!(read_frame(&mut a).await, b"FA00007123000;");
     assert_eq!(read_frame(&mut b).await, b"FA00007123000;");
+}
+
+/// End-to-end N1MM SO1V regression: when the operator switches the radio to VFO B, a
+/// single-VFO face must keep tracking. The hub re-presents the operating VFO as VFO A, so
+/// the face receives an `FA`(operating freq) + `MD` + `IF` (with the active-VFO digit '0')
+/// and never an `FB` or an `IF` reporting VFO B (which trips N1MM's "do not use VFO B"
+/// guard and freezes its frequency display).
+#[tokio::test]
+async fn single_vfo_face_tracks_an_a_to_b_switch_without_leaking_vfo_b() {
+    let rig = rig();
+    let mut n1mm = rig.single_vfo_face(ts590(), FacePermissions::read_only(), 1);
+
+    // N1MM enables auto-info.
+    n1mm.write_all(b"AI2;").await.expect("write");
+    tokio::time::sleep(Duration::from_millis(20)).await;
+
+    // The radio already knows VFO B's frequency and mode (primed by the initial poll).
+    rig.state.record(
+        StateChange::Freq {
+            vfo: Vfo::B,
+            hz: 14_034_320,
+        },
+        RadioEventSource::PollDiff,
+    );
+    rig.state.record(
+        StateChange::Mode {
+            vfo: Vfo::B,
+            mode: crate::model::Mode::Cw,
+        },
+        RadioEventSource::PollDiff,
+    );
+
+    // Operator switches the radio to VFO B.
+    rig.state.record(
+        StateChange::RxVfo { vfo: Vfo::B },
+        RadioEventSource::PollDiff,
+    );
+
+    // Collect the re-presentation push (FA + MD + IF) and assert it never exposes VFO B.
+    let mut pushed = Vec::new();
+    for _ in 0..3 {
+        let frame = match tokio::time::timeout(Duration::from_secs(1), read_frame(&mut n1mm)).await
+        {
+            Ok(frame) if !frame.is_empty() => frame,
+            _ => break,
+        };
+        pushed.extend_from_slice(&frame);
+        if pushed.windows(2).any(|w| w == b"IF") {
+            break;
+        }
+    }
+
+    assert!(
+        pushed
+            .windows(b"FA00014034320;".len())
+            .any(|w| w == b"FA00014034320;"),
+        "the switch must push the operating frequency as FA; got {}",
+        String::from_utf8_lossy(&pushed)
+    );
+    assert!(
+        !pushed.windows(2).any(|w| w == b"FB"),
+        "a single-VFO face must never receive an FB frame; got {}",
+        String::from_utf8_lossy(&pushed)
+    );
+    let if_pos = pushed
+        .windows(2)
+        .position(|w| w == b"IF")
+        .expect("the push must include an IF frame");
+    assert_eq!(
+        pushed[if_pos + 30],
+        b'0',
+        "the IF frame must present the operating VFO as VFO A (P10 == '0')"
+    );
 }
 
 /// Writes fanned in from several faces are strictly serialized through the one radio task.

--- a/src/rust/qsoripper-cathub/src/lib.rs
+++ b/src/rust/qsoripper-cathub/src/lib.rs
@@ -291,7 +291,8 @@ pub async fn run(cli: Cli) -> Result<(), CatHubError> {
             radio.clone(),
             ptt.clone(),
             caps.clone(),
-        );
+        )
+        .with_single_vfo(face.single_vfo);
         let port = open_serial(&face.name, &face.transport, face.baud)?;
         tokio::spawn(run_face(port, dialect, ctx, b';'));
         tracing::info!(


### PR DESCRIPTION
N1MM Logger+ in SO1V mode rejects VFO B ("You should not use VFO B when configured for SO1V") and freezes its frequency display whenever the radio reports VFO B as the active VFO in the Kenwood IF; frame (P10=1). Reporting P10=1 is faithful radio behavior (PR #493), but it defeats the hub's goal of seamless A/B operation for single-VFO loggers.

This adds an opt-in, per-face single_vfo policy to the native ts590 dialect. When enabled, the face never exposes the physical VFO letter and always presents the operating (receive) VFO as VFO A:

- IF; reads force the active-VFO digit (P10) and split to 0, carrying the operating VFO frequency and mode. The 38-byte frame length is preserved.
- FA reads/writes target the operating VFO; FB is mirrored onto it so physical VFO B never leaks, and split-on-B is hidden.
- FR/FT receive/transmit VFO selectors are intercepted: reads report VFO A and a select write is swallowed (never reaches the radio).
- Notifications are re-presented: an active-VFO frequency change pushes FA (not FB) + IF; an A/B switch re-presents the new operating VFO as FA + MD + IF with P10=0, so the logger retunes seamlessly with no SO1V warning. Inactive-VFO churn is suppressed.
- Raw passthrough is suppressed for single-VFO faces so a verbatim native frame cannot leak a VFO-B verb.

The policy is off by default. It is enabled for the n1mm face only. ARCP-590 stays a genuine dual-VFO faceplate (single_vfo=false). WSJT-X/Log4OM (Hamlib NET) and HDSDR/OmniRig (ts2000) already follow the operating VFO and are unchanged.

Tests: 8 new ts590 unit tests plus an end-to-end A/B-switch integration test asserting the face tracks the switch and never receives an FB or an IF reporting VFO B. Full cathub suite green (177 lib + 3 cli), fmt/clippy clean, coverage 85.9% (>=80% gate).

Docs: design section 8.4.2, engine specification rig-control front-door note, and the operator setup N1MM section. Live config and repo config/cathub.toml set single_vfo=true on the n1mm face.

Verified live on the TS-590: rebuilt/republished daemon, CAT read returns 14033000 / CW on the engine endpoint.