### PR TITLE
cathub: extend single_vfo virtualization to hamlib_net faces (WSJT-X, Log4OM)

### DIFF
--- a/config/cathub.toml
+++ b/config/cathub.toml
@@ -36,15 +36,23 @@ bind = "127.0.0.1:4532"
 perms = ["read"]
 
 # Write + PTT endpoint for WSJT-X (configured as Hamlib NET rigctl).
+# single_vfo: WSJT-X expects to receive on VFO A and stops decoding if the hub reports the
+# operator is on VFO B. Present the operating VFO as VFO A so WSJT-X decodes on either VFO.
+# Use WSJT-X's "Fake It" split mode (Settings -> Radio -> Split Operation) with this endpoint;
+# real "Rig" split is rejected because a single-VFO presentation cannot model an A/B split.
 [[hamlib_net]]
 name = "wsjtx"
 bind = "127.0.0.1:4533"
+single_vfo = true
 perms = ["read", "write", "ptt"]
 
 # Read/write endpoint for Log4OM (CAT over Hamlib NET rigctl).
+# single_vfo: Log4OM polls `\get_vfo_info VFOA`. Presenting the operating VFO as VFO A makes
+# Log4OM log the live frequency/mode on either VFO instead of the stale inactive VFO A.
 [[hamlib_net]]
 name = "log4om"
 bind = "127.0.0.1:4534"
+single_vfo = true
 perms = ["read", "write"]
 
 # --- Serial faces (com0com virtual pairs) ----------------------------------------------

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -510,6 +510,17 @@ which otherwise warns "You should not use VFO B when configured for SO1V" and fr
 the radio seamlessly across A/B switches. It is **off by default** and must stay off for genuine
 dual-VFO faceplates such as ARCP-590. See design §8.4.2.
 
+The **same `single_vfo` policy is available on `[[hamlib_net]]` (rigctld) endpoints** for
+rigctld clients that, like N1MM SO1V, expect to receive on VFO A: WSJT-X stops decoding when
+it sees VFO B as the active VFO, and Log4OM polls the fixed `\get_vfo_info VFOA` and would log
+the inactive VFO's stale frequency on VFO B. On a `single_vfo` Hamlib NET endpoint the face
+uses a **strict** single-VFO contract: `get_vfo` reports `VFOA`; `get_vfo_info` resolves any
+requested VFO to the operating VFO and reports `Split: 0`; `get_split_vfo` reports `0`/`VFOA`;
+`set_split_vfo 1` is **rejected** (`RPRT -11`) because the presentation cannot model a real
+split (use WSJT-X "Fake It"); and `\set_vfo ?` advertises only `VFOA`. Reads and writes already
+target the operating VFO, so the frequency/mode are real on either physical VFO. The engine's
+read-only endpoint leaves `single_vfo = false` so it logs the true operating VFO.
+
 The hub's Hamlib NET faces accept both the plain rigctld protocol (WSJT-X, N1MM, the engine)
 and Hamlib's **Extended Response Protocol** (ERP). An ERP request prefixes the command with a
 separator (`+` joins records with newlines; `;`, `|`, or `,` joins them on one line with that

--- a/docs/design/cathub-multi-client-cat-hub.md
+++ b/docs/design/cathub-multi-client-cat-hub.md
@@ -290,6 +290,19 @@ The fix is a per-face, opt-in **operating-VFO virtualization** policy (`single_v
 
 This policy is **opt-in per face and off by default**. It is enabled only for genuine single-VFO loggers (N1MM SO1V). Dual-VFO faceplates such as **ARCP-590 must leave it off** (`single_vfo = false`), because they legitimately control and display the real VFO A and VFO B. Split-aware clients are out of scope for this simplification: a single-VFO face always sees split = `0`. SO2V is an N1MM-side workaround, not a substitute for this hub-side virtualization.
 
+#### `single_vfo` on Hamlib NET (rigctld) faces
+
+The same virtualization is available on `[[hamlib_net]]` endpoints (`single_vfo = true`) for rigctld-protocol clients that, like N1MM SO1V, fundamentally expect to receive on VFO A. **WSJT-X** stops decoding when the hub reports the operator is on VFO B, and **Log4OM** polls `\get_vfo_info VFOA`, so on VFO B it logs the stale inactive VFO A frequency. With `single_vfo = true` the rigctld face presents the operating VFO as VFO A using a **strict** single-VFO contract — the inactive VFO is never exposed:
+
+- **`v` / `\get_vfo`** always report `VFOA`.
+- **`\get_vfo_info <vfo>`** resolves *any* requested VFO to the operating VFO and reports `Split: 0`; the inactive VFO's data is never returned (a `VFOB` request also answers with the operating VFO).
+- **`s` / `\get_split_vfo`** report `0` / `VFOA`.
+- **`f`/`m` reads** and **`F`/`M` writes** already target the operating (receive) VFO, so the frequency/mode are real on either physical VFO and a `set_freq` tunes the VFO the operator is actually using.
+- **`S 1` / `\set_split_vfo 1`** (enable split) is **rejected** (`RPRT -11`) because a single-VFO presentation cannot model a real A/B split; `S 0` is accepted as a no-op. WSJT-X must therefore use **"Fake It"** split (which QSYs the single VFO at TX time), not **"Rig"** split, on a `single_vfo` endpoint.
+- **`V ?` / `\set_vfo ?`** advertise only `VFOA`, so a client never targets the inactive VFO.
+
+The QsoRipper engine endpoint leaves `single_vfo = false` so the engine logs the true operating VFO letter.
+
 ### 8.5 PTT ownership and arbitration
 
 Multiple clients are now PTT-capable (N1MM CAT PTT, WSJT-X `T 1`, ARCP-590). The daemon arbitrates with a single-owner lease:

--- a/docs/integrations/cathub-setup.md
+++ b/docs/integrations/cathub-setup.md
@@ -140,7 +140,13 @@ hub on its own (for example with `-DryRun` to validate config).
 
 ### WSJT-X
 - Settings > Radio: Rig `Hamlib NET rigctl`, Network Server **127.0.0.1:4533**.
-- PTT method `CAT`. The `wsjtx` endpoint is `perms = ["read", "write", "ptt"]`.
+- PTT method `CAT`. The `wsjtx` endpoint is `perms = ["read", "write", "ptt"]`, `single_vfo = true`.
+- **`single_vfo = true` keeps WSJT-X decoding on either VFO.** WSJT-X fundamentally expects to
+  receive on VFO A and stops decoding if the hub reports the operator is on VFO B. With
+  `single_vfo = true` the endpoint always presents whichever VFO the radio is actually on as
+  VFO A (`get_vfo` -> `VFOA`, with the live operating frequency/mode), so WSJT-X decodes
+  whether the rig is on A or B. The frequency is always real; only the VFO *letter* is
+  virtualized.
 - **Mode:** set the WSJT-X *Mode* selector to **Data/Pkt** (the default for FT8/WSPR). The
   hub maps Hamlib's `PKTUSB`/`PKTLSB` to the TS-590's DATA sub-mode by composing the base
   mode (`MD`) with the radio's independent DATA flag (`DA`): `PKTUSB` -> `MD2;`+`DA1;`,
@@ -148,8 +154,10 @@ hub on its own (for example with `-DryRun` to validate config).
   read-back recomposes the token, so WSJT-X sees `PKTUSB`/`PKTLSB` echoed back and the radio
   shows its DATA indicator lit. *Mode = None* (operator selects DATA on the front panel) and
   *Mode = USB* also round-trip cleanly if you prefer to manage the sub-mode yourself.
-- **Split Operation:** `Rig` or `Fake It` both work; the hub tracks split and TX-VFO
-  state and never retargets VFO A/B on a poll.
+- **Split Operation:** use **`Fake It`** (not `Rig`). A `single_vfo` endpoint presents a
+  single operating VFO and cannot model a real A/B split, so it **rejects** rig split-enable
+  (`RPRT -11`); "Fake It" QSYs the single VFO at TX time and works correctly on either VFO.
+  If you genuinely need real `Rig` split, point WSJT-X at a non-virtualized endpoint instead.
 - **PTT:** WSJT-X keys with Hamlib `RIG_PTT_ON_DATA` (`T 3`). The hub maps the Hamlib PTT
   family faithfully to the TS-590 — `T 1` -> `TX;`, `T 2` (mic) -> `TX0;`, `T 3` (data) ->
   `TX1;`, `T 0` -> `RX;`. `TX1;` keys with modulation from the DATA/USB audio path, which is
@@ -181,15 +189,21 @@ No radio-menu change is needed. Leave **Beep Volume** at your normal setting.
 
 ### Log4OM
 - CAT interface: Hamlib `NET rigctl`, host **127.0.0.1**, port **4534**.
-- The `log4om` endpoint is `perms = ["read", "write"]`.
+- The `log4om` endpoint is `perms = ["read", "write"]`, `single_vfo = true`.
 - Log4OM-NG uses Hamlib's **Extended Response Protocol** (ERP): it opens every session with
   `;V ?` (list supported VFOs) and then polls with `+\get_vfo_info VFOA` (~2 Hz). The hub's
   `hamlib_net` face parses the ERP separator prefix (`+ ; | ,`) and answers both shapes in the
   exact byte format real `rigctld` produces, so Log4OM connects and stays **online**. Plain
   clients (WSJT-X, N1MM, the engine) are unaffected — they never send the ERP prefix.
+- **`single_vfo = true` makes Log4OM log the live frequency on either VFO.** Because Log4OM
+  polls the fixed VFO `VFOA`, without virtualization it would read the *inactive* VFO A's
+  stale frequency whenever the operator works on VFO B. With `single_vfo = true` the endpoint
+  resolves the `VFOA` poll to whichever VFO is actually operating, so Log4OM tracks the real
+  dial on both VFOs (and `;V ?` advertises only `VFOA`).
 
 ### QsoRipper engine (TUI and GUI)
-- The engine's `RigctldProvider` points at the read-only endpoint **127.0.0.1:4532**.
+- The engine's `RigctldProvider` points at the read-only endpoint **127.0.0.1:4532**
+  (`single_vfo = false`, so the engine sees and logs the true operating VFO letter).
 - The TUI and GUI both consume the engine over gRPC; neither talks to the radio directly, so
   both get a consistent view fed by the same hub. TCP allows the engine and any other NET
   client to share an endpoint simultaneously.

--- a/src/rust/qsoripper-cathub/src/config.rs
+++ b/src/rust/qsoripper-cathub/src/config.rs
@@ -168,6 +168,19 @@ pub(crate) struct HamlibNetConfig {
     /// Permission tokens (`read`, `write`, `ptt`, `config_write`).
     #[serde(default)]
     pub(crate) perms: Vec<String>,
+    /// Present the *operating* VFO as VFO A to this endpoint (operating-VFO virtualization).
+    ///
+    /// Single-VFO rigctld clients (notably WSJT-X, which expects to receive on VFO A, and
+    /// Log4OM, which polls `\get_vfo_info VFOA`) misbehave when the hub reports the true
+    /// VFO B as the active receive VFO: WSJT-X stops decoding and Log4OM logs the inactive
+    /// VFO A's stale frequency. With `single_vfo = true` the endpoint always presents
+    /// whichever VFO the operator is actually using as VFO A (`get_vfo` -> `VFOA`,
+    /// `get_vfo_info` answers from the operating VFO with `Split: 0`, `get_split_vfo` is
+    /// `0/VFOA`, and `set_split_vfo 1` is rejected so a client never believes a real A/B
+    /// split was armed). Leave this `false` for true dual-VFO control endpoints that must
+    /// see and address real VFO A and B independently.
+    #[serde(default)]
+    pub(crate) single_vfo: bool,
 }
 
 impl HamlibNetConfig {
@@ -334,8 +347,8 @@ impl Config {
         for ep in &self.hamlib_net {
             let _ = writeln!(
                 out,
-                "hamlib_net: name={} bind={} perms={:?}",
-                ep.name, ep.bind, ep.perms
+                "hamlib_net: name={} bind={} perms={:?} single_vfo={}",
+                ep.name, ep.bind, ep.perms, ep.single_vfo
             );
         }
         if !self.face.is_empty() || !self.hamlib_net.is_empty() {

--- a/src/rust/qsoripper-cathub/src/hamlib_net.rs
+++ b/src/rust/qsoripper-cathub/src/hamlib_net.rs
@@ -34,6 +34,36 @@ fn vfo_name(vfo: Vfo) -> &'static str {
     }
 }
 
+/// Resolve a client-requested VFO to the physical VFO whose state should answer.
+///
+/// On a `single_vfo` endpoint the hub presents the operator's *operating* (receive) VFO as
+/// VFO A and never exposes the inactive VFO, so every request resolves to the operating VFO
+/// regardless of the letter the client asked for. On a normal dual-VFO endpoint the
+/// requested VFO is honored verbatim.
+fn resolve_vfo(ctx: &FaceContext, snapshot: &crate::state::Snapshot, requested: Vfo) -> Vfo {
+    if ctx.single_vfo() {
+        snapshot.rx_vfo
+    } else {
+        requested
+    }
+}
+
+/// The VFO letter this endpoint presents as "current". A `single_vfo` endpoint always shows
+/// the operating VFO as VFO A; a dual-VFO endpoint shows the real receive VFO.
+fn presented_current_vfo(ctx: &FaceContext, snapshot: &crate::state::Snapshot) -> Vfo {
+    if ctx.single_vfo() {
+        Vfo::A
+    } else {
+        snapshot.rx_vfo
+    }
+}
+
+/// The split flag this endpoint presents. A `single_vfo` endpoint can only represent one
+/// VFO, so it always reports "no split" to avoid exposing a real A/B split it cannot model.
+fn presented_split(ctx: &FaceContext, snapshot: &crate::state::Snapshot) -> bool {
+    !ctx.single_vfo() && snapshot.split
+}
+
 /// Parse a `set_freq` argument into whole Hz.
 ///
 /// Hamlib clients (WSJT-X, the engine, Log4OM) format frequencies as a double with
@@ -160,28 +190,39 @@ async fn handle_ext(sep: char, rest: &str, ctx: &FaceContext) -> Vec<u8> {
     // The supported-token list line is newline-terminated regardless of the separator,
     // matching real `rigctld`.
     if matches!(cmd, "V" | "\\set_vfo") && args.first() == Some(&"?") {
-        return format!("set_vfo: ?{sep}VFOA VFOB \nRPRT 0\n").into_bytes();
+        // A single_vfo endpoint advertises only VFOA so clients never target the inactive
+        // VFO; a dual-VFO endpoint advertises both.
+        let list = if ctx.single_vfo() {
+            "VFOA "
+        } else {
+            "VFOA VFOB "
+        };
+        return format!("set_vfo: ?{sep}{list}\nRPRT 0\n").into_bytes();
     }
 
-    // get_vfo_info: Log4OM-NG's poll command (`+\get_vfo_info VFOA`). Reports the named
-    // VFO's frequency, mode, passband, split, and (always 0) satellite mode.
+    // get_vfo_info: Log4OM-NG's poll command (`+\get_vfo_info VFOA`). Reports the resolved
+    // VFO's frequency, mode, passband, split, and (always 0) satellite mode. A single_vfo
+    // endpoint resolves any requested VFO to the operating VFO, labels it VFOA, and reports
+    // no split.
     if cmd == "\\get_vfo_info" {
         if !reads {
             return erp_records(sep, &[ext_echo(cmd, &args), "RPRT -1".to_string()]);
         }
-        let vfo = match args.first() {
+        let requested = match args.first() {
             Some(v) if v.eq_ignore_ascii_case("VFOB") => Vfo::B,
             _ => Vfo::A,
         };
-        let v = snapshot.vfo(vfo);
+        let resolved = resolve_vfo(ctx, &snapshot, requested);
+        let shown_name = if ctx.single_vfo() { Vfo::A } else { requested };
+        let v = snapshot.vfo(resolved);
         return erp_records(
             sep,
             &[
-                format!("get_vfo_info: {}", vfo_name(vfo)),
+                format!("get_vfo_info: {}", vfo_name(shown_name)),
                 format!("Freq: {}", v.freq_hz),
                 format!("Mode: {}", v.mode.hamlib_token_with_data(v.data)),
                 format!("Width: {}", v.passband_hz),
-                format!("Split: {}", u8::from(snapshot.split)),
+                format!("Split: {}", u8::from(presented_split(ctx, &snapshot))),
                 "SatMode: 0".to_string(),
                 "RPRT 0".to_string(),
             ],
@@ -206,7 +247,7 @@ async fn handle_ext(sep: char, rest: &str, ctx: &FaceContext) -> Vec<u8> {
         }
         "v" | "\\get_vfo" if reads => Some(vec![
             "get_vfo:".to_string(),
-            format!("VFO: {}", vfo_name(snapshot.rx_vfo)),
+            format!("VFO: {}", vfo_name(presented_current_vfo(ctx, &snapshot))),
             "RPRT 0".to_string(),
         ]),
         "t" | "\\get_ptt" if reads => Some(vec![
@@ -266,32 +307,36 @@ async fn dispatch_plain(cmd: &str, args: &[&str], ctx: &FaceContext) -> LineResu
             .into_bytes()
         }),
         "v" | "\\get_vfo" => guard_read(ctx, || {
-            format!("{}\n", vfo_name(snapshot.rx_vfo)).into_bytes()
+            format!("{}\n", vfo_name(presented_current_vfo(ctx, &snapshot))).into_bytes()
         }),
-        // get_vfo_info: report the named VFO's freq/mode/width/split/satmode as bare
-        // values (Freq, Mode, Width, Split, SatMode), matching real `rigctld`.
+        // get_vfo_info: report the resolved VFO's freq/mode/width/split/satmode as bare
+        // values (Freq, Mode, Width, Split, SatMode), matching real `rigctld`. A single_vfo
+        // endpoint resolves any requested VFO to the operating VFO and reports no split.
         "\\get_vfo_info" => guard_read(ctx, || {
-            let vfo = match args.first() {
+            let requested = match args.first() {
                 Some(v) if v.eq_ignore_ascii_case("VFOB") => Vfo::B,
                 _ => Vfo::A,
             };
-            let v = snapshot.vfo(vfo);
+            let v = snapshot.vfo(resolve_vfo(ctx, &snapshot, requested));
             format!(
                 "{}\n{}\n{}\n{}\n0\n",
                 v.freq_hz,
                 v.mode.hamlib_token_with_data(v.data),
                 v.passband_hz,
-                u8::from(snapshot.split),
+                u8::from(presented_split(ctx, &snapshot)),
             )
             .into_bytes()
         }),
         "s" | "\\get_split_vfo" => guard_read(ctx, || {
-            let tx = if snapshot.split {
+            let split = presented_split(ctx, &snapshot);
+            let tx = if ctx.single_vfo() {
+                Vfo::A
+            } else if snapshot.split {
                 snapshot.tx_vfo
             } else {
                 snapshot.rx_vfo
             };
-            format!("{}\n{}\n", u8::from(snapshot.split), vfo_name(tx)).into_bytes()
+            format!("{}\n{}\n", u8::from(split), vfo_name(tx)).into_bytes()
         }),
         "t" | "\\get_ptt" => {
             guard_read(ctx, || format!("{}\n", u8::from(snapshot.ptt)).into_bytes())
@@ -360,17 +405,31 @@ async fn dispatch_plain(cmd: &str, args: &[&str], ctx: &FaceContext) -> LineResu
         },
         "S" | "\\set_split_vfo" => {
             let enabled = args.first().copied() == Some("1");
-            let tx_vfo = match args.get(1).copied() {
-                Some(v) if v.eq_ignore_ascii_case("VFOB") => Some(Vfo::B),
-                _ => Some(Vfo::A),
-            };
-            outcome_rprt(
-                ctx.apply_modeled(
-                    StateMutation::SetSplit { enabled, tx_vfo },
-                    CommandClass::ModeledWrite,
+            // A single_vfo endpoint presents one operating VFO and cannot model a real A/B
+            // split. Accept "split off" as a no-op success, but reject "split on" so a
+            // client (e.g. WSJT-X "Rig" split) sees split is unavailable instead of a false
+            // success that would route TX to the wrong frequency. Use "Fake It" split.
+            if ctx.single_vfo() {
+                if !ctx.perms.allows(CommandClass::ModeledWrite) {
+                    RPRT_EINVAL.to_vec()
+                } else if enabled {
+                    RPRT_ENAVAIL.to_vec()
+                } else {
+                    RPRT_OK.to_vec()
+                }
+            } else {
+                let tx_vfo = match args.get(1).copied() {
+                    Some(v) if v.eq_ignore_ascii_case("VFOB") => Some(Vfo::B),
+                    _ => Some(Vfo::A),
+                };
+                outcome_rprt(
+                    ctx.apply_modeled(
+                        StateMutation::SetSplit { enabled, tx_vfo },
+                        CommandClass::ModeledWrite,
+                    )
+                    .await,
                 )
-                .await,
-            )
+            }
         }
         "T" | "\\set_ptt" => {
             // Hamlib PTT values: 0 = RX, 1 = TX (generic), 2 = TX on mic, 3 = TX on data.
@@ -800,6 +859,182 @@ mod tests {
         );
         // Default base mode is USB; with DATA on a Hamlib client must read PKTUSB.
         assert_eq!(reply_of("m", &ctx).await, b"PKTUSB\n2400\n".to_vec());
+    }
+
+    /// Build a read-only single-VFO endpoint with the rig parked on VFO B: A is the inactive
+    /// 14.035 CW VFO, B is the operating 14.074 PKTUSB VFO.
+    fn single_vfo_on_b() -> (FaceContext, LoopbackBackend, StateHandle) {
+        let (ctx, backend, state) = ctx_with(FacePermissions::from_tokens(&["read", "write"]));
+        state.record(
+            StateChange::Freq {
+                vfo: Vfo::A,
+                hz: 14_035_000,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::Mode {
+                vfo: Vfo::A,
+                mode: Mode::Cw,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 14_074_000,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::DataMode {
+                vfo: Vfo::B,
+                on: true,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::PollDiff,
+        );
+        (ctx.with_single_vfo(true), backend, state)
+    }
+
+    #[tokio::test]
+    async fn single_vfo_get_vfo_reports_vfoa_on_b() {
+        // WSJT-X expects to receive on VFO A. On a single_vfo endpoint, get_vfo must report
+        // VFOA even though the rig is physically on VFO B, while freq/mode follow the
+        // operating VFO so the data is real.
+        let (ctx, _b, _s) = single_vfo_on_b();
+        assert_eq!(reply_of("v", &ctx).await, b"VFOA\n".to_vec());
+        assert_eq!(reply_of("f", &ctx).await, b"14074000\n".to_vec());
+        assert_eq!(reply_of("m", &ctx).await, b"PKTUSB\n2400\n".to_vec());
+    }
+
+    #[tokio::test]
+    async fn single_vfo_get_vfo_info_vfoa_returns_operating_vfo() {
+        // Log4OM polls `\get_vfo_info VFOA`. On a single_vfo endpoint a VFOA request must
+        // resolve to the operating VFO (B's 14.074 PKTUSB), not the stale inactive VFO A.
+        let (ctx, _b, _s) = single_vfo_on_b();
+        assert_eq!(
+            reply_of("\\get_vfo_info VFOA", &ctx).await,
+            b"14074000\nPKTUSB\n2400\n0\n0\n".to_vec()
+        );
+        // A VFOB request also resolves to the operating VFO (strict single-VFO contract):
+        // the inactive VFO is never exposed.
+        assert_eq!(
+            reply_of("\\get_vfo_info VFOB", &ctx).await,
+            b"14074000\nPKTUSB\n2400\n0\n0\n".to_vec()
+        );
+    }
+
+    #[tokio::test]
+    async fn single_vfo_erp_get_vfo_info_returns_operating_vfo_labeled_a() {
+        // Log4OM-NG uses the Extended Response Protocol form `+\get_vfo_info VFOA`.
+        let (ctx, _b, _s) = single_vfo_on_b();
+        let reply = String::from_utf8(reply_of("+\\get_vfo_info VFOA", &ctx).await).unwrap();
+        assert!(reply.contains("get_vfo_info: VFOA"), "label VFOA: {reply}");
+        assert!(reply.contains("Freq: 14074000"), "operating freq: {reply}");
+        assert!(reply.contains("Mode: PKTUSB"), "operating mode: {reply}");
+        assert!(reply.contains("Split: 0"), "no split presented: {reply}");
+    }
+
+    #[tokio::test]
+    async fn single_vfo_get_split_reports_no_split_vfoa() {
+        // Even when the radio is physically in split, a single_vfo endpoint reports no split
+        // and VFOA, so the client never sees a leaked VFOB letter or a split it can't model.
+        let (ctx, _b, state) = single_vfo_on_b();
+        state.record(
+            StateChange::Split {
+                enabled: true,
+                tx_vfo: Some(Vfo::A),
+            },
+            RadioEventSource::PollDiff,
+        );
+        assert_eq!(reply_of("s", &ctx).await, b"0\nVFOA\n".to_vec());
+        // get_vfo_info's Split field is likewise forced to 0.
+        let reply = String::from_utf8(reply_of("\\get_vfo_info VFOA", &ctx).await).unwrap();
+        assert!(reply.ends_with("0\n0\n"), "split + satmode both 0: {reply}");
+    }
+
+    #[tokio::test]
+    async fn single_vfo_rejects_enable_split_accepts_disable() {
+        // WSJT-X "Rig" split would issue `S 1 VFOB`. A single_vfo endpoint cannot model a
+        // real A/B split, so enable-split must be rejected (not a false success that routes
+        // TX to the wrong frequency). Disable-split is a harmless no-op success.
+        let (ctx, backend, _s) = single_vfo_on_b();
+        assert_eq!(reply_of("S 1 VFOB", &ctx).await, RPRT_ENAVAIL.to_vec());
+        assert_eq!(reply_of("S 0 VFOA", &ctx).await, RPRT_OK.to_vec());
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            !backend
+                .mutations()
+                .iter()
+                .any(|m| matches!(m, StateMutation::SetSplit { .. })),
+            "single_vfo split commands must never reach the radio"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_vfo_set_freq_still_targets_operating_vfo_b() {
+        // Virtualizing the VFO letter must not change where writes land: a set_freq still
+        // tunes the real operating VFO (B), so WSJT-X "Fake It" QSY works on VFO B.
+        let (ctx, backend, _s) = single_vfo_on_b();
+        assert_eq!(reply_of("F 14076000", &ctx).await, RPRT_OK.to_vec());
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            backend.mutations().contains(&StateMutation::SetVfoFreq {
+                vfo: Vfo::B,
+                hz: 14_076_000,
+            }),
+            "set_freq must target operating VFO B, got {:?}",
+            backend.mutations()
+        );
+    }
+
+    #[tokio::test]
+    async fn single_vfo_erp_set_vfo_query_advertises_only_vfoa() {
+        let (ctx, _b, _s) = single_vfo_on_b();
+        let reply = String::from_utf8(reply_of(";V ?", &ctx).await).unwrap();
+        assert!(reply.contains("VFOA"), "advertises VFOA: {reply}");
+        assert!(!reply.contains("VFOB"), "must not advertise VFOB: {reply}");
+    }
+
+    #[tokio::test]
+    async fn single_vfo_erp_get_vfo_reports_vfoa() {
+        let (ctx, _b, _s) = single_vfo_on_b();
+        let reply = String::from_utf8(reply_of("+v", &ctx).await).unwrap();
+        assert!(reply.contains("VFO: VFOA"), "ERP get_vfo VFOA: {reply}");
+    }
+
+    #[tokio::test]
+    async fn dual_vfo_endpoint_still_exposes_real_vfo_b() {
+        // Regression guard: without single_vfo (e.g. ARCP-590, the engine), the endpoint
+        // must keep telling the truth about VFO B and the inactive VFO A.
+        let (ctx, _b, state) = ctx_with(FacePermissions::read_only());
+        state.record(
+            StateChange::Freq {
+                vfo: Vfo::A,
+                hz: 14_035_000,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 14_074_000,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::PollDiff,
+        );
+        assert_eq!(reply_of("v", &ctx).await, b"VFOB\n".to_vec());
+        assert_eq!(
+            reply_of("\\get_vfo_info VFOA", &ctx).await,
+            b"14035000\nUSB\n2400\n0\n0\n".to_vec()
+        );
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-cathub/src/lib.rs
+++ b/src/rust/qsoripper-cathub/src/lib.rs
@@ -313,7 +313,8 @@ pub async fn run(cli: Cli) -> Result<(), CatHubError> {
             radio.clone(),
             ptt.clone(),
             caps.clone(),
-        );
+        )
+        .with_single_vfo(ep.single_vfo);
         let bind = ep.bind.clone();
         let name = ep.name.clone();
         let ids = next_id.clone();


### PR DESCRIPTION
WSJT-X stopped decoding on VFO B and Log4OM logged the wrong frequency because the rigctld-compatible hamlib_net faces never got the single_vfo operating-VFO virtualization that the serial faces received in #494.

On VFO B the hub exposed VFOB through the 'v' command (which confuses WSJT-X) and get_vfo_info VFOA returned the stale inactive VFO A frequency, so Log4OM (which polls +\get_vfo_info VFOA) tracked the wrong frequency.

This change adds a strict single-VFO contract to any hamlib_net face flagged single_vfo=true. Any requested VFO resolves to the operating (rx) VFO and is presented as VFOA. get_vfo_info forces Split 0, get_split reports 0/VFOA, V ? advertises only VFOA, and set_split_vfo 1 is rejected with RPRT_ENAVAIL so split is visibly unavailable (forcing WSJT-X Fake It split rather than silently transmitting on the wrong frequency). Frequency and mode writes already target the operating VFO, so tuning stays real.

The wsjtx (4533) and log4om (4534) faces get single_vfo=true. The engine face (4532) stays single_vfo=false so the QsoRipper engine continues to log the true operating VFO letter.

Adds 10 hamlib_net unit tests. All 186 cathub tests pass; fmt and clippy -D warnings clean. Verified live on the TS-590 with the operator on VFO B: wsjtx v->VFOA, get_vfo_info VFOA->operating 14074000/PKTUSB, S 1 rejected; log4om +\get_vfo_info VFOA->operating freq; engine 4532 still reports VFOB.
