### PR TITLE
Speed up TUI CAT status updates

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -1233,7 +1233,7 @@ All configuration is driven by environment variables prefixed with `QSORIPPER_`.
 | `QSORIPPER_RIGCTLD_HOST` | String | `localhost` | rigctld TCP host |
 | `QSORIPPER_RIGCTLD_PORT` | Integer | `4532` | rigctld TCP port |
 | `QSORIPPER_RIGCTLD_READ_TIMEOUT_MS` | Integer | `2000` | Per-command read timeout |
-| `QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS` | Integer | `200` | Snapshot staleness threshold (kept below a typical interactive poll interval so live UIs surface rig changes within one poll) |
+| `QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS` | Integer | `100` | Snapshot staleness threshold (kept at the fast interactive poll cadence so live UIs surface rig changes in the next refresh) |
 
 #### Space Weather
 

--- a/docs/integrations/cathub-setup.md
+++ b/docs/integrations/cathub-setup.md
@@ -193,7 +193,7 @@ No radio-menu change is needed. Leave **Beep Volume** at your normal setting.
 - The TUI and GUI both consume the engine over gRPC; neither talks to the radio directly, so
   both get a consistent view fed by the same hub. TCP allows the engine and any other NET
   client to share an endpoint simultaneously.
-- Keep `[rig_control].stale_threshold_ms` low (e.g. **200**) when reading through cathub. The hub
+- Keep `[rig_control].stale_threshold_ms` low (e.g. **100**) when reading through cathub. The hub
   serves reads from its in-memory state cache (kept current by the radio's native AI2 push), so a
   short freshness window is cheap and makes the GUI/TUI frequency display follow knob turns almost
   immediately. A large value such as 5000 makes the engine reuse a stale snapshot for that many

--- a/src/dotnet/QsoRipper.Engine.RigControl.Tests/RigControlMonitorTests.cs
+++ b/src/dotnet/QsoRipper.Engine.RigControl.Tests/RigControlMonitorTests.cs
@@ -15,6 +15,14 @@ public sealed class RigControlMonitorTests
     }
 
     [Fact]
+    public void DefaultStaleThresholdStaysInteractive()
+    {
+        Assert.True(
+            RigControlMonitor.DefaultStaleThresholdMs <= 100,
+            "Default rig snapshot caching must stay fast enough for CAT changes to feel immediate.");
+    }
+
+    [Fact]
     public void CurrentSnapshotReturnsCachedWithinThreshold()
     {
         var callCount = 0;

--- a/src/dotnet/QsoRipper.Engine.RigControl/RigControlMonitor.cs
+++ b/src/dotnet/QsoRipper.Engine.RigControl/RigControlMonitor.cs
@@ -20,7 +20,7 @@ namespace QsoRipper.Engine.RigControl;
 public sealed class RigControlMonitor
 {
     /// <summary>Default stale threshold in milliseconds.</summary>
-    public const int DefaultStaleThresholdMs = 500;
+    public const int DefaultStaleThresholdMs = 100;
 
     private readonly IRigControlProvider _provider;
     private readonly TimeSpan _staleThreshold;

--- a/src/rust/qsoripper-core/src/rig_control/monitor.rs
+++ b/src/rust/qsoripper-core/src/rig_control/monitor.rs
@@ -219,15 +219,15 @@ mod tests {
         }
     }
 
-    /// Regression test for the cathub rig-status lag: a live GUI polls rig state
-    /// roughly every 500 ms, so the default staleness threshold must surface a
-    /// frequency change within one poll window rather than masking it behind a
+    /// Regression test for cathub rig-status lag: an interactive UI polls rig state
+    /// at a fast cadence, so the default staleness threshold must surface a
+    /// frequency change within that budget rather than masking it behind a
     /// multi-second cached snapshot.
     #[tokio::test]
     async fn default_threshold_reflects_rig_changes_within_interactive_budget() {
         use crate::rig_control::rigctld::DEFAULT_RIGCTLD_STALE_THRESHOLD_MS;
 
-        const INTERACTIVE_BUDGET_MS: u64 = 300;
+        const INTERACTIVE_BUDGET_MS: u64 = 150;
 
         let provider = Arc::new(MutableProvider::new(14_074_000));
         let monitor = RigControlMonitor::new(

--- a/src/rust/qsoripper-core/src/rig_control/rigctld.rs
+++ b/src/rust/qsoripper-core/src/rig_control/rigctld.rs
@@ -34,11 +34,11 @@ pub const RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR: &str = "QSORIPPER_RIGCTLD_STALE_TH
 
 /// Default stale threshold in milliseconds.
 ///
-/// Kept well below a typical interactive poll interval (~500 ms) so a live GUI
-/// or TUI surfaces frequency/mode changes within one poll instead of reusing a
-/// multi-second cached snapshot. This matters most when reading through the
-/// cathub front door, which serves fresh rig state in well under 50 ms.
-pub const DEFAULT_RIGCTLD_STALE_THRESHOLD_MS: u64 = 200;
+/// Kept at the TUI's fast CAT poll cadence so live frequency/mode changes are
+/// visible in the next interactive refresh instead of being hidden behind a
+/// multi-second cache. This matters most when reading through the cathub front
+/// door, which serves fresh rig state in well under 50 ms.
+pub const DEFAULT_RIGCTLD_STALE_THRESHOLD_MS: u64 = 100;
 
 /// Configuration for the rigctld adapter.
 #[derive(Debug, Clone)]

--- a/src/rust/qsoripper-tui/src/events.rs
+++ b/src/rust/qsoripper-tui/src/events.rs
@@ -14,7 +14,7 @@ use crate::app::{CallsignInfo, EngineStatus, RecentQso, RigInfo, SpaceWeatherInf
 use crate::grpc;
 
 const SPACE_WEATHER_REFRESH_INTERVAL: Duration = Duration::from_secs(60 * 60);
-const RIG_POLL_INTERVAL: Duration = Duration::from_millis(500);
+const RIG_POLL_INTERVAL: Duration = Duration::from_millis(100);
 const ENGINE_HEALTH_INTERVAL: Duration = Duration::from_secs(5);
 const ENGINE_HEALTH_TIMEOUT: Duration = Duration::from_millis(1500);
 
@@ -159,7 +159,7 @@ pub(crate) fn spawn_space_weather_task(
     });
 }
 
-/// Spawn a rig control polling task that fetches rig snapshots every 500ms.
+/// Spawn a rig control polling task that fetches rig snapshots every 100 ms.
 ///
 /// The poll is gated by `enabled_rx`: when the value is `false`, the task pauses
 /// polling and sends `None` snapshots. This avoids leaking multiple poll loops on toggle.
@@ -175,6 +175,7 @@ pub(crate) fn spawn_rig_poll_task(
             if event_tx.is_closed() {
                 break;
             }
+
             let enabled = *enabled_rx.borrow_and_update();
             if !enabled {
                 continue;
@@ -227,4 +228,17 @@ pub(crate) fn spawn_engine_health_task(
             }
         }
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rig_poll_interval_stays_interactive() {
+        assert!(
+            RIG_POLL_INTERVAL <= Duration::from_millis(100),
+            "TUI rig polling must stay fast enough for CAT changes to feel immediate"
+        );
+    }
 }


### PR DESCRIPTION
The QsoRipper TUI was not getting slow updates because cathub was slow to report radio state. The TUI asks the engine for a rig snapshot on a timer, and that timer was set to 500 ms. The Rust engine also caches rigctld snapshots behind QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS, so even after the TUI woke up it could still receive a cached snapshot instead of re-polling cathub. That made the perceived latency closer to a UI poll plus cache window, which is why it felt noticeably slower than HDSDR when turning the radio knob.

The fix reduces the TUI rig polling interval to 100 ms and lowers the Rust engine's default rig snapshot stale threshold to 100 ms. That keeps the TUI's refresh cadence and the engine cache window aligned, so a cathub state change should be visible on the next interactive refresh instead of waiting behind the old half-second poll.

Because the project treats the Rust and .NET engines as conformant implementations of the same behavior, the .NET rig-control default stale threshold is also reduced to 100 ms. The engine specification and cathub setup guide now document the new default and recommended value.

Regression coverage was added to keep the TUI poll interval and .NET rig-control default within the 100 ms interactive budget, and the existing Rust monitor regression now checks that the default cache threshold surfaces changed rig state within that tighter budget.

Validation run locally: cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check; cargo test --manifest-path src\rust\Cargo.toml; cargo clippy --manifest-path src\rust\Cargo.toml --all-targets -- -D warnings; dotnet format src\dotnet\QsoRipper.slnx --verify-no-changes; dotnet build src\dotnet\QsoRipper.slnx; dotnet test src\dotnet\QsoRipper.slnx --no-build.