### PR TITLE
Add opt-in CatHub frequency diagnostics

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -23,7 +23,7 @@
 
 param(
     [Parameter(Position = 0)]
-    [ValidateSet('build', 'check', 'rust', 'cw-decoder', 'dotnet', 'win32', 'check-rust', 'check-dotnet', 'proto', 'help')]
+    [ValidateSet('build', 'check', 'rust', 'cw-decoder', 'dotnet', 'win32', 'cathub-probe-native', 'check-rust', 'check-dotnet', 'proto', 'help')]
     [string]$Command = 'build',
 
     [ValidateSet('Release', 'Debug')]
@@ -168,6 +168,8 @@ $CwScopeGuiPublishDir = Join-Path $PSScriptRoot 'artifacts' 'publish' | Join-Pat
 $DotnetEngineProject = Join-Path $PSScriptRoot 'src' 'dotnet' 'QsoRipper.Engine.DotNet' 'QsoRipper.Engine.DotNet.csproj'
 $DotnetDebugHostProject = Join-Path $PSScriptRoot 'src' 'dotnet' 'QsoRipper.DebugHost' 'QsoRipper.DebugHost.csproj'
 $CwScopeGuiProject = Join-Path $PSScriptRoot 'experiments' 'cw-decoder' 'gui' 'CwDecoderGui.csproj'
+$CatHubNativeProbeSourceDir = Join-Path $PSScriptRoot 'experiments' 'cathub-frequency-probe-native'
+$CatHubNativeProbeBuildDir = Join-Path $PSScriptRoot 'artifacts' 'build' 'cathub-frequency-probe-native'
 $ServerBinary = if ($IsWindows) { 'qsoripper-server.exe' } else { 'qsoripper-server' }
 $CatHubBinary = if ($IsWindows) { 'qsoripper-cathub.exe' } else { 'qsoripper-cathub' }
 $CwDecoderRustManifest = Join-Path $PSScriptRoot 'experiments' 'cw-decoder' 'Cargo.toml'
@@ -571,6 +573,74 @@ function Build-CwDecoderRust {
     }
 }
 
+function Build-CatHubNativeProbe {
+    if (-not $IsWindows) {
+        Write-Step 'CatHub native frequency probe'
+        Write-Host 'The native CatHub frequency probe is Win32-only; skipping on this platform.' -ForegroundColor Yellow
+        return
+    }
+
+    $cmake = Get-Command cmake -ErrorAction SilentlyContinue
+    if (-not $cmake) {
+        Write-Step 'CatHub native frequency probe'
+        Write-Host 'CMake not found, skipping native CatHub frequency probe. Install CMake and the Visual Studio C++ workload.' -ForegroundColor Yellow
+        return
+    }
+
+    if (-not (Test-Path -LiteralPath (Join-Path $CatHubNativeProbeSourceDir 'CMakeLists.txt'))) {
+        Write-Step 'CatHub native frequency probe'
+        Write-Host "Source not found at $CatHubNativeProbeSourceDir, skipping." -ForegroundColor Yellow
+        return
+    }
+
+    $catHubNativeProbeOutputDir = Join-Path $CatHubNativeProbeBuildDir $Configuration
+    Clear-LockedPublishArtifacts -DestinationDir $catHubNativeProbeOutputDir
+
+    Measure-BuildStep "Configuring CatHub native frequency probe ($Configuration)" {
+        $configured = $false
+        $generators = @('Visual Studio 18 2026', 'Visual Studio 17 2022')
+        foreach ($generator in $generators) {
+            Write-Host "  Trying CMake generator: $generator"
+            cmake -S $CatHubNativeProbeSourceDir -B $CatHubNativeProbeBuildDir -G $generator -A x64
+            if ($LASTEXITCODE -eq 0) {
+                $configured = $true
+                break
+            }
+
+            Remove-Item (Join-Path $CatHubNativeProbeBuildDir 'CMakeCache.txt') -Force -ErrorAction SilentlyContinue
+            Remove-Item (Join-Path $CatHubNativeProbeBuildDir 'CMakeFiles') -Recurse -Force -ErrorAction SilentlyContinue
+        }
+
+        if (-not $configured) {
+            Write-Host 'FAILED: no supported Visual Studio CMake generator found for native CatHub frequency probe.' -ForegroundColor Red
+            exit 1
+        }
+    }
+
+    Invoke-Build "Building CatHub native frequency probe ($Configuration)" cmake @(
+        '--build',
+        $CatHubNativeProbeBuildDir,
+        '--config',
+        $Configuration
+    )
+
+    $ffiDll = Join-Path $PSScriptRoot 'src' 'rust' 'target' $RustTargetProfile 'qsoripper_ffi.dll'
+    if (Test-Path -LiteralPath $ffiDll) {
+        Copy-PublishArtifact -Path $ffiDll -DestinationDir $catHubNativeProbeOutputDir
+    }
+    else {
+        Write-Host "  Warning: qsoripper_ffi.dll not found at $ffiDll; native probe will run direct cathub reads but ENGINE SKEW will show ERR." -ForegroundColor Yellow
+    }
+
+    $exe = Join-Path $catHubNativeProbeOutputDir 'CatHubFrequencyProbeNative.exe'
+    if (Test-Path -LiteralPath $exe) {
+        Write-Host "  -> $exe"
+    }
+    else {
+        Write-Host "  Warning: expected CatHubFrequencyProbeNative.exe at $exe but it was not found." -ForegroundColor Yellow
+    }
+}
+
 function Build-All {
     Build-Rust
     Build-CwDecoderRust
@@ -732,6 +802,8 @@ Commands:
   cw-decoder    Build the experiments/cw-decoder Rust binaries (cw-decoder + eval) only
   dotnet        Publish the CLI and GUI apps only
   win32         Build the Win32 C GUI app only
+  cathub-probe-native
+                Build the native C++ CatHub frequency probe only
   check-rust    Rust quality: fmt, clippy, test + coverage threshold, buf lint, cargo deny
   check-dotnet  .NET quality: format, build, test + coverage threshold, vulnerable package check
   proto         Run buf lint
@@ -754,6 +826,7 @@ try {
         'cw-decoder'   { Build-CwDecoderRust }
         'dotnet'       { Build-Dotnet }
         'win32'        { Build-Win32 }
+        'cathub-probe-native' { Build-CatHubNativeProbe }
         'check-rust'   { Check-Rust }
         'check-dotnet' { Check-Dotnet }
         'proto'        { Check-Proto }

--- a/experiments/cathub-frequency-probe-native/CMakeLists.txt
+++ b/experiments/cathub-frequency-probe-native/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.24)
+
+project(CatHubFrequencyProbeNative LANGUAGES CXX)
+
+add_executable(CatHubFrequencyProbeNative WIN32
+    main.cpp
+)
+
+target_compile_features(CatHubFrequencyProbeNative PRIVATE cxx_std_20)
+target_include_directories(CatHubFrequencyProbeNative PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../src/rust/qsoripper-ffi
+)
+target_compile_definitions(CatHubFrequencyProbeNative PRIVATE
+    UNICODE
+    _UNICODE
+    WIN32_LEAN_AND_MEAN
+    NOMINMAX
+)
+target_link_libraries(CatHubFrequencyProbeNative PRIVATE
+    gdi32
+    user32
+    ws2_32
+)
+
+if (MSVC)
+    target_compile_options(CatHubFrequencyProbeNative PRIVATE /W4 /permissive-)
+endif()

--- a/experiments/cathub-frequency-probe-native/README.md
+++ b/experiments/cathub-frequency-probe-native/README.md
@@ -1,0 +1,29 @@
+# CatHub Native Frequency Probe
+
+Native C++/Win32 diagnostic app for fast-launch CAT latency testing.
+
+This is a no-.NET sibling of `experiments\cathub-frequency-probe`. It talks directly to cathub's rigctld-compatible endpoint at `127.0.0.1:4532` over Winsock, polls `f`, `m`, and `v` every 100 ms, and displays a large amber TS-590-style frequency readout.
+
+It also loads `qsoripper_ffi.dll` beside the executable and uses the existing Rust FFI shim to call the engine gRPC `GetRigSnapshot` path at `http://127.0.0.1:50051`. That keeps the native probe aligned with the C# WinUI probe's direct cathub vs engine skew comparison without adding a C++ gRPC stack.
+
+Build from the repository root:
+
+```powershell
+.\build.ps1 cathub-probe-native
+```
+
+The probe is opt-in and is not part of the default `.\build.ps1` flow. Running the standalone command expects `src\rust\target\release\qsoripper_ffi.dll` to already exist for engine skew; if it is missing, the direct cathub display still works but `ENGINE SKEW` reports `ERR`.
+
+Run:
+
+```powershell
+artifacts\build\cathub-frequency-probe-native\Release\CatHubFrequencyProbeNative.exe
+```
+
+Diagnostic log:
+
+```text
+%LOCALAPPDATA%\qsoripper\cathub-frequency-probe-native.log
+```
+
+The `ENGINE SKEW` tile is `engine_frequency_hz - direct_cathub_frequency_hz`. `0 Hz` means the engine and cathub agree; a persistent non-zero value means the engine/UI path is behind or ahead of live cathub state.

--- a/experiments/cathub-frequency-probe-native/main.cpp
+++ b/experiments/cathub-frequency-probe-native/main.cpp
@@ -1,0 +1,856 @@
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <windows.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <deque>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include "qsoripper_ffi.h"
+
+namespace {
+
+constexpr wchar_t kWindowClassName[] = L"CatHubFrequencyProbeNativeWindow";
+constexpr wchar_t kWindowTitle[] = L"CatHub Native Frequency Probe";
+constexpr UINT kUpdateMessage = WM_APP + 1;
+constexpr int kPollMilliseconds = 100;
+constexpr int kMaxLogLines = 8;
+constexpr int kDefaultWindowWidth = 1100;
+constexpr int kDefaultWindowHeight = 700;
+constexpr int kMinWindowWidth = 1000;
+constexpr int kMinWindowHeight = 660;
+
+constexpr COLORREF kBackground = RGB(10, 6, 1);
+constexpr COLORREF kPanel = RGB(18, 11, 2);
+constexpr COLORREF kPanelDark = RGB(7, 4, 1);
+constexpr COLORREF kAmber = RGB(255, 191, 0);
+constexpr COLORREF kAmberDim = RGB(185, 133, 25);
+constexpr COLORREF kAmberBorder = RGB(255, 159, 28);
+
+struct Snapshot {
+    std::uint64_t frequency_hz{};
+    std::wstring frequency;
+    std::wstring vfo;
+    std::wstring mode;
+    long long query_ms{};
+    std::optional<long long> change_gap_ms;
+    std::optional<std::uint64_t> engine_frequency_hz;
+    std::optional<long long> engine_query_ms;
+    std::wstring engine_error;
+    bool connected{};
+    std::wstring error;
+};
+
+struct SharedState {
+    std::mutex gate;
+    Snapshot snapshot;
+    std::deque<std::wstring> log_lines;
+    std::filesystem::path log_path;
+};
+
+std::atomic_bool g_running{true};
+SharedState g_state;
+
+std::wstring WidenAscii(const std::string& value) {
+    return std::wstring(value.begin(), value.end());
+}
+
+std::string NarrowUtf8(const std::wstring& value) {
+    if (value.empty()) {
+        return {};
+    }
+
+    const int bytes = WideCharToMultiByte(CP_UTF8, 0, value.data(),
+                                          static_cast<int>(value.size()), nullptr, 0,
+                                          nullptr, nullptr);
+    if (bytes <= 0) {
+        return {};
+    }
+
+    std::string result(static_cast<std::size_t>(bytes), '\0');
+    WideCharToMultiByte(CP_UTF8, 0, value.data(), static_cast<int>(value.size()),
+                        result.data(), bytes, nullptr, nullptr);
+    return result;
+}
+
+std::wstring FormatFrequency(std::uint64_t frequency_hz) {
+    const auto mhz = frequency_hz / 1'000'000;
+    const auto khz = (frequency_hz % 1'000'000) / 1'000;
+    const auto ten_hz = (frequency_hz % 1'000) / 10;
+
+    wchar_t buffer[32]{};
+    std::swprintf(buffer, std::size(buffer), L"%llu.%03llu.%02llu",
+                 static_cast<unsigned long long>(mhz),
+                 static_cast<unsigned long long>(khz),
+                 static_cast<unsigned long long>(ten_hz));
+    return buffer;
+}
+
+std::wstring FormatSkew(std::uint64_t direct_frequency_hz,
+                        std::optional<std::uint64_t> engine_frequency_hz) {
+    if (!engine_frequency_hz) {
+        return L"--";
+    }
+
+    const auto skew = static_cast<long long>(*engine_frequency_hz) -
+                      static_cast<long long>(direct_frequency_hz);
+    if (skew > 0) {
+        return L"+" + std::to_wstring(skew) + L" Hz";
+    }
+    if (skew < 0) {
+        return std::to_wstring(skew) + L" Hz";
+    }
+    return L"0 Hz";
+}
+
+std::string FixedBufferToString(const std::uint8_t* buffer, std::size_t size) {
+    const auto end = std::find(buffer, buffer + size, 0);
+    return std::string(reinterpret_cast<const char*>(buffer),
+                       reinterpret_cast<const char*>(end));
+}
+
+std::uint64_t ParseMhzToHz(const std::string& mhz) {
+    const auto dot = mhz.find('.');
+    const auto whole_text = dot == std::string::npos ? mhz : mhz.substr(0, dot);
+    auto fractional = dot == std::string::npos ? std::string{} : mhz.substr(dot + 1);
+    while (fractional.size() < 6) {
+        fractional.push_back('0');
+    }
+    if (fractional.size() > 6) {
+        fractional.resize(6);
+    }
+
+    const auto whole = whole_text.empty() ? 0ULL : std::stoull(whole_text);
+    const auto frac = fractional.empty() ? 0ULL : std::stoull(fractional);
+    return (whole * 1'000'000ULL) + frac;
+}
+
+std::wstring NowTime() {
+    SYSTEMTIME now{};
+    GetLocalTime(&now);
+    wchar_t buffer[32]{};
+    std::swprintf(buffer, std::size(buffer), L"%02u:%02u:%02u.%03u",
+                 now.wHour, now.wMinute, now.wSecond, now.wMilliseconds);
+    return buffer;
+}
+
+std::filesystem::path LogPath() {
+    wchar_t buffer[MAX_PATH]{};
+    const auto length = GetEnvironmentVariableW(L"LOCALAPPDATA", buffer, MAX_PATH);
+    std::filesystem::path root = length == 0 ? std::filesystem::temp_directory_path()
+                                             : std::filesystem::path(buffer);
+    auto directory = root / L"qsoripper";
+    std::filesystem::create_directories(directory);
+    return directory / L"cathub-frequency-probe-native.log";
+}
+
+void AppendLog(const std::wstring& message) {
+    const auto line = NowTime() + L" " + message;
+    {
+        std::lock_guard lock(g_state.gate);
+        g_state.log_lines.push_back(line);
+        while (g_state.log_lines.size() > kMaxLogLines) {
+            g_state.log_lines.pop_front();
+        }
+    }
+
+    std::ofstream file(g_state.log_path, std::ios::app);
+    file << NarrowUtf8(line) << '\n';
+}
+
+class WinSockSession {
+public:
+    WinSockSession() {
+        WSADATA data{};
+        ok_ = WSAStartup(MAKEWORD(2, 2), &data) == 0;
+    }
+
+    ~WinSockSession() {
+        if (ok_) {
+            WSACleanup();
+        }
+    }
+
+    WinSockSession(const WinSockSession&) = delete;
+    WinSockSession& operator=(const WinSockSession&) = delete;
+
+    [[nodiscard]] bool ok() const {
+        return ok_;
+    }
+
+private:
+    bool ok_{};
+};
+
+class CatHubClient {
+public:
+    ~CatHubClient() {
+        Disconnect();
+    }
+
+    CatHubClient(const CatHubClient&) = delete;
+    CatHubClient& operator=(const CatHubClient&) = delete;
+
+    CatHubClient() = default;
+
+    Snapshot ReadSnapshot() {
+        const auto start = std::chrono::steady_clock::now();
+        EnsureConnected();
+
+        const auto frequency_line = CommandLine("f");
+        const auto mode = CommandLine("m");
+        const auto ignored_passband = CommandLineRaw();
+        (void)ignored_passband;
+        const auto vfo = CommandLine("v");
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+
+        std::uint64_t frequency = 0;
+        try {
+            frequency = std::stoull(frequency_line);
+        } catch (...) {
+            throw std::runtime_error("invalid frequency reply: " + frequency_line);
+        }
+
+        Snapshot snapshot;
+        snapshot.frequency_hz = frequency;
+        snapshot.frequency = FormatFrequency(frequency);
+        snapshot.mode = WidenAscii(mode);
+        snapshot.vfo = WidenAscii(vfo);
+        snapshot.query_ms = elapsed.count();
+        snapshot.connected = true;
+        return snapshot;
+    }
+
+private:
+    SOCKET socket_{INVALID_SOCKET};
+
+    void EnsureConnected() {
+        if (socket_ != INVALID_SOCKET) {
+            return;
+        }
+
+        addrinfo hints{};
+        hints.ai_family = AF_INET;
+        hints.ai_socktype = SOCK_STREAM;
+        hints.ai_protocol = IPPROTO_TCP;
+
+        addrinfo* result = nullptr;
+        if (getaddrinfo("127.0.0.1", "4532", &hints, &result) != 0) {
+            throw std::runtime_error("getaddrinfo failed");
+        }
+
+        SOCKET candidate = INVALID_SOCKET;
+        for (auto* ptr = result; ptr != nullptr; ptr = ptr->ai_next) {
+            candidate = socket(ptr->ai_family, ptr->ai_socktype, ptr->ai_protocol);
+            if (candidate == INVALID_SOCKET) {
+                continue;
+            }
+
+            DWORD timeout_ms = 500;
+            setsockopt(candidate, SOL_SOCKET, SO_RCVTIMEO,
+                       reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+            setsockopt(candidate, SOL_SOCKET, SO_SNDTIMEO,
+                       reinterpret_cast<const char*>(&timeout_ms), sizeof(timeout_ms));
+
+            if (connect(candidate, ptr->ai_addr, static_cast<int>(ptr->ai_addrlen)) == 0) {
+                socket_ = candidate;
+                break;
+            }
+
+            closesocket(candidate);
+            candidate = INVALID_SOCKET;
+        }
+
+        freeaddrinfo(result);
+
+        if (socket_ == INVALID_SOCKET) {
+            throw std::runtime_error("connect 127.0.0.1:4532 failed");
+        }
+    }
+
+    void Disconnect() {
+        if (socket_ != INVALID_SOCKET) {
+            closesocket(socket_);
+            socket_ = INVALID_SOCKET;
+        }
+    }
+
+    std::string CommandLine(const char* command) {
+        const std::string wire = std::string(command) + "\n";
+        if (send(socket_, wire.data(), static_cast<int>(wire.size()), 0) == SOCKET_ERROR) {
+            Disconnect();
+            throw std::runtime_error("send failed");
+        }
+
+        return CommandLineRaw();
+    }
+
+    std::string CommandLineRaw() {
+        std::string line;
+        char ch = '\0';
+        while (true) {
+            const auto read = recv(socket_, &ch, 1, 0);
+            if (read <= 0) {
+                Disconnect();
+                throw std::runtime_error("recv failed");
+            }
+            if (ch == '\n') {
+                break;
+            }
+            if (ch != '\r') {
+                line.push_back(ch);
+            }
+        }
+        return line;
+    }
+};
+
+class EngineClient {
+public:
+    EngineClient() {
+        Load();
+    }
+
+    ~EngineClient() {
+        if (client_ != nullptr && disconnect_ != nullptr) {
+            disconnect_(client_);
+            client_ = nullptr;
+        }
+        if (library_ != nullptr) {
+            FreeLibrary(library_);
+        }
+    }
+
+    EngineClient(const EngineClient&) = delete;
+    EngineClient& operator=(const EngineClient&) = delete;
+
+    struct Result {
+        std::optional<std::uint64_t> frequency_hz;
+        long long query_ms{};
+        std::wstring error;
+    };
+
+    Result ReadSnapshot() {
+        Result result;
+        const auto start = std::chrono::steady_clock::now();
+
+        if (!available_) {
+            result.error = error_;
+            return result;
+        }
+
+        EnsureConnected();
+        if (client_ == nullptr) {
+            result.error = error_;
+            return result;
+        }
+
+        QsrRigStatus status{};
+        if (get_rig_status_(client_, &status) != 0) {
+            const auto message = last_error_ == nullptr ? nullptr : last_error_();
+            error_ = L"engine snapshot failed";
+            if (message != nullptr && message[0] != '\0') {
+                error_ += L": " + WidenAscii(message);
+            }
+            result.error = error_;
+            return result;
+        }
+
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start);
+        result.query_ms = elapsed.count();
+
+        if (status.connected == 0) {
+            result.error = L"engine rig snapshot disconnected";
+            return result;
+        }
+
+        const auto mhz = FixedBufferToString(status.freq_mhz, std::size(status.freq_mhz));
+        if (mhz.empty()) {
+            result.error = L"engine snapshot had no frequency";
+            return result;
+        }
+
+        try {
+            result.frequency_hz = ParseMhzToHz(mhz);
+        } catch (...) {
+            result.error = L"invalid engine frequency: " + WidenAscii(mhz);
+        }
+        return result;
+    }
+
+private:
+    using ConnectFn = QsrClient* (*)(const char*);
+    using DisconnectFn = void (*)(QsrClient*);
+    using LastErrorFn = const char* (*)();
+    using GetRigStatusFn = std::int32_t (*)(QsrClient*, QsrRigStatus*);
+
+    HMODULE library_{};
+    ConnectFn connect_{};
+    DisconnectFn disconnect_{};
+    LastErrorFn last_error_{};
+    GetRigStatusFn get_rig_status_{};
+    QsrClient* client_{};
+    bool available_{};
+    std::wstring error_;
+
+    void Load() {
+        const auto dll_path = ExeDirectory() / L"qsoripper_ffi.dll";
+        library_ = LoadLibraryExW(dll_path.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
+        if (library_ == nullptr) {
+            error_ = L"qsoripper_ffi.dll not found beside probe executable";
+            return;
+        }
+
+        connect_ = reinterpret_cast<ConnectFn>(GetProcAddress(library_, "qsr_connect"));
+        disconnect_ = reinterpret_cast<DisconnectFn>(GetProcAddress(library_, "qsr_disconnect"));
+        last_error_ = reinterpret_cast<LastErrorFn>(GetProcAddress(library_, "qsr_last_error"));
+        get_rig_status_ = reinterpret_cast<GetRigStatusFn>(GetProcAddress(library_, "qsr_get_rig_status"));
+        if (connect_ == nullptr || disconnect_ == nullptr || last_error_ == nullptr ||
+            get_rig_status_ == nullptr) {
+            error_ = L"qsoripper_ffi.dll is missing required exports";
+            available_ = false;
+            return;
+        }
+
+        available_ = true;
+    }
+
+    void EnsureConnected() {
+        if (client_ != nullptr) {
+            return;
+        }
+
+        client_ = connect_("http://127.0.0.1:50051");
+        if (client_ == nullptr) {
+            error_ = L"engine connect failed";
+            const auto message = last_error_ == nullptr ? nullptr : last_error_();
+            if (message != nullptr && message[0] != '\0') {
+                error_ += L": " + WidenAscii(message);
+            }
+        }
+    }
+
+    static std::filesystem::path ExeDirectory() {
+        std::wstring buffer(MAX_PATH, L'\0');
+        DWORD length = 0;
+        while (true) {
+            length = GetModuleFileNameW(nullptr, buffer.data(), static_cast<DWORD>(buffer.size()));
+            if (length == 0) {
+                return std::filesystem::current_path();
+            }
+            if (length < buffer.size() - 1) {
+                buffer.resize(length);
+                return std::filesystem::path(buffer).parent_path();
+            }
+            buffer.resize(buffer.size() * 2);
+        }
+    }
+};
+
+HFONT MakeFont(int height, int weight = FW_NORMAL) {
+    return CreateFontW(-height, 0, 0, 0, weight, FALSE, FALSE, FALSE, DEFAULT_CHARSET,
+                       OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY,
+                       FIXED_PITCH | FF_MODERN, L"Cascadia Mono");
+}
+
+int RectWidth(const RECT& rect) {
+    return std::max(0, static_cast<int>(rect.right - rect.left));
+}
+
+int RectHeight(const RECT& rect) {
+    return std::max(0, static_cast<int>(rect.bottom - rect.top));
+}
+
+int ChooseFittingFontHeight(HDC dc, const std::wstring& text, const RECT& rect,
+                            int minimum_height, int maximum_height, int weight) {
+    const int available_width = std::max(0, RectWidth(rect) - 8);
+    const int available_height = std::max(0, RectHeight(rect) - 14);
+
+    for (int height = maximum_height; height >= minimum_height; --height) {
+        const auto font = MakeFont(height, weight);
+        const auto old_font = SelectObject(dc, font);
+        SIZE size{};
+        const auto measured = GetTextExtentPoint32W(
+            dc, text.c_str(), static_cast<int>(text.size()), &size);
+        SelectObject(dc, old_font);
+        DeleteObject(font);
+
+        if (measured && size.cx <= available_width && size.cy <= available_height) {
+            return height;
+        }
+    }
+
+    return minimum_height;
+}
+
+void DrawTextInRect(HDC dc, const std::wstring& text, const RECT& rect, HFONT font,
+                    COLORREF color, UINT format) {
+    const auto old_font = SelectObject(dc, font);
+    SetBkMode(dc, TRANSPARENT);
+    SetTextColor(dc, color);
+    RECT copy = rect;
+    DrawTextW(dc, text.c_str(), static_cast<int>(text.size()), &copy, format);
+    SelectObject(dc, old_font);
+}
+
+void FillSolid(HDC dc, const RECT& rect, COLORREF color) {
+    const auto brush = CreateSolidBrush(color);
+    FillRect(dc, &rect, brush);
+    DeleteObject(brush);
+}
+
+void StrokeRoundRect(HDC dc, const RECT& rect, COLORREF border, COLORREF fill,
+                     int radius, int width) {
+    const auto brush = CreateSolidBrush(fill);
+    const auto pen = CreatePen(PS_SOLID, width, border);
+    const auto old_brush = SelectObject(dc, brush);
+    const auto old_pen = SelectObject(dc, pen);
+    RoundRect(dc, rect.left, rect.top, rect.right, rect.bottom, radius, radius);
+    SelectObject(dc, old_pen);
+    SelectObject(dc, old_brush);
+    DeleteObject(pen);
+    DeleteObject(brush);
+}
+
+void DrawTile(HDC dc, const RECT& rect, const std::wstring& label, const std::wstring& value) {
+    StrokeRoundRect(dc, rect, RGB(111, 71, 0), kPanelDark, 10, 1);
+
+    const auto label_font = MakeFont(14, FW_BOLD);
+    RECT label_rect{rect.left + 18, rect.top + 16, rect.right - 14, rect.top + 40};
+    RECT value_rect{rect.left + 18, rect.top + 48, rect.right - 14, rect.bottom - 12};
+    const auto value_font = MakeFont(
+        ChooseFittingFontHeight(dc, value, value_rect, 16, 28, FW_BOLD),
+        FW_BOLD);
+    DrawTextInRect(dc, label, label_rect, label_font, kAmberDim, DT_LEFT | DT_TOP | DT_SINGLELINE);
+    DrawTextInRect(dc, value, value_rect, value_font, kAmber,
+                   DT_LEFT | DT_VCENTER | DT_SINGLELINE);
+    DeleteObject(label_font);
+    DeleteObject(value_font);
+}
+
+void Paint(HWND hwnd, HDC target) {
+    RECT client{};
+    GetClientRect(hwnd, &client);
+
+    const int width = client.right - client.left;
+    const int height = client.bottom - client.top;
+    HDC memory = CreateCompatibleDC(target);
+    HBITMAP bitmap = CreateCompatibleBitmap(target, width, height);
+    const auto old_bitmap = SelectObject(memory, bitmap);
+
+    FillSolid(memory, client, kBackground);
+
+    Snapshot snapshot;
+    std::vector<std::wstring> log_lines;
+    std::filesystem::path log_path;
+    {
+        std::lock_guard lock(g_state.gate);
+        snapshot = g_state.snapshot;
+        log_lines.assign(g_state.log_lines.begin(), g_state.log_lines.end());
+        log_path = g_state.log_path;
+    }
+
+    const auto header_font = MakeFont(24, FW_BOLD);
+    const auto small_font = MakeFont(15, FW_BOLD);
+    const auto footer_font = MakeFont(14, FW_BOLD);
+
+    RECT header{34, 28, width - 34, 104};
+    DrawTextInRect(memory, L"CATHUB NATIVE FREQUENCY PROBE", header, header_font,
+                   kAmber, DT_LEFT | DT_TOP | DT_SINGLELINE);
+    RECT endpoint{34, 58, width - 34, 90};
+    DrawTextInRect(memory, L"native Win32/Winsock - direct 127.0.0.1:4532 - 100 ms poll",
+                   endpoint, small_font, RGB(255, 209, 102), DT_LEFT | DT_TOP | DT_SINGLELINE);
+
+    HPEN line_pen = CreatePen(PS_SOLID, 1, kAmberBorder);
+    const auto old_pen = SelectObject(memory, line_pen);
+    MoveToEx(memory, 0, 118, nullptr);
+    LineTo(memory, width, 118);
+    SelectObject(memory, old_pen);
+    DeleteObject(line_pen);
+
+    const int footer_height = 44;
+    const int log_height = std::max(120, std::min(150, height / 5));
+    RECT card{34, 138, width - 34, height - footer_height - log_height - 42};
+    StrokeRoundRect(memory, card, kAmberBorder, kPanel, 26, 2);
+
+    const auto label_font = MakeFont(20, FW_BOLD);
+    RECT live_label{card.left + 42, card.top + 36, card.right - 42, card.top + 70};
+    DrawTextInRect(memory, L"LIVE RADIO FREQUENCY", live_label, label_font, kAmberDim,
+                   DT_LEFT | DT_TOP | DT_SINGLELINE);
+
+    const int tile_height = 92;
+    const int tile_bottom = card.bottom - 28;
+    const int tile_top = tile_bottom - tile_height;
+    const int tile_count = 5;
+    const int gap = 12;
+    const int tile_width = (card.right - card.left - 84 - (gap * (tile_count - 1))) / tile_count;
+
+    const int frequency_top = card.top + 84;
+    const int frequency_bottom = std::max(frequency_top + 44, tile_top - 20);
+    const auto frequency = snapshot.connected && snapshot.frequency_hz != 0
+        ? snapshot.frequency
+        : L"--.---.--";
+    const auto frequency_display = frequency + L" MHz";
+    RECT frequency_rect{card.left + 42, frequency_top, card.right - 42, frequency_bottom};
+    const int freq_font_size =
+        ChooseFittingFontHeight(memory, frequency_display, frequency_rect, 38, 96, FW_HEAVY);
+    const auto freq_font = MakeFont(freq_font_size, FW_HEAVY);
+    DrawTextInRect(memory, frequency_display, frequency_rect, freq_font, kAmber,
+                   DT_CENTER | DT_VCENTER | DT_SINGLELINE);
+
+    RECT tile{card.left + 42, tile_top, card.left + 42 + tile_width, tile_bottom};
+    DrawTile(memory, tile, L"VFO", snapshot.vfo.empty() ? L"--" : snapshot.vfo);
+    OffsetRect(&tile, tile_width + gap, 0);
+    DrawTile(memory, tile, L"MODE", snapshot.mode.empty() ? L"--" : snapshot.mode);
+    OffsetRect(&tile, tile_width + gap, 0);
+    DrawTile(memory, tile, L"QUERY", std::to_wstring(snapshot.query_ms) + L" ms");
+    OffsetRect(&tile, tile_width + gap, 0);
+    DrawTile(memory, tile, L"CHANGE GAP",
+             snapshot.change_gap_ms ? std::to_wstring(*snapshot.change_gap_ms) + L" ms" : L"-- ms");
+    OffsetRect(&tile, tile_width + gap, 0);
+    DrawTile(memory, tile, L"ENGINE SKEW",
+             snapshot.engine_error.empty() ? FormatSkew(snapshot.frequency_hz, snapshot.engine_frequency_hz) : L"ERR");
+
+    RECT log_box{34, height - footer_height - log_height - 16, width - 34, height - footer_height - 12};
+    StrokeRoundRect(memory, log_box, RGB(111, 71, 0), kPanelDark, 0, 1);
+    RECT log_path_rect{log_box.left + 18, log_box.top + 14, log_box.right - 18, log_box.top + 36};
+    DrawTextInRect(memory, L"log: " + log_path.wstring(), log_path_rect, small_font, kAmberDim,
+                   DT_LEFT | DT_TOP | DT_SINGLELINE | DT_END_ELLIPSIS);
+    int y = log_box.top + 46;
+    for (const auto& line : log_lines) {
+        if (y + 19 > log_box.bottom - 10) {
+            break;
+        }
+        RECT line_rect{log_box.left + 18, y, log_box.right - 18, y + 19};
+        DrawTextInRect(memory, line, line_rect, small_font, RGB(255, 209, 102),
+                       DT_LEFT | DT_TOP | DT_SINGLELINE | DT_END_ELLIPSIS);
+        y += 18;
+    }
+
+    RECT footer{0, height - footer_height, width, height};
+    FillSolid(memory, footer, RGB(20, 13, 3));
+    std::wstring footer_text = snapshot.connected
+        ? L"polling direct cathub - frequency=" + frequency + L" MHz - query=" +
+              std::to_wstring(snapshot.query_ms) + L" ms - engine=" +
+              (snapshot.engine_frequency_hz ? FormatFrequency(*snapshot.engine_frequency_hz) + L" MHz/" +
+                   std::to_wstring(snapshot.engine_query_ms.value_or(0)) + L" ms"
+                                            : L"--") +
+              L" - skew=" + FormatSkew(snapshot.frequency_hz, snapshot.engine_frequency_hz)
+        : L"link down - " + snapshot.error;
+    RECT footer_text_rect{34, height - 34, width - 34, height - 10};
+    DrawTextInRect(memory, footer_text, footer_text_rect, footer_font, kAmberDim,
+                   DT_LEFT | DT_TOP | DT_SINGLELINE | DT_END_ELLIPSIS);
+
+    BitBlt(target, 0, 0, width, height, memory, 0, 0, SRCCOPY);
+
+    DeleteObject(header_font);
+    DeleteObject(small_font);
+    DeleteObject(footer_font);
+    DeleteObject(label_font);
+    DeleteObject(freq_font);
+    SelectObject(memory, old_bitmap);
+    DeleteObject(bitmap);
+    DeleteDC(memory);
+}
+
+void PollLoop(HWND hwnd) {
+    WinSockSession winsock;
+    if (!winsock.ok()) {
+        AppendLog(L"WSAStartup failed");
+        return;
+    }
+
+    CatHubClient client;
+    EngineClient engine;
+    std::optional<std::uint64_t> last_frequency;
+    std::optional<std::chrono::steady_clock::time_point> last_change;
+    int poll_count = 0;
+
+    AppendLog(L"native probe starting; direct=127.0.0.1:4532 engine=http://127.0.0.1:50051 poll=100ms commands=f,m,v");
+
+    while (g_running.load()) {
+        const auto loop_start = std::chrono::steady_clock::now();
+        Snapshot snapshot;
+        try {
+            snapshot = client.ReadSnapshot();
+            const auto engine_snapshot = engine.ReadSnapshot();
+            snapshot.engine_frequency_hz = engine_snapshot.frequency_hz;
+            snapshot.engine_query_ms = engine_snapshot.query_ms;
+            snapshot.engine_error = engine_snapshot.error;
+            poll_count++;
+
+            const bool changed = !last_frequency || *last_frequency != snapshot.frequency_hz;
+            if (changed) {
+                if (last_change) {
+                    snapshot.change_gap_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                        loop_start - *last_change)
+                                                 .count();
+                }
+                last_frequency = snapshot.frequency_hz;
+                last_change = loop_start;
+
+                std::wstringstream message;
+                message << L"change #" << poll_count << L": direct=" << snapshot.frequency_hz
+                        << L" Hz " << snapshot.frequency << L" MHz engine=";
+                if (snapshot.engine_frequency_hz) {
+                    message << *snapshot.engine_frequency_hz << L" Hz "
+                            << FormatFrequency(*snapshot.engine_frequency_hz) << L" MHz";
+                } else {
+                    message << L"--";
+                }
+                message << L" skew=" << FormatSkew(snapshot.frequency_hz, snapshot.engine_frequency_hz)
+                        << L" vfo=" << snapshot.vfo
+                        << L" mode=" << snapshot.mode << L" direct_query=" << snapshot.query_ms
+                        << L"ms engine_query=";
+                if (snapshot.engine_query_ms) {
+                    message << *snapshot.engine_query_ms << L"ms";
+                } else {
+                    message << L"--ms";
+                }
+                message << L" gap=";
+                if (snapshot.change_gap_ms) {
+                    message << *snapshot.change_gap_ms << L"ms";
+                } else {
+                    message << L"--ms";
+                }
+                AppendLog(message.str());
+            } else if (poll_count % 25 == 0) {
+                std::wstringstream message;
+                message << L"poll #" << poll_count << L": unchanged direct=" << snapshot.frequency_hz
+                        << L" Hz engine=";
+                if (snapshot.engine_frequency_hz) {
+                    message << *snapshot.engine_frequency_hz << L" Hz "
+                            << FormatFrequency(*snapshot.engine_frequency_hz) << L" MHz";
+                } else {
+                    message << L"--";
+                }
+                message << L" skew=" << FormatSkew(snapshot.frequency_hz, snapshot.engine_frequency_hz)
+                        << L" direct_query=" << snapshot.query_ms << L"ms engine_query=";
+                if (snapshot.engine_query_ms) {
+                    message << *snapshot.engine_query_ms << L"ms";
+                } else {
+                    message << L"--ms";
+                }
+                AppendLog(message.str());
+            }
+            if (!snapshot.engine_error.empty() && poll_count % 10 == 1) {
+                AppendLog(L"engine poll error: " + snapshot.engine_error);
+            }
+        } catch (const std::exception& ex) {
+            snapshot.connected = false;
+            snapshot.error = WidenAscii(ex.what());
+            AppendLog(L"poll error: " + snapshot.error);
+        }
+
+        {
+            std::lock_guard lock(g_state.gate);
+            g_state.snapshot = snapshot;
+        }
+        PostMessageW(hwnd, kUpdateMessage, 0, 0);
+
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - loop_start);
+        if (elapsed.count() < kPollMilliseconds) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(kPollMilliseconds - elapsed.count()));
+        }
+    }
+}
+
+LRESULT CALLBACK WindowProc(HWND hwnd, UINT message, WPARAM wparam, LPARAM lparam) {
+    switch (message) {
+    case WM_CREATE:
+        return 0;
+    case kUpdateMessage:
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return 0;
+    case WM_PAINT: {
+        PAINTSTRUCT paint{};
+        const auto dc = BeginPaint(hwnd, &paint);
+        Paint(hwnd, dc);
+        EndPaint(hwnd, &paint);
+        return 0;
+    }
+    case WM_SIZE:
+        InvalidateRect(hwnd, nullptr, FALSE);
+        return 0;
+    case WM_GETMINMAXINFO: {
+        auto* min_max = reinterpret_cast<MINMAXINFO*>(lparam);
+        min_max->ptMinTrackSize.x = kMinWindowWidth;
+        min_max->ptMinTrackSize.y = kMinWindowHeight;
+        return 0;
+    }
+    case WM_DESTROY:
+        g_running = false;
+        PostQuitMessage(0);
+        return 0;
+    default:
+        return DefWindowProcW(hwnd, message, wparam, lparam);
+    }
+}
+
+} // namespace
+
+int WINAPI wWinMain(HINSTANCE instance, HINSTANCE, PWSTR, int show_command) {
+    g_state.log_path = LogPath();
+
+    WNDCLASSW wc{};
+    wc.lpfnWndProc = WindowProc;
+    wc.hInstance = instance;
+    wc.lpszClassName = kWindowClassName;
+    wc.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+    wc.hbrBackground = CreateSolidBrush(kBackground);
+
+    if (RegisterClassW(&wc) == 0) {
+        return 1;
+    }
+
+    const auto hwnd = CreateWindowExW(
+        0,
+        kWindowClassName,
+        kWindowTitle,
+        WS_OVERLAPPEDWINDOW,
+        40,
+        40,
+        kDefaultWindowWidth,
+        kDefaultWindowHeight,
+        nullptr,
+        nullptr,
+        instance,
+        nullptr);
+
+    if (hwnd == nullptr) {
+        return 1;
+    }
+
+    std::thread poll_thread(PollLoop, hwnd);
+    ShowWindow(hwnd, show_command);
+    UpdateWindow(hwnd);
+
+    MSG message{};
+    while (GetMessageW(&message, nullptr, 0, 0) > 0) {
+        TranslateMessage(&message);
+        DispatchMessageW(&message);
+    }
+
+    g_running = false;
+    if (poll_thread.joinable()) {
+        poll_thread.join();
+    }
+
+    return 0;
+}

--- a/experiments/cathub-frequency-probe/App.xaml
+++ b/experiments/cathub-frequency-probe/App.xaml
@@ -1,0 +1,9 @@
+<Application
+    x:Class="CatHubFrequencyProbe.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls">
+    <Application.Resources>
+        <controls:XamlControlsResources />
+    </Application.Resources>
+</Application>

--- a/experiments/cathub-frequency-probe/App.xaml.cs
+++ b/experiments/cathub-frequency-probe/App.xaml.cs
@@ -1,0 +1,19 @@
+using Microsoft.UI.Xaml;
+
+namespace CatHubFrequencyProbe;
+
+public partial class App : Application
+{
+    private Window? _window;
+
+    public App()
+    {
+        InitializeComponent();
+    }
+
+    protected override void OnLaunched(LaunchActivatedEventArgs args)
+    {
+        _window = new MainWindow();
+        _window.Activate();
+    }
+}

--- a/experiments/cathub-frequency-probe/CatHubFrequencyProbe.csproj
+++ b/experiments/cathub-frequency-probe/CatHubFrequencyProbe.csproj
@@ -1,0 +1,52 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
+    <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
+    <RootNamespace>CatHubFrequencyProbe</RootNamespace>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <UseWinUI>true</UseWinUI>
+    <WindowsPackageType>None</WindowsPackageType>
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <UseAppHost>true</UseAppHost>
+    <IsAotCompatible>true</IsAotCompatible>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Google.Protobuf" Version="3.34.1" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.80.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.1.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="..\..\proto\domain\*.proto"
+              ProtoRoot="..\..\proto"
+              GrpcServices="None" />
+    <Protobuf Include="..\..\proto\services\*.proto"
+              ProtoRoot="..\..\proto"
+              GrpcServices="None" />
+    <Protobuf Update="..\..\proto\services\*service.proto"
+              GrpcServices="Client" />
+  </ItemGroup>
+
+  <Target Name="GenerateProtobufBeforeWinUiMarkup"
+          BeforeTargets="MarkupCompilePass1"
+          DependsOnTargets="Protobuf_Compile" />
+
+  <Target Name="CopyWinUiPriToPublishDirectory"
+          AfterTargets="Publish"
+          Condition="'$(PublishDir)' != '' and Exists('$(TargetDir)$(TargetName).pri')">
+    <Copy SourceFiles="$(TargetDir)$(TargetName).pri"
+          DestinationFolder="$(PublishDir)" />
+  </Target>
+
+</Project>

--- a/experiments/cathub-frequency-probe/CatHubRigClient.cs
+++ b/experiments/cathub-frequency-probe/CatHubRigClient.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Net.Sockets;
+using System.Text;
+
+namespace CatHubFrequencyProbe;
+
+internal sealed class CatHubRigClient : IAsyncDisposable
+{
+    private static readonly TimeSpan ConnectTimeout = TimeSpan.FromMilliseconds(750);
+    private static readonly TimeSpan CommandTimeout = TimeSpan.FromMilliseconds(500);
+
+    private readonly string _host;
+    private readonly int _port;
+    private TcpClient? _client;
+    private StreamReader? _reader;
+    private NetworkStream? _stream;
+
+    public CatHubRigClient(string host, int port)
+    {
+        _host = host;
+        _port = port;
+    }
+
+    public async Task<FrequencySnapshot> ReadSnapshotAsync(CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            await EnsureConnectedAsync(cancellationToken).ConfigureAwait(false);
+
+            var frequency = await ReadFrequencyAsync(cancellationToken).ConfigureAwait(false);
+            var (mode, _) = await ReadModeAsync(cancellationToken).ConfigureAwait(false);
+            var vfo = await ReadVfoAsync(cancellationToken).ConfigureAwait(false);
+
+            stopwatch.Stop();
+            return new FrequencySnapshot(
+                frequency,
+                mode,
+                vfo,
+                stopwatch.ElapsedMilliseconds,
+                DateTimeOffset.Now);
+        }
+        catch
+        {
+            await DisconnectAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await DisconnectAsync().ConfigureAwait(false);
+    }
+
+    private async Task EnsureConnectedAsync(CancellationToken cancellationToken)
+    {
+        if (_client?.Connected == true && _stream is not null && _reader is not null)
+        {
+            return;
+        }
+
+        await DisconnectAsync().ConfigureAwait(false);
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(ConnectTimeout);
+
+        _client = new TcpClient();
+        await _client.ConnectAsync(_host, _port, timeout.Token).ConfigureAwait(false);
+        _stream = _client.GetStream();
+        _reader = new StreamReader(_stream, Encoding.ASCII, detectEncodingFromByteOrderMarks: false, bufferSize: 256, leaveOpen: true);
+    }
+
+    private async Task<ulong> ReadFrequencyAsync(CancellationToken cancellationToken)
+    {
+        var line = await CommandLineAsync("f", cancellationToken).ConfigureAwait(false);
+        if (!ulong.TryParse(line, NumberStyles.None, CultureInfo.InvariantCulture, out var frequency))
+        {
+            throw new InvalidDataException($"Invalid frequency reply: '{line}'");
+        }
+
+        return frequency;
+    }
+
+    private async Task<(string Mode, int PassbandHz)> ReadModeAsync(CancellationToken cancellationToken)
+    {
+        await WriteCommandAsync("m", cancellationToken).ConfigureAwait(false);
+        var mode = await ReadLineWithTimeoutAsync(cancellationToken).ConfigureAwait(false);
+        var passbandLine = await ReadLineWithTimeoutAsync(cancellationToken).ConfigureAwait(false);
+        _ = int.TryParse(passbandLine, NumberStyles.Integer, CultureInfo.InvariantCulture, out var passband);
+        return (mode, passband);
+    }
+
+    private async Task<string> ReadVfoAsync(CancellationToken cancellationToken)
+    {
+        return await CommandLineAsync("v", cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<string> CommandLineAsync(string command, CancellationToken cancellationToken)
+    {
+        await WriteCommandAsync(command, cancellationToken).ConfigureAwait(false);
+        return await ReadLineWithTimeoutAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task WriteCommandAsync(string command, CancellationToken cancellationToken)
+    {
+        var stream = _stream ?? throw new InvalidOperationException("Not connected.");
+        var bytes = Encoding.ASCII.GetBytes(command + "\n");
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(CommandTimeout);
+        await stream.WriteAsync(bytes, timeout.Token).ConfigureAwait(false);
+        await stream.FlushAsync(timeout.Token).ConfigureAwait(false);
+    }
+
+    private async Task<string> ReadLineWithTimeoutAsync(CancellationToken cancellationToken)
+    {
+        var reader = _reader ?? throw new InvalidOperationException("Not connected.");
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(CommandTimeout);
+        var line = await reader.ReadLineAsync(timeout.Token).ConfigureAwait(false);
+        return line ?? throw new EndOfStreamException("cathub closed the rigctld connection.");
+    }
+
+    private Task DisconnectAsync()
+    {
+        _reader?.Dispose();
+        _stream?.Dispose();
+        _client?.Dispose();
+        _reader = null;
+        _stream = null;
+        _client = null;
+        return Task.CompletedTask;
+    }
+}

--- a/experiments/cathub-frequency-probe/DiagnosticLog.cs
+++ b/experiments/cathub-frequency-probe/DiagnosticLog.cs
@@ -1,0 +1,36 @@
+using System.Globalization;
+
+namespace CatHubFrequencyProbe;
+
+internal sealed class DiagnosticLog
+{
+    private const int MaxUiLines = 18;
+    private readonly Queue<string> _recentLines = new();
+    private readonly string _path;
+
+    public DiagnosticLog()
+    {
+        var directory = System.IO.Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "qsoripper");
+        Directory.CreateDirectory(directory);
+        _path = System.IO.Path.Combine(directory, "cathub-frequency-probe.log");
+    }
+
+    public string Path => _path;
+
+    public string UiText => string.Join(Environment.NewLine, _recentLines);
+
+    public void Write(string message)
+    {
+        var line = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{DateTimeOffset.Now:HH:mm:ss.fff} {message}");
+        File.AppendAllText(_path, line + Environment.NewLine);
+        _recentLines.Enqueue(line);
+        while (_recentLines.Count > MaxUiLines)
+        {
+            _recentLines.Dequeue();
+        }
+    }
+}

--- a/experiments/cathub-frequency-probe/EngineFrequencySnapshot.cs
+++ b/experiments/cathub-frequency-probe/EngineFrequencySnapshot.cs
@@ -1,0 +1,7 @@
+namespace CatHubFrequencyProbe;
+
+internal sealed record EngineFrequencySnapshot(
+    ulong FrequencyHz,
+    string Mode,
+    long QueryMilliseconds,
+    DateTimeOffset SampledAt);

--- a/experiments/cathub-frequency-probe/EngineRigClient.cs
+++ b/experiments/cathub-frequency-probe/EngineRigClient.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics;
+using Grpc.Net.Client;
+using QsoRipper.Services;
+
+namespace CatHubFrequencyProbe;
+
+internal sealed class EngineRigClient : IDisposable
+{
+    private readonly GrpcChannel _channel;
+    private readonly RigControlService.RigControlServiceClient _client;
+
+    public EngineRigClient(string endpoint)
+    {
+        _channel = GrpcChannel.ForAddress(endpoint);
+        _client = new RigControlService.RigControlServiceClient(_channel);
+    }
+
+    public async Task<EngineFrequencySnapshot> ReadSnapshotAsync(CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var response = await _client.GetRigSnapshotAsync(
+            new GetRigSnapshotRequest(),
+            cancellationToken: cancellationToken);
+        stopwatch.Stop();
+
+        var snapshot = response.Snapshot
+            ?? throw new InvalidDataException("Engine returned no rig snapshot.");
+        if (snapshot.ErrorMessage.Length > 0)
+        {
+            throw new InvalidDataException($"Engine rig snapshot error: {snapshot.ErrorMessage}");
+        }
+
+        return new EngineFrequencySnapshot(
+            snapshot.FrequencyHz,
+            snapshot.RawMode.Length == 0 ? snapshot.Mode.ToString() : snapshot.RawMode,
+            stopwatch.ElapsedMilliseconds,
+            DateTimeOffset.Now);
+    }
+
+    public void Dispose()
+    {
+        _channel.Dispose();
+    }
+}

--- a/experiments/cathub-frequency-probe/FrequencySnapshot.cs
+++ b/experiments/cathub-frequency-probe/FrequencySnapshot.cs
@@ -1,0 +1,8 @@
+namespace CatHubFrequencyProbe;
+
+internal sealed record FrequencySnapshot(
+    ulong FrequencyHz,
+    string Mode,
+    string Vfo,
+    long QueryMilliseconds,
+    DateTimeOffset SampledAt);

--- a/experiments/cathub-frequency-probe/MainWindow.xaml
+++ b/experiments/cathub-frequency-probe/MainWindow.xaml
@@ -1,0 +1,177 @@
+<Window
+    x:Class="CatHubFrequencyProbe.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    Title="CatHub Frequency Probe">
+
+    <Grid Background="#090601">
+        <Grid.Resources>
+            <Style x:Key="TileBorderStyle" TargetType="Border">
+                <Setter Property="Background" Value="#100a02" />
+                <Setter Property="BorderBrush" Value="#6f4700" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="Padding" Value="14" />
+                <Setter Property="CornerRadius" Value="8" />
+            </Style>
+            <Style x:Key="TileLabelStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="#b98519" />
+                <Setter Property="FontFamily" Value="Cascadia Mono,Consolas" />
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="CharacterSpacing" Value="120" />
+            </Style>
+            <Style x:Key="TileValueStyle" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="#ffbf00" />
+                <Setter Property="FontFamily" Value="Cascadia Mono,Consolas" />
+                <Setter Property="FontSize" Value="28" />
+                <Setter Property="FontWeight" Value="Bold" />
+            </Style>
+        </Grid.Resources>
+
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <Border Grid.Row="0" Background="#140d03" BorderBrush="#ff9f1c" BorderThickness="0,0,0,1" Padding="24,18">
+            <Grid>
+                <StackPanel>
+                    <TextBlock Text="CATHUB DIRECT FREQUENCY PROBE"
+                               Foreground="#ffbf00"
+                               FontFamily="Cascadia Mono,Consolas"
+                               FontSize="18"
+                               FontWeight="Bold"
+                               CharacterSpacing="120" />
+                    <TextBlock x:Name="EndpointText"
+                               Foreground="#ffd166"
+                               FontFamily="Cascadia Mono,Consolas"
+                               FontSize="13"
+                               Text="direct 127.0.0.1:4532 · engine http://127.0.0.1:50051 · 100 ms poll" />
+                </StackPanel>
+            </Grid>
+        </Border>
+
+        <Grid Grid.Row="1" Padding="28">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="170" />
+            </Grid.RowDefinitions>
+
+            <Border Grid.Row="0"
+                    CornerRadius="16"
+                    BorderBrush="#ff9f1c"
+                    BorderThickness="2"
+                    Background="#100a02"
+                    Padding="28">
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+
+                    <TextBlock Text="LIVE RADIO FREQUENCY"
+                               Foreground="#b98519"
+                               FontFamily="Cascadia Mono,Consolas"
+                               FontSize="16"
+                               FontWeight="SemiBold"
+                               CharacterSpacing="160" />
+
+                    <Viewbox Grid.Row="1" Stretch="Uniform">
+                        <StackPanel Orientation="Horizontal" Spacing="18">
+                            <TextBlock x:Name="FrequencyText"
+                                       Text="--.------"
+                                       Foreground="#ffbf00"
+                                       FontFamily="Cascadia Mono,Consolas"
+                                       FontWeight="Black"
+                                       FontSize="132"
+                                       CharacterSpacing="50" />
+                            <TextBlock Text="MHz"
+                                       Foreground="#d88900"
+                                       FontFamily="Cascadia Mono,Consolas"
+                                       FontWeight="Bold"
+                                       FontSize="44"
+                                       VerticalAlignment="Bottom"
+                                       Margin="0,0,0,22" />
+                        </StackPanel>
+                    </Viewbox>
+
+                    <Grid Grid.Row="2" ColumnSpacing="18">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                        </Grid.ColumnDefinitions>
+                        <Border Style="{StaticResource TileBorderStyle}">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TileLabelStyle}" Text="VFO" />
+                                <TextBlock x:Name="VfoText" Style="{StaticResource TileValueStyle}" Text="--" />
+                            </StackPanel>
+                        </Border>
+                        <Border Grid.Column="1" Style="{StaticResource TileBorderStyle}">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TileLabelStyle}" Text="MODE" />
+                                <TextBlock x:Name="ModeText" Style="{StaticResource TileValueStyle}" Text="--" />
+                            </StackPanel>
+                        </Border>
+                        <Border Grid.Column="2" Style="{StaticResource TileBorderStyle}">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TileLabelStyle}" Text="QUERY" />
+                                <TextBlock x:Name="QueryText" Style="{StaticResource TileValueStyle}" Text="-- ms" />
+                            </StackPanel>
+                        </Border>
+                        <Border Grid.Column="3" Style="{StaticResource TileBorderStyle}">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TileLabelStyle}" Text="CHANGE GAP" />
+                                <TextBlock x:Name="ChangeGapText" Style="{StaticResource TileValueStyle}" Text="-- ms" />
+                            </StackPanel>
+                        </Border>
+                        <Border Grid.Column="4" Style="{StaticResource TileBorderStyle}">
+                            <StackPanel>
+                                <TextBlock Style="{StaticResource TileLabelStyle}" Text="ENGINE SKEW" />
+                                <TextBlock x:Name="EngineSkewText" Style="{StaticResource TileValueStyle}" Text="--" />
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </Grid>
+            </Border>
+
+            <Border Grid.Row="1"
+                    Margin="0,22,0,0"
+                    Background="#090601"
+                    BorderBrush="#6f4700"
+                    BorderThickness="1"
+                    Padding="14">
+                <Grid RowSpacing="8">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <TextBlock x:Name="LogPathText"
+                               Foreground="#b98519"
+                               FontFamily="Cascadia Mono,Consolas"
+                               FontSize="12" />
+                    <ScrollViewer Grid.Row="1"
+                                  VerticalScrollBarVisibility="Auto"
+                                  HorizontalScrollBarVisibility="Disabled">
+                        <TextBlock x:Name="LogText"
+                                   Foreground="#ffd166"
+                                   FontFamily="Cascadia Mono,Consolas"
+                                   FontSize="12"
+                                   TextWrapping="NoWrap" />
+                    </ScrollViewer>
+                </Grid>
+            </Border>
+        </Grid>
+
+        <Border Grid.Row="2" Background="#140d03" Padding="24,10">
+            <TextBlock x:Name="FooterText"
+                       Foreground="#b98519"
+                       FontFamily="Cascadia Mono,Consolas"
+                       FontSize="12"
+                       Text="Direct cathub rigctld reads only. No QsoRipper engine, GUI, TUI, or Win32 UI code path involved." />
+        </Border>
+    </Grid>
+</Window>

--- a/experiments/cathub-frequency-probe/MainWindow.xaml.cs
+++ b/experiments/cathub-frequency-probe/MainWindow.xaml.cs
@@ -1,0 +1,174 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Net.Sockets;
+using Microsoft.UI.Dispatching;
+using Microsoft.UI.Xaml;
+
+namespace CatHubFrequencyProbe;
+
+public sealed partial class MainWindow : Window
+{
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(100);
+    private readonly CatHubRigClient _client;
+    private readonly EngineRigClient _engineClient;
+    private readonly DiagnosticLog _log = new();
+    private readonly DispatcherQueueTimer _timer;
+    private bool _pollInFlight;
+    private ulong? _lastFrequencyHz;
+    private DateTimeOffset? _lastFrequencyChange;
+    private long _pollCount;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        Title = "CatHub Frequency Probe";
+        ExtendsContentIntoTitleBar = false;
+        _client = new CatHubRigClient("127.0.0.1", 4532);
+        _engineClient = new EngineRigClient("http://127.0.0.1:50051");
+        _timer = DispatcherQueue.CreateTimer();
+        _timer.Interval = PollInterval;
+        _timer.Tick += OnTimerTick;
+
+        LogPathText.Text = $"log: {_log.Path}";
+        WriteLog("probe starting; target=127.0.0.1:4532 poll=100ms commands=f,m,v");
+        Closed += OnClosed;
+        _timer.Start();
+    }
+
+    private async void OnTimerTick(DispatcherQueueTimer sender, object args)
+    {
+        if (_pollInFlight)
+        {
+            WriteLog("poll skipped; previous poll still in flight");
+            return;
+        }
+
+        _pollInFlight = true;
+        try
+        {
+            using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(1));
+            var directSnapshot = await _client.ReadSnapshotAsync(timeout.Token);
+            EngineFrequencySnapshot? engineSnapshot = null;
+            string? engineError = null;
+            try
+            {
+                engineSnapshot = await _engineClient.ReadSnapshotAsync(timeout.Token);
+            }
+            catch (Exception ex) when (ex is IOException or InvalidDataException or Grpc.Core.RpcException or OperationCanceledException)
+            {
+                engineError = $"{ex.GetType().Name}: {ex.Message}";
+            }
+
+            UpdateSnapshot(directSnapshot, engineSnapshot, engineError);
+        }
+        catch (Exception ex) when (ex is IOException or SocketException or InvalidOperationException or TimeoutException or OperationCanceledException)
+        {
+            FooterText.Text = "LINK DOWN - direct cathub rigctld read failed";
+            WriteLog($"poll error: {ex.GetType().Name}: {ex.Message}");
+        }
+        finally
+        {
+            _pollInFlight = false;
+        }
+    }
+
+    private void UpdateSnapshot(
+        FrequencySnapshot snapshot,
+        EngineFrequencySnapshot? engineSnapshot,
+        string? engineError)
+    {
+        _pollCount++;
+        var changed = _lastFrequencyHz != snapshot.FrequencyHz;
+        long? changeGap = null;
+
+        if (changed)
+        {
+            if (_lastFrequencyChange is { } previous)
+            {
+                changeGap = (long)(snapshot.SampledAt - previous).TotalMilliseconds;
+            }
+
+            _lastFrequencyHz = snapshot.FrequencyHz;
+            _lastFrequencyChange = snapshot.SampledAt;
+            WriteLog(string.Create(
+                CultureInfo.InvariantCulture,
+                $"change #{_pollCount}: direct={snapshot.FrequencyHz} Hz {FormatFrequency(snapshot.FrequencyHz)} MHz engine={EngineFrequencyForLog(engineSnapshot)} skew={FormatEngineSkew(snapshot, engineSnapshot)} vfo={snapshot.Vfo} mode={snapshot.Mode} direct_query={snapshot.QueryMilliseconds}ms engine_query={engineSnapshot?.QueryMilliseconds.ToString(CultureInfo.InvariantCulture) ?? "--"}ms gap={(changeGap?.ToString(CultureInfo.InvariantCulture) ?? "--")}ms"));
+        }
+        else if (_pollCount % 25 == 0)
+        {
+            WriteLog(string.Create(
+                CultureInfo.InvariantCulture,
+                $"poll #{_pollCount}: unchanged direct={snapshot.FrequencyHz} Hz engine={EngineFrequencyForLog(engineSnapshot)} skew={FormatEngineSkew(snapshot, engineSnapshot)} direct_query={snapshot.QueryMilliseconds}ms engine_query={engineSnapshot?.QueryMilliseconds.ToString(CultureInfo.InvariantCulture) ?? "--"}ms"));
+        }
+
+        if (engineError is not null && _pollCount % 10 == 1)
+        {
+            WriteLog($"engine poll error: {engineError}");
+        }
+
+        FrequencyText.Text = FormatFrequency(snapshot.FrequencyHz);
+        VfoText.Text = snapshot.Vfo;
+        ModeText.Text = snapshot.Mode;
+        QueryText.Text = string.Create(CultureInfo.InvariantCulture, $"{snapshot.QueryMilliseconds} ms");
+        ChangeGapText.Text = changeGap.HasValue
+            ? string.Create(CultureInfo.InvariantCulture, $"{changeGap.Value} ms")
+            : "-- ms";
+        EngineSkewText.Text = engineError is not null
+            ? "ERR"
+            : FormatEngineSkew(snapshot, engineSnapshot);
+        FooterText.Text = string.Create(
+            CultureInfo.InvariantCulture,
+            $"polls={_pollCount}  last={snapshot.SampledAt:HH:mm:ss.fff}  direct={FormatFrequency(snapshot.FrequencyHz)} MHz  engine={EngineFrequencyForFooter(engineSnapshot)}  skew={FormatEngineSkew(snapshot, engineSnapshot)}");
+    }
+
+    private void WriteLog(string message)
+    {
+        _log.Write(message);
+        LogText.Text = _log.UiText;
+        Debug.WriteLine(message);
+    }
+
+    private async void OnClosed(object sender, WindowEventArgs args)
+    {
+        _timer.Stop();
+        await _client.DisposeAsync();
+        _engineClient.Dispose();
+    }
+
+    private static string FormatFrequency(ulong frequencyHz)
+    {
+        var mhz = frequencyHz / 1_000_000;
+        var khz = frequencyHz % 1_000_000 / 1_000;
+        var tenHz = frequencyHz % 1_000 / 10;
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{mhz}.{khz:000}.{tenHz:00}");
+    }
+
+    private static string FormatEngineSkew(FrequencySnapshot direct, EngineFrequencySnapshot? engine)
+    {
+        if (engine is null)
+        {
+            return "--";
+        }
+
+        var skew = (long)engine.FrequencyHz - (long)direct.FrequencyHz;
+        return string.Create(CultureInfo.InvariantCulture, $"{skew:+#;-#;0} Hz");
+    }
+
+    private static string EngineFrequencyForLog(EngineFrequencySnapshot? engine)
+    {
+        return engine is null
+            ? "--"
+            : string.Create(CultureInfo.InvariantCulture, $"{engine.FrequencyHz} Hz {FormatFrequency(engine.FrequencyHz)} MHz");
+    }
+
+    private static string EngineFrequencyForFooter(EngineFrequencySnapshot? engine)
+    {
+        return engine is null
+            ? "--"
+            : string.Create(CultureInfo.InvariantCulture, $"{FormatFrequency(engine.FrequencyHz)} MHz/{engine.QueryMilliseconds}ms");
+    }
+}

--- a/experiments/cathub-frequency-probe/README.md
+++ b/experiments/cathub-frequency-probe/README.md
@@ -1,0 +1,38 @@
+# CatHub Frequency Probe
+
+Single-purpose WinUI 3 diagnostic app for CAT latency testing.
+
+The app bypasses the normal QsoRipper UI update paths. It opens one persistent TCP connection to cathub's rigctld-compatible endpoint at `127.0.0.1:4532`, polls `f`, `m`, and `v` every 100 ms, and also polls the engine's gRPC `GetRigSnapshot` endpoint at `http://127.0.0.1:50051`.
+
+It displays the live direct cathub frequency, VFO, mode, query time, detected frequency-change gap, and engine skew. Engine skew is `engine_frequency_hz - direct_cathub_frequency_hz`.
+
+Run from the repository root:
+
+```powershell
+dotnet run --project experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj
+```
+
+Publish the Native AOT executable from the repository root:
+
+```powershell
+dotnet publish experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj -c Release -p:PublishAot=true -o artifacts\publish\cathub-frequency-probe-aot\Release
+```
+
+Native AOT executable:
+
+```text
+artifacts\publish\cathub-frequency-probe-aot\Release\CatHubFrequencyProbe.exe
+```
+
+Diagnostic log:
+
+```text
+%LOCALAPPDATA%\qsoripper\cathub-frequency-probe.log
+```
+
+Interpretation:
+
+- If direct cathub updates immediately and engine skew stays `0 Hz`, the slow behavior is in the individual UI poll/render/update path.
+- If direct cathub updates immediately but engine skew diverges while tuning, the slow behavior is in the engine rig snapshot/cache/provider path.
+- If direct cathub also lags, the problem is cathub state freshness or the radio/CAT path feeding cathub.
+- Direct query time measures only cathub TCP response time, not the age of cathub's cached radio state.

--- a/experiments/cathub-frequency-probe/app.manifest
+++ b/experiments/cathub-frequency-probe/app.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="CatHubFrequencyProbe.app" />
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+    </application>
+  </compatibility>
+</assembly>


### PR DESCRIPTION
This replaces the diagnostic-tooling portion of #499 with a focused opt-in PR.

The review on #499 concluded that the engine freshness override and broader UI/runtime behavior should not merge as-is now that the 5 second delay was traced to configuration. PR #501 already keeps the focused TUI field-ownership behavior. This PR keeps only the CatHub frequency diagnostic probes so they can be reviewed independently.

The managed WinUI probe polls CatHub directly and compares that value with engine GetRigSnapshot so ENGINE SKEW is visible while tuning. It also keeps the explicit Native AOT publish path and the publish-time PRI copy needed for the unpackaged WinUI app to launch from publish output.

The native Win32 probe provides a fast-launch C++ diagnostic with direct CatHub polling and optional engine skew through qsoripper_ffi.dll. The native build is opt-in through .\build.ps1 cathub-probe-native and is intentionally not part of the default .\build.ps1 flow.

Validation: dotnet build experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj -c Release --no-incremental; dotnet publish experiments\cathub-frequency-probe\CatHubFrequencyProbe.csproj -c Release -p:PublishAot=true -o artifacts\publish\cathub-frequency-probe-aot\Release; .\build.ps1 cathub-probe-native -Configuration Release.