### PR TITLE
cathub: track real TS-590 split and TX VFO and reflect to attached programs

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -510,6 +510,31 @@ which otherwise warns "You should not use VFO B when configured for SO1V" and fr
 the radio seamlessly across A/B switches. It is **off by default** and must stay off for genuine
 dual-VFO faceplates such as ARCP-590. See design §8.4.2.
 
+Native TS-590 controllers that speak the radio's exact protocol — notably **ARCP-590**, Kenwood's
+own control panel — get a dedicated **transparent mirror** dialect (`dialect = "ts590-transparent"`)
+instead of the virtualizing `ts590` dialect. A transparent face behaves as if it were wired
+directly to the rig: every request except PTT and auto-information is forwarded to the radio
+verbatim (`format_notification` returns nothing — the face never consumes a synthesized frame),
+and the radio's entire CAT stream — both modeled frames and unmodeled ones — is relayed back
+byte-for-byte whenever the face has auto-information enabled. Because the rig runs in AI2 and
+echoes every change any client makes through the hub, a transparent controller stays perfectly in
+sync with the radio's true VFO/frequency/mode/split state, eliminating the synthesis/snapshot
+drift (stale A/B, frozen frequency) that a virtualizing view can accumulate for a client that
+already knows the native protocol. The hub still owns the single physical port, so three things
+stay hub-mediated even on a mirror face: PTT (`TX`/`RX`) routes through the shared single-owner
+lease; auto-information (`AI`) is virtualized per face (the rig itself stays in hub-owned AI2);
+and identity/keepalive reads (`ID;`/`PS;`) are answered locally so the controller's steady-state
+heartbeat generates zero radio traffic. A lagged mirror face is re-synced by re-presenting the
+full current state as raw frames (`FA`/`FB`/`FR`/`FT`/`MD`/`IF`). `ts590-transparent` is
+mutually exclusive with `single_vfo = true` (a mirror relays the radio's real dual-VFO stream and
+cannot virtualize the operating VFO); the daemon rejects that combination at config validation.
+
+To support transparent relay, the hub broadcasts a modeled native frame **twice** on its internal
+event bus: once as a coalesced modeled change (consumed by virtualizing faces) and once as a
+verbatim raw-native event (consumed only by transparent faces). Unmodeled frames continue to
+broadcast as a single verbatim raw event. This keeps existing virtualizing dialects byte-for-byte
+unchanged while giving a mirror face the radio's exact stream.
+
 The hub's Hamlib NET faces accept both the plain rigctld protocol (WSJT-X, N1MM, the engine)
 and Hamlib's **Extended Response Protocol** (ERP). An ERP request prefixes the command with a
 separator (`+` joins records with newlines; `;`, `|`, or `,` joins them on one line with that
@@ -627,7 +652,7 @@ Persists setup configuration and station profile.
   configuration. This mirrors the conditional-ownership rule in the unified-configuration note.
 - Validation enforces the same constraints the daemon accepts: `backend` ∈ {ts590, rigctld,
   loopback}; radio `transport` ∈ {serial, tcp}; non-loopback serial radios require a `port`;
-  face `dialect` ∈ {ts590, ts2000}; endpoint names unique across faces and hamlib_net; face
+  face `dialect` ∈ {ts590, ts590-transparent, ts2000}; endpoint names unique across faces and hamlib_net; face
   transports distinct; hamlib_net binds distinct and in `host:port` form; a face transport may
   not reuse the radio port. Violations return `INVALID_ARGUMENT`.
 

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -510,6 +510,19 @@ which otherwise warns "You should not use VFO B when configured for SO1V" and fr
 the radio seamlessly across A/B switches. It is **off by default** and must stay off for genuine
 dual-VFO faceplates such as ARCP-590. See design §8.4.2.
 
+`single_vfo` is equally a per-face policy on **Hamlib NET faces** (`[[cat_hub.hamlib_net]]`), used
+for SO1V/single-VFO loggers that poll over rigctld — notably **Log4OM**, which polls
+`+\get_vfo_info VFOA`. A single-VFO Hamlib face presents the same virtualized view: every
+VFO-identity read resolves to the operating (receive) VFO rather than the literal requested VFO,
+so `get_vfo_info VFOA`, `get_vfo`, and `get_split_vfo` all follow the radio across an A/B switch.
+The face always labels the presented VFO `VFOA`, forces `Split` to `0`, advertises only `VFOA` in
+the `;V ?` handshake, and absorbs `set_split_vfo` without mutating the radio's real split (so the
+client never desyncs the rig). Faithful dual-VFO Hamlib faces (the engine read endpoint) leave
+`single_vfo` off and keep reporting the literal physical VFO and real split. Plain `get_freq` /
+`get_mode` already read the operating VFO on every face, which is why a logger that polls only `f`
+(WSJT-X) tracks A/B even without virtualization, whereas one that polls `get_vfo_info VFOA`
+(Log4OM) requires it.
+
 Native TS-590 controllers that speak the radio's exact protocol — notably **ARCP-590**, Kenwood's
 own control panel — get a dedicated **transparent mirror** dialect (`dialect = "ts590-transparent"`)
 instead of the virtualizing `ts590` dialect. A transparent face behaves as if it were wired

--- a/src/rust/qsoripper-cathub/src/backend/kenwood/ts590.rs
+++ b/src/rust/qsoripper-cathub/src/backend/kenwood/ts590.rs
@@ -114,10 +114,19 @@ fn record_if_status(state: &StateHandle, status: IfStatus, source: RadioEventSou
         source,
     );
     state.record(StateChange::Ptt { keyed: status.ptt }, source);
+    // The IF frame carries the split bit and the receive VFO but not the transmit VFO. On a
+    // two-VFO radio the transmit VFO during split is always the non-receiving VFO, so derive
+    // it here. This keeps the hub's notion of split/TX-VFO authoritative from the rig itself
+    // and propagates the real state to every attached program.
+    let tx_vfo = if status.split {
+        status.rx_vfo.other()
+    } else {
+        status.rx_vfo
+    };
     state.record(
         StateChange::Split {
             enabled: status.split,
-            tx_vfo: None,
+            tx_vfo: Some(tx_vfo),
         },
         source,
     );
@@ -164,17 +173,25 @@ impl RadioBackend for Ts590Backend {
         link: &RadioLink,
         state: &StateHandle,
     ) -> Result<(), BackendError> {
+        let snap = state.snapshot();
         let bytes = match mutation {
             StateMutation::SetRxVfo { vfo } => {
                 let mut bytes = rx_vfo_set(vfo);
-                let snap = state.snapshot();
-                if snap.split {
-                    let tx = match snap.tx_vfo {
-                        Vfo::A => b'0',
-                        Vfo::B => b'1',
-                    };
-                    bytes.extend_from_slice(&[b'F', b'T', tx, b';']);
-                }
+                let tx = if snap.split {
+                    // Preserve a deliberate split: move only the receive VFO, keep the
+                    // operator's transmit VFO untouched.
+                    snap.tx_vfo
+                } else {
+                    // Switching the operating VFO must move RX *and* TX together. Sending a
+                    // bare `FR` would leave the transmit VFO behind and silently create an
+                    // accidental reverse-split (RX=new, TX=old).
+                    vfo
+                };
+                let tx_digit = match tx {
+                    Vfo::A => b'0',
+                    Vfo::B => b'1',
+                };
+                bytes.extend_from_slice(&[b'F', b'T', tx_digit, b';']);
                 bytes
             }
             StateMutation::SetVfoFreq { vfo, hz } => freq_set(vfo, hz),
@@ -236,6 +253,19 @@ impl RadioBackend for Ts590Backend {
         // Kenwood sets are not acknowledged: fire and forget.
         link.submit(bytes, Expect::NoReply).await?;
         state.record(mutation.into_change(), RadioEventSource::OptimisticWrite);
+        // A non-split operating-VFO switch also moves TX, so reflect the cleared split and
+        // the new transmit VFO in the snapshot (the bare RxVfo change above cannot).
+        if let StateMutation::SetRxVfo { vfo } = mutation {
+            if !snap.split {
+                state.record(
+                    StateChange::Split {
+                        enabled: false,
+                        tx_vfo: Some(vfo),
+                    },
+                    RadioEventSource::OptimisticWrite,
+                );
+            }
+        }
         Ok(())
     }
 
@@ -288,6 +318,21 @@ impl RadioBackend for Ts590Backend {
             }),
             b"FR" => parse_rx_vfo_digit(payload).is_some_and(|vfo| {
                 state.record(StateChange::RxVfo { vfo }, source);
+                true
+            }),
+            // A raw `FT` from a client (e.g. ARCP-590/N1MM split control) selects the
+            // transmit VFO. Observe it so the snapshot's split/tx_vfo track reality instead
+            // of going stale: split is active whenever the transmit VFO differs from the
+            // receive VFO.
+            b"FT" => parse_rx_vfo_digit(payload).is_some_and(|tx_vfo| {
+                let rx_vfo = state.snapshot().rx_vfo;
+                state.record(
+                    StateChange::Split {
+                        enabled: rx_vfo != tx_vfo,
+                        tx_vfo: Some(tx_vfo),
+                    },
+                    source,
+                );
                 true
             }),
             b"MD" => payload.first().is_some_and(|digit| {
@@ -440,6 +485,56 @@ mod tests {
     }
 
     #[test]
+    fn if_poll_derives_tx_vfo_from_split_and_rx_vfo() {
+        let backend = Ts590Backend::new();
+
+        // RX=VFO B with split set -> TX must be derived as the non-receiving VFO (A).
+        let split = StateHandle::new();
+        assert!(backend.record_event(
+            b"IF000140343201234-0000012345121019999;",
+            &split,
+            RadioEventSource::PollDiff,
+        ));
+        let snap = split.snapshot();
+        assert_eq!(snap.rx_vfo, Vfo::B);
+        assert!(snap.split);
+        assert_eq!(snap.tx_vfo, Vfo::A, "split TX VFO is the non-RX VFO");
+
+        // RX=VFO B with split clear -> TX tracks the operating (RX) VFO.
+        let simplex = StateHandle::new();
+        assert!(backend.record_event(
+            b"IF000140343201234-0000012345021009999;",
+            &simplex,
+            RadioEventSource::PollDiff,
+        ));
+        let snap = simplex.snapshot();
+        assert_eq!(snap.rx_vfo, Vfo::B);
+        assert!(!snap.split);
+        assert_eq!(snap.tx_vfo, Vfo::B, "simplex TX VFO equals the RX VFO");
+    }
+
+    #[test]
+    fn native_ft_records_split_and_tx_vfo() {
+        let backend = Ts590Backend::new();
+        let state = StateHandle::new();
+
+        // Operator on VFO B; a client (ARCP-590) then commands transmit on VFO A -> the
+        // radio is in reverse-split and the snapshot must reflect it.
+        assert!(backend.record_event(b"FR1;", &state, RadioEventSource::NativePush));
+        assert!(backend.record_event(b"FT0;", &state, RadioEventSource::NativePush));
+        let snap = state.snapshot();
+        assert_eq!(snap.rx_vfo, Vfo::B);
+        assert!(snap.split, "FR=B / FT=A must register as split");
+        assert_eq!(snap.tx_vfo, Vfo::A);
+
+        // Re-aligning the transmit VFO to the receive VFO clears the split.
+        assert!(backend.record_event(b"FT1;", &state, RadioEventSource::NativePush));
+        let snap = state.snapshot();
+        assert!(!snap.split, "FR=B / FT=B must clear split");
+        assert_eq!(snap.tx_vfo, Vfo::B);
+    }
+
+    #[test]
     fn native_fr_then_md_records_mode_on_active_vfo() {
         let backend = Ts590Backend::new();
         let state = StateHandle::new();
@@ -505,7 +600,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn apply_rx_vfo_writes_fr_and_updates_state() {
+    async fn apply_rx_vfo_switches_operating_vfo_with_fr_and_ft() {
         let (link, raw_rx) = link_channel();
         let backend = Arc::new(Ts590Backend::new());
         let arc: Arc<dyn RadioBackend> = backend.clone();
@@ -518,10 +613,15 @@ mod tests {
             .await
             .expect("apply");
 
-        let mut buf = vec![0u8; 4];
+        // A non-split operating-VFO switch must move RX and TX together so the radio is
+        // never left in an accidental reverse-split (RX=B, TX=A).
+        let mut buf = vec![0u8; 8];
         radio_side.read_exact(&mut buf).await.expect("read frame");
-        assert_eq!(&buf, b"FR1;");
-        assert_eq!(state.snapshot().rx_vfo, Vfo::B);
+        assert_eq!(&buf, b"FR1;FT1;");
+        let snap = state.snapshot();
+        assert_eq!(snap.rx_vfo, Vfo::B);
+        assert!(!snap.split, "operating-VFO switch must not be split");
+        assert_eq!(snap.tx_vfo, Vfo::B);
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-cathub/src/config.rs
+++ b/src/rust/qsoripper-cathub/src/config.rs
@@ -168,6 +168,12 @@ pub(crate) struct HamlibNetConfig {
     /// Permission tokens (`read`, `write`, `ptt`, `config_write`).
     #[serde(default)]
     pub(crate) perms: Vec<String>,
+    /// When true, this face is virtualized as a single-VFO radio: the operating
+    /// (receive) VFO is always presented as `VFOA`, split is hidden, and the radio's
+    /// physical A/B identity never leaks. Single-VFO loggers (N1MM SO1V, Log4OM)
+    /// then track the operating VFO seamlessly across A/B swaps.
+    #[serde(default)]
+    pub(crate) single_vfo: bool,
 }
 
 impl HamlibNetConfig {

--- a/src/rust/qsoripper-cathub/src/config.rs
+++ b/src/rust/qsoripper-cathub/src/config.rs
@@ -269,10 +269,21 @@ impl Config {
             }
         }
         for face in &self.face {
-            if !matches!(face.dialect.as_str(), "ts590" | "ts2000") {
+            if !matches!(
+                face.dialect.as_str(),
+                "ts590" | "ts590-transparent" | "ts2000"
+            ) {
                 return Err(ConfigError::Invalid(format!(
-                    "face '{}' has unknown dialect '{}' (expected ts590 or ts2000)",
+                    "face '{}' has unknown dialect '{}' (expected ts590, ts590-transparent, or ts2000)",
                     face.name, face.dialect
+                )));
+            }
+            if face.dialect == "ts590-transparent" && face.single_vfo {
+                return Err(ConfigError::Invalid(format!(
+                    "face '{}' combines dialect 'ts590-transparent' with single_vfo = true; a \
+                     transparent mirror face relays the radio's real dual-VFO stream verbatim and \
+                     cannot virtualize the operating VFO",
+                    face.name
                 )));
             }
         }

--- a/src/rust/qsoripper-cathub/src/dialect/kenwood/mod.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/kenwood/mod.rs
@@ -4,6 +4,7 @@
 //! Log4OM-as-TS590). [`Ts2000Dialect`](ts2000::Ts2000Dialect) is the OmniRig/HDSDR translator.
 //! Both share the small frame helpers below.
 
+pub(crate) mod transparent;
 pub(crate) mod ts2000;
 pub(crate) mod ts590;
 

--- a/src/rust/qsoripper-cathub/src/dialect/kenwood/transparent.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/kenwood/transparent.rs
@@ -1,0 +1,308 @@
+//! The transparent mirror dialect for native TS-590 controllers (notably ARCP-590).
+//!
+//! Unlike [`Ts590Dialect`](super::ts590::Ts590Dialect), which virtualizes the radio behind a
+//! modeled cache, a transparent face behaves as if it were wired directly to the rig: every
+//! request except PTT and auto-information is forwarded to the radio verbatim, and the
+//! radio's entire CAT stream is relayed back verbatim. The rig runs in AI2, so it echoes
+//! every change any client makes through the hub — which is exactly what keeps a transparent
+//! controller perfectly in sync. This removes the whole class of synthesis/drift bugs (stale
+//! A/B, frozen frequency) for a client that already speaks the radio's exact protocol.
+//!
+//! The hub still owns the single physical port, so a few things stay hub-mediated:
+//!   * PTT (`TX`/`RX`) routes through the shared lease so a mirror client can never key the
+//!     transmitter while another face owns it (design §8.5).
+//!   * Auto-information (`AI`) is virtualized per face; the radio itself stays in AI2, and the
+//!     hub gates this face's fan-out on its own `AI` flag.
+//!   * Identity/keepalive reads (`ID`/`PS`) are answered locally so a mirror client's steady
+//!     heartbeat never generates radio traffic.
+
+use async_trait::async_trait;
+
+use super::ts590::snapshot_resync_frames;
+use super::{ai_frame, parse_command, ERR};
+use crate::dialect::{ApplyOutcome, ClientDialect, FaceContext};
+use crate::model::{PttSource, StateChange, StateMutation};
+use crate::permissions::CommandClass;
+use crate::state::Snapshot;
+
+/// The transparent TS-590 mirror dialect.
+#[derive(Clone, Default)]
+pub(crate) struct TransparentTs590Dialect;
+
+impl TransparentTs590Dialect {
+    /// Create the dialect.
+    pub(crate) fn new() -> Self {
+        TransparentTs590Dialect
+    }
+}
+
+#[async_trait]
+impl ClientDialect for TransparentTs590Dialect {
+    async fn handle(&self, request: &[u8], ctx: &FaceContext) -> Vec<u8> {
+        let Some((verb, payload)) = parse_command(request) else {
+            return ERR.to_vec();
+        };
+        let read = payload.is_empty();
+        match verb.as_slice() {
+            // PTT stays hub-arbitrated even on a mirror face: a transparent client must not be
+            // able to key the rig while another face owns the transmitter.
+            b"TX" => reply(
+                ctx.apply_modeled(
+                    StateMutation::SetPtt {
+                        keyed: true,
+                        source: PttSource::Generic,
+                    },
+                    CommandClass::PttWrite,
+                )
+                .await,
+            ),
+            b"RX" => reply(
+                ctx.apply_modeled(
+                    StateMutation::SetPtt {
+                        keyed: false,
+                        source: PttSource::Generic,
+                    },
+                    CommandClass::PttWrite,
+                )
+                .await,
+            ),
+            // Auto-information is virtualized per face: the radio is already in AI2 (hub-owned
+            // native push), so a mirror client toggling AI only flips its own fan-out flag.
+            b"AI" => {
+                if read {
+                    ai_frame(ctx.ai_on())
+                } else {
+                    ctx.set_ai(payload.first().is_some_and(|&d| d != b'0'));
+                    Vec::new()
+                }
+            }
+            // Identity/keepalive reads are answered locally so a mirror client's heartbeat
+            // never hits the radio. (ARCP-590 polls `PS;`/`AI;` continuously when idle.)
+            b"ID" if read => b"ID021;".to_vec(),
+            b"PS" if read => b"PS1;".to_vec(),
+            // Everything else is forwarded to the radio verbatim: a transparent face behaves
+            // as if wired directly to the rig, so reads and writes alike reach the real radio.
+            _ => {
+                let class = if read {
+                    CommandClass::PassthroughRead
+                } else {
+                    CommandClass::ConfigWrite
+                };
+                ctx.passthrough(request, class).await
+            }
+        }
+    }
+
+    fn format_notification(&self, _change: &StateChange, _ctx: &FaceContext) -> Option<Vec<u8>> {
+        // A transparent face is driven entirely by the radio's verbatim CAT stream
+        // (`format_native_passthrough` / `format_passthrough`); it never consumes a synthesized
+        // modeled notification, which is precisely what kept drifting out of sync.
+        None
+    }
+
+    fn format_passthrough(&self, raw: &[u8], ctx: &FaceContext) -> Option<Vec<u8>> {
+        if ctx.ai_on() {
+            Some(raw.to_vec())
+        } else {
+            None
+        }
+    }
+
+    fn format_native_passthrough(&self, raw: &[u8], ctx: &FaceContext) -> Option<Vec<u8>> {
+        if ctx.ai_on() {
+            Some(raw.to_vec())
+        } else {
+            None
+        }
+    }
+
+    fn resync(&self, snapshot: &Snapshot, ctx: &FaceContext) -> Vec<Vec<u8>> {
+        // A lagged mirror face never received the raw frames it missed and ignores synthesized
+        // notifications, so re-present the current radio state as a full set of raw frames.
+        if ctx.ai_on() {
+            snapshot_resync_frames(snapshot)
+        } else {
+            Vec::new()
+        }
+    }
+}
+
+fn reply(outcome: ApplyOutcome) -> Vec<u8> {
+    match outcome {
+        ApplyOutcome::Ok => Vec::new(),
+        _ => ERR.to_vec(),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use crate::backend::loopback::LoopbackBackend;
+    use crate::backend::RadioBackend;
+    use crate::model::{RadioEventSource, StateChange, Vfo};
+    use crate::permissions::FacePermissions;
+    use crate::ptt::PttManager;
+    use crate::radio::{detached_link, spawn_scheduler};
+    use crate::state::StateHandle;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    fn ctx_with(perms: FacePermissions) -> (FaceContext, LoopbackBackend, StateHandle, PttManager) {
+        let backend = LoopbackBackend::new();
+        let caps = backend.capabilities();
+        let arc: Arc<dyn RadioBackend> = Arc::new(backend.clone());
+        let state = StateHandle::new();
+        let radio = spawn_scheduler(arc, detached_link(), state.clone());
+        let ptt = PttManager::new(Duration::from_secs(300));
+        (
+            FaceContext::new(1, perms, state.clone(), radio, ptt.clone(), caps),
+            backend,
+            state,
+            ptt,
+        )
+    }
+
+    #[tokio::test]
+    async fn forwards_a_vfo_select_to_the_radio_verbatim() {
+        // The core bug fix: an A/B (`FR1;`) from a mirror client must reach the radio raw, not
+        // be swallowed by virtualization.
+        let (ctx, backend, _state, _ptt) = ctx_with(FacePermissions::from_tokens(&[
+            "read",
+            "write",
+            "config_write",
+        ]));
+        let reply = TransparentTs590Dialect::new().handle(b"FR1;", &ctx).await;
+        // Loopback echoes the passthrough; production fire-and-forget writes return empty.
+        assert_eq!(reply, b"FR1;");
+        assert_eq!(backend.passthroughs(), vec![b"FR1;".to_vec()]);
+    }
+
+    #[tokio::test]
+    async fn forwards_a_frequency_read_to_the_radio() {
+        let (ctx, backend, _state, _ptt) = ctx_with(FacePermissions::from_tokens(&[
+            "read",
+            "write",
+            "config_write",
+        ]));
+        let _ = TransparentTs590Dialect::new().handle(b"FA;", &ctx).await;
+        assert_eq!(backend.passthroughs(), vec![b"FA;".to_vec()]);
+    }
+
+    #[tokio::test]
+    async fn keys_and_unkeys_through_the_ptt_lease() {
+        let (ctx, _backend, _state, ptt) = ctx_with(FacePermissions::from_tokens(&["read", "ptt"]));
+        let dialect = TransparentTs590Dialect::new();
+        assert!(dialect.handle(b"TX;", &ctx).await.is_empty());
+        assert_eq!(ptt.owner(), Some(1), "TX must take the shared PTT lease");
+        assert!(dialect.handle(b"RX;", &ctx).await.is_empty());
+        assert_eq!(ptt.owner(), None, "RX must release the shared PTT lease");
+    }
+
+    #[tokio::test]
+    async fn ptt_command_never_reaches_the_radio_as_a_raw_write() {
+        // TX/RX must be modeled (lease-arbitrated), not passed through as raw bytes.
+        let (ctx, backend, _state, _ptt) = ctx_with(FacePermissions::from_tokens(&["read", "ptt"]));
+        let _ = TransparentTs590Dialect::new().handle(b"TX;", &ctx).await;
+        assert!(
+            backend.passthroughs().is_empty(),
+            "PTT must not be forwarded as a raw passthrough"
+        );
+    }
+
+    #[tokio::test]
+    async fn keepalive_reads_are_answered_locally() {
+        let (ctx, backend, _state, _ptt) = ctx_with(FacePermissions::read_only());
+        let dialect = TransparentTs590Dialect::new();
+        assert_eq!(dialect.handle(b"ID;", &ctx).await, b"ID021;");
+        assert_eq!(dialect.handle(b"PS;", &ctx).await, b"PS1;");
+        assert!(
+            backend.passthroughs().is_empty(),
+            "ID/PS keepalives must not generate radio traffic"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_information_is_virtualized_per_face() {
+        let (ctx, backend, _state, _ptt) = ctx_with(FacePermissions::read_only());
+        let dialect = TransparentTs590Dialect::new();
+        assert_eq!(dialect.handle(b"AI;", &ctx).await, b"AI0;");
+        assert!(dialect.handle(b"AI2;", &ctx).await.is_empty());
+        assert!(ctx.ai_on());
+        assert_eq!(dialect.handle(b"AI;", &ctx).await, b"AI2;");
+        assert!(
+            backend.passthroughs().is_empty(),
+            "AI must never reach the radio; the rig stays in hub-owned AI2"
+        );
+    }
+
+    #[tokio::test]
+    async fn relays_modeled_and_unmodeled_frames_verbatim_when_auto_info_on() {
+        let (ctx, _backend, _state, _ptt) = ctx_with(FacePermissions::read_only());
+        let dialect = TransparentTs590Dialect::new();
+        // AI off: suppress everything.
+        assert_eq!(dialect.format_native_passthrough(b"FR1;", &ctx), None);
+        assert_eq!(dialect.format_passthrough(b"NB1;", &ctx), None);
+        ctx.set_ai(true);
+        // AI on: relay both the modeled CAT echo and the unmodeled frame byte-for-byte.
+        assert_eq!(
+            dialect.format_native_passthrough(b"FA00014035000;", &ctx),
+            Some(b"FA00014035000;".to_vec())
+        );
+        assert_eq!(
+            dialect.format_passthrough(b"NB1;", &ctx),
+            Some(b"NB1;".to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn never_synthesizes_a_modeled_notification() {
+        let (ctx, _backend, _state, _ptt) = ctx_with(FacePermissions::read_only());
+        ctx.set_ai(true);
+        let dialect = TransparentTs590Dialect::new();
+        assert_eq!(
+            dialect.format_notification(
+                &StateChange::Freq {
+                    vfo: Vfo::A,
+                    hz: 14_035_000,
+                },
+                &ctx
+            ),
+            None,
+            "a transparent face must never emit a synthesized notification"
+        );
+    }
+
+    #[tokio::test]
+    async fn resync_re_presents_full_state_after_a_lag() {
+        let (ctx, _backend, state, _ptt) = ctx_with(FacePermissions::read_only());
+        ctx.set_ai(true);
+        state.record(
+            StateChange::Freq {
+                vfo: Vfo::A,
+                hz: 14_035_000,
+            },
+            RadioEventSource::PollDiff,
+        );
+        let frames = TransparentTs590Dialect::new().resync(&state.snapshot(), &ctx);
+        assert!(
+            frames.iter().any(|f| f == b"FA00014035000;"),
+            "re-sync must include the current VFO A frequency, got {frames:?}"
+        );
+        assert!(
+            frames.iter().any(|f| f.starts_with(b"IF")),
+            "re-sync must include the operating-status IF frame"
+        );
+    }
+
+    #[tokio::test]
+    async fn resync_is_empty_when_auto_info_off() {
+        let (ctx, _backend, state, _ptt) = ctx_with(FacePermissions::read_only());
+        assert!(
+            TransparentTs590Dialect::new()
+                .resync(&state.snapshot(), &ctx)
+                .is_empty(),
+            "an AI-off mirror face must emit nothing on re-sync"
+        );
+    }
+}

--- a/src/rust/qsoripper-cathub/src/dialect/kenwood/ts590.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/kenwood/ts590.rs
@@ -30,7 +30,7 @@ impl Ts590Dialect {
 /// When `single_vfo` is true (operating-VFO virtualization) the operating VFO is always
 /// presented as VFO A with no split, so a single-VFO logger (N1MM SO1V) never sees VFO B
 /// in the P10 field and never warns about it.
-fn synth_if(snapshot: &Snapshot, single_vfo: bool) -> Vec<u8> {
+pub(crate) fn synth_if(snapshot: &Snapshot, single_vfo: bool) -> Vec<u8> {
     let freq = snapshot.vfo(snapshot.rx_vfo).freq_hz;
     let tx = u8::from(snapshot.ptt);
     let mode = mode_to_digit(snapshot.vfo(snapshot.rx_vfo).mode) - b'0';
@@ -274,6 +274,23 @@ fn reply(outcome: ApplyOutcome) -> Vec<u8> {
         ApplyOutcome::Ok => Vec::new(),
         _ => ERR.to_vec(),
     }
+}
+
+/// Build the full set of raw TS-590 frames that re-present the current state to a native
+/// controller: both VFO frequencies, the receive/transmit VFO selectors, the active mode,
+/// and the operating-status `IF`. Used to re-sync a transparent mirror face that lagged the
+/// broadcast ring, restoring it to the radio's true state without a reconnect.
+pub(crate) fn snapshot_resync_frames(snap: &Snapshot) -> Vec<Vec<u8>> {
+    let rx = if snap.rx_vfo == Vfo::A { b'0' } else { b'1' };
+    let tx = if snap.tx_vfo == Vfo::A { b'0' } else { b'1' };
+    vec![
+        freq_frame(b"FA", snap.vfo(Vfo::A).freq_hz),
+        freq_frame(b"FB", snap.vfo(Vfo::B).freq_hz),
+        vec![b'F', b'R', rx, b';'],
+        vec![b'F', b'T', tx, b';'],
+        vec![b'M', b'D', mode_to_digit(snap.vfo(snap.rx_vfo).mode), b';'],
+        synth_if(snap, false),
+    ]
 }
 
 #[cfg(test)]

--- a/src/rust/qsoripper-cathub/src/dialect/mod.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/mod.rs
@@ -260,6 +260,31 @@ pub(crate) trait ClientDialect: Send + Sync {
     fn format_passthrough(&self, _raw: &[u8], _ctx: &FaceContext) -> Option<Vec<u8>> {
         None
     }
+
+    /// Render a *modeled* native frame (one the backend parsed into a state change) as a
+    /// verbatim relay for this face, if it applies. Returns the bytes to push, or `None`.
+    ///
+    /// The default suppresses it: a virtualizing face consumes the coalesced
+    /// [`StateChange`](crate::model::StateChange) via [`Self::format_notification`] instead.
+    /// A transparent mirror dialect overrides this to forward the radio's real CAT stream
+    /// byte-for-byte, so the client never diverges from the rig.
+    fn format_native_passthrough(&self, _raw: &[u8], _ctx: &FaceContext) -> Option<Vec<u8>> {
+        None
+    }
+
+    /// Re-present the full current state to a face that lagged the broadcast ring and lost
+    /// one or more events. Returns the frames to write, in order.
+    ///
+    /// The default replays the snapshot through [`Self::format_notification`], which restores
+    /// a virtualizing face to live state. A transparent mirror dialect overrides this to emit
+    /// the radio's state as raw frames (it never consumes synthesized notifications).
+    fn resync(&self, snapshot: &Snapshot, ctx: &FaceContext) -> Vec<Vec<u8>> {
+        snapshot
+            .as_changes()
+            .iter()
+            .filter_map(|change| self.format_notification(change, ctx))
+            .collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/rust/qsoripper-cathub/src/hamlib_net.rs
+++ b/src/rust/qsoripper-cathub/src/hamlib_net.rs
@@ -16,6 +16,7 @@ use tokio::net::TcpListener;
 use crate::dialect::{ApplyOutcome, FaceContext};
 use crate::model::{Mode, PttSource, StateMutation, Vfo};
 use crate::permissions::CommandClass;
+use crate::state::Snapshot;
 
 /// The capability dump served for `\dump_state`. Captured verbatim from Hamlib 4.7.0
 /// `rigctld` (protocol version 1) so the WSJT-X / engine Hamlib clients parse it exactly.
@@ -31,6 +32,44 @@ fn vfo_name(vfo: Vfo) -> &'static str {
     match vfo {
         Vfo::A => "VFOA",
         Vfo::B => "VFOB",
+    }
+}
+
+/// The VFO whose data this face presents when a client requests `requested`.
+///
+/// Single-VFO faces (N1MM SO1V, Log4OM) always present the operating (receive) VFO so
+/// the radio's physical A/B identity never leaks; dual-VFO faces honor the literal
+/// requested VFO. This is the chokepoint that makes single-VFO loggers follow A/B swaps.
+fn presented_vfo(ctx: &FaceContext, snapshot: &Snapshot, requested: Vfo) -> Vfo {
+    if ctx.single_vfo() {
+        snapshot.rx_vfo
+    } else {
+        requested
+    }
+}
+
+/// The VFO name this face advertises for the real VFO `real`. Single-VFO faces always
+/// claim `VFOA` (the operating VFO is virtualized as A); dual-VFO faces report the real
+/// name.
+fn presented_vfo_name(ctx: &FaceContext, real: Vfo) -> &'static str {
+    if ctx.single_vfo() {
+        "VFOA"
+    } else {
+        vfo_name(real)
+    }
+}
+
+/// The split flag this face exposes. Single-VFO faces always hide split (they know only
+/// the operating VFO), matching the single-VFO virtualization contract.
+fn presented_split(ctx: &FaceContext, snapshot: &Snapshot) -> bool {
+    !ctx.single_vfo() && snapshot.split
+}
+
+/// Parse a requested VFO name argument into a [`Vfo`], defaulting to `VFOA`.
+fn parse_vfo_arg(arg: Option<&&str>) -> Vfo {
+    match arg {
+        Some(v) if v.eq_ignore_ascii_case("VFOB") => Vfo::B,
+        _ => Vfo::A,
     }
 }
 
@@ -160,7 +199,12 @@ async fn handle_ext(sep: char, rest: &str, ctx: &FaceContext) -> Vec<u8> {
     // The supported-token list line is newline-terminated regardless of the separator,
     // matching real `rigctld`.
     if matches!(cmd, "V" | "\\set_vfo") && args.first() == Some(&"?") {
-        return format!("set_vfo: ?{sep}VFOA VFOB \nRPRT 0\n").into_bytes();
+        let vfos = if ctx.single_vfo() {
+            "VFOA "
+        } else {
+            "VFOA VFOB "
+        };
+        return format!("set_vfo: ?{sep}{vfos}\nRPRT 0\n").into_bytes();
     }
 
     // get_vfo_info: Log4OM-NG's poll command (`+\get_vfo_info VFOA`). Reports the named
@@ -169,19 +213,16 @@ async fn handle_ext(sep: char, rest: &str, ctx: &FaceContext) -> Vec<u8> {
         if !reads {
             return erp_records(sep, &[ext_echo(cmd, &args), "RPRT -1".to_string()]);
         }
-        let vfo = match args.first() {
-            Some(v) if v.eq_ignore_ascii_case("VFOB") => Vfo::B,
-            _ => Vfo::A,
-        };
+        let vfo = presented_vfo(ctx, &snapshot, parse_vfo_arg(args.first()));
         let v = snapshot.vfo(vfo);
         return erp_records(
             sep,
             &[
-                format!("get_vfo_info: {}", vfo_name(vfo)),
+                format!("get_vfo_info: {}", presented_vfo_name(ctx, vfo)),
                 format!("Freq: {}", v.freq_hz),
                 format!("Mode: {}", v.mode.hamlib_token_with_data(v.data)),
                 format!("Width: {}", v.passband_hz),
-                format!("Split: {}", u8::from(snapshot.split)),
+                format!("Split: {}", u8::from(presented_split(ctx, &snapshot))),
                 "SatMode: 0".to_string(),
                 "RPRT 0".to_string(),
             ],
@@ -206,7 +247,7 @@ async fn handle_ext(sep: char, rest: &str, ctx: &FaceContext) -> Vec<u8> {
         }
         "v" | "\\get_vfo" if reads => Some(vec![
             "get_vfo:".to_string(),
-            format!("VFO: {}", vfo_name(snapshot.rx_vfo)),
+            format!("VFO: {}", presented_vfo_name(ctx, snapshot.rx_vfo)),
             "RPRT 0".to_string(),
         ]),
         "t" | "\\get_ptt" if reads => Some(vec![
@@ -266,32 +307,30 @@ async fn dispatch_plain(cmd: &str, args: &[&str], ctx: &FaceContext) -> LineResu
             .into_bytes()
         }),
         "v" | "\\get_vfo" => guard_read(ctx, || {
-            format!("{}\n", vfo_name(snapshot.rx_vfo)).into_bytes()
+            format!("{}\n", presented_vfo_name(ctx, snapshot.rx_vfo)).into_bytes()
         }),
         // get_vfo_info: report the named VFO's freq/mode/width/split/satmode as bare
         // values (Freq, Mode, Width, Split, SatMode), matching real `rigctld`.
         "\\get_vfo_info" => guard_read(ctx, || {
-            let vfo = match args.first() {
-                Some(v) if v.eq_ignore_ascii_case("VFOB") => Vfo::B,
-                _ => Vfo::A,
-            };
+            let vfo = presented_vfo(ctx, &snapshot, parse_vfo_arg(args.first()));
             let v = snapshot.vfo(vfo);
             format!(
                 "{}\n{}\n{}\n{}\n0\n",
                 v.freq_hz,
                 v.mode.hamlib_token_with_data(v.data),
                 v.passband_hz,
-                u8::from(snapshot.split),
+                u8::from(presented_split(ctx, &snapshot)),
             )
             .into_bytes()
         }),
         "s" | "\\get_split_vfo" => guard_read(ctx, || {
-            let tx = if snapshot.split {
+            let split = presented_split(ctx, &snapshot);
+            let tx = if split {
                 snapshot.tx_vfo
             } else {
                 snapshot.rx_vfo
             };
-            format!("{}\n{}\n", u8::from(snapshot.split), vfo_name(tx)).into_bytes()
+            format!("{}\n{}\n", u8::from(split), presented_vfo_name(ctx, tx)).into_bytes()
         }),
         "t" | "\\get_ptt" => {
             guard_read(ctx, || format!("{}\n", u8::from(snapshot.ptt)).into_bytes())
@@ -359,18 +398,27 @@ async fn dispatch_plain(cmd: &str, args: &[&str], ctx: &FaceContext) -> LineResu
             None => RPRT_EINVAL.to_vec(),
         },
         "S" | "\\set_split_vfo" => {
-            let enabled = args.first().copied() == Some("1");
-            let tx_vfo = match args.get(1).copied() {
-                Some(v) if v.eq_ignore_ascii_case("VFOB") => Some(Vfo::B),
-                _ => Some(Vfo::A),
-            };
-            outcome_rprt(
-                ctx.apply_modeled(
-                    StateMutation::SetSplit { enabled, tx_vfo },
-                    CommandClass::ModeledWrite,
+            if !ctx.perms.allows(CommandClass::ModeledWrite) {
+                RPRT_EINVAL.to_vec()
+            } else if ctx.single_vfo() {
+                // Single-VFO faces virtualize away split entirely. Absorb the request
+                // without mutating real radio split so reads stay consistent (Split: 0)
+                // and a single-VFO client never desyncs the radio's true split state.
+                RPRT_OK.to_vec()
+            } else {
+                let enabled = args.first().copied() == Some("1");
+                let tx_vfo = match args.get(1).copied() {
+                    Some(v) if v.eq_ignore_ascii_case("VFOB") => Some(Vfo::B),
+                    _ => Some(Vfo::A),
+                };
+                outcome_rprt(
+                    ctx.apply_modeled(
+                        StateMutation::SetSplit { enabled, tx_vfo },
+                        CommandClass::ModeledWrite,
+                    )
+                    .await,
                 )
-                .await,
-            )
+            }
         }
         "T" | "\\set_ptt" => {
             // Hamlib PTT values: 0 = RX, 1 = TX (generic), 2 = TX on mic, 3 = TX on data.
@@ -585,6 +633,58 @@ mod tests {
         let ptt = PttManager::new(Duration::from_secs(300));
         let ctx = FaceContext::new(1, perms, state.clone(), radio, ptt, caps);
         (ctx, backend, state)
+    }
+
+    /// A single-VFO-virtualized face: the operating VFO is always presented as `VFOA`,
+    /// split is hidden, and physical A/B identity never leaks (N1MM SO1V, Log4OM).
+    fn ctx_single_vfo(perms: FacePermissions) -> (FaceContext, LoopbackBackend, StateHandle) {
+        let (ctx, backend, state) = ctx_with(perms);
+        (ctx.with_single_vfo(true), backend, state)
+    }
+
+    /// Put the radio on physical VFO B (14.074 USB) with VFO A on 14.035 CW, split on
+    /// with TX on the inactive VFO — the classic state a single-VFO logger must collapse
+    /// to "operating VFO is VFOA".
+    fn operating_on_b(state: &StateHandle) {
+        state.record(
+            StateChange::Freq {
+                vfo: Vfo::A,
+                hz: 14_035_000,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::Mode {
+                vfo: Vfo::A,
+                mode: Mode::Cw,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::Freq {
+                vfo: Vfo::B,
+                hz: 14_074_000,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::Mode {
+                vfo: Vfo::B,
+                mode: Mode::Usb,
+            },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::RxVfo { vfo: Vfo::B },
+            RadioEventSource::PollDiff,
+        );
+        state.record(
+            StateChange::Split {
+                enabled: true,
+                tx_vfo: Some(Vfo::A),
+            },
+            RadioEventSource::PollDiff,
+        );
     }
 
     async fn reply_of(line: &str, ctx: &FaceContext) -> Vec<u8> {
@@ -1142,6 +1242,95 @@ mod tests {
         assert!(
             joined.is_ok(),
             "serve_conn must close the connection on an overlong line"
+        );
+    }
+
+    // --- single-VFO virtualization (N1MM SO1V, Log4OM) ---
+
+    #[tokio::test]
+    async fn single_vfo_erp_get_vfo_info_follows_operating_vfo_as_vfoa() {
+        // Log4OM bug: it polls `+\get_vfo_info VFOA` and must see the OPERATING VFO (B),
+        // presented as VFOA, with split hidden — not stale physical VFO A.
+        let (ctx, _b, state) = ctx_single_vfo(FacePermissions::from_tokens(&["read", "write"]));
+        operating_on_b(&state);
+        assert_eq!(
+            reply_of("+\\get_vfo_info VFOA", &ctx).await,
+            b"get_vfo_info: VFOA\nFreq: 14074000\nMode: USB\nWidth: 2400\nSplit: 0\nSatMode: 0\nRPRT 0\n"
+                .to_vec()
+        );
+    }
+
+    #[tokio::test]
+    async fn single_vfo_plain_get_vfo_info_follows_operating_vfo() {
+        let (ctx, _b, state) = ctx_single_vfo(FacePermissions::read_only());
+        operating_on_b(&state);
+        // Bare values: operating VFO B's freq/mode/width, split forced to 0.
+        assert_eq!(
+            reply_of("\\get_vfo_info VFOA", &ctx).await,
+            b"14074000\nUSB\n2400\n0\n0\n".to_vec()
+        );
+    }
+
+    #[tokio::test]
+    async fn single_vfo_get_vfo_always_reports_vfoa() {
+        let (ctx, _b, state) = ctx_single_vfo(FacePermissions::read_only());
+        operating_on_b(&state);
+        // Even operating on physical B, a single-VFO face claims VFOA.
+        assert_eq!(reply_of("v", &ctx).await, b"VFOA\n".to_vec());
+    }
+
+    #[tokio::test]
+    async fn single_vfo_get_split_vfo_hides_split() {
+        let (ctx, _b, state) = ctx_single_vfo(FacePermissions::read_only());
+        operating_on_b(&state);
+        // Radio is split, but a single-VFO face reports no split and TX on VFOA.
+        assert_eq!(reply_of("s", &ctx).await, b"0\nVFOA\n".to_vec());
+    }
+
+    #[tokio::test]
+    async fn single_vfo_erp_set_vfo_query_lists_only_vfoa() {
+        let (ctx, _b, _s) = ctx_single_vfo(FacePermissions::from_tokens(&["read", "write"]));
+        assert_eq!(
+            reply_of(";V ?", &ctx).await,
+            b"set_vfo: ?;VFOA \nRPRT 0\n".to_vec()
+        );
+    }
+
+    #[tokio::test]
+    async fn single_vfo_set_split_is_absorbed_without_mutating_radio() {
+        let (ctx, backend, _s) = ctx_single_vfo(FacePermissions::from_tokens(&["read", "write"]));
+        // A single-VFO client must never desync the radio's real split state.
+        assert_eq!(reply_of("S 1 VFOB", &ctx).await, RPRT_OK.to_vec());
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        assert!(
+            backend.mutations().is_empty(),
+            "single-VFO set_split_vfo must not mutate real radio split"
+        );
+    }
+
+    #[tokio::test]
+    async fn single_vfo_read_only_set_split_is_denied() {
+        let (ctx, _b, _s) = ctx_single_vfo(FacePermissions::read_only());
+        assert_eq!(reply_of("S 1 VFOB", &ctx).await, RPRT_EINVAL.to_vec());
+    }
+
+    #[tokio::test]
+    async fn dual_vfo_get_vfo_info_still_reports_literal_physical_vfo() {
+        // Regression guard: a non-single-VFO face (e.g. the engine endpoint) keeps the
+        // faithful dual-VFO view — `get_vfo_info VFOA` returns physical VFO A even when
+        // operating on B, and real split is reported.
+        let (ctx, _b, state) = ctx_with(FacePermissions::from_tokens(&["read", "write"]));
+        operating_on_b(&state);
+        assert_eq!(
+            reply_of("+\\get_vfo_info VFOA", &ctx).await,
+            b"get_vfo_info: VFOA\nFreq: 14035000\nMode: CW\nWidth: 2400\nSplit: 1\nSatMode: 0\nRPRT 0\n"
+                .to_vec()
+        );
+        // And VFOB explicitly is still addressable.
+        assert_eq!(
+            reply_of("+\\get_vfo_info VFOB", &ctx).await,
+            b"get_vfo_info: VFOB\nFreq: 14074000\nMode: USB\nWidth: 2400\nSplit: 1\nSatMode: 0\nRPRT 0\n"
+                .to_vec()
         );
     }
 }

--- a/src/rust/qsoripper-cathub/src/lib.rs
+++ b/src/rust/qsoripper-cathub/src/lib.rs
@@ -42,6 +42,7 @@ use crate::backend::loopback::LoopbackBackend;
 use crate::backend::rigctld::RigctldBackend;
 use crate::backend::{BackendError, RadioBackend};
 use crate::config::{Config, RadioConfig};
+use crate::dialect::kenwood::transparent::TransparentTs590Dialect;
 use crate::dialect::kenwood::ts2000::Ts2000Dialect;
 use crate::dialect::kenwood::ts590::Ts590Dialect;
 use crate::dialect::{ClientDialect, FaceContext};
@@ -115,6 +116,7 @@ fn build_backend(cfg: &Config) -> Result<Arc<dyn RadioBackend>, CatHubError> {
 fn dialect_for(name: &str) -> Result<Arc<dyn ClientDialect>, CatHubError> {
     match name {
         "ts590" => Ok(Arc::new(Ts590Dialect::new())),
+        "ts590-transparent" => Ok(Arc::new(TransparentTs590Dialect::new())),
         "ts2000" => Ok(Arc::new(Ts2000Dialect::new())),
         other => Err(CatHubError::Backend(format!("unknown dialect '{other}'"))),
     }

--- a/src/rust/qsoripper-cathub/src/lib.rs
+++ b/src/rust/qsoripper-cathub/src/lib.rs
@@ -315,7 +315,8 @@ pub async fn run(cli: Cli) -> Result<(), CatHubError> {
             radio.clone(),
             ptt.clone(),
             caps.clone(),
-        );
+        )
+        .with_single_vfo(ep.single_vfo);
         let bind = ep.bind.clone();
         let name = ep.name.clone();
         let ids = next_id.clone();

--- a/src/rust/qsoripper-cathub/src/model.rs
+++ b/src/rust/qsoripper-cathub/src/model.rs
@@ -27,6 +27,17 @@ impl fmt::Display for Vfo {
     }
 }
 
+impl Vfo {
+    /// The other of the two VFOs. On a two-VFO radio the transmit VFO during split is always
+    /// the one that is not receiving, so this derives the TX VFO from the RX VFO.
+    pub(crate) fn other(self) -> Vfo {
+        match self {
+            Vfo::A => Vfo::B,
+            Vfo::B => Vfo::A,
+        }
+    }
+}
+
 /// Operating mode, normalized across radio families.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum Mode {

--- a/src/rust/qsoripper-cathub/src/radio/mod.rs
+++ b/src/rust/qsoripper-cathub/src/radio/mod.rs
@@ -402,7 +402,12 @@ pub(crate) async fn run_transport_supervised<T, F, Fut>(
 /// faces (which consume the CAT stream directly) keep features like the radio's noise
 /// blanker and front-panel changes in sync.
 fn route_event(backend: &Arc<dyn RadioBackend>, state: &StateHandle, frame: &[u8]) {
-    if !backend.record_event(frame, state, RadioEventSource::NativePush) {
+    if backend.record_event(frame, state, RadioEventSource::NativePush) {
+        // The frame was modeled: the snapshot is updated and a coalesced `Change` is
+        // broadcast for virtualizing faces. Also relay the verbatim frame so transparent
+        // mirror faces (ARCP-590) track the radio's real CAT stream instead of a synthesis.
+        state.record_raw_native(frame);
+    } else {
         tracing::trace!(
             frame = %String::from_utf8_lossy(frame),
             "relaying unmodeled unsolicited radio frame to native pass-through faces"
@@ -532,12 +537,14 @@ async fn execute(
     clippy::expect_used,
     clippy::unwrap_used,
     clippy::indexing_slicing,
+    clippy::panic,
     clippy::similar_names
 )]
 mod tests {
     use super::*;
     use crate::backend::kenwood::ts590::Ts590Backend;
     use crate::model::{Mode, Vfo};
+    use crate::state::RadioEvent;
 
     #[test]
     fn framer_splits_on_semicolons() {
@@ -589,6 +596,57 @@ mod tests {
         assert_eq!(snap.vfo(Vfo::B).mode, Mode::Usb);
         assert!(snap.ptt);
         assert!(snap.split);
+    }
+
+    #[test]
+    fn route_event_relays_modeled_frame_as_raw_native_for_mirror_faces() {
+        let backend: Arc<dyn RadioBackend> = Arc::new(Ts590Backend::new());
+        let state = StateHandle::new();
+        let mut rx = state.subscribe();
+
+        route_event(&backend, &state, b"FA00014035000;");
+
+        // A modeled frame must broadcast BOTH the coalesced Change (for virtualizing faces)
+        // and the verbatim RawNative (for transparent mirror faces like ARCP-590).
+        let mut saw_change = false;
+        let mut saw_raw_native = false;
+        while let Ok(evt) = rx.try_recv() {
+            match evt {
+                RadioEvent::Change(_) => saw_change = true,
+                RadioEvent::RawNative(bytes) => {
+                    assert_eq!(&*bytes, b"FA00014035000;");
+                    saw_raw_native = true;
+                }
+                RadioEvent::Raw(_) => panic!("a modeled frame must not broadcast as Raw"),
+            }
+        }
+        assert!(
+            saw_change,
+            "modeled frame must broadcast a coalesced Change"
+        );
+        assert!(
+            saw_raw_native,
+            "modeled frame must also relay verbatim as RawNative"
+        );
+    }
+
+    #[test]
+    fn route_event_relays_unmodeled_frame_as_raw_only() {
+        let backend: Arc<dyn RadioBackend> = Arc::new(Ts590Backend::new());
+        let state = StateHandle::new();
+        let mut rx = state.subscribe();
+
+        route_event(&backend, &state, b"NB1;");
+
+        let evt = rx.try_recv().expect("one event");
+        assert!(
+            matches!(&evt, RadioEvent::Raw(bytes) if &**bytes == b"NB1;"),
+            "an unmodeled frame must relay as Raw only, got {evt:?}"
+        );
+        assert!(
+            rx.try_recv().is_err(),
+            "no second event for an unmodeled frame"
+        );
     }
 
     #[test]

--- a/src/rust/qsoripper-cathub/src/serial_face.rs
+++ b/src/rust/qsoripper-cathub/src/serial_face.rs
@@ -83,6 +83,9 @@ pub(crate) async fn run_face<T>(
                                 dialect.format_notification(change, &ctx)
                             }
                             RadioEvent::Raw(raw) => dialect.format_passthrough(raw, &ctx),
+                            RadioEvent::RawNative(raw) => {
+                                dialect.format_native_passthrough(raw, &ctx)
+                            }
                         };
                         if let Some(bytes) = bytes {
                             tracing::trace!(
@@ -110,11 +113,9 @@ pub(crate) async fn run_face<T>(
                             "face lagged the broadcast ring; re-syncing full snapshot"
                         );
                         let snapshot = ctx.snapshot();
-                        for change in snapshot.as_changes() {
-                            if let Some(bytes) = dialect.format_notification(&change, &ctx) {
-                                if writer.write_all(&bytes).await.is_err() {
-                                    break 'serve;
-                                }
+                        for bytes in dialect.resync(&snapshot, &ctx) {
+                            if writer.write_all(&bytes).await.is_err() {
+                                break 'serve;
                             }
                         }
                         let _ = writer.flush().await;

--- a/src/rust/qsoripper-cathub/src/state.rs
+++ b/src/rust/qsoripper-cathub/src/state.rs
@@ -203,6 +203,11 @@ pub(crate) enum RadioEvent {
     /// native pass-through faces so client-side feature state machines (for example
     /// ARCP-590's NB on/NB1/NB2/off cycle) and front-panel changes stay in sync.
     Raw(Arc<[u8]>),
+    /// A native frame the backend *did* model, forwarded verbatim for transparent mirror
+    /// faces (ARCP-590). Virtualizing faces ignore it — they consume the coalesced
+    /// [`RadioEvent::Change`] instead — but a transparent face relays it so it tracks the
+    /// radio's real CAT stream rather than a synthesis, eliminating push/snapshot drift.
+    RawNative(Arc<[u8]>),
 }
 
 struct Inner {
@@ -220,7 +225,11 @@ pub(crate) struct StateHandle {
 impl StateHandle {
     /// Create an empty state at its defaults.
     pub(crate) fn new() -> Self {
-        let (tx, _rx) = broadcast::channel(256);
+        // Capacity headroom: a modeled native frame now broadcasts both a coalesced `Change`
+        // and a verbatim `RawNative`, so the bus carries up to two events per radio frame.
+        // A larger ring keeps a momentarily busy face (notably a transparent mirror during a
+        // contest-rate tuning sweep) from lagging and having to re-sync.
+        let (tx, _rx) = broadcast::channel(1024);
         StateHandle {
             inner: Arc::new(Inner {
                 snapshot: RwLock::new(Snapshot::default()),
@@ -260,6 +269,15 @@ impl StateHandle {
     /// native-push coverage set; it is a transparent relay of the radio's CAT stream.
     pub(crate) fn record_raw(&self, frame: &[u8]) {
         let _ = self.inner.tx.send(RadioEvent::Raw(Arc::from(frame)));
+    }
+
+    /// Broadcast a *modeled* native frame verbatim for transparent mirror faces. The caller
+    /// has already recorded the modeled change (updating the snapshot and broadcasting a
+    /// coalesced [`RadioEvent::Change`]); this additionally relays the original bytes so a
+    /// transparent face mirrors the radio's exact CAT stream. Non-transparent faces ignore
+    /// this event. It does not touch the snapshot or the native-push coverage set.
+    pub(crate) fn record_raw_native(&self, frame: &[u8]) {
+        let _ = self.inner.tx.send(RadioEvent::RawNative(Arc::from(frame)));
     }
 
     /// A consistent point-in-time view of the radio.
@@ -561,6 +579,22 @@ mod tests {
             "expected RadioEvent::Raw(NB1;), got {evt:?}"
         );
         // A raw relay must not mark native-push coverage.
+        assert!(!state.is_native_push_covered(Field::Freq(Vfo::A)));
+    }
+
+    #[tokio::test]
+    async fn record_raw_native_broadcasts_verbatim_without_touching_snapshot() {
+        let state = StateHandle::new();
+        let mut rx = state.subscribe();
+        state.record_raw_native(b"FA00014035000;");
+        let evt = rx.try_recv().expect("one raw-native event");
+        assert!(
+            matches!(&evt, RadioEvent::RawNative(bytes) if &**bytes == b"FA00014035000;"),
+            "expected RadioEvent::RawNative(FA...), got {evt:?}"
+        );
+        // Relaying the verbatim frame must not itself mutate the snapshot or coverage; the
+        // caller has already recorded the modeled change.
+        assert_eq!(state.snapshot().vfo(Vfo::A).freq_hz, 0);
         assert!(!state.is_native_push_covered(Field::Freq(Vfo::A)));
     }
 


### PR DESCRIPTION
The hub modeled the receive VFO and split state but never learned the transmit VFO from the rig, and a raw FT write from a client (ARCP-590, N1MM) was not observed at all. The hub's split/TX-VFO view could go stale, so attached programs did not always reflect what the radio was actually doing.

This was surfaced while chasing an ARCP-590 "A/B switches within split" report. A direct ARCP-590-to-radio test confirmed ARCP-590 and the radio behave correctly: the radio had simply been left in split by an earlier action, and ARCP-590 faithfully performed its split-mode A/B (swap RX/TX). The hub was not the cause. The real gap was that the hub did not fully track or reflect the rig's true split/TX-VFO state to attached programs.

Changes on the native TS-590 backend:

- record_if_status derives the transmit VFO from each IF poll. On a two-VFO radio the TX VFO during split is always the non-receiving VFO, so split plus RX VFO fully determines it. The hub's split/TX-VFO state is now authoritative from the rig on every poll.
- record_event observes raw FT passthrough writes, recording split as active whenever the transmit VFO differs from the receive VFO, so the snapshot tracks reality between polls.
- apply(SetRxVfo) emits FR;FT; together when not in a deliberate split, so a modeled operating-VFO switch can never leave the radio in an accidental reverse-split. The deliberate-split path still preserves the operator's transmit VFO.

Adds tests for IF-derived TX VFO (split and simplex), raw FT observation, and the FR+FT operating-VFO switch. Workspace line coverage 84.85 percent.
