### PR TITLE
Speed up GUI CAT status updates

### DIFF
--- a/src/dotnet/QsoRipper.Gui.Tests/AsyncVoidHandlerSafetyTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/AsyncVoidHandlerSafetyTests.cs
@@ -28,6 +28,14 @@ public sealed class AsyncVoidHandlerSafetyTests
     }
 
     [Fact]
+    public void MainWindowViewModel_rig_timer_stays_interactive()
+    {
+        var source = File.ReadAllText(GetSourcePath("src", "dotnet", "QsoRipper.Gui", "ViewModels", "MainWindowViewModel.cs"));
+
+        Assert.Contains("RigPollInterval = TimeSpan.FromMilliseconds(100)", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void MainWindowViewModel_space_weather_periodic_refresh_preserves_stale_data_on_failure()
     {
         var source = File.ReadAllText(GetSourcePath("src", "dotnet", "QsoRipper.Gui", "ViewModels", "MainWindowViewModel.cs"));

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -23,7 +23,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 {
     private static readonly TimeSpan PreferredEngineSwitchTimeout = TimeSpan.FromSeconds(1.5);
     private static readonly TimeSpan SpaceWeatherRefreshInterval = TimeSpan.FromHours(1);
-    private static readonly TimeSpan RigPollInterval = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan RigPollInterval = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan EngineHealthPollInterval = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan EngineHealthProbeTimeout = TimeSpan.FromMilliseconds(1500);
 


### PR DESCRIPTION
The previous CAT-latency fix reduced the TUI rig polling interval and the engine rig snapshot stale threshold, but the Avalonia GUI still had its own 500 ms DispatcherTimer for GetRigSnapshot. That meant GUI frequency tracking could still feel slow even when cathub and the engine were responding quickly.

This change lowers the GUI rig polling interval to 100 ms so the GUI matches the interactive latency budget used by the TUI and rig-control defaults. It also adds a regression test that reads the view-model source and fails if the GUI rig timer drifts back to the old half-second cadence.

During investigation, direct cathub rigctl reads were around 1 ms, so cathub was not the slow component. The local station config also still had stale_threshold_ms = 200 from the old default; I updated the local active config to 100 and restarted the Rust engine so the running process reports staleThresholdMs = 100.

Validation run locally: dotnet format src\dotnet\QsoRipper.slnx --verify-no-changes; dotnet test src\dotnet\QsoRipper.Gui.Tests\QsoRipper.Gui.Tests.csproj; dotnet build src\dotnet\QsoRipper.slnx; dotnet test src\dotnet\QsoRipper.slnx --no-build. I also published the updated GUI artifact to artifacts\publish\qsoripper-gui\Release for local launcher use.