### PR TITLE
Fix CAT frequency tracking latency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 ## A streamlined .gitignore for a polyglot project
 ## covering .NET, Rust, C/CMake, and common editor/OS artifacts.
 
+# Misc
+*.zip
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/

--- a/build.ps1
+++ b/build.ps1
@@ -23,7 +23,7 @@
 
 param(
     [Parameter(Position = 0)]
-    [ValidateSet('build', 'check', 'rust', 'cw-decoder', 'dotnet', 'win32', 'check-rust', 'check-dotnet', 'proto', 'help')]
+    [ValidateSet('build', 'check', 'rust', 'cw-decoder', 'dotnet', 'win32', 'cathub-probe-native', 'check-rust', 'check-dotnet', 'proto', 'help')]
     [string]$Command = 'build',
 
     [ValidateSet('Release', 'Debug')]
@@ -168,6 +168,8 @@ $CwScopeGuiPublishDir = Join-Path $PSScriptRoot 'artifacts' 'publish' | Join-Pat
 $DotnetEngineProject = Join-Path $PSScriptRoot 'src' 'dotnet' 'QsoRipper.Engine.DotNet' 'QsoRipper.Engine.DotNet.csproj'
 $DotnetDebugHostProject = Join-Path $PSScriptRoot 'src' 'dotnet' 'QsoRipper.DebugHost' 'QsoRipper.DebugHost.csproj'
 $CwScopeGuiProject = Join-Path $PSScriptRoot 'experiments' 'cw-decoder' 'gui' 'CwDecoderGui.csproj'
+$CatHubNativeProbeSourceDir = Join-Path $PSScriptRoot 'experiments' 'cathub-frequency-probe-native'
+$CatHubNativeProbeBuildDir = Join-Path $PSScriptRoot 'artifacts' 'build' 'cathub-frequency-probe-native'
 $ServerBinary = if ($IsWindows) { 'qsoripper-server.exe' } else { 'qsoripper-server' }
 $CatHubBinary = if ($IsWindows) { 'qsoripper-cathub.exe' } else { 'qsoripper-cathub' }
 $CwDecoderRustManifest = Join-Path $PSScriptRoot 'experiments' 'cw-decoder' 'Cargo.toml'
@@ -571,11 +573,80 @@ function Build-CwDecoderRust {
     }
 }
 
+function Build-CatHubNativeProbe {
+    if (-not $IsWindows) {
+        Write-Step 'CatHub native frequency probe'
+        Write-Host 'The native CatHub frequency probe is Win32-only; skipping on this platform.' -ForegroundColor Yellow
+        return
+    }
+
+    $cmake = Get-Command cmake -ErrorAction SilentlyContinue
+    if (-not $cmake) {
+        Write-Step 'CatHub native frequency probe'
+        Write-Host 'CMake not found, skipping native CatHub frequency probe. Install CMake and the Visual Studio C++ workload.' -ForegroundColor Yellow
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath (Join-Path $CatHubNativeProbeSourceDir 'CMakeLists.txt'))) {
+        Write-Step 'CatHub native frequency probe'
+        Write-Host "Source not found at $CatHubNativeProbeSourceDir, skipping." -ForegroundColor Yellow
+        return
+    }
+
+    $catHubNativeProbeOutputDir = Join-Path $CatHubNativeProbeBuildDir $Configuration
+    Clear-LockedPublishArtifacts -DestinationDir $catHubNativeProbeOutputDir
+
+    Measure-BuildStep "Configuring CatHub native frequency probe ($Configuration)" {
+        $configured = $false
+        $generators = @('Visual Studio 18 2026', 'Visual Studio 17 2022')
+        foreach ($generator in $generators) {
+            Write-Host "  Trying CMake generator: $generator"
+            cmake -S $CatHubNativeProbeSourceDir -B $CatHubNativeProbeBuildDir -G $generator -A x64
+            if ($LASTEXITCODE -eq 0) {
+                $configured = $true
+                break
+            }
+
+            Remove-Item (Join-Path $CatHubNativeProbeBuildDir 'CMakeCache.txt') -Force -ErrorAction SilentlyContinue
+            Remove-Item (Join-Path $CatHubNativeProbeBuildDir 'CMakeFiles') -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        if (-not $configured) {
+            Write-Host 'FAILED: no supported Visual Studio CMake generator found for native CatHub frequency probe.' -ForegroundColor Red
+            exit 1
+        }
+    }
+
+    Invoke-Build "Building CatHub native frequency probe ($Configuration)" cmake @(
+        '--build',
+        $CatHubNativeProbeBuildDir,
+        '--config',
+        $Configuration
+    )
+
+    $ffiDll = Join-Path $PSScriptRoot 'src' 'rust' 'target' $RustTargetProfile 'qsoripper_ffi.dll'
+    if (Test-Path -LiteralPath $ffiDll) {
+        Copy-PublishArtifact -Path $ffiDll -DestinationDir $catHubNativeProbeOutputDir
+    }
+    else {
+        Write-Host "  Warning: qsoripper_ffi.dll not found at $ffiDll; native probe will run direct cathub reads but ENGINE SKEW will show ERR." -ForegroundColor Yellow
+    }
+
+    $exe = Join-Path $catHubNativeProbeOutputDir 'CatHubFrequencyProbeNative.exe'
+    if (Test-Path -LiteralPath $exe) {
+        Write-Host "  -> $exe"
+    }
+    else {
+        Write-Host "  Warning: expected CatHubFrequencyProbeNative.exe at $exe but it was not found." -ForegroundColor Yellow
+    }
+}
+
 function Build-All {
     Build-Rust
     Build-CwDecoderRust
     Build-Dotnet
     Build-Win32
+    Build-CatHubNativeProbe
 }
 
 function Check-Proto {
@@ -732,6 +803,8 @@ Commands:
   cw-decoder    Build the experiments/cw-decoder Rust binaries (cw-decoder + eval) only
   dotnet        Publish the CLI and GUI apps only
   win32         Build the Win32 C GUI app only
+  cathub-probe-native
+                Build the native C++ CatHub frequency probe only
   check-rust    Rust quality: fmt, clippy, test + coverage threshold, buf lint, cargo deny
   check-dotnet  .NET quality: format, build, test + coverage threshold, vulnerable package check
   proto         Run buf lint
@@ -754,6 +827,7 @@ try {
         'cw-decoder'   { Build-CwDecoderRust }
         'dotnet'       { Build-Dotnet }
         'win32'        { Build-Win32 }
+        'cathub-probe-native' { Build-CatHubNativeProbe }
         'check-rust'   { Check-Rust }
         'check-dotnet' { Check-Dotnet }
         'proto'        { Check-Proto }

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -461,7 +461,8 @@ Returns the most recent frequency/mode snapshot from the rig.
 **Behavior:**
 - Return a `RigSnapshot` containing `frequency_hz`, `band`, `mode`, `submode`, `raw_mode`, `status`, and `sampled_at`.
 - If the rig is disconnected or disabled, return a snapshot with appropriate status and no frequency/mode data.
-- If the last snapshot is older than `QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS`, mark it as stale.
+- Treat this RPC as an interactive live-read path. Engines may share a very recent cached snapshot across concurrent UI polls, but must refresh rigctld state when the cached snapshot is older than the interactive freshness budget (currently 50 ms) even if the general rig-control stale threshold is higher.
+- If a live refresh fails after a previous successful read, return the last cached frequency/mode with `status = Error` and an `error_message` so clients can display both the last known value and the degraded connection state.
 
 **Error semantics:**
 - This RPC should always succeed. Rig errors are reported in the snapshot's `status` and `error_message` fields.
@@ -1141,10 +1142,10 @@ All backends must implement the `EngineStorage` trait, which decomposes into:
 | `m\n` | Mode and passband (e.g., `USB\n2400`) | Get current mode |
 
 **Polling model:**
-- The engine polls rigctld at a configurable interval.
-- Each poll reads frequency and mode, constructs a `RigSnapshot`, and caches it.
+- The engine reads rigctld on demand and caches the latest successful `RigSnapshot`.
+- Interactive snapshot reads, including `GetRigSnapshot`, must refresh when the cached value is older than the interactive freshness budget so high-frequency UI displays do not lag behind cathub.
+- Lower-frequency status consumers may use `QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS` before forcing a new rigctld read.
 - If the TCP connection fails, the rig status transitions to `Disconnected` or `Error`.
-- If the snapshot is older than `QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS`, it is marked stale.
 
 **Read timeout:** `QSORIPPER_RIGCTLD_READ_TIMEOUT_MS` controls the per-command TCP read timeout.
 

--- a/experiments/cathub-frequency-probe-native/CMakeLists.txt
+++ b/experiments/cathub-frequency-probe-native/CMakeLists.txt
@@ -7,6 +7,9 @@ add_executable(CatHubFrequencyProbeNative WIN32
 )
 
 target_compile_features(CatHubFrequencyProbeNative PRIVATE cxx_std_20)
+target_include_directories(CatHubFrequencyProbeNative PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/rust/qsoripper-ffi
+)
 target_compile_definitions(CatHubFrequencyProbeNative PRIVATE
     UNICODE
     _UNICODE

--- a/experiments/cathub-frequency-probe-native/CMakeLists.txt
+++ b/experiments/cathub-frequency-probe-native/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.24)
+
+project(CatHubFrequencyProbeNative LANGUAGES CXX)
+
+add_executable(CatHubFrequencyProbeNative WIN32
+    main.cpp
+)
+
+target_compile_features(CatHubFrequencyProbeNative PRIVATE cxx_std_20)
+target_compile_definitions(CatHubFrequencyProbeNative PRIVATE
+    UNICODE
+    _UNICODE
+    WIN32_LEAN_AND_MEAN
+    NOMINMAX
+)
+target_link_libraries(CatHubFrequencyProbeNative PRIVATE
+    gdi32
+    user32
+    ws2_32
+)
+
+if (MSVC)
+    target_compile_options(CatHubFrequencyProbeNative PRIVATE /W4 /permissive-)
+endif()

--- a/experiments/cathub-frequency-probe-native/README.md
+++ b/experiments/cathub-frequency-probe-native/README.md
@@ -4,12 +4,15 @@ Native C++/Win32 diagnostic app for fast-launch CAT latency testing.
 
 This is a no-.NET sibling of `experiments\cathub-frequency-probe`. It talks directly to cathub's rigctld-compatible endpoint at `127.0.0.1:4532` over Winsock, polls `f`, `m`, and `v` every 100 ms, and displays a large amber TS-590-style frequency readout.
 
+It also loads `qsoripper_ffi.dll` beside the executable and uses the existing Rust FFI shim to call the engine gRPC `GetRigSnapshot` path at `http://127.0.0.1:50051`. That keeps the native probe aligned with the C# WinUI probe's direct cathub vs engine skew comparison without adding a C++ gRPC stack.
+
 Build from the repository root:
 
 ```powershell
-cmake -S experiments\cathub-frequency-probe-native -B artifacts\build\cathub-frequency-probe-native -G "Visual Studio 18 2026" -A x64
-cmake --build artifacts\build\cathub-frequency-probe-native --config Release
+.\build.ps1 cathub-probe-native
 ```
+
+The default `.\build.ps1` flow also builds this probe after Rust, .NET, and Win32 outputs. Running the standalone command expects `src\rust\target\release\qsoripper_ffi.dll` to already exist for engine skew; if it is missing, the direct cathub display still works but `ENGINE SKEW` reports `ERR`.
 
 Run:
 
@@ -23,4 +26,4 @@ Diagnostic log:
 %LOCALAPPDATA%\qsoripper\cathub-frequency-probe-native.log
 ```
 
-This native probe intentionally reads cathub directly and does not include the engine gRPC skew comparison from the C# WinUI probe. Its purpose is fast startup and direct cathub responsiveness checks.
+The `ENGINE SKEW` tile is `engine_frequency_hz - direct_cathub_frequency_hz`. `0 Hz` means the engine and cathub agree; a persistent non-zero value means the engine/UI path is behind or ahead of live cathub state.

--- a/experiments/cathub-frequency-probe-native/README.md
+++ b/experiments/cathub-frequency-probe-native/README.md
@@ -1,0 +1,26 @@
+# CatHub Native Frequency Probe
+
+Native C++/Win32 diagnostic app for fast-launch CAT latency testing.
+
+This is a no-.NET sibling of `experiments\cathub-frequency-probe`. It talks directly to cathub's rigctld-compatible endpoint at `127.0.0.1:4532` over Winsock, polls `f`, `m`, and `v` every 100 ms, and displays a large amber TS-590-style frequency readout.
+
+Build from the repository root:
+
+```powershell
+cmake -S experiments\cathub-frequency-probe-native -B artifacts\build\cathub-frequency-probe-native -G "Visual Studio 18 2026" -A x64
+cmake --build artifacts\build\cathub-frequency-probe-native --config Release
+```
+
+Run:
+
+```powershell
+artifacts\build\cathub-frequency-probe-native\Release\CatHubFrequencyProbeNative.exe
+```
+
+Diagnostic log:
+
+```text
+%LOCALAPPDATA%\qsoripper\cathub-frequency-probe-native.log
+```
+
+This native probe intentionally reads cathub directly and does not include the engine gRPC skew comparison from the C# WinUI probe. Its purpose is fast startup and direct cathub responsiveness checks.

--- a/experiments/cathub-frequency-probe-native/main.cpp
+++ b/experiments/cathub-frequency-probe-native/main.cpp
@@ -1,0 +1,582 @@
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr wchar_t kWindowClassName[] = L"CatHubFrequencyProbeNativeWindow";
+constexpr wchar_t kWindowTitle[] = L"CatHub Native Frequency Probe";
+constexpr UINT kUpdateMessage = WM_APP + 1;
+constexpr int kPollMilliseconds = 100;
+constexpr int kMaxLogLines = 8;
+
+constexpr COLORREF kBackground = RGB(10, 6, 1);
+constexpr COLORREF kPanel = RGB(18, 11, 2);
+constexpr COLORREF kPanelDark = RGB(7, 4, 1);
+constexpr COLORREF kAmber = RGB(255, 191, 0);
+constexpr COLORREF kAmberDim = RGB(185, 133, 25);
+constexpr COLORREF kAmberBorder = RGB(255, 159, 28);
+
+struct Snapshot {
+    std::uint64_t frequency_hz{};
+    std::wstring frequency;
+    std::wstring vfo;
+    std::wstring mode;
+    long long query_ms{};
+    std::optional<long long> change_gap_ms;
+    bool connected{};
+    std::wstring error;
+};
+
+struct SharedState {
+    std::mutex gate;
+    Snapshot snapshot;
+    std::deque<std::wstring> log_lines;
+    std::filesystem::path log_path;
+};
+
+std::atomic_bool g_running{true};
+SharedState g_state;
+
+std::wstring WidenAscii(const std::string& value) {
+    return std::wstring(value.begin(), value.end());
+}
+
+std::string NarrowUtf8(const std::wstring& value) {
+    if (value.empty()) {
+        return {};
+    }
+
+    const int bytes = WideCharToMultiByte(CP_UTF8, 0, value.data(),
+                                          static_cast<int>(value.size()), nullptr, 0,
+                                          nullptr, nullptr);
+    if (bytes <= 0) {
+        return {};
+    }
+
+    std::string result(static_cast<std::size_t>(bytes), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, value.data(), static_cast<int>(value.size()),
+                        result.data(), bytes, nullptr, nullptr);
+    return result;
+}
+
+std::wstring FormatFrequency(std::uint64_t frequency_hz) {
+    const auto mhz = frequency_hz / 1'000'000;
+    const auto khz = (frequency_hz % 1'000'000) / 1'000;
+    const auto ten_hz = (frequency_hz % 1'000) / 10;
+
+    wchar_t buffer[32]{};
+    std::swprintf(buffer, std::size(buffer), L"%llu.%03llu.%02llu",
+                 static_cast<unsigned long long>(mhz),
+                 static_cast<unsigned long long>(khz),
+                 static_cast<unsigned long long>(ten_hz));
+    return buffer;
+}
+
+std::wstring NowTime() {
+    SYSTEMTIME now{};
+    GetLocalTime(&now);
+    wchar_t buffer[32]{};
+    std::swprintf(buffer, std::size(buffer), L"%02u:%02u:%02u.%03u",
+                 now.wHour, now.wMinute, now.wSecond, now.wMilliseconds);
+    return buffer;
+}
+
+std::filesystem::path LogPath() {
+    wchar_t buffer[MAX_PATH]{};
+    const auto length = GetEnvironmentVariableW(L"LOCALAPPDATA", buffer, MAX_PATH);
+    std::filesystem::path root = length == 0 ? std::filesystem::temp_directory_path()
+                                             : std::filesystem::path(buffer);
+    auto directory = root / L"qsoripper";
+    std::filesystem::create_directories(directory);
+    return directory / L"cathub-frequency-probe-native.log";
+}
+
+void AppendLog(const std::wstring& message) {
+    const auto line = NowTime() + L" " + message;
+    {
+        std::lock_guard lock(g_state.gate);
+        g_state.log_lines.push_back(line);
+        while (g_state.log_lines.size() > kMaxLogLines) {
+            g_state.log_lines.pop_front();
+        }
+    }
+
+    std::ofstream file(g_state.log_path, std::ios::app);
+    file << NarrowUtf8(line) << '\n';
+}
+
+class WinSockSession {
+public:
+    WinSockSession() {
+        WSADATA data{};
+        ok_ = WSAStartup(MAKEWORD(2, 2), &data) == 0;
+    }
+
+    ~WinSockSession() {
+        if (ok_) {
+            WSACleanup();
+        }
+    }
+
+    WinSockSession(const WinSockSession&) = delete;
+    WinSockSession& operator=(const WinSockSession&) = delete;
+
+    [[nodiscard]] bool ok() const {
+        return ok_;
+    }
+
+private:
+    bool ok_{};
+};
+
+class CatHubClient {
+public:
+    ~CatHubClient() {
+        Disconnect();
+    }
+
+    CatHubClient(const CatHubClient&) = delete;
+    CatHubClient& operator=(const CatHubClient&) = delete;
+
+    CatHubClient() = default;
+
+    Snapshot ReadSnapshot() {
+        const auto start = std::chrono::steady_clock::now();
+        EnsureConnected();
+
+        const auto frequency_line = CommandLine("f");
+        const auto mode = CommandLine("m");
+        const auto ignored_passband = CommandLineRaw();
+        (void)ignored_passband;
+        const auto vfo = CommandLine("v");
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+
+        std::uint64_t frequency = 0;
+        try {
+            frequency = std::stoull(frequency_line);
+        } catch (...) {
+            throw std::runtime_error("invalid frequency reply: " + frequency_line);
+        }
+
+        Snapshot snapshot;
+        snapshot.frequency_hz = frequency;
+        snapshot.frequency = FormatFrequency(frequency);
+        snapshot.mode = WidenAscii(mode);
+        snapshot.vfo = WidenAscii(vfo);
+        snapshot.query_ms = elapsed.count();
+        snapshot.connected = true;
+        return snapshot;
+    }
+
+private:
+    SOCKET socket_{INVALID_SOCKET};
+
+    void EnsureConnected() {
+        if (socket_ != INVALID_SOCKET) {
+            return;
+        }
+
+        addrinfo hints{};
+        hints.ai_family = AF_INET;
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_protocol = IPPROTO_TCP;
+
+        addrinfo* result = nullptr;
+        if (getaddrinfo("127.0.0.1", "4532", &hints, &result) != 0) {
+            throw std::runtime_error("getaddrinfo failed");
+        }
+
+        SOCKET candidate = INVALID_SOCKET;
+        for (auto* ptr = result; ptr != nullptr; ptr = ptr->ai_next) {
+            candidate = socket(ptr->ai_family, ptr->ai_socktype, ptr->ai_protocol);
+            if (candidate == INVALID_SOCKET) {
+                continue;
+            }
+
+            DWORD timeout_ms = 500;
+            setsockopt(candidate, SOL_SOCKET, SO_RCVTIMEO,
+                       reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+            setsockopt(candidate, SOL_SOCKET, SO_SNDTIMEO,
+                       reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+
+            if (connect(candidate, ptr->ai_addr, static_cast<int>(ptr->ai_addrlen)) == 0) {
+                socket_ = candidate;
+                break;
+            }
+
+            closesocket(candidate);
+            candidate = INVALID_SOCKET;
+        }
+
+        freeaddrinfo(result);
+
+        if (socket_ == INVALID_SOCKET) {
+            throw std::runtime_error("connect 127.0.0.1:4532 failed");
+        }
+    }
+
+    void Disconnect() {
+        if (socket_ != INVALID_SOCKET) {
+            closesocket(socket_);
+            socket_ = INVALID_SOCKET;
+        }
+    }
+
+    std::string CommandLine(const char* command) {
+        const std::string wire = std::string(command) + "\n";
+        if (send(socket_, wire.data(), static_cast<int>(wire.size()), 0) == SOCKET_ERROR) {
+            Disconnect();
+            throw std::runtime_error("send failed");
+        }
+
+        return CommandLineRaw();
+    }
+
+    std::string CommandLineRaw() {
+        std::string line;
+        char ch = '\0';
+        while (true) {
+            const auto read = recv(socket_, &ch, 1, 0);
+            if (read <= 0) {
+                Disconnect();
+                throw std::runtime_error("recv failed");
+            }
+            if (ch == '\n') {
+                break;
+            }
+            if (ch != '\r') {
+                line.push_back(ch);
+            }
+        }
+        return line;
+    }
+};
+
+HFONT MakeFont(int height, int weight = FW_NORMAL) {
+    return CreateFontW(-height, 0, 0, 0, weight, FALSE, FALSE, FALSE, DEFAULT_CHARSET,
+                       OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY,
+                       FIXED_PITCH | FF_MODERN, L"Cascadia Mono");
+}
+
+void DrawTextInRect(HDC dc, const std::wstring& text, const RECT& rect, HFONT font,
+                    COLORREF color, UINT format) {
+    const auto old_font = SelectObject(dc, font);
+    SetBkMode(dc, TRANSPARENT);
+    SetTextColor(dc, color);
+    RECT copy = rect;
+    DrawTextW(dc, text.c_str(), static_cast<int>(text.size()), &copy, format);
+    SelectObject(dc, old_font);
+}
+
+void FillSolid(HDC dc, const RECT& rect, COLORREF color) {
+    const auto brush = CreateSolidBrush(color);
+    FillRect(dc, &rect, brush);
+    DeleteObject(brush);
+}
+
+void StrokeRoundRect(HDC dc, const RECT& rect, COLORREF border, COLORREF fill,
+                     int radius, int width) {
+    const auto brush = CreateSolidBrush(fill);
+    const auto pen = CreatePen(PS_SOLID, width, border);
+    const auto old_brush = SelectObject(dc, brush);
+    const auto old_pen = SelectObject(dc, pen);
+    RoundRect(dc, rect.left, rect.top, rect.right, rect.bottom, radius, radius);
+    SelectObject(dc, old_pen);
+    SelectObject(dc, old_brush);
+    DeleteObject(pen);
+    DeleteObject(brush);
+}
+
+void DrawTile(HDC dc, const RECT& rect, const std::wstring& label, const std::wstring& value) {
+    StrokeRoundRect(dc, rect, RGB(111, 71, 0), kPanelDark, 10, 1);
+
+    const auto label_font = MakeFont(14, FW_BOLD);
+    const auto value_font = MakeFont(30, FW_BOLD);
+    RECT label_rect{rect.left + 18, rect.top + 14, rect.right - 14, rect.top + 38};
+    RECT value_rect{rect.left + 18, rect.top + 46, rect.right - 14, rect.bottom - 10};
+    DrawTextInRect(dc, label, label_rect, label_font, kAmberDim, DT_LEFT | DT_TOP | DT_SINGLELINE);
+    DrawTextInRect(dc, value, value_rect, value_font, kAmber, DT_LEFT | DT_TOP | DT_SINGLELINE);
+    DeleteObject(label_font);
+    DeleteObject(value_font);
+}
+
+void Paint(HWND hwnd, HDC target) {
+    RECT client{};
+    GetClientRect(hwnd, &client);
+
+    const int width = client.right - client.left;
+    const int height = client.bottom - client.top;
+    HDC memory = CreateCompatibleDC(target);
+    HBITMAP bitmap = CreateCompatibleBitmap(target, width, height);
+    const auto old_bitmap = SelectObject(memory, bitmap);
+
+    FillSolid(memory, client, kBackground);
+
+    Snapshot snapshot;
+    std::vector<std::wstring> log_lines;
+    std::filesystem::path log_path;
+    {
+        std::lock_guard lock(g_state.gate);
+        snapshot = g_state.snapshot;
+        log_lines.assign(g_state.log_lines.begin(), g_state.log_lines.end());
+        log_path = g_state.log_path;
+    }
+
+    const auto header_font = MakeFont(24, FW_BOLD);
+    const auto small_font = MakeFont(15, FW_BOLD);
+    const auto footer_font = MakeFont(14, FW_BOLD);
+
+    RECT header{34, 28, width - 34, 104};
+    DrawTextInRect(memory, L"CATHUB NATIVE FREQUENCY PROBE", header, header_font,
+                   kAmber, DT_LEFT | DT_TOP | DT_SINGLELINE);
+    RECT endpoint{34, 58, width - 34, 90};
+    DrawTextInRect(memory, L"native Win32/Winsock - direct 127.0.0.1:4532 - 100 ms poll",
+                   endpoint, small_font, RGB(255, 209, 102), DT_LEFT | DT_TOP | DT_SINGLELINE);
+
+    HPEN line_pen = CreatePen(PS_SOLID, 1, kAmberBorder);
+    const auto old_pen = SelectObject(memory, line_pen);
+    MoveToEx(memory, 0, 118, nullptr);
+    LineTo(memory, width, 118);
+    SelectObject(memory, old_pen);
+    DeleteObject(line_pen);
+
+    const int footer_height = 52;
+    const int log_height = 170;
+    RECT card{34, 152, width - 34, height - footer_height - log_height - 58};
+    if (card.bottom < card.top + 280) {
+        card.bottom = card.top + 280;
+    }
+    StrokeRoundRect(memory, card, kAmberBorder, kPanel, 26, 2);
+
+    const auto label_font = MakeFont(20, FW_BOLD);
+    RECT live_label{card.left + 42, card.top + 36, card.right - 42, card.top + 70};
+    DrawTextInRect(memory, L"LIVE RADIO FREQUENCY", live_label, label_font, kAmberDim,
+                   DT_LEFT | DT_TOP | DT_SINGLELINE);
+
+    const int card_height = static_cast<int>(card.bottom - card.top);
+    const int freq_font_size = std::max(70, std::min(156, card_height / 3));
+    const auto freq_font = MakeFont(freq_font_size, FW_HEAVY);
+    const auto mhz_font = MakeFont(42, FW_BOLD);
+    RECT frequency_rect{card.left + 42, card.top + 86, card.right - 160, card.top + 215};
+    RECT mhz_rect{card.right - 160, card.top + 150, card.right - 34, card.top + 215};
+    const auto frequency = snapshot.connected && snapshot.frequency_hz != 0
+        ? snapshot.frequency
+        : L"--.---.--";
+    DrawTextInRect(memory, frequency, frequency_rect, freq_font, kAmber,
+                   DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+    DrawTextInRect(memory, L"MHz", mhz_rect, mhz_font, RGB(216, 137, 0),
+                   DT_LEFT | DT_VCENTER | DT_SINGLELINE);
+
+    const int tile_top = card.bottom - 118;
+    const int gap = 18;
+    const int tile_width = (card.right - card.left - 84 - (gap * 3)) / 4;
+    RECT tile{card.left + 42, tile_top, card.left + 42 + tile_width, card.bottom - 38};
+    DrawTile(memory, tile, L"VFO", snapshot.vfo.empty() ? L"--" : snapshot.vfo);
+    OffsetRect(&tile, tile_width + gap, 0);
+    DrawTile(memory, tile, L"MODE", snapshot.mode.empty() ? L"--" : snapshot.mode);
+    OffsetRect(&tile, tile_width + gap, 0);
+    DrawTile(memory, tile, L"QUERY", std::to_wstring(snapshot.query_ms) + L" ms");
+    OffsetRect(&tile, tile_width + gap, 0);
+    DrawTile(memory, tile, L"CHANGE GAP",
+             snapshot.change_gap_ms ? std::to_wstring(*snapshot.change_gap_ms) + L" ms" : L"-- ms");
+
+    RECT log_box{34, height - footer_height - log_height - 26, width - 34, height - footer_height - 24};
+    StrokeRoundRect(memory, log_box, RGB(111, 71, 0), kPanelDark, 0, 1);
+    RECT log_path_rect{log_box.left + 18, log_box.top + 14, log_box.right - 18, log_box.top + 36};
+    DrawTextInRect(memory, L"log: " + log_path.wstring(), log_path_rect, small_font, kAmberDim,
+                   DT_LEFT | DT_TOP | DT_SINGLELINE | DT_END_ELLIPSIS);
+    int y = log_box.top + 46;
+    for (const auto& line : log_lines) {
+        RECT line_rect{log_box.left + 18, y, log_box.right - 18, y + 19};
+        DrawTextInRect(memory, line, line_rect, small_font, RGB(255, 209, 102),
+                       DT_LEFT | DT_TOP | DT_SINGLELINE | DT_END_ELLIPSIS);
+        y += 18;
+    }
+
+    RECT footer{0, height - footer_height, width, height};
+    FillSolid(memory, footer, RGB(20, 13, 3));
+    std::wstring footer_text = snapshot.connected
+        ? L"polling direct cathub - frequency=" + frequency + L" MHz - query=" +
+              std::to_wstring(snapshot.query_ms) + L" ms"
+        : L"link down - " + snapshot.error;
+    RECT footer_text_rect{34, height - 34, width - 34, height - 10};
+    DrawTextInRect(memory, footer_text, footer_text_rect, footer_font, kAmberDim,
+                   DT_LEFT | DT_TOP | DT_SINGLELINE | DT_END_ELLIPSIS);
+
+    BitBlt(target, 0, 0, width, height, memory, 0, 0, SRCCOPY);
+
+    DeleteObject(header_font);
+    DeleteObject(small_font);
+    DeleteObject(footer_font);
+    DeleteObject(label_font);
+    DeleteObject(freq_font);
+    DeleteObject(mhz_font);
+    SelectObject(memory, old_bitmap);
+    DeleteObject(bitmap);
+    DeleteDC(memory);
+}
+
+void PollLoop(HWND hwnd) {
+    WinSockSession winsock;
+    if (!winsock.ok()) {
+        AppendLog(L"WSAStartup failed");
+        return;
+    }
+
+    CatHubClient client;
+    std::optional<std::uint64_t> last_frequency;
+    std::optional<std::chrono::steady_clock::time_point> last_change;
+    int poll_count = 0;
+
+    AppendLog(L"native probe starting; target=127.0.0.1:4532 poll=100ms commands=f,m,v");
+
+    while (g_running.load()) {
+        const auto loop_start = std::chrono::steady_clock::now();
+        Snapshot snapshot;
+        try {
+            snapshot = client.ReadSnapshot();
+            poll_count++;
+
+            const bool changed = !last_frequency || *last_frequency != snapshot.frequency_hz;
+            if (changed) {
+                if (last_change) {
+                    snapshot.change_gap_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        loop_start - *last_change)
+                                                 .count();
+                }
+                last_frequency = snapshot.frequency_hz;
+                last_change = loop_start;
+
+                std::wstringstream message;
+                message << L"change #" << poll_count << L": " << snapshot.frequency_hz
+                        << L" Hz " << snapshot.frequency << L" MHz vfo=" << snapshot.vfo
+                        << L" mode=" << snapshot.mode << L" query=" << snapshot.query_ms
+                        << L"ms gap=";
+                if (snapshot.change_gap_ms) {
+                    message << *snapshot.change_gap_ms << L"ms";
+                } else {
+                    message << L"--ms";
+                }
+                AppendLog(message.str());
+            } else if (poll_count % 25 == 0) {
+                std::wstringstream message;
+                message << L"poll #" << poll_count << L": unchanged " << snapshot.frequency_hz
+                        << L" Hz query=" << snapshot.query_ms << L"ms";
+                AppendLog(message.str());
+            }
+        } catch (const std::exception& ex) {
+            snapshot.connected = false;
+            snapshot.error = WidenAscii(ex.what());
+            AppendLog(L"poll error: " + snapshot.error);
+        }
+
+        {
+            std::lock_guard lock(g_state.gate);
+            g_state.snapshot = snapshot;
+        }
+        PostMessageW(hwnd, kUpdateMessage, 0, 0);
+
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - loop_start);
+        if (elapsed.count() < kPollMilliseconds) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(kPollMilliseconds - elapsed.count()));
+        }
+    }
+}
+
+LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) {
+    switch (message) {
+    case WM_CREATE:
+        return 0;
+    case kUpdateMessage:
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return 0;
+    case WM_PAINT: {
+        PAINTSTRUCT paint{};
+        const auto dc = BeginPaint(hwnd, &paint);
+        Paint(hwnd, dc);
+        EndPaint(hwnd, &paint);
+        return 0;
+    }
+    case WM_SIZE:
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return 0;
+    case WM_DESTROY:
+        g_running = false;
+        PostQuitMessage(0);
+        return 0;
+    default:
+        return DefWindowProcW(hwnd, message, wparam, lparam);
+    }
+}
+
+} // namespace
+
+int WINAPI wWinMain(HINSTANCE instance, HINSTANCE, PWSTR, int show_command) {
+    g_state.log_path = LogPath();
+
+    WNDCLASSW wc{};
+    wc.lpfnWndProc = WindowProc;
+    wc.hInstance = instance;
+    wc.lpszClassName = kWindowClassName;
+    wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+    wc.hbrBackground = CreateSolidBrush(kBackground);
+
+    if (RegisterClassW(&wc) == 0) {
+        return 1;
+    }
+
+    const auto hwnd = CreateWindowExW(
+        0,
+        kWindowClassName,
+        kWindowTitle,
+        WS_OVERLAPPEDWINDOW,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        1500,
+        760,
+        nullptr,
+        nullptr,
+        instance,
+        nullptr);
+
+    if (hwnd == nullptr) {
+        return 1;
+    }
+
+    std::thread poll_thread(PollLoop, hwnd);
+    ShowWindow(hwnd, show_command);
+    UpdateWindow(hwnd);
+
+    MSG message{};
+    while (GetMessageW(&message, nullptr, 0, 0) > 0) {
+        TranslateMessage(&message);
+        DispatchMessageW(&message);
+    }
+
+    g_running = false;
+    if (poll_thread.joinable()) {
+        poll_thread.join();
+    }
+
+    return 0;
+}

--- a/experiments/cathub-frequency-probe-native/main.cpp
+++ b/experiments/cathub-frequency-probe-native/main.cpp
@@ -18,6 +18,8 @@
 #include <thread>
 #include <vector>
 
+#include "qsoripper_ffi.h"
+
 namespace {
 
 constexpr wchar_t kWindowClassName[] = L"CatHubFrequencyProbeNativeWindow";
@@ -44,6 +46,9 @@ struct Snapshot {
     std::wstring mode;
     long long query_ms{};
     std::optional<long long> change_gap_ms;
+    std::optional<std::uint64_t> engine_frequency_hz;
+    std::optional<long long> engine_query_ms;
+    std::wstring engine_error;
     bool connected{};
     std::wstring error;
 };
@@ -91,6 +96,45 @@ std::wstring FormatFrequency(std::uint64_t frequency_hz) {
                  static_cast<unsigned long long>(khz),
                  static_cast<unsigned long long>(ten_hz));
     return buffer;
+}
+
+std::wstring FormatSkew(std::uint64_t direct_frequency_hz,
+                        std::optional<std::uint64_t> engine_frequency_hz) {
+    if (!engine_frequency_hz) {
+        return L"--";
+    }
+
+    const auto skew = static_cast<long long>(*engine_frequency_hz) -
+                      static_cast<long long>(direct_frequency_hz);
+    if (skew > 0) {
+        return L"+" + std::to_wstring(skew) + L" Hz";
+    }
+    if (skew < 0) {
+        return std::to_wstring(skew) + L" Hz";
+    }
+    return L"0 Hz";
+}
+
+std::string FixedBufferToString(const std::uint8_t* buffer, std::size_t size) {
+    const auto end = std::find(buffer, buffer + size, 0);
+    return std::string(reinterpret_cast<const char*>(buffer),
+                       reinterpret_cast<const char*>(end));
+}
+
+std::uint64_t ParseMhzToHz(const std::string& mhz) {
+    const auto dot = mhz.find('.');
+    const auto whole_text = dot == std::string::npos ? mhz : mhz.substr(0, dot);
+    auto fractional = dot == std::string::npos ? std::string{} : mhz.substr(dot + 1);
+    while (fractional.size() < 6) {
+        fractional.push_back('0');
+    }
+    if (fractional.size() > 6) {
+        fractional.resize(6);
+    }
+
+    const auto whole = whole_text.empty() ? 0ULL : std::stoull(whole_text);
+    const auto frac = fractional.empty() ? 0ULL : std::stoull(fractional);
+    return (whole * 1'000'000ULL) + frac;
 }
 
 std::wstring NowTime() {
@@ -274,6 +318,149 @@ private:
     }
 };
 
+class EngineClient {
+public:
+    EngineClient() {
+        Load();
+    }
+
+    ~EngineClient() {
+        if (client_ != nullptr && disconnect_ != nullptr) {
+            disconnect_(client_);
+            client_ = nullptr;
+        }
+        if (library_ != nullptr) {
+            FreeLibrary(library_);
+        }
+    }
+
+    EngineClient(const EngineClient&) = delete;
+    EngineClient& operator=(const EngineClient&) = delete;
+
+    struct Result {
+        std::optional<std::uint64_t> frequency_hz;
+        long long query_ms{};
+        std::wstring error;
+    };
+
+    Result ReadSnapshot() {
+        Result result;
+        const auto start = std::chrono::steady_clock::now();
+
+        if (!available_) {
+            result.error = error_;
+            return result;
+        }
+
+        EnsureConnected();
+        if (client_ == nullptr) {
+            result.error = error_;
+            return result;
+        }
+
+        QsrRigStatus status{};
+        if (get_rig_status_(client_, &status) != 0) {
+            const auto message = last_error_ == nullptr ? nullptr : last_error_();
+            error_ = L"engine snapshot failed";
+            if (message != nullptr && message[0] != '\0') {
+                error_ += L": " + WidenAscii(message);
+            }
+            result.error = error_;
+            return result;
+        }
+
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+        result.query_ms = elapsed.count();
+
+        if (status.connected == 0) {
+            result.error = L"engine rig snapshot disconnected";
+            return result;
+        }
+
+        const auto mhz = FixedBufferToString(status.freq_mhz, std::size(status.freq_mhz));
+        if (mhz.empty()) {
+            result.error = L"engine snapshot had no frequency";
+            return result;
+        }
+
+        try {
+            result.frequency_hz = ParseMhzToHz(mhz);
+        } catch (...) {
+            result.error = L"invalid engine frequency: " + WidenAscii(mhz);
+        }
+        return result;
+    }
+
+private:
+    using ConnectFn = QsrClient* (*)(const char*);
+    using DisconnectFn = void (*)(QsrClient*);
+    using LastErrorFn = const char* (*)();
+    using GetRigStatusFn = std::int32_t (*)(QsrClient*, QsrRigStatus*);
+
+    HMODULE library_{};
+    ConnectFn connect_{};
+    DisconnectFn disconnect_{};
+    LastErrorFn last_error_{};
+    GetRigStatusFn get_rig_status_{};
+    QsrClient* client_{};
+    bool available_{};
+    std::wstring error_;
+
+    void Load() {
+        const auto dll_path = ExeDirectory() / L"qsoripper_ffi.dll";
+        library_ = LoadLibraryExW(dll_path.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
+        if (library_ == nullptr) {
+            error_ = L"qsoripper_ffi.dll not found beside probe executable";
+            return;
+        }
+
+        connect_ = reinterpret_cast<ConnectFn>(GetProcAddress(library_, "qsr_connect"));
+        disconnect_ = reinterpret_cast<DisconnectFn>(GetProcAddress(library_, "qsr_disconnect"));
+        last_error_ = reinterpret_cast<LastErrorFn>(GetProcAddress(library_, "qsr_last_error"));
+        get_rig_status_ = reinterpret_cast<GetRigStatusFn>(GetProcAddress(library_, "qsr_get_rig_status"));
+        if (connect_ == nullptr || disconnect_ == nullptr || last_error_ == nullptr ||
+            get_rig_status_ == nullptr) {
+            error_ = L"qsoripper_ffi.dll is missing required exports";
+            available_ = false;
+            return;
+        }
+
+        available_ = true;
+    }
+
+    void EnsureConnected() {
+        if (client_ != nullptr) {
+            return;
+        }
+
+        client_ = connect_("http://127.0.0.1:50051");
+        if (client_ == nullptr) {
+            error_ = L"engine connect failed";
+            const auto message = last_error_ == nullptr ? nullptr : last_error_();
+            if (message != nullptr && message[0] != '\0') {
+                error_ += L": " + WidenAscii(message);
+            }
+        }
+    }
+
+    static std::filesystem::path ExeDirectory() {
+        std::wstring buffer(MAX_PATH, L'\0');
+        DWORD length = 0;
+        while (true) {
+            length = GetModuleFileNameW(nullptr, buffer.data(), static_cast<DWORD>(buffer.size()));
+            if (length == 0) {
+                return std::filesystem::current_path();
+            }
+            if (length < buffer.size() - 1) {
+                buffer.resize(length);
+                return std::filesystem::path(buffer).parent_path();
+            }
+            buffer.resize(buffer.size() * 2);
+        }
+    }
+};
+
 HFONT MakeFont(int height, int weight = FW_NORMAL) {
     return CreateFontW(-height, 0, 0, 0, weight, FALSE, FALSE, FALSE, DEFAULT_CHARSET,
                        OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY,
@@ -343,9 +530,11 @@ void DrawTile(HDC dc, const RECT& rect, const std::wstring& label, const std::ws
     StrokeRoundRect(dc, rect, RGB(111, 71, 0), kPanelDark, 10, 1);
 
     const auto label_font = MakeFont(14, FW_BOLD);
-    const auto value_font = MakeFont(28, FW_BOLD);
     RECT label_rect{rect.left + 18, rect.top + 16, rect.right - 14, rect.top + 40};
     RECT value_rect{rect.left + 18, rect.top + 48, rect.right - 14, rect.bottom - 12};
+    const auto value_font = MakeFont(
+        ChooseFittingFontHeight(dc, value, value_rect, 16, 28, FW_BOLD),
+        FW_BOLD);
     DrawTextInRect(dc, label, label_rect, label_font, kAmberDim, DT_LEFT | DT_TOP | DT_SINGLELINE);
     DrawTextInRect(dc, value, value_rect, value_font, kAmber,
                    DT_LEFT | DT_VCENTER | DT_SINGLELINE);
@@ -406,8 +595,9 @@ void Paint(HWND hwnd, HDC target) {
     const int tile_height = 92;
     const int tile_bottom = card.bottom - 28;
     const int tile_top = tile_bottom - tile_height;
-    const int gap = 14;
-    const int tile_width = (card.right - card.left - 84 - (gap * 3)) / 4;
+    const int tile_count = 5;
+    const int gap = 12;
+    const int tile_width = (card.right - card.left - 84 - (gap * (tile_count - 1))) / tile_count;
 
     const int frequency_top = card.top + 84;
     const int frequency_bottom = std::max(frequency_top + 44, tile_top - 20);
@@ -431,6 +621,9 @@ void Paint(HWND hwnd, HDC target) {
     OffsetRect(&tile, tile_width + gap, 0);
     DrawTile(memory, tile, L"CHANGE GAP",
              snapshot.change_gap_ms ? std::to_wstring(*snapshot.change_gap_ms) + L" ms" : L"-- ms");
+    OffsetRect(&tile, tile_width + gap, 0);
+    DrawTile(memory, tile, L"ENGINE SKEW",
+             snapshot.engine_error.empty() ? FormatSkew(snapshot.frequency_hz, snapshot.engine_frequency_hz) : L"ERR");
 
     RECT log_box{34, height - footer_height - log_height - 16, width - 34, height - footer_height - 12};
     StrokeRoundRect(memory, log_box, RGB(111, 71, 0), kPanelDark, 0, 1);
@@ -452,7 +645,11 @@ void Paint(HWND hwnd, HDC target) {
     FillSolid(memory, footer, RGB(20, 13, 3));
     std::wstring footer_text = snapshot.connected
         ? L"polling direct cathub - frequency=" + frequency + L" MHz - query=" +
-              std::to_wstring(snapshot.query_ms) + L" ms"
+              std::to_wstring(snapshot.query_ms) + L" ms - engine=" +
+              (snapshot.engine_frequency_hz ? FormatFrequency(*snapshot.engine_frequency_hz) + L" MHz/" +
+                   std::to_wstring(snapshot.engine_query_ms.value_or(0)) + L" ms"
+                                            : L"--") +
+              L" - skew=" + FormatSkew(snapshot.frequency_hz, snapshot.engine_frequency_hz)
         : L"link down - " + snapshot.error;
     RECT footer_text_rect{34, height - 34, width - 34, height - 10};
     DrawTextInRect(memory, footer_text, footer_text_rect, footer_font, kAmberDim,
@@ -478,17 +675,22 @@ void PollLoop(HWND hwnd) {
     }
 
     CatHubClient client;
+    EngineClient engine;
     std::optional<std::uint64_t> last_frequency;
     std::optional<std::chrono::steady_clock::time_point> last_change;
     int poll_count = 0;
 
-    AppendLog(L"native probe starting; target=127.0.0.1:4532 poll=100ms commands=f,m,v");
+    AppendLog(L"native probe starting; direct=127.0.0.1:4532 engine=http://127.0.0.1:50051 poll=100ms commands=f,m,v");
 
     while (g_running.load()) {
         const auto loop_start = std::chrono::steady_clock::now();
         Snapshot snapshot;
         try {
             snapshot = client.ReadSnapshot();
+            const auto engine_snapshot = engine.ReadSnapshot();
+            snapshot.engine_frequency_hz = engine_snapshot.frequency_hz;
+            snapshot.engine_query_ms = engine_snapshot.query_ms;
+            snapshot.engine_error = engine_snapshot.error;
             poll_count++;
 
             const bool changed = !last_frequency || *last_frequency != snapshot.frequency_hz;
@@ -502,10 +704,24 @@ void PollLoop(HWND hwnd) {
                 last_change = loop_start;
 
                 std::wstringstream message;
-                message << L"change #" << poll_count << L": " << snapshot.frequency_hz
-                        << L" Hz " << snapshot.frequency << L" MHz vfo=" << snapshot.vfo
-                        << L" mode=" << snapshot.mode << L" query=" << snapshot.query_ms
-                        << L"ms gap=";
+                message << L"change #" << poll_count << L": direct=" << snapshot.frequency_hz
+                        << L" Hz " << snapshot.frequency << L" MHz engine=";
+                if (snapshot.engine_frequency_hz) {
+                    message << *snapshot.engine_frequency_hz << L" Hz "
+                            << FormatFrequency(*snapshot.engine_frequency_hz) << L" MHz";
+                } else {
+                    message << L"--";
+                }
+                message << L" skew=" << FormatSkew(snapshot.frequency_hz, snapshot.engine_frequency_hz)
+                        << L" vfo=" << snapshot.vfo
+                        << L" mode=" << snapshot.mode << L" direct_query=" << snapshot.query_ms
+                        << L"ms engine_query=";
+                if (snapshot.engine_query_ms) {
+                    message << *snapshot.engine_query_ms << L"ms";
+                } else {
+                    message << L"--ms";
+                }
+                message << L" gap=";
                 if (snapshot.change_gap_ms) {
                     message << *snapshot.change_gap_ms << L"ms";
                 } else {
@@ -514,9 +730,25 @@ void PollLoop(HWND hwnd) {
                 AppendLog(message.str());
             } else if (poll_count % 25 == 0) {
                 std::wstringstream message;
-                message << L"poll #" << poll_count << L": unchanged " << snapshot.frequency_hz
-                        << L" Hz query=" << snapshot.query_ms << L"ms";
+                message << L"poll #" << poll_count << L": unchanged direct=" << snapshot.frequency_hz
+                        << L" Hz engine=";
+                if (snapshot.engine_frequency_hz) {
+                    message << *snapshot.engine_frequency_hz << L" Hz "
+                            << FormatFrequency(*snapshot.engine_frequency_hz) << L" MHz";
+                } else {
+                    message << L"--";
+                }
+                message << L" skew=" << FormatSkew(snapshot.frequency_hz, snapshot.engine_frequency_hz)
+                        << L" direct_query=" << snapshot.query_ms << L"ms engine_query=";
+                if (snapshot.engine_query_ms) {
+                    message << *snapshot.engine_query_ms << L"ms";
+                } else {
+                    message << L"--ms";
+                }
                 AppendLog(message.str());
+            }
+            if (!snapshot.engine_error.empty() && poll_count % 10 == 1) {
+                AppendLog(L"engine poll error: " + snapshot.engine_error);
             }
         } catch (const std::exception& ex) {
             snapshot.connected = false;

--- a/experiments/cathub-frequency-probe-native/main.cpp
+++ b/experiments/cathub-frequency-probe-native/main.cpp
@@ -25,6 +25,10 @@ constexpr wchar_t kWindowTitle[] = L"CatHub Native Frequency Probe";
 constexpr UINT kUpdateMessage = WM_APP + 1;
 constexpr int kPollMilliseconds = 100;
 constexpr int kMaxLogLines = 8;
+constexpr int kDefaultWindowWidth = 1100;
+constexpr int kDefaultWindowHeight = 700;
+constexpr int kMinWindowWidth = 1000;
+constexpr int kMinWindowHeight = 660;
 
 constexpr COLORREF kBackground = RGB(10, 6, 1);
 constexpr COLORREF kPanel = RGB(18, 11, 2);
@@ -276,6 +280,36 @@ HFONT MakeFont(int height, int weight = FW_NORMAL) {
                        FIXED_PITCH | FF_MODERN, L"Cascadia Mono");
 }
 
+int RectWidth(const RECT& rect) {
+    return std::max(0, static_cast<int>(rect.right - rect.left));
+}
+
+int RectHeight(const RECT& rect) {
+    return std::max(0, static_cast<int>(rect.bottom - rect.top));
+}
+
+int ChooseFittingFontHeight(HDC dc, const std::wstring& text, const RECT& rect,
+                            int minimum_height, int maximum_height, int weight) {
+    const int available_width = std::max(0, RectWidth(rect) - 8);
+    const int available_height = std::max(0, RectHeight(rect) - 14);
+
+    for (int height = maximum_height; height >= minimum_height; --height) {
+        const auto font = MakeFont(height, weight);
+        const auto old_font = SelectObject(dc, font);
+        SIZE size{};
+        const auto measured = GetTextExtentPoint32W(
+            dc, text.c_str(), static_cast<int>(text.size()), &size);
+        SelectObject(dc, old_font);
+        DeleteObject(font);
+
+        if (measured && size.cx <= available_width && size.cy <= available_height) {
+            return height;
+        }
+    }
+
+    return minimum_height;
+}
+
 void DrawTextInRect(HDC dc, const std::wstring& text, const RECT& rect, HFONT font,
                     COLORREF color, UINT format) {
     const auto old_font = SelectObject(dc, font);
@@ -309,11 +343,12 @@ void DrawTile(HDC dc, const RECT& rect, const std::wstring& label, const std::ws
     StrokeRoundRect(dc, rect, RGB(111, 71, 0), kPanelDark, 10, 1);
 
     const auto label_font = MakeFont(14, FW_BOLD);
-    const auto value_font = MakeFont(30, FW_BOLD);
-    RECT label_rect{rect.left + 18, rect.top + 14, rect.right - 14, rect.top + 38};
-    RECT value_rect{rect.left + 18, rect.top + 46, rect.right - 14, rect.bottom - 10};
+    const auto value_font = MakeFont(28, FW_BOLD);
+    RECT label_rect{rect.left + 18, rect.top + 16, rect.right - 14, rect.top + 40};
+    RECT value_rect{rect.left + 18, rect.top + 48, rect.right - 14, rect.bottom - 12};
     DrawTextInRect(dc, label, label_rect, label_font, kAmberDim, DT_LEFT | DT_TOP | DT_SINGLELINE);
-    DrawTextInRect(dc, value, value_rect, value_font, kAmber, DT_LEFT | DT_TOP | DT_SINGLELINE);
+    DrawTextInRect(dc, value, value_rect, value_font, kAmber,
+                   DT_LEFT | DT_VCENTER | DT_SINGLELINE);
     DeleteObject(label_font);
     DeleteObject(value_font);
 }
@@ -358,12 +393,9 @@ void Paint(HWND hwnd, HDC target) {
     SelectObject(memory, old_pen);
     DeleteObject(line_pen);
 
-    const int footer_height = 52;
-    const int log_height = 170;
-    RECT card{34, 152, width - 34, height - footer_height - log_height - 58};
-    if (card.bottom < card.top + 280) {
-        card.bottom = card.top + 280;
-    }
+    const int footer_height = 44;
+    const int log_height = std::max(120, std::min(150, height / 5));
+    RECT card{34, 138, width - 34, height - footer_height - log_height - 42};
     StrokeRoundRect(memory, card, kAmberBorder, kPanel, 26, 2);
 
     const auto label_font = MakeFont(20, FW_BOLD);
@@ -371,24 +403,26 @@ void Paint(HWND hwnd, HDC target) {
     DrawTextInRect(memory, L"LIVE RADIO FREQUENCY", live_label, label_font, kAmberDim,
                    DT_LEFT | DT_TOP | DT_SINGLELINE);
 
-    const int card_height = static_cast<int>(card.bottom - card.top);
-    const int freq_font_size = std::max(70, std::min(156, card_height / 3));
-    const auto freq_font = MakeFont(freq_font_size, FW_HEAVY);
-    const auto mhz_font = MakeFont(42, FW_BOLD);
-    RECT frequency_rect{card.left + 42, card.top + 86, card.right - 160, card.top + 215};
-    RECT mhz_rect{card.right - 160, card.top + 150, card.right - 34, card.top + 215};
+    const int tile_height = 92;
+    const int tile_bottom = card.bottom - 28;
+    const int tile_top = tile_bottom - tile_height;
+    const int gap = 14;
+    const int tile_width = (card.right - card.left - 84 - (gap * 3)) / 4;
+
+    const int frequency_top = card.top + 84;
+    const int frequency_bottom = std::max(frequency_top + 44, tile_top - 20);
     const auto frequency = snapshot.connected && snapshot.frequency_hz != 0
         ? snapshot.frequency
         : L"--.---.--";
-    DrawTextInRect(memory, frequency, frequency_rect, freq_font, kAmber,
+    const auto frequency_display = frequency + L" MHz";
+    RECT frequency_rect{card.left + 42, frequency_top, card.right - 42, frequency_bottom};
+    const int freq_font_size =
+        ChooseFittingFontHeight(memory, frequency_display, frequency_rect, 38, 96, FW_HEAVY);
+    const auto freq_font = MakeFont(freq_font_size, FW_HEAVY);
+    DrawTextInRect(memory, frequency_display, frequency_rect, freq_font, kAmber,
                    DT_CENTER | DT_VCENTER | DT_SINGLELINE);
-    DrawTextInRect(memory, L"MHz", mhz_rect, mhz_font, RGB(216, 137, 0),
-                   DT_LEFT | DT_VCENTER | DT_SINGLELINE);
 
-    const int tile_top = card.bottom - 118;
-    const int gap = 18;
-    const int tile_width = (card.right - card.left - 84 - (gap * 3)) / 4;
-    RECT tile{card.left + 42, tile_top, card.left + 42 + tile_width, card.bottom - 38};
+    RECT tile{card.left + 42, tile_top, card.left + 42 + tile_width, tile_bottom};
     DrawTile(memory, tile, L"VFO", snapshot.vfo.empty() ? L"--" : snapshot.vfo);
     OffsetRect(&tile, tile_width + gap, 0);
     DrawTile(memory, tile, L"MODE", snapshot.mode.empty() ? L"--" : snapshot.mode);
@@ -398,13 +432,16 @@ void Paint(HWND hwnd, HDC target) {
     DrawTile(memory, tile, L"CHANGE GAP",
              snapshot.change_gap_ms ? std::to_wstring(*snapshot.change_gap_ms) + L" ms" : L"-- ms");
 
-    RECT log_box{34, height - footer_height - log_height - 26, width - 34, height - footer_height - 24};
+    RECT log_box{34, height - footer_height - log_height - 16, width - 34, height - footer_height - 12};
     StrokeRoundRect(memory, log_box, RGB(111, 71, 0), kPanelDark, 0, 1);
     RECT log_path_rect{log_box.left + 18, log_box.top + 14, log_box.right - 18, log_box.top + 36};
     DrawTextInRect(memory, L"log: " + log_path.wstring(), log_path_rect, small_font, kAmberDim,
                    DT_LEFT | DT_TOP | DT_SINGLELINE | DT_END_ELLIPSIS);
     int y = log_box.top + 46;
     for (const auto& line : log_lines) {
+        if (y + 19 > log_box.bottom - 10) {
+            break;
+        }
         RECT line_rect{log_box.left + 18, y, log_box.right - 18, y + 19};
         DrawTextInRect(memory, line, line_rect, small_font, RGB(255, 209, 102),
                        DT_LEFT | DT_TOP | DT_SINGLELINE | DT_END_ELLIPSIS);
@@ -428,7 +465,6 @@ void Paint(HWND hwnd, HDC target) {
     DeleteObject(footer_font);
     DeleteObject(label_font);
     DeleteObject(freq_font);
-    DeleteObject(mhz_font);
     SelectObject(memory, old_bitmap);
     DeleteObject(bitmap);
     DeleteDC(memory);
@@ -520,6 +556,12 @@ LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lpara
     case WM_SIZE:
         InvalidateRect(hwnd, nullptr, FALSE);
         return 0;
+    case WM_GETMINMAXINFO: {
+        auto* min_max = reinterpret_cast<MINMAXINFO*>(lparam);
+        min_max->ptMinTrackSize.x = kMinWindowWidth;
+        min_max->ptMinTrackSize.y = kMinWindowHeight;
+        return 0;
+    }
     case WM_DESTROY:
         g_running = false;
         PostQuitMessage(0);
@@ -550,10 +592,10 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE, PWSTR, int show_command) {
         kWindowClassName,
         kWindowTitle,
         WS_OVERLAPPEDWINDOW,
-        CW_USEDEFAULT,
-        CW_USEDEFAULT,
-        1500,
-        760,
+        40,
+        40,
+        kDefaultWindowWidth,
+        kDefaultWindowHeight,
         nullptr,
         nullptr,
         instance,

--- a/experiments/cathub-frequency-probe/App.xaml
+++ b/experiments/cathub-frequency-probe/App.xaml
@@ -1,0 +1,9 @@
+<Application
+    x:Class="CatHubFrequencyProbe.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls">
+    <Application.Resources>
+        <controls:XamlControlsResources />
+    </Application.Resources>
+</Application>

--- a/experiments/cathub-frequency-probe/App.xaml.cs
+++ b/experiments/cathub-frequency-probe/App.xaml.cs
@@ -1,0 +1,19 @@
+using Microsoft.UI.Xaml;
+
+namespace CatHubFrequencyProbe;
+
+public partial class App : Application
+{
+    private Window? _window;
+
+    public App()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        _window = new MainWindow();
+        _window.Activate();
+    }
+}

--- a/experiments/cathub-frequency-probe/CatHubFrequencyProbe.csproj
+++ b/experiments/cathub-frequency-probe/CatHubFrequencyProbe.csproj
@@ -42,4 +42,11 @@
           BeforeTargets="MarkupCompilePass1"
           DependsOnTargets="Protobuf_Compile" />
 
+  <Target Name="CopyWinUiPriToPublishDirectory"
+          AfterTargets="Publish"
+          Condition="'$(PublishDir)' != '' and Exists('$(TargetDir)$(TargetName).pri')">
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pri"
+          DestinationFolder="$(PublishDir)" />
+  </Target>
+
 </Project>

--- a/experiments/cathub-frequency-probe/CatHubFrequencyProbe.csproj
+++ b/experiments/cathub-frequency-probe/CatHubFrequencyProbe.csproj
@@ -1,0 +1,42 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <RootNamespace>CatHubFrequencyProbe</RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <UseWinUI>true</UseWinUI>
+    <WindowsPackageType>None</WindowsPackageType>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.34.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.80.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="..\..\proto\domain\*.proto"
+              ProtoRoot="..\..\proto"
+              GrpcServices="None" />
+    <Protobuf Include="..\..\proto\services\*.proto"
+              ProtoRoot="..\..\proto"
+              GrpcServices="None" />
+    <Protobuf Update="..\..\proto\services\*service.proto"
+              GrpcServices="Client" />
+  </ItemGroup>
+
+  <Target Name="GenerateProtobufBeforeWinUiMarkup"
+          BeforeTargets="MarkupCompilePass1"
+          DependsOnTargets="Protobuf_Compile" />
+
+</Project>

--- a/experiments/cathub-frequency-probe/CatHubFrequencyProbe.csproj
+++ b/experiments/cathub-frequency-probe/CatHubFrequencyProbe.csproj
@@ -10,6 +10,9 @@
     <WindowsPackageType>None</WindowsPackageType>
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishAot>true</PublishAot>
+    <IsAotCompatible>true</IsAotCompatible>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/experiments/cathub-frequency-probe/CatHubFrequencyProbe.csproj
+++ b/experiments/cathub-frequency-probe/CatHubFrequencyProbe.csproj
@@ -11,7 +11,7 @@
     <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <PublishAot>true</PublishAot>
+    <UseAppHost>true</UseAppHost>
     <IsAotCompatible>true</IsAotCompatible>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/experiments/cathub-frequency-probe/CatHubRigClient.cs
+++ b/experiments/cathub-frequency-probe/CatHubRigClient.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Net.Sockets;
+using System.Text;
+
+namespace CatHubFrequencyProbe;
+
+internal sealed class CatHubRigClient : IAsyncDisposable
+{
+    private static readonly TimeSpan ConnectTimeout = TimeSpan.FromMilliseconds(750);
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromMilliseconds(500);
+
+    private readonly string _host;
+    private readonly int _port;
+    private TcpClient? _client;
+    private StreamReader? _reader;
+    private NetworkStream? _stream;
+
+    public CatHubRigClient(string host, int port)
+    {
+        _host = host;
+        _port = port;
+    }
+
+    public async Task<FrequencySnapshot> ReadSnapshotAsync(CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false);
+
+            var frequency = await ReadFrequencyAsync(cancellationToken).ConfigureAwait(false);
+            var (mode, _) = await ReadModeAsync(cancellationToken).ConfigureAwait(false);
+            var vfo = await ReadVfoAsync(cancellationToken).ConfigureAwait(false);
+
+            stopwatch.Stop();
+            return new FrequencySnapshot(
+                frequency,
+                mode,
+                vfo,
+                stopwatch.ElapsedMilliseconds,
+                DateTimeOffset.Now);
+        }
+        catch
+        {
+            await DisconnectAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisconnectAsync().ConfigureAwait(false);
+    }
+
+    private async Task EnsureConnectedAsync(CancellationToken cancellationToken)
+    {
+        if (_client?.Connected == true && _stream is not null && _reader is not null)
+        {
+            return;
+        }
+
+        await DisconnectAsync().ConfigureAwait(false);
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(ConnectTimeout);
+
+        _client = new TcpClient();
+        await _client.ConnectAsync(_host, _port, timeout.Token).ConfigureAwait(false);
+        _stream = _client.GetStream();
+        _reader = new StreamReader(_stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 256, leaveOpen: true);
+    }
+
+    private async Task<ulong> ReadFrequencyAsync(CancellationToken cancellationToken)
+    {
+        var line = await CommandLineAsync("f", cancellationToken).ConfigureAwait(false);
+        if (!ulong.TryParse(line, NumberStyles.None, CultureInfo.InvariantCulture, out var frequency))
+        {
+            throw new InvalidDataException($"Invalid frequency reply: '{line}'");
+        }
+
+        return frequency;
+    }
+
+    private async Task<(string Mode, int PassbandHz)> ReadModeAsync(CancellationToken cancellationToken)
+    {
+        await WriteCommandAsync("m", cancellationToken).ConfigureAwait(false);
+        var mode = await ReadLineWithTimeoutAsync(cancellationToken).ConfigureAwait(false);
+        var passbandLine = await ReadLineWithTimeoutAsync(cancellationToken).ConfigureAwait(false);
+        _ = int.TryParse(passbandLine, NumberStyles.Integer, CultureInfo.InvariantCulture, out var passband);
+        return (mode, passband);
+    }
+
+    private async Task<string> ReadVfoAsync(CancellationToken cancellationToken)
+    {
+        return await CommandLineAsync("v", cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<string> CommandLineAsync(string command, CancellationToken cancellationToken)
+    {
+        await WriteCommandAsync(command, cancellationToken).ConfigureAwait(false);
+        return await ReadLineWithTimeoutAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task WriteCommandAsync(string command, CancellationToken cancellationToken)
+    {
+        var stream = _stream ?? throw new InvalidOperationException("Not connected.");
+        var bytes = Encoding.ASCII.GetBytes(command + "\n");
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(CommandTimeout);
+        await stream.WriteAsync(bytes, timeout.Token).ConfigureAwait(false);
+        await stream.FlushAsync(timeout.Token).ConfigureAwait(false);
+    }
+
+    private async Task<string> ReadLineWithTimeoutAsync(CancellationToken cancellationToken)
+    {
+        var reader = _reader ?? throw new InvalidOperationException("Not connected.");
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(CommandTimeout);
+        var line = await reader.ReadLineAsync(timeout.Token).ConfigureAwait(false);
+        return line ?? throw new EndOfStreamException("cathub closed the rigctld connection.");
+    }
+
+    private Task DisconnectAsync()
+    {
+        _reader?.Dispose();
+        _stream?.Dispose();
+        _client?.Dispose();
+        _reader = null;
+        _stream = null;
+        _client = null;
+        return Task.CompletedTask;
+    }
+}

--- a/experiments/cathub-frequency-probe/DiagnosticLog.cs
+++ b/experiments/cathub-frequency-probe/DiagnosticLog.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+
+namespace CatHubFrequencyProbe;
+
+internal sealed class DiagnosticLog
+{
+    private const int MaxUiLines = 18;
+    private readonly Queue<string> _recentLines = new();
+    private readonly string _path;
+
+    public DiagnosticLog()
+    {
+        var directory = System.IO.Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "qsoripper");
+        Directory.CreateDirectory(directory);
+        _path = System.IO.Path.Combine(directory, "cathub-frequency-probe.log");
+    }
+
+    public string Path => _path;
+
+    public string UiText => string.Join(Environment.NewLine, _recentLines);
+
+    public void Write(string message)
+    {
+        var line = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{DateTimeOffset.Now:HH:mm:ss.fff} {message}");
+        File.AppendAllText(_path, line + Environment.NewLine);
+        _recentLines.Enqueue(line);
+        while (_recentLines.Count > MaxUiLines)
+        {
+            _recentLines.Dequeue();
+        }
+    }
+}

--- a/experiments/cathub-frequency-probe/EngineFrequencySnapshot.cs
+++ b/experiments/cathub-frequency-probe/EngineFrequencySnapshot.cs
@@ -1,0 +1,7 @@
+namespace CatHubFrequencyProbe;
+
+internal sealed record EngineFrequencySnapshot(
+    ulong FrequencyHz,
+    string Mode,
+    long QueryMilliseconds,
+    DateTimeOffset SampledAt);

--- a/experiments/cathub-frequency-probe/EngineRigClient.cs
+++ b/experiments/cathub-frequency-probe/EngineRigClient.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics;
+using Grpc.Net.Client;
+using QsoRipper.Services;
+
+namespace CatHubFrequencyProbe;
+
+internal sealed class EngineRigClient : IDisposable
+{
+    private readonly GrpcChannel _channel;
+    private readonly RigControlService.RigControlServiceClient _client;
+
+    public EngineRigClient(string endpoint)
+    {
+        _channel = GrpcChannel.ForAddress(endpoint);
+        _client = new RigControlService.RigControlServiceClient(_channel);
+    }
+
+    public async Task<EngineFrequencySnapshot> ReadSnapshotAsync(CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var response = await _client.GetRigSnapshotAsync(
+            new GetRigSnapshotRequest(),
+            cancellationToken: cancellationToken);
+        stopwatch.Stop();
+
+        var snapshot = response.Snapshot
+            ?? throw new InvalidDataException("Engine returned no rig snapshot.");
+        if (snapshot.ErrorMessage.Length > 0)
+        {
+            throw new InvalidDataException($"Engine rig snapshot error: {snapshot.ErrorMessage}");
+        }
+
+        return new EngineFrequencySnapshot(
+            snapshot.FrequencyHz,
+            snapshot.RawMode.Length == 0 ? snapshot.Mode.ToString() : snapshot.RawMode,
+            stopwatch.ElapsedMilliseconds,
+            DateTimeOffset.Now);
+    }
+
+    public void Dispose()
+    {
+        _channel.Dispose();
+    }
+}

--- a/experiments/cathub-frequency-probe/FrequencySnapshot.cs
+++ b/experiments/cathub-frequency-probe/FrequencySnapshot.cs
@@ -1,0 +1,8 @@
+namespace CatHubFrequencyProbe;
+
+internal sealed record FrequencySnapshot(
+    ulong FrequencyHz,
+    string Mode,
+    string Vfo,
+    long QueryMilliseconds,
+    DateTimeOffset SampledAt);

--- a/experiments/cathub-frequency-probe/MainWindow.xaml
+++ b/experiments/cathub-frequency-probe/MainWindow.xaml
@@ -1,0 +1,177 @@
+<Window
+    x:Class="CatHubFrequencyProbe.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="CatHub Frequency Probe">
+
+    <Grid Background="#090601">
+        <Grid.Resources>
+            <Style x:Key="TileBorderStyle" TargetType="Border">
+                <Setter Property="Background" Value="#100a02" />
+                <Setter Property="BorderBrush" Value="#6f4700" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="Padding" Value="14" />
+                <Setter Property="CornerRadius" Value="8" />
+            </Style>
+            <Style x:Key="TileLabelStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="#b98519" />
+                <Setter Property="FontFamily" Value="Cascadia Mono,Consolas" />
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="CharacterSpacing" Value="120" />
+            </Style>
+            <Style x:Key="TileValueStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="#ffbf00" />
+                <Setter Property="FontFamily" Value="Cascadia Mono,Consolas" />
+                <Setter Property="FontSize" Value="28" />
+                <Setter Property="FontWeight" Value="Bold" />
+            </Style>
+        </Grid.Resources>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Background="#140d03" BorderBrush="#ff9f1c" BorderThickness="0,0,0,1" Padding="24,18">
+            <Grid>
+                <StackPanel>
+                    <TextBlock Text="CATHUB DIRECT FREQUENCY PROBE"
+                               Foreground="#ffbf00"
+                               FontFamily="Cascadia Mono,Consolas"
+                               FontSize="18"
+                               FontWeight="Bold"
+                               CharacterSpacing="120" />
+                    <TextBlock x:Name="EndpointText"
+                               Foreground="#ffd166"
+                               FontFamily="Cascadia Mono,Consolas"
+                               FontSize="13"
+                               Text="direct 127.0.0.1:4532 · engine http://127.0.0.1:50051 · 100 ms poll" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="1" Padding="28">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="170" />
+            </Grid.RowDefinitions>
+
+            <Border Grid.Row="0"
+                    CornerRadius="16"
+                    BorderBrush="#ff9f1c"
+                    BorderThickness="2"
+                    Background="#100a02"
+                    Padding="28">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Text="LIVE RADIO FREQUENCY"
+                               Foreground="#b98519"
+                               FontFamily="Cascadia Mono,Consolas"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               CharacterSpacing="160" />
+
+                    <Viewbox Grid.Row="1" Stretch="Uniform">
+                        <StackPanel Orientation="Horizontal" Spacing="18">
+                            <TextBlock x:Name="FrequencyText"
+                                       Text="--.------"
+                                       Foreground="#ffbf00"
+                                       FontFamily="Cascadia Mono,Consolas"
+                                       FontWeight="Black"
+                                       FontSize="132"
+                                       CharacterSpacing="50" />
+                            <TextBlock Text="MHz"
+                                       Foreground="#d88900"
+                                       FontFamily="Cascadia Mono,Consolas"
+                                       FontWeight="Bold"
+                                       FontSize="44"
+                                       VerticalAlignment="Bottom"
+                                       Margin="0,0,0,22" />
+                        </StackPanel>
+                    </Viewbox>
+
+                    <Grid Grid.Row="2" ColumnSpacing="18">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Border Style="{StaticResource TileBorderStyle}">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TileLabelStyle}" Text="VFO" />
+                                <TextBlock x:Name="VfoText" Style="{StaticResource TileValueStyle}" Text="--" />
+                            </StackPanel>
+                        </Border>
+                        <Border Grid.Column="1" Style="{StaticResource TileBorderStyle}">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TileLabelStyle}" Text="MODE" />
+                                <TextBlock x:Name="ModeText" Style="{StaticResource TileValueStyle}" Text="--" />
+                            </StackPanel>
+                        </Border>
+                        <Border Grid.Column="2" Style="{StaticResource TileBorderStyle}">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TileLabelStyle}" Text="QUERY" />
+                                <TextBlock x:Name="QueryText" Style="{StaticResource TileValueStyle}" Text="-- ms" />
+                            </StackPanel>
+                        </Border>
+                        <Border Grid.Column="3" Style="{StaticResource TileBorderStyle}">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TileLabelStyle}" Text="CHANGE GAP" />
+                                <TextBlock x:Name="ChangeGapText" Style="{StaticResource TileValueStyle}" Text="-- ms" />
+                            </StackPanel>
+                        </Border>
+                        <Border Grid.Column="4" Style="{StaticResource TileBorderStyle}">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TileLabelStyle}" Text="ENGINE SKEW" />
+                                <TextBlock x:Name="EngineSkewText" Style="{StaticResource TileValueStyle}" Text="--" />
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </Grid>
+            </Border>
+
+            <Border Grid.Row="1"
+                    Margin="0,22,0,0"
+                    Background="#090601"
+                    BorderBrush="#6f4700"
+                    BorderThickness="1"
+                    Padding="14">
+                <Grid RowSpacing="8">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <TextBlock x:Name="LogPathText"
+                               Foreground="#b98519"
+                               FontFamily="Cascadia Mono,Consolas"
+                               FontSize="12" />
+                    <ScrollViewer Grid.Row="1"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <TextBlock x:Name="LogText"
+                                   Foreground="#ffd166"
+                                   FontFamily="Cascadia Mono,Consolas"
+                                   FontSize="12"
+                                   TextWrapping="NoWrap" />
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+        </Grid>
+
+        <Border Grid.Row="2" Background="#140d03" Padding="24,10">
+            <TextBlock x:Name="FooterText"
+                       Foreground="#b98519"
+                       FontFamily="Cascadia Mono,Consolas"
+                       FontSize="12"
+                       Text="Direct cathub rigctld reads only. No QsoRipper engine, GUI, TUI, or Win32 UI code path involved." />
+        </Border>
+    </Grid>
+</Window>

--- a/experiments/cathub-frequency-probe/MainWindow.xaml.cs
+++ b/experiments/cathub-frequency-probe/MainWindow.xaml.cs
@@ -1,0 +1,174 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Net.Sockets;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+
+namespace CatHubFrequencyProbe;
+
+public sealed partial class MainWindow : Window
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
+    private readonly CatHubRigClient _client;
+    private readonly EngineRigClient _engineClient;
+    private readonly DiagnosticLog _log = new();
+    private readonly DispatcherQueueTimer _timer;
+    private bool _pollInFlight;
+    private ulong? _lastFrequencyHz;
+    private DateTimeOffset? _lastFrequencyChange;
+    private long _pollCount;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        Title = "CatHub Frequency Probe";
+        ExtendsContentIntoTitleBar = false;
+        _client = new CatHubRigClient("127.0.0.1", 4532);
+        _engineClient = new EngineRigClient("http://127.0.0.1:50051");
+        _timer = DispatcherQueue.CreateTimer();
+        _timer.Interval = PollInterval;
+        _timer.Tick += OnTimerTick;
+
+        LogPathText.Text = $"log: {_log.Path}";
+        WriteLog("probe starting; target=127.0.0.1:4532 poll=100ms commands=f,m,v");
+        Closed += OnClosed;
+        _timer.Start();
+    }
+
+    private async void OnTimerTick(DispatcherQueueTimer sender, object args)
+    {
+        if (_pollInFlight)
+        {
+            WriteLog("poll skipped; previous poll still in flight");
+            return;
+        }
+
+        _pollInFlight = true;
+        try
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            var directSnapshot = await _client.ReadSnapshotAsync(timeout.Token);
+            EngineFrequencySnapshot? engineSnapshot = null;
+            string? engineError = null;
+            try
+            {
+                engineSnapshot = await _engineClient.ReadSnapshotAsync(timeout.Token);
+            }
+            catch (Exception ex) when (ex is IOException or InvalidDataException or Grpc.Core.RpcException or OperationCanceledException)
+            {
+                engineError = $"{ex.GetType().Name}: {ex.Message}";
+            }
+
+            UpdateSnapshot(directSnapshot, engineSnapshot, engineError);
+        }
+        catch (Exception ex) when (ex is IOException or SocketException or InvalidOperationException or TimeoutException or OperationCanceledException)
+        {
+            FooterText.Text = "LINK DOWN - direct cathub rigctld read failed";
+            WriteLog($"poll error: {ex.GetType().Name}: {ex.Message}");
+        }
+        finally
+        {
+            _pollInFlight = false;
+        }
+    }
+
+    private void UpdateSnapshot(
+        FrequencySnapshot snapshot,
+        EngineFrequencySnapshot? engineSnapshot,
+        string? engineError)
+    {
+        _pollCount++;
+        var changed = _lastFrequencyHz != snapshot.FrequencyHz;
+        long? changeGap = null;
+
+        if (changed)
+        {
+            if (_lastFrequencyChange is { } previous)
+            {
+                changeGap = (long)(snapshot.SampledAt - previous).TotalMilliseconds;
+            }
+
+            _lastFrequencyHz = snapshot.FrequencyHz;
+            _lastFrequencyChange = snapshot.SampledAt;
+            WriteLog(string.Create(
+                CultureInfo.InvariantCulture,
+                $"change #{_pollCount}: direct={snapshot.FrequencyHz} Hz {FormatFrequency(snapshot.FrequencyHz)} MHz engine={EngineFrequencyForLog(engineSnapshot)} skew={FormatEngineSkew(snapshot, engineSnapshot)} vfo={snapshot.Vfo} mode={snapshot.Mode} direct_query={snapshot.QueryMilliseconds}ms engine_query={engineSnapshot?.QueryMilliseconds.ToString(CultureInfo.InvariantCulture) ?? "--"}ms gap={(changeGap?.ToString(CultureInfo.InvariantCulture) ?? "--")}ms"));
+        }
+        else if (_pollCount % 25 == 0)
+        {
+            WriteLog(string.Create(
+                CultureInfo.InvariantCulture,
+                $"poll #{_pollCount}: unchanged direct={snapshot.FrequencyHz} Hz engine={EngineFrequencyForLog(engineSnapshot)} skew={FormatEngineSkew(snapshot, engineSnapshot)} direct_query={snapshot.QueryMilliseconds}ms engine_query={engineSnapshot?.QueryMilliseconds.ToString(CultureInfo.InvariantCulture) ?? "--"}ms"));
+        }
+
+        if (engineError is not null && _pollCount % 10 == 1)
+        {
+            WriteLog($"engine poll error: {engineError}");
+        }
+
+        FrequencyText.Text = FormatFrequency(snapshot.FrequencyHz);
+        VfoText.Text = snapshot.Vfo;
+        ModeText.Text = snapshot.Mode;
+        QueryText.Text = string.Create(CultureInfo.InvariantCulture, $"{snapshot.QueryMilliseconds} ms");
+        ChangeGapText.Text = changeGap.HasValue
+            ? string.Create(CultureInfo.InvariantCulture, $"{changeGap.Value} ms")
+            : "-- ms";
+        EngineSkewText.Text = engineError is not null
+            ? "ERR"
+            : FormatEngineSkew(snapshot, engineSnapshot);
+        FooterText.Text = string.Create(
+            CultureInfo.InvariantCulture,
+            $"polls={_pollCount}  last={snapshot.SampledAt:HH:mm:ss.fff}  direct={FormatFrequency(snapshot.FrequencyHz)} MHz  engine={EngineFrequencyForFooter(engineSnapshot)}  skew={FormatEngineSkew(snapshot, engineSnapshot)}");
+    }
+
+    private void WriteLog(string message)
+    {
+        _log.Write(message);
+        LogText.Text = _log.UiText;
+        Debug.WriteLine(message);
+    }
+
+    private async void OnClosed(object sender, WindowEventArgs args)
+    {
+        _timer.Stop();
+        await _client.DisposeAsync();
+        _engineClient.Dispose();
+    }
+
+    private static string FormatFrequency(ulong frequencyHz)
+    {
+        var mhz = frequencyHz / 1_000_000;
+        var khz = frequencyHz % 1_000_000 / 1_000;
+        var tenHz = frequencyHz % 1_000 / 10;
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{mhz}.{khz:000}.{tenHz:00}");
+    }
+
+    private static string FormatEngineSkew(FrequencySnapshot direct, EngineFrequencySnapshot? engine)
+    {
+        if (engine is null)
+        {
+            return "--";
+        }
+
+        var skew = (long)engine.FrequencyHz - (long)direct.FrequencyHz;
+        return string.Create(CultureInfo.InvariantCulture, $"{skew:+#;-#;0} Hz");
+    }
+
+    private static string EngineFrequencyForLog(EngineFrequencySnapshot? engine)
+    {
+        return engine is null
+            ? "--"
+            : string.Create(CultureInfo.InvariantCulture, $"{engine.FrequencyHz} Hz {FormatFrequency(engine.FrequencyHz)} MHz");
+    }
+
+    private static string EngineFrequencyForFooter(EngineFrequencySnapshot? engine)
+    {
+        return engine is null
+            ? "--"
+            : string.Create(CultureInfo.InvariantCulture, $"{FormatFrequency(engine.FrequencyHz)} MHz/{engine.QueryMilliseconds}ms");
+    }
+}

--- a/experiments/cathub-frequency-probe/README.md
+++ b/experiments/cathub-frequency-probe/README.md
@@ -1,0 +1,26 @@
+# CatHub Frequency Probe
+
+Single-purpose WinUI 3 diagnostic app for CAT latency testing.
+
+The app bypasses the normal QsoRipper UI update paths. It opens one persistent TCP connection to cathub's rigctld-compatible endpoint at `127.0.0.1:4532`, polls `f`, `m`, and `v` every 100 ms, and also polls the engine's gRPC `GetRigSnapshot` endpoint at `http://127.0.0.1:50051`.
+
+It displays the live direct cathub frequency, VFO, mode, query time, detected frequency-change gap, and engine skew. Engine skew is `engine_frequency_hz - direct_cathub_frequency_hz`.
+
+Run from the repository root:
+
+```powershell
+dotnet run --project experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj
+```
+
+Diagnostic log:
+
+```text
+%LOCALAPPDATA%\qsoripper\cathub-frequency-probe.log
+```
+
+Interpretation:
+
+- If direct cathub updates immediately and engine skew stays `0 Hz`, the slow behavior is in the individual UI poll/render/update path.
+- If direct cathub updates immediately but engine skew diverges while tuning, the slow behavior is in the engine rig snapshot/cache/provider path.
+- If direct cathub also lags, the problem is cathub state freshness or the radio/CAT path feeding cathub.
+- Direct query time measures only cathub TCP response time, not the age of cathub's cached radio state.

--- a/experiments/cathub-frequency-probe/README.md
+++ b/experiments/cathub-frequency-probe/README.md
@@ -12,6 +12,18 @@ Run from the repository root:
 dotnet run --project experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj
 ```
 
+Publish the Native AOT executable from the repository root:
+
+```powershell
+dotnet publish experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj -c Release -o artifacts\publish\cathub-frequency-probe-aot\Release
+```
+
+Native AOT executable:
+
+```text
+artifacts\publish\cathub-frequency-probe-aot\Release\CatHubFrequencyProbe.exe
+```
+
 Diagnostic log:
 
 ```text

--- a/experiments/cathub-frequency-probe/README.md
+++ b/experiments/cathub-frequency-probe/README.md
@@ -15,7 +15,7 @@ dotnet run --project experiments\cathub-frequency-probe\CatHubFrequencyProbe.csp
 Publish the Native AOT executable from the repository root:
 
 ```powershell
-dotnet publish experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj -c Release -o artifacts\publish\cathub-frequency-probe-aot\Release
+dotnet publish experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj -c Release -p:PublishAot=true -o artifacts\publish\cathub-frequency-probe-aot\Release
 ```
 
 Native AOT executable:

--- a/experiments/cathub-frequency-probe/app.manifest
+++ b/experiments/cathub-frequency-probe/app.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="CatHubFrequencyProbe.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -468,6 +468,30 @@ public sealed class ManagedEngineStateTests : IDisposable
     }
 
     [Fact]
+    public void Build_rig_snapshot_refreshes_interactive_monitor_cache()
+    {
+        var frequencyHz = 14_074_000UL;
+        var monitor = new RigControlMonitor(
+            new FakeRigControlProvider(() => new RigSnapshot
+            {
+                Status = RigConnectionStatus.Connected,
+                FrequencyHz = frequencyHz,
+                Band = Band._20M,
+                Mode = Mode.Cw,
+            }),
+            TimeSpan.FromSeconds(60));
+        var state = CreateStateWithRigMonitor(monitor);
+
+        var first = state.BuildRigSnapshot();
+        frequencyHz = 14_055_000;
+        Thread.Sleep(75);
+        var second = state.BuildRigSnapshot();
+
+        Assert.Equal(14_074_000UL, first.FrequencyHz);
+        Assert.Equal(14_055_000UL, second.FrequencyHz);
+    }
+
+    [Fact]
     public void Log_qso_requires_timestamp_band_and_mode()
     {
         var state = CreateState();
@@ -1616,10 +1640,15 @@ public sealed class ManagedEngineStateTests : IDisposable
 
     private ManagedEngineState CreateStateWithRigSnapshot(RigSnapshot snapshot)
     {
-        var storage = new MemoryStorage();
         var monitor = new RigControlMonitor(
             new FakeRigControlProvider(() => snapshot.Clone()),
             TimeSpan.Zero);
+        return CreateStateWithRigMonitor(monitor);
+    }
+
+    private ManagedEngineState CreateStateWithRigMonitor(RigControlMonitor monitor)
+    {
+        var storage = new MemoryStorage();
         return new ManagedEngineState(
             Path.Combine(_tempDirectory, "config.toml"),
             storage,

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -60,6 +60,7 @@ internal sealed class ManagedEngineState
 
     private static readonly JsonFormatter ProtoJsonFormatter = new(JsonFormatter.Settings.Default.WithFormatDefaultValues(true));
     private static readonly JsonParser ProtoJsonParser = new(JsonParser.Settings.Default.WithIgnoreUnknownFields(true));
+    private static readonly TimeSpan InteractiveRigSnapshotMaxAge = TimeSpan.FromMilliseconds(50);
 
     private readonly Lock _gate = new();
     private readonly IEngineStorage _storage;
@@ -994,7 +995,7 @@ internal sealed class ManagedEngineState
 
         if (_rigControlMonitor is not null)
         {
-            return _rigControlMonitor.CurrentSnapshot();
+            return _rigControlMonitor.CurrentSnapshot(InteractiveRigSnapshotMaxAge);
         }
 
         return BuildRigSnapshot(CreateRigStatusResponse());

--- a/src/dotnet/QsoRipper.Engine.RigControl.Tests/RigControlMonitorTests.cs
+++ b/src/dotnet/QsoRipper.Engine.RigControl.Tests/RigControlMonitorTests.cs
@@ -81,6 +81,43 @@ public sealed class RigControlMonitorTests
     }
 
     [Fact]
+    public void CurrentSnapshotWithMaxAgeRefreshesBeforeConfiguredThreshold()
+    {
+        var frequencyHz = 14_074_000UL;
+        var provider = new FakeProvider(() => new RigSnapshot { FrequencyHz = frequencyHz });
+        var monitor = new RigControlMonitor(provider, TimeSpan.FromSeconds(60));
+
+        var first = monitor.CurrentSnapshot();
+        frequencyHz = 14_055_000;
+        Thread.Sleep(20);
+        var second = monitor.CurrentSnapshot(TimeSpan.FromMilliseconds(10));
+
+        Assert.Equal(14_074_000UL, first.FrequencyHz);
+        Assert.Equal(14_055_000UL, second.FrequencyHz);
+    }
+
+    [Fact]
+    public void CurrentSnapshotWithMaxAgeReusesCacheWhenFreshEnough()
+    {
+        var callCount = 0;
+        var frequencyHz = 14_074_000UL;
+        var provider = new FakeProvider(() =>
+        {
+            callCount++;
+            return new RigSnapshot { FrequencyHz = frequencyHz };
+        });
+        var monitor = new RigControlMonitor(provider, TimeSpan.FromSeconds(60));
+
+        var first = monitor.CurrentSnapshot();
+        frequencyHz = 14_055_000;
+        var second = monitor.CurrentSnapshot(TimeSpan.FromSeconds(60));
+
+        Assert.Equal(14_074_000UL, first.FrequencyHz);
+        Assert.Equal(14_074_000UL, second.FrequencyHz);
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
     public void FailureWithoutCacheReturnsErrorSnapshot()
     {
         var provider = new FailingProvider(

--- a/src/dotnet/QsoRipper.Engine.RigControl/RigControlMonitor.cs
+++ b/src/dotnet/QsoRipper.Engine.RigControl/RigControlMonitor.cs
@@ -40,9 +40,17 @@ public sealed class RigControlMonitor
     /// </summary>
     public RigSnapshot CurrentSnapshot()
     {
+        return CurrentSnapshot(_staleThreshold);
+    }
+
+    /// <summary>
+    /// Return the current snapshot, refreshing when it is older than <paramref name="maxAge"/>.
+    /// </summary>
+    public RigSnapshot CurrentSnapshot(TimeSpan maxAge)
+    {
         lock (_gate)
         {
-            if (_cached is not null && Stopwatch.GetElapsedTime(_lastFetchTimestamp) < _staleThreshold)
+            if (_cached is not null && Stopwatch.GetElapsedTime(_lastFetchTimestamp) < maxAge)
             {
                 return _cached.Clone();
             }

--- a/src/dotnet/QsoRipper.Gui.Tests/AsyncVoidHandlerSafetyTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/AsyncVoidHandlerSafetyTests.cs
@@ -28,6 +28,14 @@ public sealed class AsyncVoidHandlerSafetyTests
     }
 
     [Fact]
+    public void MainWindowViewModel_rig_timer_uses_interactive_refresh_interval()
+    {
+        var source = File.ReadAllText(GetSourcePath("src", "dotnet", "QsoRipper.Gui", "ViewModels", "MainWindowViewModel.cs"));
+
+        Assert.Contains("RigPollInterval = TimeSpan.FromMilliseconds(100)", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void MainWindowViewModel_space_weather_periodic_refresh_preserves_stale_data_on_failure()
     {
         var source = File.ReadAllText(GetSourcePath("src", "dotnet", "QsoRipper.Gui", "ViewModels", "MainWindowViewModel.cs"));

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -23,7 +23,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
 {
     private static readonly TimeSpan PreferredEngineSwitchTimeout = TimeSpan.FromSeconds(1.5);
     private static readonly TimeSpan SpaceWeatherRefreshInterval = TimeSpan.FromHours(1);
-    private static readonly TimeSpan RigPollInterval = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan RigPollInterval = TimeSpan.FromMilliseconds(100);
     private static readonly TimeSpan EngineHealthPollInterval = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan EngineHealthProbeTimeout = TimeSpan.FromMilliseconds(1500);
 

--- a/src/rust/qsoripper-core/src/rig_control/monitor.rs
+++ b/src/rust/qsoripper-core/src/rig_control/monitor.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use prost_types::Timestamp;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 
 use crate::proto::qsoripper::domain::{RigConnectionStatus, RigSnapshot};
 
@@ -25,6 +25,7 @@ struct CachedSnapshot {
 pub struct RigControlMonitor {
     provider: Arc<dyn RigControlProvider>,
     stale_threshold: Duration,
+    refresh_gate: Mutex<()>,
     state: RwLock<Option<CachedSnapshot>>,
 }
 
@@ -35,23 +36,42 @@ impl RigControlMonitor {
         Self {
             provider,
             stale_threshold,
+            refresh_gate: Mutex::new(()),
             state: RwLock::new(None),
         }
     }
 
     /// Return the current snapshot, refreshing when stale or missing.
     pub async fn current_snapshot(&self) -> RigSnapshot {
+        self.current_snapshot_with_max_age(self.stale_threshold)
+            .await
+    }
+
+    /// Return the current snapshot, refreshing when it is older than `max_age`.
+    pub async fn current_snapshot_with_max_age(&self, max_age: Duration) -> RigSnapshot {
         if let Some(cached) = self.state.read().await.clone() {
-            if cached.fetched_monotonic.elapsed() < self.stale_threshold {
+            if cached.fetched_monotonic.elapsed() < max_age {
                 return cached.snapshot.clone();
             }
         }
 
-        self.refresh_snapshot().await
+        let _guard = self.refresh_gate.lock().await;
+        if let Some(cached) = self.state.read().await.clone() {
+            if cached.fetched_monotonic.elapsed() < max_age {
+                return cached.snapshot.clone();
+            }
+        }
+
+        self.refresh_snapshot_core().await
     }
 
     /// Force a refresh and return the latest available snapshot.
     pub async fn refresh_snapshot(&self) -> RigSnapshot {
+        let _guard = self.refresh_gate.lock().await;
+        self.refresh_snapshot_core().await
+    }
+
+    async fn refresh_snapshot_core(&self) -> RigSnapshot {
         let cached = self.state.read().await.clone();
 
         match self.provider.get_snapshot().await {
@@ -169,6 +189,7 @@ mod tests {
         let monitor = RigControlMonitor {
             provider: bad_provider,
             stale_threshold: Duration::from_secs(0),
+            refresh_gate: Mutex::new(()),
             state: RwLock::new(existing),
         };
 
@@ -247,5 +268,36 @@ mod tests {
             14_055_000, snapshot.frequency_hz,
             "default stale threshold must surface rig changes within {INTERACTIVE_BUDGET_MS} ms",
         );
+    }
+
+    #[tokio::test]
+    async fn max_age_override_refreshes_before_configured_threshold() {
+        let provider = Arc::new(MutableProvider::new(14_074_000));
+        let monitor = RigControlMonitor::new(provider.clone(), Duration::from_secs(60));
+
+        let _ = monitor.refresh_snapshot().await;
+        provider.set_frequency(14_055_000);
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        let snapshot = monitor
+            .current_snapshot_with_max_age(Duration::from_millis(10))
+            .await;
+
+        assert_eq!(14_055_000, snapshot.frequency_hz);
+    }
+
+    #[tokio::test]
+    async fn max_age_override_reuses_cache_when_fresh_enough() {
+        let provider = Arc::new(MutableProvider::new(14_074_000));
+        let monitor = RigControlMonitor::new(provider.clone(), Duration::from_secs(60));
+
+        let _ = monitor.refresh_snapshot().await;
+        provider.set_frequency(14_055_000);
+
+        let snapshot = monitor
+            .current_snapshot_with_max_age(Duration::from_secs(60))
+            .await;
+
+        assert_eq!(14_074_000, snapshot.frequency_hz);
     }
 }

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -14,7 +14,7 @@ use std::{
     net::SocketAddr,
     path::PathBuf,
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use qsoripper_core::adif::{parse_adi_qsos, serialize_adi_qsos};
@@ -68,6 +68,8 @@ use setup::{
     default_config_path, SetupControlSurface, SetupState, StationProfileControlSurface,
     CONFIG_PATH_ENV_VAR,
 };
+
+const INTERACTIVE_RIG_SNAPSHOT_MAX_AGE: Duration = Duration::from_millis(50);
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -1220,7 +1222,7 @@ impl RigControlService for RigControlControlSurface {
             .runtime_config
             .rig_control_monitor()
             .await
-            .current_snapshot()
+            .current_snapshot_with_max_age(INTERACTIVE_RIG_SNAPSHOT_MAX_AGE)
             .await;
         Ok(Response::new(GetRigSnapshotResponse {
             snapshot: Some(snapshot),

--- a/src/rust/qsoripper-tui/src/app.rs
+++ b/src/rust/qsoripper-tui/src/app.rs
@@ -182,6 +182,11 @@ pub(crate) struct App {
     pub(crate) space_weather: Option<SpaceWeatherInfo>,
     /// Current rig control snapshot.
     pub(crate) rig_info: Option<RigInfo>,
+    /// Last frequency value written into the form from rig control.
+    ///
+    /// If the form still contains this value, later rig snapshots may keep it in sync even
+    /// after the operator starts typing a callsign. A manual frequency edit breaks that match.
+    pub(crate) last_auto_rig_frequency_mhz: Option<String>,
     /// Whether rig control polling is enabled (default: `true`).
     pub(crate) rig_control_enabled: bool,
     /// Transient status bar message.
@@ -227,6 +232,7 @@ impl App {
             recent_qsos: Vec::new(),
             space_weather: None,
             rig_info: None,
+            last_auto_rig_frequency_mhz: None,
             rig_control_enabled: true,
             status_message: None,
             qso_list_focused: false,

--- a/src/rust/qsoripper-tui/src/main.rs
+++ b/src/rust/qsoripper-tui/src/main.rs
@@ -218,6 +218,7 @@ fn handle_event_with_channel(
             let band_idx = app.form.band_idx;
             let mode_idx = app.form.mode_idx;
             app.form = LogForm::new();
+            app.last_auto_rig_frequency_mhz = None;
             app.form.band_idx = band_idx;
             app.form.mode_idx = mode_idx;
             app.form.on_band_change();
@@ -233,6 +234,7 @@ fn handle_event_with_channel(
             let band_idx = app.form.band_idx;
             let mode_idx = app.form.mode_idx;
             app.form = LogForm::new();
+            app.last_auto_rig_frequency_mhz = None;
             app.form.band_idx = band_idx;
             app.form.mode_idx = mode_idx;
             app.form.on_band_change();
@@ -505,6 +507,7 @@ fn handle_key_with_channel(
             }
             app::View::LogEntry => {
                 app.form = LogForm::new();
+                app.last_auto_rig_frequency_mhz = None;
                 app.lookup_result = None;
                 app.editing_local_id = None;
                 app.reset_timer();
@@ -978,6 +981,7 @@ fn load_qso_into_form(app: &mut App, local_id: &str, lookup_tx: &watch::Sender<S
 
     let advanced_tab = app.form.advanced_tab;
     app.form = LogForm::new();
+    app.last_auto_rig_frequency_mhz = None;
     app.form.advanced_tab = advanced_tab;
 
     app.form.callsign = qso.callsign.clone();
@@ -1331,8 +1335,16 @@ fn apply_rig_snapshot(app: &mut App, rig: Option<app::RigInfo>) {
                 reason = "ham radio frequencies are well within f64 mantissa range"
             )]
             let new_freq = format!("{:.3}", info.frequency_hz as f64 / 1_000_000.0);
-            if app.form.callsign.is_empty() || app.form.frequency_mhz.is_empty() {
-                app.form.frequency_mhz = new_freq;
+            let frequency_still_auto = app
+                .last_auto_rig_frequency_mhz
+                .as_deref()
+                .is_some_and(|last| last == app.form.frequency_mhz);
+            if app.form.callsign.is_empty()
+                || app.form.frequency_mhz.is_empty()
+                || frequency_still_auto
+            {
+                app.form.frequency_mhz.clone_from(&new_freq);
+                app.last_auto_rig_frequency_mhz = Some(new_freq);
             }
         }
 
@@ -3097,6 +3109,7 @@ mod tests {
         apply_rig_snapshot(&mut app, rig);
         assert!(app.rig_info.is_some());
         assert_eq!(app.form.frequency_mhz, "14.225");
+        assert_eq!(app.last_auto_rig_frequency_mhz.as_deref(), Some("14.225"));
         assert_eq!(BANDS[app.form.band_idx], "20M");
         assert_eq!(MODES[app.form.mode_idx], "SSB");
     }
@@ -3126,6 +3139,7 @@ mod tests {
         let mut app = make_app();
         app.form.callsign = "K7ABC".to_string();
         app.form.band_idx = 3; // 40M
+        let original_freq = app.form.frequency_mhz.clone();
         let rig = Some(RigInfo {
             frequency_display: "7.150 MHz".to_string(),
             frequency_hz: 7_150_000,
@@ -3138,6 +3152,80 @@ mod tests {
         apply_rig_snapshot(&mut app, rig);
         // Band and mode should NOT change when callsign is entered
         assert_eq!(app.form.band_idx, 3);
+        assert_eq!(app.form.frequency_mhz, original_freq);
+    }
+
+    #[test]
+    fn apply_rig_snapshot_keeps_auto_frequency_tracking_after_callsign_entry() {
+        use crate::app::{RigInfo, RigStatus};
+        let mut app = make_app();
+
+        apply_rig_snapshot(
+            &mut app,
+            Some(RigInfo {
+                frequency_display: "14.225 MHz".to_string(),
+                frequency_hz: 14_225_000,
+                band: Some("20M".to_string()),
+                mode: Some("SSB".to_string()),
+                submode: None,
+                status: RigStatus::Connected,
+                error_message: None,
+            }),
+        );
+        app.form.callsign = "K7ABC".to_string();
+
+        apply_rig_snapshot(
+            &mut app,
+            Some(RigInfo {
+                frequency_display: "14.230 MHz".to_string(),
+                frequency_hz: 14_230_000,
+                band: Some("20M".to_string()),
+                mode: Some("SSB".to_string()),
+                submode: None,
+                status: RigStatus::Connected,
+                error_message: None,
+            }),
+        );
+
+        assert_eq!(app.form.frequency_mhz, "14.230");
+        assert_eq!(app.last_auto_rig_frequency_mhz.as_deref(), Some("14.230"));
+    }
+
+    #[test]
+    fn apply_rig_snapshot_does_not_overwrite_manually_edited_frequency() {
+        use crate::app::{RigInfo, RigStatus};
+        let mut app = make_app();
+
+        apply_rig_snapshot(
+            &mut app,
+            Some(RigInfo {
+                frequency_display: "14.225 MHz".to_string(),
+                frequency_hz: 14_225_000,
+                band: Some("20M".to_string()),
+                mode: Some("SSB".to_string()),
+                submode: None,
+                status: RigStatus::Connected,
+                error_message: None,
+            }),
+        );
+        app.form.callsign = "K7ABC".to_string();
+        app.form.frequency_mhz = "14.229".to_string();
+
+        apply_rig_snapshot(
+            &mut app,
+            Some(RigInfo {
+                frequency_display: "14.230 MHz".to_string(),
+                frequency_hz: 14_230_000,
+                band: Some("20M".to_string()),
+                mode: Some("SSB".to_string()),
+                submode: None,
+                status: RigStatus::Connected,
+                error_message: None,
+            }),
+        );
+
+        assert_eq!(app.form.frequency_mhz, "14.229");
+        assert_eq!(app.last_auto_rig_frequency_mhz.as_deref(), Some("14.225"));
     }
 
     #[test]


### PR DESCRIPTION
This PR fixes the CAT frequency display lag that showed up across the TUI, Avalonia GUI, and other QsoRipper UIs.What was wrong: the UIs do not read cathub directly. They poll the engine gRPC RigControlService.GetRigSnapshot path. The standalone WinUI cathub frequency probe showed that direct cathub rigctld reads were instant, while the engine snapshot path could stay pinned to an old cached frequency across repeated UI polls. In the probe this appeared as large ENGINE SKEW values such as direct 14.035.95 MHz while engine remained at 14.042.22 MHz, with engine_query=0ms. That 0ms query time was the important clue: the engine was returning a cache hit instead of refreshing cathub state.The fix: GetRigSnapshot is now treated as an interactive frequency-read path. Both Rust and .NET rig monitors support a stricter max-age read, and the engine snapshot path uses a 50 ms interactive freshness budget. This keeps very recent reads shared so multiple UIs do not all force independent cathub TCP fetches, but it refreshes before the cache can lag behind active tuning. GetRigStatus stays on the normal cached/current path because exact frequency freshness is less important for status-only consumers.This also keeps the UI side aligned: the TUI already polls at 100 ms on this branch, and the Avalonia GUI poll interval is now 100 ms as well. The WinUI cathub frequency probe remains under experiments/cathub-frequency-probe as a focused diagnostic tool that compares direct cathub TCP against engine gRPC and displays ENGINE SKEW.Validation performed locally: cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check; cargo test --manifest-path src\rust\Cargo.toml -p qsoripper-core rig_control::monitor; cargo test --manifest-path src\rust\Cargo.toml -p qsoripper-server; cargo clippy --manifest-path src\rust\Cargo.toml -p qsoripper-core -p qsoripper-server --all-targets -- -D warnings; dotnet test src\dotnet\QsoRipper.Engine.RigControl.Tests\QsoRipper.Engine.RigControl.Tests.csproj; dotnet test src\dotnet\QsoRipper.Engine.DotNet.Tests\QsoRipper.Engine.DotNet.Tests.csproj; dotnet test src\dotnet\QsoRipper.Gui.Tests\QsoRipper.Gui.Tests.csproj; dotnet build src\dotnet\QsoRipper.slnx; dotnet build experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj.I also rebuilt and restarted the local Rust engine from artifacts\publish\qsoripper-server\Release and confirmed direct cathub and engine frequency matched at rest with skew=0.Follow-up: added `experiments\cathub-frequency-probe-native`, a fast-launch native C++/Win32/Winsock version of the cathub probe. It avoids the .NET runtime, polls cathub directly at `127.0.0.1:4532`, renders the amber TS-590-style frequency display, and logs to `%LOCALAPPDATA%\qsoripper\cathub-frequency-probe-native.log`. Validation: configured and built with CMake/Visual Studio 18 2026, then smoke-launched the Release exe and confirmed it read cathub immediately (`14.032.60 MHz`, `VFOB`, `CW`, first query 1 ms).Native probe layout follow-up: fixed the Win32 probe clipping by replacing fixed-size frequency layout with measured font fitting, reducing the default window to 1100x700, setting a safe minimum size, keeping the log panel bounded, and rendering the frequency plus MHz as one measured string so it cannot collide with the tiles. Validation: rebuilt the native probe with `cmake --build artifacts\build\cathub-frequency-probe-native --config Release`, launched the Release exe, captured `artifacts\ux\current\cathub-frequency-probe-native-printwindow.png`, and confirmed the full frequency, VFO/mode/query tiles, log panel, and footer are visible.WinUI probe Native AOT follow-up: `experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj` now enables `SelfContained`, `PublishAot`, and `IsAotCompatible` for the standalone WinUI diagnostic probe. Publish command: `dotnet publish experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj -c Release -o artifacts\publish\cathub-frequency-probe-aot\Release`. The published executable is `artifacts\publish\cathub-frequency-probe-aot\Release\CatHubFrequencyProbe.exe`. Validation: `dotnet build experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj -c Release --no-incremental` and the Release publish both completed successfully.WinUI probe Native AOT follow-up: `experiments\\cathub-frequency-probe\\CatHubFrequencyProbe.csproj` now keeps normal Release builds runnable with `UseAppHost=true` while supporting explicit Native AOT publish through `IsAotCompatible=true` and `-p:PublishAot=true`. Publish command: `dotnet publish experiments\\cathub-frequency-probe\\CatHubFrequencyProbe.csproj -c Release -p:PublishAot=true -o artifacts\\publish\\cathub-frequency-probe-aot\\Release`. The normal build apphost is `experiments\\cathub-frequency-probe\\bin\\Release\\net10.0-windows10.0.19041.0\\win-x64\\CatHubFrequencyProbe.exe`; the Native AOT executable is `artifacts\\publish\\cathub-frequency-probe-aot\\Release\\CatHubFrequencyProbe.exe`. Validation: `dotnet build experiments\\cathub-frequency-probe\\CatHubFrequencyProbe.csproj -c Release --no-incremental` and the explicit Native AOT Release publish both completed successfully.WinUI probe publish launch follow-up: fixed a publish-only startup crash where both non-AOT and Native AOT publish folders were missing `CatHubFrequencyProbe.pri`. The normal build output had the generated WinUI app PRI file, but `dotnet publish -o ...` did not copy it, causing the unpackaged WinUI app to exit immediately in `Microsoft.UI.Xaml.dll` with no app log. The project now copies `$(TargetDir)$(TargetName).pri` into `$(PublishDir)` after publish. Validation: republished both `-p:PublishAot=false` and `-p:PublishAot=true`, confirmed `CatHubFrequencyProbe.pri` exists in both publish folders, and launched the AOT executable successfully with a visible `CatHub Frequency Probe` window and live log updates.
Native C++ probe parity follow-up: `build.ps1` now includes a `cathub-probe-native` command and the default build flow builds `experiments\cathub-frequency-probe-native`, copying `qsoripper_ffi.dll` beside the executable when available. The native probe now matches the managed WinUI diagnostic path by loading the existing Rust FFI shim for engine gRPC `GetRigSnapshot`, displaying an `ENGINE SKEW` tile, and logging direct cathub frequency, engine frequency, direct query time, engine query time, and skew on every change. Validation: `.uild.ps1 cathub-probe-native -Configuration Release`; launched `artifacts\build\cathub-frequency-probe-native\Release\CatHubFrequencyProbeNative.exe`, captured `artifacts\ux\current\cathub-frequency-probe-native-engine-skew.png`, and confirmed live logs showed direct and engine frequency matching with `skew=0 Hz`.