### PR TITLE
Implement WSJT-X QSO ingestion

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -289,6 +289,8 @@ Imports QSO records from a client-streamed ADIF payload.
 
 **Duplicate handling:** The engine should detect duplicates by matching on station callsign + worked callsign + band + mode + compatible submode/frequency + compatible UTC timestamp and skip them rather than creating duplicate entries. Timestamp matching must handle minute-precision ADIF sources (for example N1MM contest exports) by matching an existing second-precision QSO in the same displayed minute when either side is minute-precision. Small frequency drift between ADIF sources and QRZ-enriched rows should not create a duplicate when the contact identity otherwise matches.
 
+WSJT-X ingestion, manual ADIF imports, and any future ADIF-based recovery inputs MUST use this same import path so duplicate behavior, active station-profile fallback, refresh semantics, and storage state remain consistent across sources.
+
 **Error semantics:**
 - `INVALID_ARGUMENT` — ADIF content is malformed or unparseable.
 - `INTERNAL` — storage write failure.
@@ -567,7 +569,7 @@ arrays); a standalone file with top-level `[radio]` … tables is still accepted
 
 Because multiple components write the same file, every engine setup save is **merge-preserving**:
 the engine replaces only its own top-level tables (`logbook`, `storage`, `station_profile`,
-`station_profiles`, `qrz_xml`, `qrz_logbook`, `sync`, `rig_control`) and preserves all other
+`station_profiles`, `qrz_xml`, `qrz_logbook`, `sync`, `rig_control`, `wsjtx_ingest`) and preserves all other
 tables (`[cat_hub]`, `[launcher]`, and any future component sections). A conformant engine in
 any language must implement this merge-preserving behavior rather than rewriting the whole
 file, so it never clobbers another component's configuration.
@@ -643,6 +645,7 @@ Returns whether initial setup has been completed.
 **Behavior:**
 - Check if a valid configuration and station profile exist.
 - Return a `SetupStatus` indicating `complete` or `incomplete` with details about what is missing.
+- Include current `wsjtx_ingest` settings when configured and live `wsjtx_ingest_status` diagnostics when the engine implements the WSJT-X supervisor.
 
 #### SaveSetup
 
@@ -670,8 +673,41 @@ Persists setup configuration and station profile.
   transports distinct; hamlib_net binds distinct and in `host:port` form; a face transport may
   not reuse the radio port. Violations return `INVALID_ARGUMENT`.
 
+**WSJT-X ingest (`wsjtx_ingest`) management:**
+- The optional `wsjtx_ingest` field (`WsjtxIngestSettings`) lets setup clients manage the
+  engine-owned `[wsjtx_ingest]` section.
+- Omit `wsjtx_ingest` to leave existing WSJT-X ingest settings unchanged. When present, the
+  engine persists a replacement `[wsjtx_ingest]` table with `enabled`, `udp_enabled`,
+  `udp_bind`, `adif_tail_enabled`, `adif_tail_path`, `poll_interval_ms`, and `sync_to_qrz`.
+- Defaults are conservative: ingestion disabled; UDP bind `127.0.0.1:2237`; UDP enabled when
+  ingestion is enabled and the field is omitted; ADIF tail disabled unless a path is supplied;
+  poll interval defaults to a modest nonzero value; immediate QRZ sync disabled.
+- Validation requires `udp_bind` to be `host:port` with port 1-65535, `poll_interval_ms` to
+  be nonzero when supplied, and `adif_tail_path` to be present when ADIF tailing is enabled.
+  Violations return `INVALID_ARGUMENT`.
+
+**WSJT-X ingest runtime behavior:**
+- When enabled, the Rust engine starts a background supervisor with independent UDP and ADIF-tail
+  inputs. The supervisor MUST NOT block normal logging or engine startup after configuration has
+  been accepted.
+- UDP input listens for WSJT-X Logged ADIF datagrams and ignores non-logged WSJT-X messages. Raw
+  ADIF and lightweight JSON-wrapped ADIF may be accepted by test/simulation helpers, but runtime
+  framed WSJT-X packets must only import logged-QSO ADIF payloads.
+- ADIF-tail input polls `wsjtx_log.adi`, scans from byte 0 on first run for startup recovery, and
+  then imports only appended complete ADIF records while the engine is running. It must not advance
+  its cursor past an incomplete trailing record or a failed import.
+- Both inputs feed `LogbookEngine::import_adif_qsos`. Duplicate UDP events, repeated ADIF scans,
+  and later manual imports must not create duplicate QSOs.
+- `WsjtxIngestStatus` reports enabled/running state, UDP/tail health, last event time, last
+  imported callsign/local id, imported/updated/skipped/duplicate counters, parse errors, last
+  ingestion error, and last QRZ sync result.
+- When `sync_to_qrz=true`, imported or refreshed WSJT-X QSOs use the same per-operation QRZ upload
+  semantics as `LogQso(sync_to_qrz=true)`: success writes QRZ metadata back locally, while failure
+  leaves the local QSO persisted and retryable and records an actionable diagnostic. QRZ upload
+  work must not block the local UDP/tail ingestion loops.
+
 **Error semantics:**
-- `INVALID_ARGUMENT` — invalid or missing required setup fields, or an invalid `cat_hub` section.
+- `INVALID_ARGUMENT` — invalid or missing required setup fields, an invalid `cat_hub` section, or invalid `wsjtx_ingest` settings.
 - `INTERNAL` — failed to persist configuration.
 
 #### GetSetupWizardState

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -684,16 +684,17 @@ Persists setup configuration and station profile.
 - Defaults are conservative: ingestion disabled; UDP bind `127.0.0.1:2237`; UDP enabled when
   ingestion is enabled and the field is omitted; ADIF tail disabled unless a path is supplied;
   poll interval defaults to a modest nonzero value; immediate QRZ sync disabled.
-- Validation requires `udp_bind` to be `host:port` with port 1-65535, `poll_interval_ms` to
-  be nonzero when supplied, and `adif_tail_path` to be present when ADIF tailing is enabled.
-  Violations return `INVALID_ARGUMENT`.
+- Validation requires `udp_bind` to be `host:port` with port 1-65535 and `adif_tail_path` to
+  be present when ADIF tailing is enabled. `poll_interval_ms=0` means use the engine default;
+  positive values are accepted as supplied. Violations return `INVALID_ARGUMENT`.
 - WSJT-X ingest is a first-class setup surface, not a TOML-only escape hatch. GUI setup wizard,
   GUI Settings, CLI `setup --status`, CLI `setup --from-env`, and the interactive CLI setup
   wizard must all project the same `WsjtxIngestSettings` fields. `setup --from-env` recognizes
-  `QSORIPPER_WSJTX_INGEST_ENABLED`, `QSORIPPER_WSJTX_UDP_ENABLED`,
-  `QSORIPPER_WSJTX_UDP_BIND`, `QSORIPPER_WSJTX_ADIF_TAIL_ENABLED`,
-  `QSORIPPER_WSJTX_ADIF_TAIL_PATH`, `QSORIPPER_WSJTX_POLL_INTERVAL_MS`, and
-  `QSORIPPER_WSJTX_SYNC_TO_QRZ`.
+  `QSORIPPER_WSJTX_INGEST_ENABLED`, `QSORIPPER_WSJTX_INGEST_UDP_ENABLED`,
+  `QSORIPPER_WSJTX_INGEST_UDP_BIND`, `QSORIPPER_WSJTX_INGEST_ADIF_TAIL_ENABLED`,
+  `QSORIPPER_WSJTX_INGEST_ADIF_TAIL_PATH`, `QSORIPPER_WSJTX_INGEST_POLL_INTERVAL_MS`, and
+  `QSORIPPER_WSJTX_INGEST_SYNC_TO_QRZ`. CLI setup may also accept shorter non-runtime aliases
+  for compatibility, but documentation and examples should prefer the canonical runtime names.
 
 **WSJT-X ingest runtime behavior:**
 - When enabled, the Rust engine starts a background supervisor with independent UDP and ADIF-tail

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -687,6 +687,13 @@ Persists setup configuration and station profile.
 - Validation requires `udp_bind` to be `host:port` with port 1-65535, `poll_interval_ms` to
   be nonzero when supplied, and `adif_tail_path` to be present when ADIF tailing is enabled.
   Violations return `INVALID_ARGUMENT`.
+- WSJT-X ingest is a first-class setup surface, not a TOML-only escape hatch. GUI setup wizard,
+  GUI Settings, CLI `setup --status`, CLI `setup --from-env`, and the interactive CLI setup
+  wizard must all project the same `WsjtxIngestSettings` fields. `setup --from-env` recognizes
+  `QSORIPPER_WSJTX_INGEST_ENABLED`, `QSORIPPER_WSJTX_UDP_ENABLED`,
+  `QSORIPPER_WSJTX_UDP_BIND`, `QSORIPPER_WSJTX_ADIF_TAIL_ENABLED`,
+  `QSORIPPER_WSJTX_ADIF_TAIL_PATH`, `QSORIPPER_WSJTX_POLL_INTERVAL_MS`, and
+  `QSORIPPER_WSJTX_SYNC_TO_QRZ`.
 
 **WSJT-X ingest runtime behavior:**
 - When enabled, the Rust engine starts a background supervisor with independent UDP and ADIF-tail

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -569,10 +569,12 @@ arrays); a standalone file with top-level `[radio]` … tables is still accepted
 
 Because multiple components write the same file, every engine setup save is **merge-preserving**:
 the engine replaces only its own top-level tables (`logbook`, `storage`, `station_profile`,
-`station_profiles`, `qrz_xml`, `qrz_logbook`, `sync`, `rig_control`, `wsjtx_ingest`) and preserves all other
-tables (`[cat_hub]`, `[launcher]`, and any future component sections). A conformant engine in
-any language must implement this merge-preserving behavior rather than rewriting the whole
-file, so it never clobbers another component's configuration.
+`station_profiles`, `qrz_xml`, `qrz_logbook`, `sync`, `rig_control`) and preserves all other
+tables (`[cat_hub]`, `[launcher]`, and any future component sections). The conditional
+`[wsjtx_ingest]` setup table is replaced only when `SaveSetup.wsjtx_ingest` is explicitly
+supplied; omitted WSJT-X ingest settings are preserved verbatim. A conformant engine in any
+language must implement this merge-preserving behavior rather than rewriting the whole file,
+so it never clobbers another component's configuration.
 
 `[cat_hub]` is **conditionally engine-owned**: it is preserved verbatim on every save *unless*
 the `SaveSetup` request explicitly carries a `cat_hub` (`CatHubSettings`) message, in which case
@@ -694,8 +696,12 @@ Persists setup configuration and station profile.
   ADIF and lightweight JSON-wrapped ADIF may be accepted by test/simulation helpers, but runtime
   framed WSJT-X packets must only import logged-QSO ADIF payloads.
 - ADIF-tail input polls `wsjtx_log.adi`, scans from byte 0 on first run for startup recovery, and
-  then imports only appended complete ADIF records while the engine is running. It must not advance
-  its cursor past an incomplete trailing record or a failed import.
+  then imports only appended complete ADIF records while the engine is running. Complete-record
+  detection must honor ADIF field lengths as character counts so literal `<EOR>` text inside a
+  field value cannot move the cursor. It must not advance its cursor past an incomplete trailing
+  record or a failed import. Startup replay is recovery-only: it imports missing QSOs and skips
+  existing duplicates, including soft-deleted or locally edited rows that retain the original import
+  fingerprint, rather than refreshing older ADIF rows over newer local edits.
 - Both inputs feed `LogbookEngine::import_adif_qsos`. Duplicate UDP events, repeated ADIF scans,
   and later manual imports must not create duplicate QSOs.
 - `WsjtxIngestStatus` reports enabled/running state, UDP/tail health, last event time, last
@@ -703,8 +709,10 @@ Persists setup configuration and station profile.
   ingestion error, and last QRZ sync result.
 - When `sync_to_qrz=true`, imported or refreshed WSJT-X QSOs use the same per-operation QRZ upload
   semantics as `LogQso(sync_to_qrz=true)`: success writes QRZ metadata back locally, while failure
-  leaves the local QSO persisted and retryable and records an actionable diagnostic. QRZ upload
-  work must not block the local UDP/tail ingestion loops.
+  leaves the local QSO persisted and retryable and records an actionable diagnostic. The async
+  writeback must patch only QRZ metadata and sync state onto the current local row so a stale upload
+  task cannot overwrite newer operator edits. QRZ upload work must not block the local UDP/tail
+  ingestion loops.
 
 **Error semantics:**
 - `INVALID_ARGUMENT` — invalid or missing required setup fields, an invalid `cat_hub` section, or invalid `wsjtx_ingest` settings.

--- a/proto/services/save_setup_request.proto
+++ b/proto/services/save_setup_request.proto
@@ -10,6 +10,7 @@ import "services/cat_hub_settings.proto";
 import "services/rig_control_settings.proto";
 import "services/setup_field_value.proto";
 import "services/storage_backend.proto";
+import "services/wsjtx_ingest_settings.proto";
 
 message SaveSetupRequest {
   // Deprecated: legacy storage backend selector. Use log_file_path instead.
@@ -30,4 +31,6 @@ message SaveSetupRequest {
   repeated SetupFieldValue persistence_values = 10;
   // CAT hub (`[cat_hub]`) configuration. Omit to leave unchanged.
   optional CatHubSettings cat_hub = 11;
+  // WSJT-X ingestion (`[wsjtx_ingest]`) configuration. Omit to leave unchanged.
+  optional WsjtxIngestSettings wsjtx_ingest = 12;
 }

--- a/proto/services/setup_status.proto
+++ b/proto/services/setup_status.proto
@@ -11,6 +11,8 @@ import "services/rig_control_settings.proto";
 import "services/runtime_config_definition.proto";
 import "services/runtime_config_value.proto";
 import "services/storage_backend.proto";
+import "services/wsjtx_ingest_settings.proto";
+import "services/wsjtx_ingest_status.proto";
 
 message SetupStatus {
   bool config_file_exists = 1;
@@ -54,4 +56,8 @@ message SetupStatus {
   bool persistence_contract_explicit = 25;
   // Current persisted CAT hub (`[cat_hub]`) configuration, if set.
   optional CatHubSettings cat_hub = 26;
+  // Current persisted WSJT-X ingestion configuration, if set.
+  optional WsjtxIngestSettings wsjtx_ingest = 27;
+  // Live WSJT-X ingestion diagnostics.
+  optional WsjtxIngestStatus wsjtx_ingest_status = 28;
 }

--- a/proto/services/wsjtx_ingest_settings.proto
+++ b/proto/services/wsjtx_ingest_settings.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+// Engine-owned WSJT-X ingestion configuration. Omit this message from
+// SaveSetupRequest to leave the existing [wsjtx_ingest] config untouched.
+message WsjtxIngestSettings {
+  // Enables the WSJT-X ingestion subsystem.
+  bool enabled = 1;
+  // Enables the real-time UDP Logged ADIF listener.
+  optional bool udp_enabled = 2;
+  // UDP bind address in host:port form, for example "127.0.0.1:2237".
+  string udp_bind = 3;
+  // Enables recovery by tailing WSJT-X's wsjtx_log.adi file.
+  bool adif_tail_enabled = 4;
+  // Path to WSJT-X's wsjtx_log.adi file.
+  optional string adif_tail_path = 5;
+  // ADIF tail polling interval in milliseconds.
+  uint32 poll_interval_ms = 6;
+  // Immediately sync imported WSJT-X QSOs to QRZ Logbook.
+  bool sync_to_qrz = 7;
+}

--- a/proto/services/wsjtx_ingest_status.proto
+++ b/proto/services/wsjtx_ingest_status.proto
@@ -1,0 +1,45 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "google/protobuf/timestamp.proto";
+
+// Live diagnostics for the engine-owned WSJT-X ingestion subsystem.
+message WsjtxIngestStatus {
+  // True when ingestion is enabled in configuration.
+  bool enabled = 1;
+  // True when at least one ingestion worker is currently running.
+  bool running = 2;
+  // True when the UDP listener is configured and running.
+  bool udp_running = 3;
+  // UDP bind address currently in use or last attempted.
+  string udp_bind = 4;
+  // True when ADIF tail recovery is configured and running.
+  bool adif_tail_running = 5;
+  // ADIF tail path currently in use or last attempted.
+  optional string adif_tail_path = 6;
+  // Last time any WSJT-X event was processed.
+  optional google.protobuf.Timestamp last_event_at = 7;
+  // Last imported or updated worked callsign.
+  optional string last_imported_callsign = 8;
+  // Last imported or updated local QSO id.
+  optional string last_imported_local_id = 9;
+  // Number of inserted records.
+  uint32 records_imported = 10;
+  // Number of refreshed records.
+  uint32 records_updated = 11;
+  // Number of skipped records, including duplicates and ignored datagrams.
+  uint32 records_skipped = 12;
+  // Number of duplicate records skipped by the import path.
+  uint32 duplicates_skipped = 13;
+  // Number of datagrams or appended chunks that failed parsing.
+  uint32 parse_errors = 14;
+  // Most recent ingestion error, if any.
+  optional string last_error = 15;
+  // True when the last requested per-import QRZ sync succeeded.
+  bool last_qrz_sync_success = 16;
+  // Most recent per-import QRZ sync error, if any.
+  optional string last_qrz_sync_error = 17;
+}

--- a/scripts/automation/avalonia-setup-wizard-smoke.json
+++ b/scripts/automation/avalonia-setup-wizard-smoke.json
@@ -83,6 +83,14 @@
       "milliseconds": 200
     },
     {
+      "type": "click",
+      "automationId": "WizardSkipButton"
+    },
+    {
+      "type": "wait",
+      "milliseconds": 200
+    },
+    {
       "type": "screenshot",
       "path": "wizard-review.png"
     },

--- a/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CommandHelperTests.cs
@@ -5,6 +5,7 @@ using QsoRipper.Services;
 namespace QsoRipper.Cli.Tests;
 
 #pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+[Collection("ConsoleCapture")]
 public sealed class CommandHelperTests
 {
     [Fact]

--- a/src/dotnet/QsoRipper.Cli.Tests/SetupWizardTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/SetupWizardTests.cs
@@ -1,5 +1,6 @@
 using QsoRipper.Cli.Commands;
 using QsoRipper.EngineSelection;
+using QsoRipper.Services;
 
 namespace QsoRipper.Cli.Tests;
 
@@ -120,6 +121,83 @@ public class SetupWizardTests
 
         Assert.False(args.SetupStatus);
         Assert.True(args.SetupFromEnv);
+    }
+
+    [Fact]
+    public void WsjtxIngestFromEnvironmentReadsCanonicalRuntimeVariables()
+    {
+        var snapshot = new Dictionary<string, string?>
+        {
+            ["QSORIPPER_WSJTX_INGEST_ENABLED"] = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_ENABLED"),
+            ["QSORIPPER_WSJTX_INGEST_UDP_ENABLED"] = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_UDP_ENABLED"),
+            ["QSORIPPER_WSJTX_INGEST_UDP_BIND"] = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_UDP_BIND"),
+            ["QSORIPPER_WSJTX_INGEST_ADIF_TAIL_ENABLED"] = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_ADIF_TAIL_ENABLED"),
+            ["QSORIPPER_WSJTX_INGEST_ADIF_TAIL_PATH"] = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_ADIF_TAIL_PATH"),
+            ["QSORIPPER_WSJTX_INGEST_POLL_INTERVAL_MS"] = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_POLL_INTERVAL_MS"),
+            ["QSORIPPER_WSJTX_INGEST_SYNC_TO_QRZ"] = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_SYNC_TO_QRZ"),
+        };
+
+        try
+        {
+            Environment.SetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_ENABLED", "true");
+            Environment.SetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_UDP_ENABLED", "true");
+            Environment.SetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_UDP_BIND", "0.0.0.0:2237");
+            Environment.SetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_ADIF_TAIL_ENABLED", "true");
+            Environment.SetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_ADIF_TAIL_PATH", @"C:\logs\wsjtx_log.adi");
+            Environment.SetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_POLL_INTERVAL_MS", "0");
+            Environment.SetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_SYNC_TO_QRZ", "true");
+
+            var success = SetupCommand.TryBuildWsjtxIngestSettingsFromEnvironment(
+                existing: null,
+                out var settings,
+                out var error);
+
+            Assert.True(success, error);
+            Assert.NotNull(settings);
+            Assert.True(settings.Enabled);
+            Assert.True(settings.UdpEnabled);
+            Assert.Equal("0.0.0.0:2237", settings.UdpBind);
+            Assert.True(settings.AdifTailEnabled);
+            Assert.Equal(@"C:\logs\wsjtx_log.adi", settings.AdifTailPath);
+            Assert.Equal(0u, settings.PollIntervalMs);
+            Assert.True(settings.SyncToQrz);
+        }
+        finally
+        {
+            foreach (var (key, value) in snapshot)
+            {
+                Environment.SetEnvironmentVariable(key, value);
+            }
+        }
+    }
+
+    [Fact]
+    public void WsjtxIngestFromEnvironmentRejectsInvalidUdpBindPort()
+    {
+        var originalEnabled = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_ENABLED");
+        var originalBind = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_UDP_BIND");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_ENABLED", "true");
+            Environment.SetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_UDP_BIND", "127.0.0.1:notaport");
+
+            var success = SetupCommand.TryBuildWsjtxIngestSettingsFromEnvironment(
+                existing: null,
+                out var settings,
+                out var error);
+
+            Assert.False(success);
+            Assert.Null(settings);
+            Assert.Equal(
+                "Error: WSJT-X UDP bind must be host:port with a port between 1 and 65535.",
+                error);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_ENABLED", originalEnabled);
+            Environment.SetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_UDP_BIND", originalBind);
+        }
     }
 }
 #pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli.Tests/SetupWizardTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/SetupWizardTests.cs
@@ -4,6 +4,7 @@ using QsoRipper.EngineSelection;
 namespace QsoRipper.Cli.Tests;
 
 #pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+[Collection("ConsoleCapture")]
 public class SetupWizardTests
 {
     [Fact]

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -229,6 +229,10 @@ internal static class CliHelpText
                   QSORIPPER_GRID                  Grid square
                   QSORIPPER_QRZ_XML_USERNAME      QRZ XML username (optional)
                   QSORIPPER_QRZ_XML_PASSWORD      QRZ XML password (optional)
+                  QSORIPPER_WSJTX_INGEST_ENABLED  Enable WSJT-X QSO ingestion (optional)
+                  QSORIPPER_WSJTX_INGEST_UDP_BIND WSJT-X UDP bind, e.g. 127.0.0.1:2237
+                  QSORIPPER_WSJTX_INGEST_ADIF_TAIL_PATH
+                                                   WSJT-X ADIF log path for tail recovery
 
                 Examples:
                   setup                           Start the interactive wizard

--- a/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
@@ -90,13 +90,25 @@ internal static class SetupCommand
         var rigPortEnv = Environment.GetEnvironmentVariable("QSORIPPER_RIGCTLD_PORT");
         var rigReadTimeoutEnv = Environment.GetEnvironmentVariable("QSORIPPER_RIGCTLD_READ_TIMEOUT_MS");
         var rigStaleThresholdEnv = Environment.GetEnvironmentVariable("QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS");
-        var wsjtxEnabledEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_ENABLED");
-        var wsjtxUdpEnabledEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_UDP_ENABLED");
-        var wsjtxUdpBindEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_UDP_BIND");
-        var wsjtxAdifTailEnabledEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_ADIF_TAIL_ENABLED");
-        var wsjtxAdifTailPathEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_ADIF_TAIL_PATH");
-        var wsjtxPollIntervalEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_POLL_INTERVAL_MS");
-        var wsjtxSyncToQrzEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_SYNC_TO_QRZ");
+        var wsjtxEnabledEnv = WsjtxIngestSetup.ReadEnvironmentValue(WsjtxIngestSetup.EnabledEnvironmentVariable);
+        var wsjtxUdpEnabledEnv = WsjtxIngestSetup.ReadEnvironmentValue(
+            WsjtxIngestSetup.UdpEnabledEnvironmentVariable,
+            "QSORIPPER_WSJTX_UDP_ENABLED");
+        var wsjtxUdpBindEnv = WsjtxIngestSetup.ReadEnvironmentValue(
+            WsjtxIngestSetup.UdpBindEnvironmentVariable,
+            "QSORIPPER_WSJTX_UDP_BIND");
+        var wsjtxAdifTailEnabledEnv = WsjtxIngestSetup.ReadEnvironmentValue(
+            WsjtxIngestSetup.AdifTailEnabledEnvironmentVariable,
+            "QSORIPPER_WSJTX_ADIF_TAIL_ENABLED");
+        var wsjtxAdifTailPathEnv = WsjtxIngestSetup.ReadEnvironmentValue(
+            WsjtxIngestSetup.AdifTailPathEnvironmentVariable,
+            "QSORIPPER_WSJTX_ADIF_TAIL_PATH");
+        var wsjtxPollIntervalEnv = WsjtxIngestSetup.ReadEnvironmentValue(
+            WsjtxIngestSetup.PollIntervalMsEnvironmentVariable,
+            "QSORIPPER_WSJTX_POLL_INTERVAL_MS");
+        var wsjtxSyncToQrzEnv = WsjtxIngestSetup.ReadEnvironmentValue(
+            WsjtxIngestSetup.SyncToQrzEnvironmentVariable,
+            "QSORIPPER_WSJTX_SYNC_TO_QRZ");
 
         if (!TryParseOptionalBooleanEnv(
                 rigEnabledEnv,
@@ -597,9 +609,9 @@ internal static class SetupCommand
                 var syncToQrz = PromptYesNo("Upload imported WSJT-X QSOs to QRZ?", defaultYes: existingWsjtx?.SyncToQrz ?? false);
 
                 if (!uint.TryParse(pollIntervalInput, System.Globalization.CultureInfo.InvariantCulture, out var pollIntervalMs)
-                    || pollIntervalMs is < 100 or > 86_400_000)
+                    || !WsjtxIngestSetup.IsValidPollInterval(pollIntervalMs))
                 {
-                    Console.WriteLine("  Poll interval must be between 100 and 86400000 milliseconds.");
+                    Console.WriteLine("  Poll interval must be 0 for the engine default or a positive whole number.");
                     continue;
                 }
 
@@ -802,6 +814,36 @@ internal static class SetupCommand
         return settings;
     }
 
+    internal static bool TryBuildWsjtxIngestSettingsFromEnvironment(
+        WsjtxIngestSettings? existing,
+        out WsjtxIngestSettings? settings,
+        out string? error)
+    {
+        return TryBuildWsjtxIngestSettingsFromEnv(
+            existing,
+            WsjtxIngestSetup.ReadEnvironmentValue(WsjtxIngestSetup.EnabledEnvironmentVariable),
+            WsjtxIngestSetup.ReadEnvironmentValue(
+                WsjtxIngestSetup.UdpEnabledEnvironmentVariable,
+                "QSORIPPER_WSJTX_UDP_ENABLED"),
+            WsjtxIngestSetup.ReadEnvironmentValue(
+                WsjtxIngestSetup.UdpBindEnvironmentVariable,
+                "QSORIPPER_WSJTX_UDP_BIND"),
+            WsjtxIngestSetup.ReadEnvironmentValue(
+                WsjtxIngestSetup.AdifTailEnabledEnvironmentVariable,
+                "QSORIPPER_WSJTX_ADIF_TAIL_ENABLED"),
+            WsjtxIngestSetup.ReadEnvironmentValue(
+                WsjtxIngestSetup.AdifTailPathEnvironmentVariable,
+                "QSORIPPER_WSJTX_ADIF_TAIL_PATH"),
+            WsjtxIngestSetup.ReadEnvironmentValue(
+                WsjtxIngestSetup.PollIntervalMsEnvironmentVariable,
+                "QSORIPPER_WSJTX_POLL_INTERVAL_MS"),
+            WsjtxIngestSetup.ReadEnvironmentValue(
+                WsjtxIngestSetup.SyncToQrzEnvironmentVariable,
+                "QSORIPPER_WSJTX_SYNC_TO_QRZ"),
+            out settings,
+            out error);
+    }
+
     private static bool TryBuildWsjtxIngestSettingsFromEnv(
         WsjtxIngestSettings? existing,
         string? enabledEnv,
@@ -832,40 +874,40 @@ internal static class SetupCommand
 
         if (!TryParseOptionalBooleanEnv(
                 enabledEnv,
-                "QSORIPPER_WSJTX_INGEST_ENABLED",
+                WsjtxIngestSetup.EnabledEnvironmentVariable,
                 out var enabled)
             || !TryParseOptionalBooleanEnv(
                 udpEnabledEnv,
-                "QSORIPPER_WSJTX_UDP_ENABLED",
+                WsjtxIngestSetup.UdpEnabledEnvironmentVariable,
                 out var udpEnabled)
             || !TryParseOptionalBooleanEnv(
                 adifTailEnabledEnv,
-                "QSORIPPER_WSJTX_ADIF_TAIL_ENABLED",
+                WsjtxIngestSetup.AdifTailEnabledEnvironmentVariable,
                 out var adifTailEnabled)
             || !TryParseOptionalBooleanEnv(
                 syncToQrzEnv,
-                "QSORIPPER_WSJTX_SYNC_TO_QRZ",
+                WsjtxIngestSetup.SyncToQrzEnvironmentVariable,
                 out var syncToQrz)
             || !TryParseOptionalUInt32Env(
                 pollIntervalEnv,
-                "QSORIPPER_WSJTX_POLL_INTERVAL_MS",
+                WsjtxIngestSetup.PollIntervalMsEnvironmentVariable,
                 out var pollIntervalMs))
         {
             error = "Error: invalid WSJT-X environment variable value.";
             return false;
         }
 
-        if (pollIntervalMs is < 100 or > 86_400_000)
+        if (pollIntervalMs.HasValue && !WsjtxIngestSetup.IsValidPollInterval(pollIntervalMs.Value))
         {
-            error = "Error: QSORIPPER_WSJTX_POLL_INTERVAL_MS must be between 100 and 86400000.";
+            error = $"Error: {WsjtxIngestSetup.PollIntervalMsEnvironmentVariable} must be 0 for the engine default or a positive whole number.";
             return false;
         }
 
         settings = existing?.Clone() ?? new WsjtxIngestSettings
         {
             UdpEnabled = true,
-            UdpBind = "127.0.0.1:2237",
-            PollIntervalMs = 1000,
+            UdpBind = WsjtxIngestSetup.DefaultUdpBind,
+            PollIntervalMs = WsjtxIngestSetup.DefaultPollIntervalMs,
         };
 
         if (enabled.HasValue)
@@ -884,7 +926,7 @@ internal static class SetupCommand
         }
         else if (string.IsNullOrWhiteSpace(settings.UdpBind))
         {
-            settings.UdpBind = "127.0.0.1:2237";
+            settings.UdpBind = WsjtxIngestSetup.DefaultUdpBind;
         }
 
         if (adifTailEnabled.HasValue)
@@ -903,7 +945,7 @@ internal static class SetupCommand
         }
         else if (settings.PollIntervalMs == 0)
         {
-            settings.PollIntervalMs = 1000;
+            settings.PollIntervalMs = WsjtxIngestSetup.DefaultPollIntervalMs;
         }
 
         if (syncToQrz.HasValue)
@@ -914,6 +956,7 @@ internal static class SetupCommand
         if (!TryValidateWsjtxIngestSettings(settings, out var validationError))
         {
             error = $"Error: {validationError}";
+            settings = null;
             return false;
         }
 
@@ -925,11 +968,12 @@ internal static class SetupCommand
         ArgumentNullException.ThrowIfNull(settings);
         error = null;
 
-        if (settings.UdpEnabled
-            && (string.IsNullOrWhiteSpace(settings.UdpBind)
-                || !settings.UdpBind.Contains(':', StringComparison.Ordinal)))
+        if (!string.IsNullOrWhiteSpace(settings.UdpBind)
+            && !WsjtxIngestSetup.TryValidateHostPort(
+                settings.UdpBind,
+                "WSJT-X UDP bind",
+                out error))
         {
-            error = "WSJT-X UDP bind must be host:port (for example 127.0.0.1:2237).";
             return false;
         }
 
@@ -939,9 +983,9 @@ internal static class SetupCommand
             return false;
         }
 
-        if (settings.PollIntervalMs is < 100 or > 86_400_000)
+        if (!WsjtxIngestSetup.IsValidPollInterval(settings.PollIntervalMs))
         {
-            error = "WSJT-X poll interval must be between 100 and 86400000 milliseconds.";
+            error = "WSJT-X poll interval must be 0 for the engine default or a positive whole number.";
             return false;
         }
 

--- a/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/SetupCommand.cs
@@ -58,6 +58,7 @@ internal static class SetupCommand
         Console.WriteLine($"Station profile:   {status.HasStationProfile}");
         Console.WriteLine($"Rig control:       {FormatRigControlSummary(status.RigControl)}");
         Console.WriteLine($"CAT hub:           {FormatCatHubSummary(status.CatHub)}");
+        Console.WriteLine($"WSJT-X ingest:     {FormatWsjtxIngestSummary(status.WsjtxIngest)}");
 
         return status.SetupComplete ? 0 : 1;
     }
@@ -89,6 +90,13 @@ internal static class SetupCommand
         var rigPortEnv = Environment.GetEnvironmentVariable("QSORIPPER_RIGCTLD_PORT");
         var rigReadTimeoutEnv = Environment.GetEnvironmentVariable("QSORIPPER_RIGCTLD_READ_TIMEOUT_MS");
         var rigStaleThresholdEnv = Environment.GetEnvironmentVariable("QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS");
+        var wsjtxEnabledEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_INGEST_ENABLED");
+        var wsjtxUdpEnabledEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_UDP_ENABLED");
+        var wsjtxUdpBindEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_UDP_BIND");
+        var wsjtxAdifTailEnabledEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_ADIF_TAIL_ENABLED");
+        var wsjtxAdifTailPathEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_ADIF_TAIL_PATH");
+        var wsjtxPollIntervalEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_POLL_INTERVAL_MS");
+        var wsjtxSyncToQrzEnv = Environment.GetEnvironmentVariable("QSORIPPER_WSJTX_SYNC_TO_QRZ");
 
         if (!TryParseOptionalBooleanEnv(
                 rigEnabledEnv,
@@ -116,6 +124,22 @@ internal static class SetupCommand
                 "QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS",
                 out var rigStaleThresholdMs))
         {
+            return 1;
+        }
+
+        if (!TryBuildWsjtxIngestSettingsFromEnv(
+                currentStatus?.WsjtxIngest,
+                wsjtxEnabledEnv,
+                wsjtxUdpEnabledEnv,
+                wsjtxUdpBindEnv,
+                wsjtxAdifTailEnabledEnv,
+                wsjtxAdifTailPathEnv,
+                wsjtxPollIntervalEnv,
+                wsjtxSyncToQrzEnv,
+                out var wsjtxIngest,
+                out var wsjtxError))
+        {
+            Console.Error.WriteLine(wsjtxError);
             return 1;
         }
 
@@ -227,6 +251,11 @@ internal static class SetupCommand
             saveRequest.RigControl = rigControl;
         }
 
+        if (wsjtxIngest is not null)
+        {
+            saveRequest.WsjtxIngest = wsjtxIngest;
+        }
+
         // Include sync config when a logbook API key is provided.
         if (!string.IsNullOrWhiteSpace(qrzLogbookApiKey))
         {
@@ -288,7 +317,7 @@ internal static class SetupCommand
         var persistenceTitle = string.IsNullOrWhiteSpace(status.PersistenceLabel)
             ? "Storage"
             : status.PersistenceLabel;
-        Console.WriteLine($"Step 1 of 5: {persistenceTitle}");
+        Console.WriteLine($"Step 1 of 6: {persistenceTitle}");
         Console.WriteLine(new string('-', 30));
         if (!string.IsNullOrWhiteSpace(status.PersistenceDescription))
         {
@@ -327,7 +356,7 @@ internal static class SetupCommand
 
         // ── Step 2: Station Profile ────────────────────────────────
         Console.WriteLine();
-        Console.WriteLine("Step 2 of 5: Station Profile");
+        Console.WriteLine("Step 2 of 6: Station Profile");
         Console.WriteLine(new string('-', 30));
 
         var existingProfile = status.StationProfile;
@@ -389,7 +418,7 @@ internal static class SetupCommand
 
         // ── Step 3: QRZ Integration (Optional) ────────────────────
         Console.WriteLine();
-        Console.WriteLine("Step 3 of 5: QRZ Integration (Optional)");
+        Console.WriteLine("Step 3 of 6: QRZ Integration (Optional)");
         Console.WriteLine(new string('-', 30));
 
         string? qrzUsername = null;
@@ -476,7 +505,7 @@ internal static class SetupCommand
 
         // ── Step 4: QRZ Logbook (Optional) ────────────────────────
         Console.WriteLine();
-        Console.WriteLine("Step 4 of 5: QRZ Logbook (Optional)");
+        Console.WriteLine("Step 4 of 6: QRZ Logbook (Optional)");
         Console.WriteLine(new string('-', 30));
         Console.WriteLine("  Enter your QRZ.com Logbook API key for bidirectional sync.");
         Console.WriteLine("  You can find this at qrz.com → Logbook → Settings → API Key.");
@@ -533,9 +562,74 @@ internal static class SetupCommand
             }
         }
 
-        // ── Step 5: Review & Save ──────────────────────────────────
+        // ── Step 5: WSJT-X Ingestion (Optional) ────────────────────
         Console.WriteLine();
-        Console.WriteLine("Step 5 of 5: Review & Save");
+        Console.WriteLine("Step 5 of 6: WSJT-X Ingestion (Optional)");
+        Console.WriteLine(new string('-', 30));
+        Console.WriteLine("  Import QSOs logged in WSJT-X using UDP packets and optional ADIF tail recovery.");
+
+        WsjtxIngestSettings? wsjtxWizardSettings = null;
+        var existingWsjtx = status.WsjtxIngest;
+        if (existingWsjtx is not null)
+        {
+            Console.WriteLine($"  Current WSJT-X ingestion: {FormatWsjtxIngestSummary(existingWsjtx)}");
+        }
+
+        var setupWsjtx = PromptYesNo("Set up WSJT-X ingestion?", defaultYes: existingWsjtx?.Enabled ?? false);
+        if (setupWsjtx)
+        {
+            while (true)
+            {
+                var enabled = PromptYesNo("Enable WSJT-X QSO ingestion?", defaultYes: existingWsjtx?.Enabled ?? true);
+                var udpEnabled = PromptYesNo("Listen for WSJT-X UDP packets?", defaultYes: existingWsjtx?.UdpEnabled ?? true);
+                var udpBind = PromptField(
+                    "WSJT-X UDP bind",
+                    string.IsNullOrWhiteSpace(existingWsjtx?.UdpBind) ? "127.0.0.1:2237" : existingWsjtx.UdpBind);
+                var adifTailEnabled = PromptYesNo("Tail WSJT-X ADIF log for missed-QSO recovery?", defaultYes: existingWsjtx?.AdifTailEnabled ?? false);
+                var adifTailPath = PromptField(
+                    "WSJT-X ADIF tail path",
+                    existingWsjtx is { HasAdifTailPath: true } ? existingWsjtx.AdifTailPath : "");
+                var pollIntervalInput = PromptField(
+                    "WSJT-X poll interval (milliseconds)",
+                    existingWsjtx is { PollIntervalMs: > 0 }
+                        ? existingWsjtx.PollIntervalMs.ToString(System.Globalization.CultureInfo.InvariantCulture)
+                        : "1000");
+                var syncToQrz = PromptYesNo("Upload imported WSJT-X QSOs to QRZ?", defaultYes: existingWsjtx?.SyncToQrz ?? false);
+
+                if (!uint.TryParse(pollIntervalInput, System.Globalization.CultureInfo.InvariantCulture, out var pollIntervalMs)
+                    || pollIntervalMs is < 100 or > 86_400_000)
+                {
+                    Console.WriteLine("  Poll interval must be between 100 and 86400000 milliseconds.");
+                    continue;
+                }
+
+                wsjtxWizardSettings = new WsjtxIngestSettings
+                {
+                    Enabled = enabled,
+                    UdpEnabled = udpEnabled,
+                    UdpBind = udpBind,
+                    AdifTailEnabled = adifTailEnabled,
+                    PollIntervalMs = pollIntervalMs,
+                    SyncToQrz = syncToQrz,
+                };
+
+                if (!string.IsNullOrWhiteSpace(adifTailPath))
+                {
+                    wsjtxWizardSettings.AdifTailPath = adifTailPath;
+                }
+
+                if (TryValidateWsjtxIngestSettings(wsjtxWizardSettings, out var validationError))
+                {
+                    break;
+                }
+
+                Console.WriteLine($"  {validationError}");
+            }
+        }
+
+        // ── Step 6: Review & Save ──────────────────────────────────
+        Console.WriteLine();
+        Console.WriteLine("Step 6 of 6: Review & Save");
         Console.WriteLine(new string('-', 30));
         Console.WriteLine();
         foreach (var field in persistenceFields)
@@ -554,6 +648,7 @@ internal static class SetupCommand
         Console.WriteLine($"  QRZ password:        {(string.IsNullOrWhiteSpace(qrzPassword) ? "(not set)" : "********")}");
         Console.WriteLine($"  QRZ Logbook key:     {(string.IsNullOrWhiteSpace(qrzLogbookApiKey) ? hasExistingLogbookKey ? "(configured)" : "(not set)" : "********")}");
         Console.WriteLine($"  Auto-sync:           {(autoSyncEnabled ? $"enabled (every {syncIntervalSeconds}s)" : "disabled")}");
+        Console.WriteLine($"  WSJT-X ingest:       {FormatWsjtxIngestSummary(wsjtxWizardSettings)}");
         Console.WriteLine();
 
         var save = PromptYesNo("Save and apply?", defaultYes: true);
@@ -606,6 +701,11 @@ internal static class SetupCommand
                 AutoSyncEnabled = autoSyncEnabled,
                 SyncIntervalSeconds = syncIntervalSeconds,
             };
+        }
+
+        if (wsjtxWizardSettings is not null)
+        {
+            saveRequest.WsjtxIngest = wsjtxWizardSettings;
         }
 
         var saveResponse = await client.SaveSetupAsync(saveRequest);
@@ -700,6 +800,169 @@ internal static class SetupCommand
         }
 
         return settings;
+    }
+
+    private static bool TryBuildWsjtxIngestSettingsFromEnv(
+        WsjtxIngestSettings? existing,
+        string? enabledEnv,
+        string? udpEnabledEnv,
+        string? udpBindEnv,
+        string? adifTailEnabledEnv,
+        string? adifTailPathEnv,
+        string? pollIntervalEnv,
+        string? syncToQrzEnv,
+        out WsjtxIngestSettings? settings,
+        out string? error)
+    {
+        settings = null;
+        error = null;
+
+        var hasEnvironmentValues = !string.IsNullOrWhiteSpace(enabledEnv)
+            || !string.IsNullOrWhiteSpace(udpEnabledEnv)
+            || !string.IsNullOrWhiteSpace(udpBindEnv)
+            || !string.IsNullOrWhiteSpace(adifTailEnabledEnv)
+            || !string.IsNullOrWhiteSpace(adifTailPathEnv)
+            || !string.IsNullOrWhiteSpace(pollIntervalEnv)
+            || !string.IsNullOrWhiteSpace(syncToQrzEnv);
+
+        if (!hasEnvironmentValues)
+        {
+            return true;
+        }
+
+        if (!TryParseOptionalBooleanEnv(
+                enabledEnv,
+                "QSORIPPER_WSJTX_INGEST_ENABLED",
+                out var enabled)
+            || !TryParseOptionalBooleanEnv(
+                udpEnabledEnv,
+                "QSORIPPER_WSJTX_UDP_ENABLED",
+                out var udpEnabled)
+            || !TryParseOptionalBooleanEnv(
+                adifTailEnabledEnv,
+                "QSORIPPER_WSJTX_ADIF_TAIL_ENABLED",
+                out var adifTailEnabled)
+            || !TryParseOptionalBooleanEnv(
+                syncToQrzEnv,
+                "QSORIPPER_WSJTX_SYNC_TO_QRZ",
+                out var syncToQrz)
+            || !TryParseOptionalUInt32Env(
+                pollIntervalEnv,
+                "QSORIPPER_WSJTX_POLL_INTERVAL_MS",
+                out var pollIntervalMs))
+        {
+            error = "Error: invalid WSJT-X environment variable value.";
+            return false;
+        }
+
+        if (pollIntervalMs is < 100 or > 86_400_000)
+        {
+            error = "Error: QSORIPPER_WSJTX_POLL_INTERVAL_MS must be between 100 and 86400000.";
+            return false;
+        }
+
+        settings = existing?.Clone() ?? new WsjtxIngestSettings
+        {
+            UdpEnabled = true,
+            UdpBind = "127.0.0.1:2237",
+            PollIntervalMs = 1000,
+        };
+
+        if (enabled.HasValue)
+        {
+            settings.Enabled = enabled.Value;
+        }
+
+        if (udpEnabled.HasValue)
+        {
+            settings.UdpEnabled = udpEnabled.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(udpBindEnv))
+        {
+            settings.UdpBind = udpBindEnv.Trim();
+        }
+        else if (string.IsNullOrWhiteSpace(settings.UdpBind))
+        {
+            settings.UdpBind = "127.0.0.1:2237";
+        }
+
+        if (adifTailEnabled.HasValue)
+        {
+            settings.AdifTailEnabled = adifTailEnabled.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(adifTailPathEnv))
+        {
+            settings.AdifTailPath = adifTailPathEnv.Trim();
+        }
+
+        if (pollIntervalMs.HasValue)
+        {
+            settings.PollIntervalMs = pollIntervalMs.Value;
+        }
+        else if (settings.PollIntervalMs == 0)
+        {
+            settings.PollIntervalMs = 1000;
+        }
+
+        if (syncToQrz.HasValue)
+        {
+            settings.SyncToQrz = syncToQrz.Value;
+        }
+
+        if (!TryValidateWsjtxIngestSettings(settings, out var validationError))
+        {
+            error = $"Error: {validationError}";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryValidateWsjtxIngestSettings(WsjtxIngestSettings settings, out string? error)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        error = null;
+
+        if (settings.UdpEnabled
+            && (string.IsNullOrWhiteSpace(settings.UdpBind)
+                || !settings.UdpBind.Contains(':', StringComparison.Ordinal)))
+        {
+            error = "WSJT-X UDP bind must be host:port (for example 127.0.0.1:2237).";
+            return false;
+        }
+
+        if (settings.AdifTailEnabled && string.IsNullOrWhiteSpace(settings.AdifTailPath))
+        {
+            error = "WSJT-X ADIF tail path is required when ADIF tail recovery is enabled.";
+            return false;
+        }
+
+        if (settings.PollIntervalMs is < 100 or > 86_400_000)
+        {
+            error = "WSJT-X poll interval must be between 100 and 86400000 milliseconds.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string FormatWsjtxIngestSummary(WsjtxIngestSettings? wsjtx)
+    {
+        if (wsjtx is null)
+        {
+            return "(not configured)";
+        }
+
+        var state = wsjtx.Enabled ? "enabled" : "disabled";
+        var udp = wsjtx.UdpEnabled
+            ? string.IsNullOrWhiteSpace(wsjtx.UdpBind) ? "UDP enabled" : $"UDP {wsjtx.UdpBind}"
+            : "UDP disabled";
+        var tail = wsjtx.AdifTailEnabled
+            ? string.IsNullOrWhiteSpace(wsjtx.AdifTailPath) ? "ADIF tail enabled" : $"ADIF tail {wsjtx.AdifTailPath}"
+            : "ADIF tail disabled";
+        return $"{state} ({udp}, {tail})";
     }
 
     private static string FormatCatHubSummary(CatHubSettings? catHub)

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -1335,7 +1335,6 @@ public sealed class ManagedEngineStateTests : IDisposable
             WsjtxIngest = new WsjtxIngestSettings
             {
                 Enabled = true,
-                UdpEnabled = true,
                 UdpBind = "127.0.0.1:2237",
                 AdifTailEnabled = true,
                 AdifTailPath = Path.Combine(_tempDirectory, "wsjtx_log.adi"),
@@ -1359,6 +1358,76 @@ public sealed class ManagedEngineStateTests : IDisposable
         Assert.Equal(Path.Combine(_tempDirectory, "wsjtx_log.adi"), status.WsjtxIngest.AdifTailPath);
         Assert.Equal(250u, status.WsjtxIngest.PollIntervalMs);
         Assert.True(status.WsjtxIngest.SyncToQrz);
+    }
+
+    [Fact]
+    public void Loaded_wsjtx_ingest_section_applies_runtime_defaults()
+    {
+        var configPath = Path.Combine(_tempDirectory, "config.toml");
+        File.WriteAllText(
+            configPath,
+            """
+            [wsjtx_ingest]
+            enabled = true
+            """);
+
+        var state = CreateState();
+        var status = state.GetSetupStatus();
+
+        Assert.NotNull(status.WsjtxIngest);
+        Assert.True(status.WsjtxIngest.Enabled);
+        Assert.True(status.WsjtxIngest.UdpEnabled);
+        Assert.Equal("127.0.0.1:2237", status.WsjtxIngest.UdpBind);
+        Assert.Equal(1000u, status.WsjtxIngest.PollIntervalMs);
+        Assert.False(status.WsjtxIngest.HasAdifTailPath);
+    }
+
+    [Fact]
+    public void Save_setup_without_wsjtx_ingest_preserves_existing_wsjtx_section()
+    {
+        var configPath = Path.Combine(_tempDirectory, "config.toml");
+        File.WriteAllText(
+            configPath,
+            """
+            [wsjtx_ingest]
+            # keep operator comment
+            enabled = true
+            future_key = "preserve-me"
+            """);
+        var state = CreateState();
+
+        state.SaveSetup(new SaveSetupRequest
+        {
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87"
+            }
+        });
+
+        var content = File.ReadAllText(configPath);
+        Assert.Contains("# keep operator comment", content, StringComparison.Ordinal);
+        Assert.Contains("future_key = \"preserve-me\"", content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Save_setup_rejects_invalid_wsjtx_ingest()
+    {
+        var state = CreateState();
+
+        var exception = Assert.Throws<InvalidOperationException>(() => state.SaveSetup(new SaveSetupRequest
+        {
+            WsjtxIngest = new WsjtxIngestSettings
+            {
+                Enabled = true,
+                UdpEnabled = false,
+                AdifTailEnabled = true,
+            },
+        }));
+
+        Assert.Contains("WSJT-X ADIF tail path is required", exception.Message, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -1325,6 +1325,42 @@ public sealed class ManagedEngineStateTests : IDisposable
         Assert.Equal("ts590", response.Status.CatHub.Radio.Backend);
     }
 
+    [Fact]
+    public void Save_setup_writes_wsjtx_ingest_section_and_round_trips()
+    {
+        var state = CreateState();
+
+        var response = state.SaveSetup(new SaveSetupRequest
+        {
+            WsjtxIngest = new WsjtxIngestSettings
+            {
+                Enabled = true,
+                UdpEnabled = true,
+                UdpBind = "127.0.0.1:2237",
+                AdifTailEnabled = true,
+                AdifTailPath = Path.Combine(_tempDirectory, "wsjtx_log.adi"),
+                PollIntervalMs = 250,
+                SyncToQrz = true,
+            },
+        });
+
+        var configPath = Path.Combine(_tempDirectory, "config.toml");
+        var content = File.ReadAllText(configPath);
+        var reloaded = CreateState();
+        var status = reloaded.GetSetupStatus();
+
+        Assert.NotNull(response.Status.WsjtxIngest);
+        Assert.Contains("[wsjtx_ingest]", content, StringComparison.Ordinal);
+        Assert.NotNull(status.WsjtxIngest);
+        Assert.True(status.WsjtxIngest.Enabled);
+        Assert.True(status.WsjtxIngest.UdpEnabled);
+        Assert.Equal("127.0.0.1:2237", status.WsjtxIngest.UdpBind);
+        Assert.True(status.WsjtxIngest.AdifTailEnabled);
+        Assert.Equal(Path.Combine(_tempDirectory, "wsjtx_log.adi"), status.WsjtxIngest.AdifTailPath);
+        Assert.Equal(250u, status.WsjtxIngest.PollIntervalMs);
+        Assert.True(status.WsjtxIngest.SyncToQrz);
+    }
+
     [Theory]
     [MemberData(nameof(InvalidCatHubCases))]
     public void Save_setup_rejects_invalid_cat_hub(CatHubSettings catHub, string expectedMessage)

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -369,6 +369,11 @@ internal sealed class ManagedEngineState
                 _persistedSetup.RigControl = _rigControl.Clone();
             }
 
+            if (request.WsjtxIngest is not null)
+            {
+                _persistedSetup.WsjtxIngest = request.WsjtxIngest.Clone();
+            }
+
             // CONDITIONAL OWNERSHIP: only an explicit cat_hub in the request triggers a
             // `[cat_hub]` rewrite. The override is consumed (cleared) by PersistNoLock so a
             // later save without cat_hub preserves the section verbatim.
@@ -1368,6 +1373,11 @@ internal sealed class ManagedEngineState
         if (_persistedSetup.RigControl is not null)
         {
             status.RigControl = _persistedSetup.RigControl.Clone();
+        }
+
+        if (_persistedSetup.WsjtxIngest is not null)
+        {
+            status.WsjtxIngest = _persistedSetup.WsjtxIngest.Clone();
         }
 
         if (_persistedSetup.CatHub is not null)

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -141,6 +141,11 @@ internal sealed class ManagedEngineState
         _hasQrzLogbookApiKey = _qrzLogbookApiKey is not null;
         _syncConfig = NormalizeSyncConfig(_persistedSetup.SyncConfig);
         _persistedSetup.SyncConfig = _syncConfig.Clone();
+        if (_persistedSetup.WsjtxIngest is not null)
+        {
+            _persistedSetup.WsjtxIngest = NormalizeWsjtxIngest(_persistedSetup.WsjtxIngest);
+        }
+
         _rigControl = _persistedSetup.RigControl?.Clone();
         _stationProfiles = _persistedSetup.StationProfiles
             .Select(static entry => new ManagedPersistedStationProfile
@@ -319,6 +324,9 @@ internal sealed class ManagedEngineState
             {
                 _ = SharedSetupConfigPersistence.BuildCatHubTableOrThrow(request.CatHub);
             }
+            var normalizedWsjtxIngest = request.WsjtxIngest is null
+                ? null
+                : NormalizeWsjtxIngest(request.WsjtxIngest);
 
             if (request.StationProfile is not null)
             {
@@ -371,7 +379,8 @@ internal sealed class ManagedEngineState
 
             if (request.WsjtxIngest is not null)
             {
-                _persistedSetup.WsjtxIngest = request.WsjtxIngest.Clone();
+                _persistedSetup.WsjtxIngest = normalizedWsjtxIngest;
+                _persistedSetup.WsjtxIngestWriteOverride = normalizedWsjtxIngest?.Clone();
             }
 
             // CONDITIONAL OWNERSHIP: only an explicit cat_hub in the request triggers a
@@ -1329,8 +1338,10 @@ internal sealed class ManagedEngineState
         SharedSetupConfigPersistence.Save(_configPath, _persistedSetup);
 
         // The CAT hub override is a one-shot replacement signal (mirrors Rust's per-request
-        // cat_hub_update). Clear it after writing so subsequent saves preserve the section.
+        // cat_hub_update). The WSJT-X override uses the same conditional-ownership model.
+        // Clear both after writing so subsequent saves preserve those sections.
         _persistedSetup.CatHubWriteOverride = null;
+        _persistedSetup.WsjtxIngestWriteOverride = null;
     }
 
     private SetupStatus BuildSetupStatusNoLock()
@@ -1930,6 +1941,46 @@ internal sealed class ManagedEngineState
         }
 
         return normalized;
+    }
+
+    private static WsjtxIngestSettings NormalizeWsjtxIngest(WsjtxIngestSettings settings)
+    {
+        var normalized = settings.Clone();
+        normalized.UdpEnabled = settings.HasUdpEnabled ? settings.UdpEnabled : true;
+        normalized.UdpBind = NormalizeOptional(settings.UdpBind) ?? "127.0.0.1:2237";
+        ValidateHostPort(normalized.UdpBind, "WSJT-X UDP bind");
+
+        normalized.AdifTailPath = NormalizeOptional(settings.AdifTailPath) ?? string.Empty;
+        if (string.IsNullOrEmpty(normalized.AdifTailPath))
+        {
+            normalized.ClearAdifTailPath();
+        }
+        if (normalized.AdifTailEnabled && string.IsNullOrWhiteSpace(normalized.AdifTailPath))
+        {
+            throw new InvalidOperationException("WSJT-X ADIF tail path is required when ADIF tailing is enabled.");
+        }
+
+        if (normalized.PollIntervalMs == 0)
+        {
+            normalized.PollIntervalMs = 1000;
+        }
+
+        return normalized;
+    }
+
+    private static void ValidateHostPort(string bind, string label)
+    {
+        var separator = bind.LastIndexOf(':');
+        if (separator <= 0 || separator == bind.Length - 1)
+        {
+            throw new InvalidOperationException($"{label} must be in host:port form.");
+        }
+
+        var portText = bind[(separator + 1)..];
+        if (!ushort.TryParse(portText, out var port) || port == 0)
+        {
+            throw new InvalidOperationException($"{label} port must be between 1 and 65535.");
+        }
     }
 
     private static bool IsTimestampUnset(Timestamp? value)

--- a/src/dotnet/QsoRipper.Engine.DotNet/SharedSetupConfigPersistence.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/SharedSetupConfigPersistence.cs
@@ -307,9 +307,8 @@ internal static class SharedSetupConfigPersistence
     }
 
     // Top-level TOML keys owned by the engine setup config. On save these are replaced
-    // wholesale; every other top-level table (for example [cat_hub] written by the CAT hub
-    // daemon and [launcher] written by the launcher) is preserved so the unified config.toml
-    // can be safely shared across all QsoRipper components.
+    // wholesale; conditionally-owned tables such as [cat_hub] and [wsjtx_ingest] are
+    // preserved unless a one-shot replacement override is supplied.
     private static readonly string[] EngineOwnedConfigKeys =
     {
         "logbook",
@@ -320,7 +319,6 @@ internal static class SharedSetupConfigPersistence
         "qrz_logbook",
         "sync",
         "rig_control",
-        "wsjtx_ingest",
     };
 
     // Splice the freshly-serialized engine-owned tables into the existing document (when one
@@ -338,6 +336,12 @@ internal static class SharedSetupConfigPersistence
             var catHubTable = BuildCatHubTableOrThrow(config.CatHubWriteOverride);
             result.Remove("cat_hub");
             result["cat_hub"] = catHubTable;
+        }
+        if (config.WsjtxIngestWriteOverride is not null)
+        {
+            var wsjtxIngest = BuildWsjtxIngestTable(config.WsjtxIngestWriteOverride);
+            result.Remove("wsjtx_ingest");
+            AddTableIfNotEmpty(result, "wsjtx_ingest", wsjtxIngest);
         }
 
         return result;
@@ -450,9 +454,6 @@ internal static class SharedSetupConfigPersistence
 
         var rigControl = BuildRigControlTable(config.RigControl);
         AddTableIfNotEmpty(root, "rig_control", rigControl);
-
-        var wsjtxIngest = BuildWsjtxIngestTable(config.WsjtxIngest);
-        AddTableIfNotEmpty(root, "wsjtx_ingest", wsjtxIngest);
 
         return root;
     }
@@ -1590,6 +1591,8 @@ internal sealed class SharedPersistedSetupConfig
     public RigControlSettings? RigControl { get; set; }
 
     public WsjtxIngestSettings? WsjtxIngest { get; set; }
+
+    public WsjtxIngestSettings? WsjtxIngestWriteOverride { get; set; }
 
     // Leniently-parsed projection of the `[cat_hub]` section for STATUS/wizard display only.
     // Never used to re-serialize the section (that would destroy comments/unknown keys).

--- a/src/dotnet/QsoRipper.Engine.DotNet/SharedSetupConfigPersistence.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/SharedSetupConfigPersistence.cs
@@ -235,6 +235,7 @@ internal static class SharedSetupConfigPersistence
         var qrzLogbook = GetTable(root, "qrz_logbook");
         var sync = GetTable(root, "sync");
         var rigControl = GetTable(root, "rig_control");
+        var wsjtxIngest = GetTable(root, "wsjtx_ingest");
         var stationProfile = GetTable(root, "station_profile");
         var stationProfiles = GetTable(root, "station_profiles");
 
@@ -248,6 +249,7 @@ internal static class SharedSetupConfigPersistence
         config.QrzLogbookBaseUrl = GetString(qrzLogbook, "base_url");
         config.SyncConfig = ParseSyncConfig(sync);
         config.RigControl = ParseRigControl(rigControl);
+        config.WsjtxIngest = ParseWsjtxIngest(wsjtxIngest);
         config.ActiveProfileId = NormalizeOptional(GetString(stationProfiles, "active_profile_id"));
 
         var entries = GetTableArray(stationProfiles, "entries");
@@ -318,6 +320,7 @@ internal static class SharedSetupConfigPersistence
         "qrz_logbook",
         "sync",
         "rig_control",
+        "wsjtx_ingest",
     };
 
     // Splice the freshly-serialized engine-owned tables into the existing document (when one
@@ -448,6 +451,9 @@ internal static class SharedSetupConfigPersistence
         var rigControl = BuildRigControlTable(config.RigControl);
         AddTableIfNotEmpty(root, "rig_control", rigControl);
 
+        var wsjtxIngest = BuildWsjtxIngestTable(config.WsjtxIngest);
+        AddTableIfNotEmpty(root, "wsjtx_ingest", wsjtxIngest);
+
         return root;
     }
 
@@ -565,6 +571,51 @@ internal static class SharedSetupConfigPersistence
             table["stale_threshold_ms"] = settings.StaleThresholdMs;
         }
 
+        return table;
+    }
+
+    private static WsjtxIngestSettings? ParseWsjtxIngest(TomlTable? table)
+    {
+        if (table is null)
+        {
+            return null;
+        }
+
+        var settings = new WsjtxIngestSettings();
+        AssignIfPresent(GetBoolean(table, "enabled"), value => settings.Enabled = value);
+        AssignIfPresent(GetBoolean(table, "udp_enabled"), value => settings.UdpEnabled = value);
+        AssignIfPresent(GetString(table, "udp_bind"), value => settings.UdpBind = value);
+        AssignIfPresent(GetBoolean(table, "adif_tail_enabled"), value => settings.AdifTailEnabled = value);
+        AssignIfPresent(GetString(table, "adif_tail_path"), value => settings.AdifTailPath = value);
+        AssignIfPresent(GetUInt32(table, "poll_interval_ms"), value => settings.PollIntervalMs = value);
+        AssignIfPresent(GetBoolean(table, "sync_to_qrz"), value => settings.SyncToQrz = value);
+
+        return WsjtxIngestHasValues(settings) ? settings : null;
+    }
+
+    private static TomlTable BuildWsjtxIngestTable(WsjtxIngestSettings? settings)
+    {
+        var table = new TomlTable();
+        if (settings is null)
+        {
+            return table;
+        }
+
+        table["enabled"] = settings.Enabled;
+        if (settings.HasUdpEnabled)
+        {
+            table["udp_enabled"] = settings.UdpEnabled;
+        }
+
+        AddIfValue(table, "udp_bind", NormalizeOptional(settings.UdpBind));
+        table["adif_tail_enabled"] = settings.AdifTailEnabled;
+        AddIfValue(table, "adif_tail_path", NormalizeOptional(settings.AdifTailPath));
+        if (settings.PollIntervalMs != 0)
+        {
+            table["poll_interval_ms"] = settings.PollIntervalMs;
+        }
+
+        table["sync_to_qrz"] = settings.SyncToQrz;
         return table;
     }
 
@@ -1310,6 +1361,17 @@ internal static class SharedSetupConfigPersistence
             || settings.HasStaleThresholdMs;
     }
 
+    private static bool WsjtxIngestHasValues(WsjtxIngestSettings settings)
+    {
+        return settings.Enabled
+            || settings.HasUdpEnabled
+            || !string.IsNullOrWhiteSpace(settings.UdpBind)
+            || settings.AdifTailEnabled
+            || !string.IsNullOrWhiteSpace(settings.AdifTailPath)
+            || settings.PollIntervalMs != 0
+            || settings.SyncToQrz;
+    }
+
     private static bool LooksLikeJson(string content)
     {
         foreach (var character in content)
@@ -1526,6 +1588,8 @@ internal sealed class SharedPersistedSetupConfig
     public SyncConfig SyncConfig { get; set; } = new();
 
     public RigControlSettings? RigControl { get; set; }
+
+    public WsjtxIngestSettings? WsjtxIngest { get; set; }
 
     // Leniently-parsed projection of the `[cat_hub]` section for STATUS/wizard display only.
     // Never used to re-serialize the section (that would destroy comments/unknown keys).

--- a/src/dotnet/QsoRipper.Gui.Tests/SettingsViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/SettingsViewModelTests.cs
@@ -288,6 +288,22 @@ public class SettingsViewModelTests
     }
 
     [Fact]
+    public async Task LoadAsyncDefaultsWsjtxUdpToEnabledWhenUnset()
+    {
+        var client = new UxFixtureEngineClient(
+            new UxCaptureFixture
+            {
+                WsjtxIngestEnabled = true,
+                WsjtxUdpBind = "127.0.0.1:2237"
+            });
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+
+        Assert.True(viewModel.WsjtxUdpEnabled);
+    }
+
+    [Fact]
     public async Task SaveEmitsWsjtxIngestSettings()
     {
         var client = new UxFixtureEngineClient(new UxCaptureFixture());
@@ -317,7 +333,7 @@ public class SettingsViewModelTests
     }
 
     [Fact]
-    public async Task SaveRejectsInvalidWsjtxIngestPollInterval()
+    public async Task SaveAllowsZeroWsjtxPollIntervalForEngineDefault()
     {
         var client = new UxFixtureEngineClient(new UxCaptureFixture());
         var viewModel = new SettingsViewModel(client);
@@ -328,9 +344,41 @@ public class SettingsViewModelTests
 
         await viewModel.SaveCommand.ExecuteAsync(null);
 
+        Assert.True(viewModel.DidSave);
+        Assert.Equal(0u, client.LastSaveSetupRequest!.WsjtxIngest.PollIntervalMs);
+    }
+
+    [Fact]
+    public async Task SaveAllowsSmallPositiveWsjtxPollIntervalAcceptedByEngine()
+    {
+        var client = new UxFixtureEngineClient(new UxCaptureFixture());
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+        viewModel.WsjtxIngestEnabled = true;
+        viewModel.WsjtxPollIntervalMs = "50";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        Assert.True(viewModel.DidSave);
+        Assert.Equal(50u, client.LastSaveSetupRequest!.WsjtxIngest.PollIntervalMs);
+    }
+
+    [Fact]
+    public async Task SaveRejectsInvalidWsjtxUdpBindPort()
+    {
+        var client = new UxFixtureEngineClient(new UxCaptureFixture());
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+        viewModel.WsjtxIngestEnabled = true;
+        viewModel.WsjtxUdpBind = "127.0.0.1:notaport";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
         Assert.False(viewModel.DidSave);
         Assert.Equal(
-            "WSJT-X poll interval must be a whole number between 100 and 86400000.",
+            "WSJT-X UDP bind must be host:port with a port between 1 and 65535.",
             viewModel.ErrorMessage);
         Assert.Null(client.LastSaveSetupRequest);
     }

--- a/src/dotnet/QsoRipper.Gui.Tests/SettingsViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/SettingsViewModelTests.cs
@@ -261,6 +261,81 @@ public class SettingsViewModelTests
     }
 
     [Fact]
+    public async Task LoadAsyncPopulatesWsjtxIngestSectionFromStatus()
+    {
+        var client = new UxFixtureEngineClient(
+            new UxCaptureFixture
+            {
+                WsjtxIngestEnabled = true,
+                WsjtxUdpEnabled = true,
+                WsjtxUdpBind = "0.0.0.0:2237",
+                WsjtxAdifTailEnabled = true,
+                WsjtxAdifTailPath = @"C:\Users\randy\AppData\Local\WSJT-X\wsjtx_log.adi",
+                WsjtxPollIntervalMs = 1500,
+                WsjtxSyncToQrz = true
+            });
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+
+        Assert.True(viewModel.WsjtxIngestEnabled);
+        Assert.True(viewModel.WsjtxUdpEnabled);
+        Assert.Equal("0.0.0.0:2237", viewModel.WsjtxUdpBind);
+        Assert.True(viewModel.WsjtxAdifTailEnabled);
+        Assert.Equal(@"C:\Users\randy\AppData\Local\WSJT-X\wsjtx_log.adi", viewModel.WsjtxAdifTailPath);
+        Assert.Equal("1500", viewModel.WsjtxPollIntervalMs);
+        Assert.True(viewModel.WsjtxSyncToQrz);
+    }
+
+    [Fact]
+    public async Task SaveEmitsWsjtxIngestSettings()
+    {
+        var client = new UxFixtureEngineClient(new UxCaptureFixture());
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+        viewModel.WsjtxIngestEnabled = true;
+        viewModel.WsjtxUdpEnabled = true;
+        viewModel.WsjtxUdpBind = "127.0.0.1:2237";
+        viewModel.WsjtxAdifTailEnabled = true;
+        viewModel.WsjtxAdifTailPath = @"C:\logs\wsjtx_log.adi";
+        viewModel.WsjtxPollIntervalMs = "500";
+        viewModel.WsjtxSyncToQrz = true;
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        Assert.True(viewModel.DidSave);
+        var settings = client.LastSaveSetupRequest!.WsjtxIngest;
+        Assert.NotNull(settings);
+        Assert.True(settings.Enabled);
+        Assert.True(settings.UdpEnabled);
+        Assert.Equal("127.0.0.1:2237", settings.UdpBind);
+        Assert.True(settings.AdifTailEnabled);
+        Assert.Equal(@"C:\logs\wsjtx_log.adi", settings.AdifTailPath);
+        Assert.Equal(500u, settings.PollIntervalMs);
+        Assert.True(settings.SyncToQrz);
+    }
+
+    [Fact]
+    public async Task SaveRejectsInvalidWsjtxIngestPollInterval()
+    {
+        var client = new UxFixtureEngineClient(new UxCaptureFixture());
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+        viewModel.WsjtxIngestEnabled = true;
+        viewModel.WsjtxPollIntervalMs = "0";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        Assert.False(viewModel.DidSave);
+        Assert.Equal(
+            "WSJT-X poll interval must be a whole number between 100 and 86400000.",
+            viewModel.ErrorMessage);
+        Assert.Null(client.LastSaveSetupRequest);
+    }
+
+    [Fact]
     public async Task SaveRejectsManagedCatHubWithoutEndpoints()
     {
         var client = new UxFixtureEngineClient(new UxCaptureFixture());

--- a/src/dotnet/QsoRipper.Gui.Tests/WsjtxIngestStepViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/WsjtxIngestStepViewModelTests.cs
@@ -1,0 +1,72 @@
+using QsoRipper.Gui.ViewModels;
+using QsoRipper.Services;
+
+namespace QsoRipper.Gui.Tests;
+
+public sealed class WsjtxIngestStepViewModelTests
+{
+    [Fact]
+    public void ConfigureFromSettingsDefaultsUdpToEnabledWhenUnset()
+    {
+        var viewModel = new WsjtxIngestStepViewModel();
+
+        viewModel.ConfigureFromSettings(new WsjtxIngestSettings { Enabled = true });
+
+        Assert.True(viewModel.UdpEnabled);
+    }
+
+    [Fact]
+    public void ConfigureFromSettingsDoesNotRequireSaveWhenUserHasNotChangedSettings()
+    {
+        var viewModel = new WsjtxIngestStepViewModel();
+
+        viewModel.ConfigureFromSettings(
+            new WsjtxIngestSettings
+            {
+                Enabled = true,
+                UdpBind = "127.0.0.1:2237",
+                PollIntervalMs = 1000
+            });
+
+        Assert.False(viewModel.ShouldSave);
+    }
+
+    [Fact]
+    public void ValidateLocallyAllowsZeroPollIntervalForEngineDefault()
+    {
+        var viewModel = new WsjtxIngestStepViewModel
+        {
+            Enabled = true,
+            PollIntervalMs = 0
+        };
+
+        Assert.True(viewModel.ValidateLocally());
+    }
+
+    [Fact]
+    public void ValidateLocallyAllowsSmallPositivePollIntervalAcceptedByEngine()
+    {
+        var viewModel = new WsjtxIngestStepViewModel
+        {
+            Enabled = true,
+            PollIntervalMs = 50
+        };
+
+        Assert.True(viewModel.ValidateLocally());
+    }
+
+    [Fact]
+    public void ValidateLocallyRejectsInvalidUdpBindPort()
+    {
+        var viewModel = new WsjtxIngestStepViewModel
+        {
+            Enabled = true,
+            UdpBind = "127.0.0.1:notaport"
+        };
+
+        Assert.False(viewModel.ValidateLocally());
+        Assert.Equal(
+            "UDP bind must be host:port with a port between 1 and 65535.",
+            viewModel.ValidationSummary);
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/Inspection/UxCaptureFixture.cs
+++ b/src/dotnet/QsoRipper.Gui/Inspection/UxCaptureFixture.cs
@@ -107,6 +107,20 @@ internal sealed record UxCaptureFixture
 
     public string? CatHubEndpointBind { get; init; }
 
+    public bool? WsjtxIngestEnabled { get; init; }
+
+    public bool? WsjtxUdpEnabled { get; init; }
+
+    public string? WsjtxUdpBind { get; init; }
+
+    public bool? WsjtxAdifTailEnabled { get; init; }
+
+    public string? WsjtxAdifTailPath { get; init; }
+
+    public uint? WsjtxPollIntervalMs { get; init; }
+
+    public bool? WsjtxSyncToQrz { get; init; }
+
     public bool IsSyncing { get; init; }
 
     public IReadOnlyList<UxCaptureQsoFixtureItem> RecentQsos { get; init; } = CreateDefaultRecentQsos();
@@ -275,6 +289,61 @@ internal sealed record UxCaptureFixture
 
         return settings;
     }
+
+    public WsjtxIngestSettings? BuildWsjtxIngestSettings()
+    {
+        var hasValues = WsjtxIngestEnabled.HasValue
+            || WsjtxUdpEnabled.HasValue
+            || !string.IsNullOrWhiteSpace(WsjtxUdpBind)
+            || WsjtxAdifTailEnabled.HasValue
+            || !string.IsNullOrWhiteSpace(WsjtxAdifTailPath)
+            || WsjtxPollIntervalMs.HasValue
+            || WsjtxSyncToQrz.HasValue;
+
+        if (!hasValues)
+        {
+            return null;
+        }
+
+        var settings = new WsjtxIngestSettings();
+        if (WsjtxIngestEnabled.HasValue)
+        {
+            settings.Enabled = WsjtxIngestEnabled.Value;
+        }
+
+        if (WsjtxUdpEnabled.HasValue)
+        {
+            settings.UdpEnabled = WsjtxUdpEnabled.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(WsjtxUdpBind))
+        {
+            settings.UdpBind = WsjtxUdpBind;
+        }
+
+        if (WsjtxAdifTailEnabled.HasValue)
+        {
+            settings.AdifTailEnabled = WsjtxAdifTailEnabled.Value;
+        }
+
+        if (!string.IsNullOrWhiteSpace(WsjtxAdifTailPath))
+        {
+            settings.AdifTailPath = WsjtxAdifTailPath;
+        }
+
+        if (WsjtxPollIntervalMs.HasValue)
+        {
+            settings.PollIntervalMs = WsjtxPollIntervalMs.Value;
+        }
+
+        if (WsjtxSyncToQrz.HasValue)
+        {
+            settings.SyncToQrz = WsjtxSyncToQrz.Value;
+        }
+
+        return settings;
+    }
+
     public SyncConfig BuildSyncConfig() => new()
     {
         AutoSyncEnabled = AutoSyncEnabled,

--- a/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
@@ -22,6 +22,7 @@ internal sealed class UxFixtureEngineClient : IEngineClient
     private string? _qrzXmlUsername;
     private RigControlSettings? _rigControl;
     private CatHubSettings? _catHub;
+    private WsjtxIngestSettings? _wsjtxIngest;
     private DateTimeOffset? _lastSyncUtc;
     private bool _configFileExists;
     private bool _setupComplete;
@@ -45,6 +46,7 @@ internal sealed class UxFixtureEngineClient : IEngineClient
         _qrzXmlUsername = fixture.QrzXmlUsername;
         _rigControl = fixture.BuildRigControlSettings();
         _catHub = fixture.BuildCatHubSettings();
+        _wsjtxIngest = fixture.BuildWsjtxIngestSettings();
         _lastSyncUtc = fixture.LastSyncUtc;
         _configFileExists = fixture.ConfigFileExists;
         _setupComplete = fixture.SetupComplete;
@@ -216,6 +218,11 @@ internal sealed class UxFixtureEngineClient : IEngineClient
             if (request.CatHub is not null)
             {
                 _catHub = request.CatHub.Clone();
+            }
+
+            if (request.WsjtxIngest is not null)
+            {
+                _wsjtxIngest = request.WsjtxIngest.Clone();
             }
 
             _configFileExists = true;
@@ -617,6 +624,11 @@ internal sealed class UxFixtureEngineClient : IEngineClient
         if (_catHub is not null)
         {
             status.CatHub = _catHub.Clone();
+        }
+
+        if (_wsjtxIngest is not null)
+        {
+            status.WsjtxIngest = _wsjtxIngest.Clone();
         }
 
         if (HasStationProfile())

--- a/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
@@ -179,6 +179,37 @@ internal sealed partial class SettingsViewModel : ObservableObject
 
     public ObservableCollection<CatHubEndpointRowViewModel> CatHubEndpoints { get; } = [];
 
+    // WSJT-X ingestion ([wsjtx_ingest]) is conditionally engine-owned like CAT hub.
+    // Untouched settings are omitted on save so existing comments and unknown keys stay intact.
+    [ObservableProperty]
+    private bool _wsjtxIngestEnabled;
+
+    [ObservableProperty]
+    private bool _wsjtxUdpEnabled = true;
+
+    [ObservableProperty]
+    private string _wsjtxUdpBind = "127.0.0.1:2237";
+
+    [ObservableProperty]
+    private bool _wsjtxAdifTailEnabled;
+
+    [ObservableProperty]
+    private string _wsjtxAdifTailPath = string.Empty;
+
+    [ObservableProperty]
+    private string _wsjtxPollIntervalMs = "1000";
+
+    [ObservableProperty]
+    private bool _wsjtxSyncToQrz;
+
+    private bool _hasPersistedWsjtxIngest;
+    private bool _wsjtxIngestLoading;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowWsjtxIngestRewriteWarning))]
+    private bool _isWsjtxIngestDirty;
+
+    public bool ShowWsjtxIngestRewriteWarning => IsWsjtxIngestDirty && _hasPersistedWsjtxIngest;
 
     [ObservableProperty]
     private string _persistenceDescription = "Where should QsoRipper store persisted logbook data?";
@@ -317,12 +348,28 @@ internal sealed partial class SettingsViewModel : ObservableObject
         nameof(CatHubNativePushIndex),
     };
 
+    private static readonly HashSet<string> WsjtxIngestScalarPropertyNames = new(StringComparer.Ordinal)
+    {
+        nameof(WsjtxIngestEnabled),
+        nameof(WsjtxUdpEnabled),
+        nameof(WsjtxUdpBind),
+        nameof(WsjtxAdifTailEnabled),
+        nameof(WsjtxAdifTailPath),
+        nameof(WsjtxPollIntervalMs),
+        nameof(WsjtxSyncToQrz),
+    };
+
     protected override void OnPropertyChanged(PropertyChangedEventArgs e)
     {
         base.OnPropertyChanged(e);
         if (e.PropertyName is not null && CatHubScalarPropertyNames.Contains(e.PropertyName))
         {
             MarkCatHubDirty();
+        }
+
+        if (e.PropertyName is not null && WsjtxIngestScalarPropertyNames.Contains(e.PropertyName))
+        {
+            MarkWsjtxIngestDirty();
         }
     }
 
@@ -334,6 +381,16 @@ internal sealed partial class SettingsViewModel : ObservableObject
         }
 
         IsCatHubDirty = true;
+    }
+
+    private void MarkWsjtxIngestDirty()
+    {
+        if (_wsjtxIngestLoading)
+        {
+            return;
+        }
+
+        IsWsjtxIngestDirty = true;
     }
 
     private void OnCatHubCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
@@ -531,6 +588,12 @@ internal sealed partial class SettingsViewModel : ObservableObject
                 return;
             }
 
+            if (IsWsjtxIngestDirty && !TryValidateWsjtxIngestInputs(out var wsjtxError))
+            {
+                ErrorMessage = wsjtxError;
+                return;
+            }
+
             var request = BuildSaveRequest();
             await _engine.SaveSetupAsync(request);
             DidSave = true;
@@ -571,10 +634,13 @@ internal sealed partial class SettingsViewModel : ObservableObject
     private void SelectCatHubSection() => SelectedSectionIndex = 5;
 
     [RelayCommand]
-    private void SelectNextSection() => SelectedSectionIndex = (SelectedSectionIndex + 1) % 6;
+    private void SelectWsjtxSection() => SelectedSectionIndex = 6;
 
     [RelayCommand]
-    private void SelectPreviousSection() => SelectedSectionIndex = (SelectedSectionIndex + 5) % 6;
+    private void SelectNextSection() => SelectedSectionIndex = (SelectedSectionIndex + 1) % 7;
+
+    [RelayCommand]
+    private void SelectPreviousSection() => SelectedSectionIndex = (SelectedSectionIndex + 6) % 7;
 
     [RelayCommand]
     private async Task TestQrzXmlAsync()
@@ -698,6 +764,34 @@ internal sealed partial class SettingsViewModel : ObservableObject
         // Password and API key are never returned by the engine for security;
         // leave them empty so the user can re-enter if they want to change them.
         ApplyCatHub(status.CatHub);
+        ApplyWsjtxIngest(status.WsjtxIngest);
+    }
+
+    private void ApplyWsjtxIngest(WsjtxIngestSettings? settings)
+    {
+        _wsjtxIngestLoading = true;
+        try
+        {
+            _hasPersistedWsjtxIngest = settings is not null;
+            WsjtxIngestEnabled = settings?.Enabled ?? false;
+            WsjtxUdpEnabled = settings?.UdpEnabled ?? true;
+            WsjtxUdpBind = !string.IsNullOrWhiteSpace(settings?.UdpBind)
+                ? settings.UdpBind
+                : "127.0.0.1:2237";
+            WsjtxAdifTailEnabled = settings?.AdifTailEnabled ?? false;
+            WsjtxAdifTailPath = settings is { HasAdifTailPath: true }
+                ? settings.AdifTailPath
+                : string.Empty;
+            WsjtxPollIntervalMs = settings is { PollIntervalMs: > 0 }
+                ? settings.PollIntervalMs.ToString(CultureInfo.InvariantCulture)
+                : "1000";
+            WsjtxSyncToQrz = settings?.SyncToQrz ?? false;
+        }
+        finally
+        {
+            _wsjtxIngestLoading = false;
+            IsWsjtxIngestDirty = false;
+        }
     }
 
     private void ApplyCatHub(CatHubSettings? catHub)
@@ -866,7 +960,28 @@ internal sealed partial class SettingsViewModel : ObservableObject
             request.CatHub = BuildCatHubSettings();
         }
 
+        if (IsWsjtxIngestDirty)
+        {
+            request.WsjtxIngest = BuildWsjtxIngestSettings();
+        }
+
         return request;
+    }
+
+    private WsjtxIngestSettings BuildWsjtxIngestSettings()
+    {
+        var settings = new WsjtxIngestSettings
+        {
+            Enabled = WsjtxIngestEnabled,
+            UdpEnabled = WsjtxUdpEnabled,
+            AdifTailEnabled = WsjtxAdifTailEnabled,
+            SyncToQrz = WsjtxSyncToQrz,
+        };
+
+        SetOptionalString(WsjtxUdpBind, value => settings.UdpBind = value);
+        SetOptionalString(WsjtxAdifTailPath, value => settings.AdifTailPath = value);
+        SetUInt32Field(WsjtxPollIntervalMs, value => settings.PollIntervalMs = value);
+        return settings;
     }
 
     private CatHubSettings BuildCatHubSettings()
@@ -1034,6 +1149,32 @@ internal sealed partial class SettingsViewModel : ObservableObject
             RigControlStaleThresholdMs,
             1,
             "Rig control stale threshold",
+            out validationError);
+    }
+
+    private bool TryValidateWsjtxIngestInputs(out string? validationError)
+    {
+        validationError = null;
+
+        if (WsjtxUdpEnabled
+            && (string.IsNullOrWhiteSpace(WsjtxUdpBind)
+                || !WsjtxUdpBind.Contains(':', StringComparison.Ordinal)))
+        {
+            validationError = "WSJT-X UDP bind must be host:port (for example 127.0.0.1:2237).";
+            return false;
+        }
+
+        if (WsjtxAdifTailEnabled && string.IsNullOrWhiteSpace(WsjtxAdifTailPath))
+        {
+            validationError = "WSJT-X ADIF tail path is required when ADIF tail recovery is enabled.";
+            return false;
+        }
+
+        return TryValidateUInt32Field(
+            WsjtxPollIntervalMs,
+            100,
+            86_400_000,
+            "WSJT-X poll interval",
             out validationError);
     }
 

--- a/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
@@ -774,17 +774,17 @@ internal sealed partial class SettingsViewModel : ObservableObject
         {
             _hasPersistedWsjtxIngest = settings is not null;
             WsjtxIngestEnabled = settings?.Enabled ?? false;
-            WsjtxUdpEnabled = settings?.UdpEnabled ?? true;
+            WsjtxUdpEnabled = settings is { HasUdpEnabled: true } ? settings.UdpEnabled : true;
             WsjtxUdpBind = !string.IsNullOrWhiteSpace(settings?.UdpBind)
                 ? settings.UdpBind
-                : "127.0.0.1:2237";
+                : WsjtxIngestSetup.DefaultUdpBind;
             WsjtxAdifTailEnabled = settings?.AdifTailEnabled ?? false;
             WsjtxAdifTailPath = settings is { HasAdifTailPath: true }
                 ? settings.AdifTailPath
                 : string.Empty;
             WsjtxPollIntervalMs = settings is { PollIntervalMs: > 0 }
                 ? settings.PollIntervalMs.ToString(CultureInfo.InvariantCulture)
-                : "1000";
+                : WsjtxIngestSetup.DefaultPollIntervalMs.ToString(CultureInfo.InvariantCulture);
             WsjtxSyncToQrz = settings?.SyncToQrz ?? false;
         }
         finally
@@ -1156,11 +1156,12 @@ internal sealed partial class SettingsViewModel : ObservableObject
     {
         validationError = null;
 
-        if (WsjtxUdpEnabled
-            && (string.IsNullOrWhiteSpace(WsjtxUdpBind)
-                || !WsjtxUdpBind.Contains(':', StringComparison.Ordinal)))
+        if (!string.IsNullOrWhiteSpace(WsjtxUdpBind)
+            && !WsjtxIngestSetup.TryValidateHostPort(
+                WsjtxUdpBind,
+                "WSJT-X UDP bind",
+                out validationError))
         {
-            validationError = "WSJT-X UDP bind must be host:port (for example 127.0.0.1:2237).";
             return false;
         }
 
@@ -1170,12 +1171,21 @@ internal sealed partial class SettingsViewModel : ObservableObject
             return false;
         }
 
-        return TryValidateUInt32Field(
-            WsjtxPollIntervalMs,
-            100,
-            86_400_000,
-            "WSJT-X poll interval",
-            out validationError);
+        if (!uint.TryParse(WsjtxPollIntervalMs, CultureInfo.InvariantCulture, out var pollInterval)
+            && !string.IsNullOrWhiteSpace(WsjtxPollIntervalMs))
+        {
+            validationError = "WSJT-X poll interval must be a whole number.";
+            return false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(WsjtxPollIntervalMs)
+            && !WsjtxIngestSetup.IsValidPollInterval(pollInterval))
+        {
+            validationError = "WSJT-X poll interval must be 0 for the engine default or a positive whole number.";
+            return false;
+        }
+
+        return true;
     }
 
     private bool TryValidateCatHubInputs(out string? validationError)

--- a/src/dotnet/QsoRipper.Gui/ViewModels/SetupWizardViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/SetupWizardViewModel.cs
@@ -49,6 +49,7 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
         Steps.Add(new StationProfileStepViewModel());
         Steps.Add(new QrzStepViewModel(engine));
         Steps.Add(new QrzLogbookStepViewModel());
+        Steps.Add(new WsjtxIngestStepViewModel());
         Steps.Add(new ReviewStepViewModel());
     }
 
@@ -126,6 +127,11 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
                         logbookStep.SyncIntervalSeconds = (int)syncConfig.SyncIntervalSeconds;
                     }
                 }
+
+                if (Steps[4] is WsjtxIngestStepViewModel wsjtxStep)
+                {
+                    wsjtxStep.ConfigureFromSettings(state.Status.WsjtxIngest);
+                }
             }
 
             foreach (var ss in state.Steps)
@@ -166,10 +172,18 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
         ErrorMessage = null;
         try
         {
-            // QRZ Logbook step uses client-side validation only (no server round-trip).
+            // QRZ Logbook and WSJT-X use client-side validation only (no server round-trip).
             if (CurrentStep is QrzLogbookStepViewModel logbookStep)
             {
                 if (!logbookStep.ValidateLocally())
+                {
+                    ErrorMessage = "Please fix the errors above before continuing.";
+                    return;
+                }
+            }
+            else if (CurrentStep is WsjtxIngestStepViewModel wsjtxStep)
+            {
+                if (!wsjtxStep.ValidateLocally())
                 {
                     ErrorMessage = "Please fix the errors above before continuing.";
                     return;
@@ -222,7 +236,7 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
     [RelayCommand]
     private void Skip()
     {
-        if (CurrentStep is QrzStepViewModel or QrzLogbookStepViewModel)
+        if (CurrentStep is QrzStepViewModel or QrzLogbookStepViewModel or WsjtxIngestStepViewModel)
         {
             CurrentStep.IsComplete = true;
             CurrentStep.ClearErrors();
@@ -264,6 +278,7 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
             var stationStep = Steps.OfType<StationProfileStepViewModel>().First();
             var qrzStep = Steps.OfType<QrzStepViewModel>().First();
             var logbookStep = Steps.OfType<QrzLogbookStepViewModel>().First();
+            var wsjtxStep = Steps.OfType<WsjtxIngestStepViewModel>().First();
 
             var request = new SaveSetupRequest
             {
@@ -291,6 +306,11 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
                     AutoSyncEnabled = logbookStep.AutoSyncEnabled,
                     SyncIntervalSeconds = (uint)logbookStep.SyncIntervalSeconds,
                 };
+            }
+
+            if (wsjtxStep.ShouldSave)
+            {
+                request.WsjtxIngest = wsjtxStep.BuildSettings();
             }
 
             var response = await _engine.SaveSetupAsync(request);
@@ -335,8 +355,8 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
         SetupWizardStep.LogFile => 0,
         SetupWizardStep.StationProfiles => 1,
         SetupWizardStep.QrzIntegration => 2,
-        // Index 3 (QrzLogbook) has no server-side wizard step.
-        SetupWizardStep.Review => 4,
+        // Indexes 3 (QrzLogbook) and 4 (WSJT-X) have no server-side wizard step.
+        SetupWizardStep.Review => 5,
         _ => -1,
     };
 
@@ -345,8 +365,8 @@ internal sealed partial class SetupWizardViewModel : ObservableObject
         0 => SetupWizardStep.LogFile,
         1 => SetupWizardStep.StationProfiles,
         2 => SetupWizardStep.QrzIntegration,
-        // Index 3 (QrzLogbook) is client-validated only.
-        4 => SetupWizardStep.Review,
+        // Indexes 3 (QrzLogbook) and 4 (WSJT-X) are client-validated only.
+        5 => SetupWizardStep.Review,
         _ => SetupWizardStep.Unspecified,
     };
 

--- a/src/dotnet/QsoRipper.Gui/ViewModels/WsjtxIngestStepViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/WsjtxIngestStepViewModel.cs
@@ -1,0 +1,126 @@
+using System.Collections.Generic;
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using QsoRipper.Services;
+
+namespace QsoRipper.Gui.ViewModels;
+
+internal sealed partial class WsjtxIngestStepViewModel : WizardStepViewModel
+{
+    private const string DefaultUdpBind = "127.0.0.1:2237";
+    private const uint DefaultPollIntervalMs = 1000;
+
+    public override string Title => "WSJT-X ingestion (optional)";
+
+    public override string Description =>
+        "Import QSOs logged in WSJT-X using UDP packets, with optional ADIF tail recovery.";
+
+    public override bool IsSkippable => true;
+
+    [ObservableProperty]
+    private bool _enabled;
+
+    [ObservableProperty]
+    private bool _udpEnabled = true;
+
+    [ObservableProperty]
+    private string _udpBind = DefaultUdpBind;
+
+    [ObservableProperty]
+    private bool _adifTailEnabled;
+
+    [ObservableProperty]
+    private string? _adifTailPath;
+
+    [ObservableProperty]
+    private int _pollIntervalMs = (int)DefaultPollIntervalMs;
+
+    [ObservableProperty]
+    private bool _syncToQrz;
+
+    [ObservableProperty]
+    private bool _hasExistingSettings;
+
+    public override Dictionary<string, string> GetFields()
+    {
+        return new Dictionary<string, string>
+        {
+            ["enabled"] = Enabled.ToString(CultureInfo.InvariantCulture),
+            ["udp_enabled"] = UdpEnabled.ToString(CultureInfo.InvariantCulture),
+            ["udp_bind"] = UdpBind,
+            ["adif_tail_enabled"] = AdifTailEnabled.ToString(CultureInfo.InvariantCulture),
+            ["adif_tail_path"] = AdifTailPath ?? string.Empty,
+            ["poll_interval_ms"] = PollIntervalMs.ToString(CultureInfo.InvariantCulture),
+            ["sync_to_qrz"] = SyncToQrz.ToString(CultureInfo.InvariantCulture),
+        };
+    }
+
+    public void ConfigureFromSettings(WsjtxIngestSettings? settings)
+    {
+        HasExistingSettings = settings is not null;
+        Enabled = settings?.Enabled ?? false;
+        UdpEnabled = settings?.UdpEnabled ?? true;
+        UdpBind = string.IsNullOrWhiteSpace(settings?.UdpBind) ? DefaultUdpBind : settings.UdpBind;
+        AdifTailEnabled = settings?.AdifTailEnabled ?? false;
+        AdifTailPath = settings is { HasAdifTailPath: true } ? settings.AdifTailPath : string.Empty;
+        PollIntervalMs = settings is { PollIntervalMs: > 0 }
+            ? (int)settings.PollIntervalMs
+            : (int)DefaultPollIntervalMs;
+        SyncToQrz = settings?.SyncToQrz ?? false;
+    }
+
+    public bool ShouldSave =>
+        HasExistingSettings
+        || Enabled
+        || !UdpEnabled
+        || !string.Equals(UdpBind, DefaultUdpBind, StringComparison.Ordinal)
+        || AdifTailEnabled
+        || !string.IsNullOrWhiteSpace(AdifTailPath)
+        || PollIntervalMs != DefaultPollIntervalMs
+        || SyncToQrz;
+
+    public WsjtxIngestSettings BuildSettings()
+    {
+        var settings = new WsjtxIngestSettings
+        {
+            Enabled = Enabled,
+            UdpEnabled = UdpEnabled,
+            UdpBind = string.IsNullOrWhiteSpace(UdpBind) ? DefaultUdpBind : UdpBind.Trim(),
+            AdifTailEnabled = AdifTailEnabled,
+            PollIntervalMs = PollIntervalMs > 0 ? (uint)PollIntervalMs : DefaultPollIntervalMs,
+            SyncToQrz = SyncToQrz,
+        };
+
+        if (!string.IsNullOrWhiteSpace(AdifTailPath))
+        {
+            settings.AdifTailPath = AdifTailPath.Trim();
+        }
+
+        return settings;
+    }
+
+    public bool ValidateLocally()
+    {
+        if (UdpEnabled
+            && (string.IsNullOrWhiteSpace(UdpBind) || !UdpBind.Contains(':', StringComparison.Ordinal)))
+        {
+            ValidationSummary = "UDP bind must be host:port (for example 127.0.0.1:2237).";
+            return false;
+        }
+
+        if (AdifTailEnabled && string.IsNullOrWhiteSpace(AdifTailPath))
+        {
+            ValidationSummary = "ADIF tail path is required when ADIF tail recovery is enabled.";
+            return false;
+        }
+
+        if (PollIntervalMs is < 100 or > 86_400_000)
+        {
+            ValidationSummary = "Poll interval must be between 100 and 86400000 milliseconds.";
+            return false;
+        }
+
+        ClearErrors();
+        return true;
+    }
+}

--- a/src/dotnet/QsoRipper.Gui/ViewModels/WsjtxIngestStepViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/WsjtxIngestStepViewModel.cs
@@ -2,13 +2,16 @@ using System.Collections.Generic;
 using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using QsoRipper.Services;
+using QsoRipper.Shared.Persistence;
 
 namespace QsoRipper.Gui.ViewModels;
 
 internal sealed partial class WsjtxIngestStepViewModel : WizardStepViewModel
 {
-    private const string DefaultUdpBind = "127.0.0.1:2237";
-    private const uint DefaultPollIntervalMs = 1000;
+    private bool _loading;
+
+    [ObservableProperty]
+    private bool _isDirty;
 
     public override string Title => "WSJT-X ingestion (optional)";
 
@@ -24,7 +27,7 @@ internal sealed partial class WsjtxIngestStepViewModel : WizardStepViewModel
     private bool _udpEnabled = true;
 
     [ObservableProperty]
-    private string _udpBind = DefaultUdpBind;
+    private string _udpBind = WsjtxIngestSetup.DefaultUdpBind;
 
     [ObservableProperty]
     private bool _adifTailEnabled;
@@ -33,7 +36,7 @@ internal sealed partial class WsjtxIngestStepViewModel : WizardStepViewModel
     private string? _adifTailPath;
 
     [ObservableProperty]
-    private int _pollIntervalMs = (int)DefaultPollIntervalMs;
+    private int _pollIntervalMs = (int)WsjtxIngestSetup.DefaultPollIntervalMs;
 
     [ObservableProperty]
     private bool _syncToQrz;
@@ -57,27 +60,37 @@ internal sealed partial class WsjtxIngestStepViewModel : WizardStepViewModel
 
     public void ConfigureFromSettings(WsjtxIngestSettings? settings)
     {
-        HasExistingSettings = settings is not null;
-        Enabled = settings?.Enabled ?? false;
-        UdpEnabled = settings?.UdpEnabled ?? true;
-        UdpBind = string.IsNullOrWhiteSpace(settings?.UdpBind) ? DefaultUdpBind : settings.UdpBind;
-        AdifTailEnabled = settings?.AdifTailEnabled ?? false;
-        AdifTailPath = settings is { HasAdifTailPath: true } ? settings.AdifTailPath : string.Empty;
-        PollIntervalMs = settings is { PollIntervalMs: > 0 }
-            ? (int)settings.PollIntervalMs
-            : (int)DefaultPollIntervalMs;
-        SyncToQrz = settings?.SyncToQrz ?? false;
+        _loading = true;
+        try
+        {
+            HasExistingSettings = settings is not null;
+            Enabled = settings?.Enabled ?? false;
+            UdpEnabled = settings is { HasUdpEnabled: true } ? settings.UdpEnabled : true;
+            UdpBind = string.IsNullOrWhiteSpace(settings?.UdpBind) ? WsjtxIngestSetup.DefaultUdpBind : settings.UdpBind;
+            AdifTailEnabled = settings?.AdifTailEnabled ?? false;
+            AdifTailPath = settings is { HasAdifTailPath: true } ? settings.AdifTailPath : string.Empty;
+            PollIntervalMs = settings is { PollIntervalMs: > 0 }
+                ? (int)settings.PollIntervalMs
+                : (int)WsjtxIngestSetup.DefaultPollIntervalMs;
+            SyncToQrz = settings?.SyncToQrz ?? false;
+        }
+        finally
+        {
+            _loading = false;
+            IsDirty = false;
+        }
     }
 
     public bool ShouldSave =>
-        HasExistingSettings
-        || Enabled
-        || !UdpEnabled
-        || !string.Equals(UdpBind, DefaultUdpBind, StringComparison.Ordinal)
-        || AdifTailEnabled
-        || !string.IsNullOrWhiteSpace(AdifTailPath)
-        || PollIntervalMs != DefaultPollIntervalMs
-        || SyncToQrz;
+        IsDirty
+        || (!HasExistingSettings
+            && (Enabled
+                || !UdpEnabled
+                || !string.Equals(UdpBind, WsjtxIngestSetup.DefaultUdpBind, StringComparison.Ordinal)
+                || AdifTailEnabled
+                || !string.IsNullOrWhiteSpace(AdifTailPath)
+                || PollIntervalMs != WsjtxIngestSetup.DefaultPollIntervalMs
+                || SyncToQrz));
 
     public WsjtxIngestSettings BuildSettings()
     {
@@ -85,9 +98,9 @@ internal sealed partial class WsjtxIngestStepViewModel : WizardStepViewModel
         {
             Enabled = Enabled,
             UdpEnabled = UdpEnabled,
-            UdpBind = string.IsNullOrWhiteSpace(UdpBind) ? DefaultUdpBind : UdpBind.Trim(),
+            UdpBind = string.IsNullOrWhiteSpace(UdpBind) ? WsjtxIngestSetup.DefaultUdpBind : UdpBind.Trim(),
             AdifTailEnabled = AdifTailEnabled,
-            PollIntervalMs = PollIntervalMs > 0 ? (uint)PollIntervalMs : DefaultPollIntervalMs,
+            PollIntervalMs = PollIntervalMs > 0 ? (uint)PollIntervalMs : 0,
             SyncToQrz = SyncToQrz,
         };
 
@@ -101,10 +114,10 @@ internal sealed partial class WsjtxIngestStepViewModel : WizardStepViewModel
 
     public bool ValidateLocally()
     {
-        if (UdpEnabled
-            && (string.IsNullOrWhiteSpace(UdpBind) || !UdpBind.Contains(':', StringComparison.Ordinal)))
+        if (!string.IsNullOrWhiteSpace(UdpBind)
+            && !WsjtxIngestSetup.TryValidateHostPort(UdpBind, "UDP bind", out var hostPortError))
         {
-            ValidationSummary = "UDP bind must be host:port (for example 127.0.0.1:2237).";
+            ValidationSummary = hostPortError;
             return false;
         }
 
@@ -114,13 +127,29 @@ internal sealed partial class WsjtxIngestStepViewModel : WizardStepViewModel
             return false;
         }
 
-        if (PollIntervalMs is < 100 or > 86_400_000)
+        if (PollIntervalMs < 0 || !WsjtxIngestSetup.IsValidPollInterval((uint)PollIntervalMs))
         {
-            ValidationSummary = "Poll interval must be between 100 and 86400000 milliseconds.";
+            ValidationSummary = "Poll interval must be 0 for the engine default or a positive whole number.";
             return false;
         }
 
         ClearErrors();
         return true;
+    }
+
+    partial void OnEnabledChanged(bool value) => MarkDirty();
+    partial void OnUdpEnabledChanged(bool value) => MarkDirty();
+    partial void OnUdpBindChanged(string value) => MarkDirty();
+    partial void OnAdifTailEnabledChanged(bool value) => MarkDirty();
+    partial void OnAdifTailPathChanged(string? value) => MarkDirty();
+    partial void OnPollIntervalMsChanged(int value) => MarkDirty();
+    partial void OnSyncToQrzChanged(bool value) => MarkDirty();
+
+    private void MarkDirty()
+    {
+        if (!_loading)
+        {
+            IsDirty = true;
+        }
     }
 }

--- a/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
@@ -57,7 +57,7 @@
                      TextWrapping="Wrap"
                      IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
           <TextBlock Classes="settingsSectionHint"
-                     Text="Sections: Ctrl+1 Station  Ctrl+2 Display  Ctrl+3 Storage  Ctrl+4 QRZ  Ctrl+5 Rig  Ctrl+6 CAT Hub  Ctrl+Tab Next"
+                     Text="Sections: Ctrl+1 Station  Ctrl+2 Display  Ctrl+3 Storage  Ctrl+4 QRZ  Ctrl+5 Rig  Ctrl+6 CAT Hub  Ctrl+7 WSJT-X  Ctrl+Tab Next"
                      IsVisible="{Binding ErrorMessage, Converter={x:Static StringConverters.IsNullOrEmpty}}" />
         </StackPanel>
 
@@ -733,6 +733,102 @@
                 </DataTemplate>
               </ItemsControl.ItemTemplate>
             </ItemsControl>
+          </StackPanel>
+        </ScrollViewer>
+      </TabItem>
+
+      <TabItem AutomationProperties.AutomationId="SettingsWsjtxTab">
+        <TabItem.Header>
+          <StackPanel Spacing="1">
+            <TextBlock Text="WSJT-X" />
+            <TextBlock Classes="settingsTabShortcut" Text="Ctrl+7" />
+          </StackPanel>
+        </TabItem.Header>
+        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                      HorizontalScrollBarVisibility="Disabled"
+                      Padding="16">
+          <StackPanel Spacing="16">
+            <TextBlock Classes="settingsSectionHeader" Text="WSJT-X ingestion" />
+            <TextBlock Classes="settingsSectionHint"
+                       Text="Import QSOs logged in WSJT-X. The UDP listener handles normal Log QSO packets; ADIF tail recovery can catch records missed while QsoRipper was offline." />
+
+            <Border AutomationProperties.AutomationId="SettingsWsjtxRewriteWarning"
+                    IsVisible="{Binding ShowWsjtxIngestRewriteWarning}"
+                    Background="#332E1A"
+                    BorderBrush="#B8862B"
+                    BorderThickness="1"
+                    CornerRadius="4"
+                    Padding="12,8">
+              <TextBlock TextWrapping="Wrap"
+                         Foreground="#E8C76B"
+                         Text="Saving rewrites the entire [wsjtx_ingest] section. Comments and any keys not shown here will be dropped." />
+            </Border>
+
+            <CheckBox x:Name="SettingsWsjtxIngestEnabledCheckBox"
+                      AutomationProperties.AutomationId="SettingsWsjtxIngestEnabledCheckBox"
+                      Content="Enable WSJT-X QSO ingestion"
+                      IsChecked="{Binding WsjtxIngestEnabled, Mode=TwoWay}" />
+
+            <Grid ColumnDefinitions="150,*,150,*"
+                  RowDefinitions="Auto,Auto,Auto"
+                  ColumnSpacing="12"
+                  RowSpacing="8">
+              <CheckBox x:Name="SettingsWsjtxUdpEnabledCheckBox"
+                        AutomationProperties.AutomationId="SettingsWsjtxUdpEnabledCheckBox"
+                        Grid.Row="0"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
+                        Content="Listen for WSJT-X UDP Logged ADIF packets"
+                        IsChecked="{Binding WsjtxUdpEnabled, Mode=TwoWay}" />
+
+              <TextBlock Grid.Row="1" Grid.Column="0" Text="UDP bind:" VerticalAlignment="Center" />
+              <TextBox x:Name="SettingsWsjtxUdpBindBox"
+                       AutomationProperties.AutomationId="SettingsWsjtxUdpBindBox"
+                       Grid.Row="1"
+                       Grid.Column="1"
+                       Text="{Binding WsjtxUdpBind, Mode=TwoWay}"
+                       PlaceholderText="127.0.0.1:2237" />
+
+              <TextBlock Grid.Row="1" Grid.Column="2" Text="Poll interval (ms):" VerticalAlignment="Center" />
+              <TextBox x:Name="SettingsWsjtxPollIntervalBox"
+                       AutomationProperties.AutomationId="SettingsWsjtxPollIntervalBox"
+                       Grid.Row="1"
+                       Grid.Column="3"
+                       Text="{Binding WsjtxPollIntervalMs, Mode=TwoWay}"
+                       PlaceholderText="1000" />
+
+              <CheckBox x:Name="SettingsWsjtxAdifTailEnabledCheckBox"
+                        AutomationProperties.AutomationId="SettingsWsjtxAdifTailEnabledCheckBox"
+                        Grid.Row="2"
+                        Grid.Column="0"
+                        Grid.ColumnSpan="2"
+                        Content="Tail WSJT-X ADIF log for missed-QSO recovery"
+                        IsChecked="{Binding WsjtxAdifTailEnabled, Mode=TwoWay}" />
+
+              <CheckBox x:Name="SettingsWsjtxSyncToQrzCheckBox"
+                        AutomationProperties.AutomationId="SettingsWsjtxSyncToQrzCheckBox"
+                        Grid.Row="2"
+                        Grid.Column="2"
+                        Grid.ColumnSpan="2"
+                        Content="Upload imported WSJT-X QSOs to QRZ"
+                        IsChecked="{Binding WsjtxSyncToQrz, Mode=TwoWay}" />
+            </Grid>
+
+            <Grid ColumnDefinitions="150,*"
+                  ColumnSpacing="12">
+              <TextBlock Grid.Column="0" Text="ADIF tail path:" VerticalAlignment="Center" />
+              <TextBox x:Name="SettingsWsjtxAdifTailPathBox"
+                       AutomationProperties.AutomationId="SettingsWsjtxAdifTailPathBox"
+                       Grid.Column="1"
+                       Text="{Binding WsjtxAdifTailPath, Mode=TwoWay}"
+                       PlaceholderText="%LOCALAPPDATA%\WSJT-X\wsjtx_log.adi"
+                       TextWrapping="NoWrap"
+                       ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                       ToolTip.Tip="{Binding WsjtxAdifTailPath}" />
+            </Grid>
+
+            <TextBlock Classes="settingsSectionHint"
+                       Text="In WSJT-X, configure Reporting → UDP Server to match the bind address above. The default local-only listener is 127.0.0.1:2237." />
           </StackPanel>
         </ScrollViewer>
       </TabItem>

--- a/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml.cs
@@ -103,6 +103,7 @@ internal sealed partial class SettingsView : Window
             3 => this.FindControl<Control>("SettingsQrzXmlUsernameBox"),
             4 => this.FindControl<Control>("SettingsRigControlEnabledCheckBox"),
             5 => this.FindControl<Control>("SettingsCatHubBackendBox"),
+            6 => this.FindControl<Control>("SettingsWsjtxIngestEnabledCheckBox"),
             _ => null
         };
 
@@ -153,6 +154,11 @@ internal sealed partial class SettingsView : Window
             case Key.D6:
             case Key.NumPad6:
                 vm.SelectCatHubSectionCommand.Execute(null);
+                e.Handled = true;
+                return true;
+            case Key.D7:
+            case Key.NumPad7:
+                vm.SelectWsjtxSectionCommand.Execute(null);
                 e.Handled = true;
                 return true;
             case Key.Tab:

--- a/src/dotnet/QsoRipper.Gui/Views/SetupWizardView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/SetupWizardView.axaml
@@ -100,6 +100,9 @@
               <DataTemplate DataType="vm:QrzLogbookStepViewModel">
                 <v:QrzLogbookStepView />
               </DataTemplate>
+              <DataTemplate DataType="vm:WsjtxIngestStepViewModel">
+                <v:WsjtxIngestStepView />
+              </DataTemplate>
               <DataTemplate DataType="vm:ReviewStepViewModel">
                 <v:ReviewStepView />
               </DataTemplate>

--- a/src/dotnet/QsoRipper.Gui/Views/WsjtxIngestStepView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/WsjtxIngestStepView.axaml
@@ -1,0 +1,68 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="using:QsoRipper.Gui.ViewModels"
+             x:Class="QsoRipper.Gui.Views.WsjtxIngestStepView"
+             x:DataType="vm:WsjtxIngestStepViewModel">
+
+  <StackPanel Spacing="12">
+    <TextBlock TextWrapping="Wrap"
+               Opacity="0.7"
+               Text="Enable this if you want QsoRipper to automatically import contacts you log in WSJT-X." />
+
+    <CheckBox x:Name="WizardWsjtxIngestEnabledCheckBox"
+              AutomationProperties.AutomationId="WizardWsjtxIngestEnabledCheckBox"
+              Content="Enable WSJT-X QSO ingestion"
+              IsChecked="{Binding Enabled, Mode=TwoWay}" />
+
+    <CheckBox x:Name="WizardWsjtxUdpEnabledCheckBox"
+              AutomationProperties.AutomationId="WizardWsjtxUdpEnabledCheckBox"
+              Content="Listen for WSJT-X UDP Logged ADIF packets"
+              IsChecked="{Binding UdpEnabled, Mode=TwoWay}" />
+
+    <StackPanel Spacing="4">
+      <TextBlock Text="UDP bind address:" FontWeight="SemiBold" />
+      <TextBox x:Name="WizardWsjtxUdpBindBox"
+               AutomationProperties.AutomationId="WizardWsjtxUdpBindBox"
+               Text="{Binding UdpBind, Mode=TwoWay}"
+               PlaceholderText="127.0.0.1:2237" />
+      <TextBlock Text="Match this in WSJT-X under Settings → Reporting → UDP Server."
+                 Opacity="0.6"
+                 FontSize="12" />
+    </StackPanel>
+
+    <StackPanel Spacing="4">
+      <TextBlock Text="Poll interval (milliseconds):" FontWeight="SemiBold" />
+      <NumericUpDown x:Name="WizardWsjtxPollIntervalInput"
+                     AutomationProperties.AutomationId="WizardWsjtxPollIntervalInput"
+                     Value="{Binding PollIntervalMs, Mode=TwoWay}"
+                     Minimum="100"
+                     Maximum="86400000"
+                     Increment="100"
+                     FormatString="0" />
+    </StackPanel>
+
+    <CheckBox x:Name="WizardWsjtxAdifTailEnabledCheckBox"
+              AutomationProperties.AutomationId="WizardWsjtxAdifTailEnabledCheckBox"
+              Content="Tail WSJT-X ADIF log for missed-QSO recovery"
+              IsChecked="{Binding AdifTailEnabled, Mode=TwoWay}" />
+
+    <StackPanel Spacing="4">
+      <TextBlock Text="ADIF tail path:" FontWeight="SemiBold" />
+      <TextBox x:Name="WizardWsjtxAdifTailPathBox"
+               AutomationProperties.AutomationId="WizardWsjtxAdifTailPathBox"
+               Text="{Binding AdifTailPath, Mode=TwoWay}"
+               PlaceholderText="%LOCALAPPDATA%\WSJT-X\wsjtx_log.adi" />
+    </StackPanel>
+
+    <CheckBox x:Name="WizardWsjtxSyncToQrzCheckBox"
+              AutomationProperties.AutomationId="WizardWsjtxSyncToQrzCheckBox"
+              Content="Upload imported WSJT-X QSOs to QRZ"
+              IsChecked="{Binding SyncToQrz, Mode=TwoWay}" />
+
+    <TextBlock Text="Local logging still works if you skip this step; you can configure WSJT-X later in Settings."
+               Opacity="0.5"
+               TextWrapping="Wrap"
+               FontSize="12"
+               Margin="0,8,0,0" />
+  </StackPanel>
+</UserControl>

--- a/src/dotnet/QsoRipper.Gui/Views/WsjtxIngestStepView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/WsjtxIngestStepView.axaml
@@ -35,8 +35,7 @@
       <NumericUpDown x:Name="WizardWsjtxPollIntervalInput"
                      AutomationProperties.AutomationId="WizardWsjtxPollIntervalInput"
                      Value="{Binding PollIntervalMs, Mode=TwoWay}"
-                     Minimum="100"
-                     Maximum="86400000"
+                     Minimum="0"
                      Increment="100"
                      FormatString="0" />
     </StackPanel>

--- a/src/dotnet/QsoRipper.Gui/Views/WsjtxIngestStepView.axaml.cs
+++ b/src/dotnet/QsoRipper.Gui/Views/WsjtxIngestStepView.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace QsoRipper.Gui.Views;
+
+internal sealed partial class WsjtxIngestStepView : UserControl
+{
+    public WsjtxIngestStepView()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/dotnet/Shared/Persistence/WsjtxIngestSetup.cs
+++ b/src/dotnet/Shared/Persistence/WsjtxIngestSetup.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Globalization;
+
+namespace QsoRipper.Shared.Persistence;
+
+internal static class WsjtxIngestSetup
+{
+    public const string DefaultUdpBind = "127.0.0.1:2237";
+    public const uint DefaultPollIntervalMs = 1000;
+
+    public const string EnabledEnvironmentVariable = "QSORIPPER_WSJTX_INGEST_ENABLED";
+    public const string UdpEnabledEnvironmentVariable = "QSORIPPER_WSJTX_INGEST_UDP_ENABLED";
+    public const string UdpBindEnvironmentVariable = "QSORIPPER_WSJTX_INGEST_UDP_BIND";
+    public const string AdifTailEnabledEnvironmentVariable = "QSORIPPER_WSJTX_INGEST_ADIF_TAIL_ENABLED";
+    public const string AdifTailPathEnvironmentVariable = "QSORIPPER_WSJTX_INGEST_ADIF_TAIL_PATH";
+    public const string PollIntervalMsEnvironmentVariable = "QSORIPPER_WSJTX_INGEST_POLL_INTERVAL_MS";
+    public const string SyncToQrzEnvironmentVariable = "QSORIPPER_WSJTX_INGEST_SYNC_TO_QRZ";
+
+    public static string? ReadEnvironmentValue(string canonicalName, params string[] aliases)
+    {
+        var value = Environment.GetEnvironmentVariable(canonicalName);
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            return value;
+        }
+
+        foreach (var alias in aliases)
+        {
+            value = Environment.GetEnvironmentVariable(alias);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+        }
+
+        return null;
+    }
+
+    public static bool TryValidateHostPort(string? value, string label, out string? errorMessage)
+    {
+        errorMessage = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            errorMessage = $"{label} must be host:port with a port between 1 and 65535.";
+            return false;
+        }
+
+        var trimmed = value.Trim();
+        var separator = trimmed.LastIndexOf(':');
+        if (separator <= 0 || separator == trimmed.Length - 1)
+        {
+            errorMessage = $"{label} must be host:port with a port between 1 and 65535.";
+            return false;
+        }
+
+        var host = trimmed[..separator];
+        var portText = trimmed[(separator + 1)..];
+        if (string.IsNullOrWhiteSpace(host)
+            || !ushort.TryParse(portText, NumberStyles.None, CultureInfo.InvariantCulture, out var port)
+            || port == 0)
+        {
+            errorMessage = $"{label} must be host:port with a port between 1 and 65535.";
+            return false;
+        }
+
+        return true;
+    }
+
+    public static bool IsValidPollInterval(uint _) => true;
+}

--- a/src/rust/qsoripper-core/Cargo.toml
+++ b/src/rust/qsoripper-core/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1"
 workspace = true
 
 [dev-dependencies]
+tempfile = "3"
 
 [build-dependencies]
 tonic-build = "0.12"

--- a/src/rust/qsoripper-core/src/application/logbook.rs
+++ b/src/rust/qsoripper-core/src/application/logbook.rs
@@ -315,6 +315,9 @@ impl LogbookEngine {
                 }
             }
 
+            if let Some(qso) = outcome.affected_qso {
+                summary.affected_qsos.push(qso);
+            }
             summary.warnings.extend(outcome.warnings);
         }
 
@@ -396,7 +399,19 @@ impl LogbookEngine {
 
         if let Some(existing) = self.find_duplicate_import(&qso).await? {
             if refresh {
-                let merged = merge_qso_for_refresh(existing, &qso);
+                let merged = merge_qso_for_refresh(existing.clone(), &qso);
+                let mut comparable_existing = existing;
+                comparable_existing.updated_at = merged.updated_at;
+                if comparable_existing == merged {
+                    warnings.push(format!(
+                        "Record {record_number}: duplicate skipped; matched an existing QSO and import data did not change it."
+                    ));
+                    return Ok(AdifImportOutcome {
+                        kind: AdifImportOutcomeKind::Skipped,
+                        affected_qso: None,
+                        warnings,
+                    });
+                }
                 self.storage.logbook().update_qso(&merged).await?;
                 warnings.push(format!(
                     "Record {record_number}: refreshed existing record '{}'.",
@@ -404,6 +419,7 @@ impl LogbookEngine {
                 ));
                 return Ok(AdifImportOutcome {
                     kind: AdifImportOutcomeKind::Updated,
+                    affected_qso: Some(merged),
                     warnings,
                 });
             }
@@ -413,13 +429,15 @@ impl LogbookEngine {
             ));
             return Ok(AdifImportOutcome {
                 kind: AdifImportOutcomeKind::Skipped,
+                affected_qso: None,
                 warnings,
             });
         }
 
-        let _ = self.log_qso(qso).await?;
+        let stored = self.log_qso(qso).await?;
         Ok(AdifImportOutcome {
             kind: AdifImportOutcomeKind::Imported,
+            affected_qso: Some(stored),
             warnings,
         })
     }
@@ -473,7 +491,7 @@ pub struct LogbookSyncStatus {
 }
 
 /// Summary of an ADIF import run.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AdifImportSummary {
     /// Number of records inserted into storage.
     pub records_imported: u32,
@@ -483,6 +501,8 @@ pub struct AdifImportSummary {
     pub records_updated: u32,
     /// Human-readable warnings collected during import.
     pub warnings: Vec<String>,
+    /// Records inserted or updated by this import.
+    pub affected_qsos: Vec<QsoRecord>,
 }
 
 impl LogbookSyncStatus {
@@ -521,9 +541,10 @@ enum AdifImportOutcomeKind {
     Skipped,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 struct AdifImportOutcome {
     kind: AdifImportOutcomeKind,
+    affected_qso: Option<QsoRecord>,
     warnings: Vec<String>,
 }
 
@@ -531,6 +552,7 @@ impl AdifImportOutcome {
     fn skipped(warning: String) -> Self {
         Self {
             kind: AdifImportOutcomeKind::Skipped,
+            affected_qso: None,
             warnings: vec![warning],
         }
     }

--- a/src/rust/qsoripper-core/src/application/logbook.rs
+++ b/src/rust/qsoripper-core/src/application/logbook.rs
@@ -6,7 +6,9 @@ use crate::domain::station::{
     station_snapshot_has_values,
 };
 use crate::proto::qsoripper::domain::{Band, Mode, QsoRecord, StationProfile, SyncStatus};
-use crate::storage::{EngineStorage, LogbookCounts, QsoListQuery, StorageError, SyncMetadata};
+use crate::storage::{
+    DeletedRecordsFilter, EngineStorage, LogbookCounts, QsoListQuery, StorageError, SyncMetadata,
+};
 use chrono::Utc;
 use prost_types::Timestamp;
 use std::sync::Arc;
@@ -14,6 +16,7 @@ use thiserror::Error;
 
 const ADIF_DUPLICATE_TIME_WINDOW_SECONDS: i64 = 59;
 const ADIF_DUPLICATE_FREQUENCY_TOLERANCE_HZ: u64 = 100;
+const ADIF_IMPORT_FINGERPRINT_FIELD: &str = "APP_QSORIPPER_IMPORT_FINGERPRINT";
 
 /// Coordinates QSO CRUD and sync-status reads through a storage backend.
 #[derive(Clone)]
@@ -390,6 +393,7 @@ impl LogbookEngine {
         }
 
         normalize_qso_for_persistence(&mut qso);
+        stamp_adif_import_fingerprint(&mut qso);
 
         if let Some(reason) = invalid_import_reason(&qso) {
             return Ok(AdifImportOutcome::skipped(format!(
@@ -398,6 +402,17 @@ impl LogbookEngine {
         }
 
         if let Some(existing) = self.find_duplicate_import(&qso).await? {
+            if existing.deleted_at.is_some() {
+                warnings.push(format!(
+                    "Record {record_number}: duplicate skipped; matched a deleted existing QSO and was not resurrected."
+                ));
+                return Ok(AdifImportOutcome {
+                    kind: AdifImportOutcomeKind::Skipped,
+                    affected_qso: None,
+                    warnings,
+                });
+            }
+
             if refresh {
                 let merged = merge_qso_for_refresh(existing.clone(), &qso);
                 let mut comparable_existing = existing;
@@ -412,14 +427,14 @@ impl LogbookEngine {
                         warnings,
                     });
                 }
-                self.storage.logbook().update_qso(&merged).await?;
+                let updated = self.update_qso(merged).await?;
                 warnings.push(format!(
                     "Record {record_number}: refreshed existing record '{}'.",
-                    merged.local_id
+                    updated.local_id
                 ));
                 return Ok(AdifImportOutcome {
                     kind: AdifImportOutcomeKind::Updated,
-                    affected_qso: Some(merged),
+                    affected_qso: Some(updated),
                     warnings,
                 });
             }
@@ -446,6 +461,23 @@ impl LogbookEngine {
         &self,
         candidate: &QsoRecord,
     ) -> Result<Option<QsoRecord>, LogbookError> {
+        if let Some(import_fingerprint) = candidate.extra_fields.get(ADIF_IMPORT_FINGERPRINT_FIELD)
+        {
+            let all_qsos = self
+                .storage
+                .logbook()
+                .list_qsos(&QsoListQuery {
+                    deleted_filter: DeletedRecordsFilter::All,
+                    ..QsoListQuery::default()
+                })
+                .await?;
+            if let Some(existing) = all_qsos.into_iter().find(|existing| {
+                existing.extra_fields.get(ADIF_IMPORT_FINGERPRINT_FIELD) == Some(import_fingerprint)
+            }) {
+                return Ok(Some(existing));
+            }
+        }
+
         let Some(timestamp) = candidate.utc_timestamp else {
             return Ok(None);
         };
@@ -465,6 +497,7 @@ impl LogbookEngine {
                     ADIF_DUPLICATE_TIME_WINDOW_SECONDS,
                 )),
                 callsign_filter,
+                deleted_filter: DeletedRecordsFilter::All,
                 ..QsoListQuery::default()
             })
             .await?;
@@ -670,6 +703,42 @@ fn qsos_match_for_duplicate(existing: &QsoRecord, candidate: &QsoRecord) -> bool
         )
         && optional_strings_compatible(existing.submode.as_deref(), candidate.submode.as_deref())
         && frequencies_compatible(existing, candidate)
+}
+
+fn stamp_adif_import_fingerprint(qso: &mut QsoRecord) {
+    let fingerprint = adif_import_fingerprint(qso);
+    qso.extra_fields
+        .insert(ADIF_IMPORT_FINGERPRINT_FIELD.to_string(), fingerprint);
+}
+
+fn adif_import_fingerprint(qso: &QsoRecord) -> String {
+    let timestamp = qso
+        .utc_timestamp
+        .as_ref()
+        .map_or_else(String::new, |stamp| {
+            format!("{}.{:09}", stamp.seconds, stamp.nanos)
+        });
+    [
+        "v1".to_string(),
+        qso.station_callsign.trim().to_ascii_uppercase(),
+        qso.worked_callsign.trim().to_ascii_uppercase(),
+        timestamp,
+        qso.band.to_string(),
+        qso.mode.to_string(),
+        qso.submode
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or_default()
+            .to_ascii_uppercase(),
+        qso.frequency_hz
+            .map_or_else(String::new, |frequency| frequency.to_string()),
+        {
+            #[allow(deprecated)]
+            let frequency_khz = qso.frequency_khz;
+            frequency_khz.map_or_else(String::new, |frequency| frequency.to_string())
+        },
+    ]
+    .join("\u{1f}")
 }
 
 /// Merge import data onto an existing record for refresh mode.

--- a/src/rust/qsoripper-core/src/lib.rs
+++ b/src/rust/qsoripper-core/src/lib.rs
@@ -25,3 +25,5 @@ pub mod rig_control;
 pub mod space_weather;
 /// Storage ports, errors, and query types for engine-owned persistence.
 pub mod storage;
+/// WSJT-X ingestion helpers that feed the ADIF import path.
+pub mod wsjtx;

--- a/src/rust/qsoripper-core/src/lookup/coordinator.rs
+++ b/src/rust/qsoripper-core/src/lookup/coordinator.rs
@@ -1001,6 +1001,14 @@ mod tests {
         ) -> Result<bool, StorageError> {
             unimplemented!()
         }
+        async fn update_qrz_sync_metadata(
+            &self,
+            _local_id: &str,
+            _expected_updated_at: Option<&prost_types::Timestamp>,
+            _qrz_logid: &str,
+        ) -> Result<Option<crate::proto::qsoripper::domain::QsoRecord>, StorageError> {
+            unimplemented!()
+        }
         async fn delete_qso(&self, _local_id: &str) -> Result<bool, StorageError> {
             unimplemented!()
         }

--- a/src/rust/qsoripper-core/src/storage/ports.rs
+++ b/src/rust/qsoripper-core/src/storage/ports.rs
@@ -4,6 +4,7 @@ use crate::proto::qsoripper::domain::QsoRecord;
 use crate::storage::{
     LogbookCounts, LookupSnapshot, QsoHistoryPage, QsoListQuery, StorageError, SyncMetadata,
 };
+use prost_types::Timestamp;
 
 /// Root engine-owned storage abstraction used by application services.
 pub trait EngineStorage: Send + Sync {
@@ -25,6 +26,22 @@ pub trait LogbookStore: Send + Sync {
 
     /// Update an existing QSO. Returns `true` when a row was updated.
     async fn update_qso(&self, qso: &QsoRecord) -> Result<bool, StorageError>;
+
+    /// Patch QRZ sync metadata onto the current row without overwriting other QSO fields.
+    ///
+    /// Implementations must update atomically against their storage lock/transaction so
+    /// concurrent operator edits cannot be replaced by stale upload snapshots. If the
+    /// current row still has `expected_updated_at`, the row becomes `SYNCED`; otherwise
+    /// only QRZ metadata is patched and the row remains pending as `MODIFIED`, except
+    /// existing conflict rows remain `CONFLICT`. If the row was soft-deleted before
+    /// the patch, implementations must preserve the tombstone, record the QRZ logid,
+    /// and set `pending_remote_delete` so a later sync removes the remote row.
+    async fn update_qrz_sync_metadata(
+        &self,
+        local_id: &str,
+        expected_updated_at: Option<&Timestamp>,
+        qrz_logid: &str,
+    ) -> Result<Option<QsoRecord>, StorageError>;
 
     /// Delete a QSO by local ID. Returns `true` when a row was removed.
     async fn delete_qso(&self, local_id: &str) -> Result<bool, StorageError>;

--- a/src/rust/qsoripper-core/src/wsjtx.rs
+++ b/src/rust/qsoripper-core/src/wsjtx.rs
@@ -3,6 +3,7 @@
 use crate::adif::parse_adi_qsos_without_header_detection;
 use crate::application::logbook::{AdifImportSummary, LogbookEngine, LogbookError};
 use crate::proto::qsoripper::domain::StationProfile;
+#[cfg(test)]
 use serde_json::Value;
 use std::fs;
 use std::path::Path;
@@ -11,17 +12,13 @@ const WSJTX_MAGIC: u32 = 0xadbc_cbda;
 const WSJTX_LOGGED_ADIF_MESSAGE_TYPE: u32 = 12;
 const WSJTX_NULL_STRING_LENGTH: u32 = u32::MAX;
 
-/// Import a WSJT-X UDP datagram by extracting any embedded ADIF payload and
-/// feeding it through the normal logbook import path.
-///
-/// The parser accepts both raw ADIF text and lightweight JSON envelopes such as
-/// `{"type":"logged_qso","adif":"<CALL:...>"}` that WSJT-X integrations often
-/// emit when forwarding QSO events to downstream tooling.
+/// Test/simulation helper that accepts permissive WSJT-X-like UDP payloads.
 ///
 /// # Errors
 ///
 /// Returns an error when the datagram has no usable ADIF payload or when the
 /// import pipeline rejects the parsed QSO records.
+#[cfg(test)]
 pub async fn ingest_wsjtx_udp_datagram(
     logbook_engine: &LogbookEngine,
     datagram: &[u8],
@@ -34,12 +31,42 @@ pub async fn ingest_wsjtx_udp_datagram(
             ..AdifImportSummary::default()
         });
     };
-    ingest_adif_payload(
+    Box::pin(ingest_adif_payload(
         logbook_engine,
         &adif_payload,
         active_station_profile,
         refresh,
-    )
+    ))
+    .await
+}
+
+/// Import a real WSJT-X Logged ADIF UDP datagram.
+///
+/// This production entry point accepts only the WSJT-X magic-framed Logged ADIF
+/// message and ignores other WSJT-X message types.
+///
+/// # Errors
+///
+/// Returns an error when a Logged ADIF datagram is malformed or when the import
+/// pipeline rejects the parsed QSO records.
+pub async fn ingest_wsjtx_logged_adif_datagram(
+    logbook_engine: &LogbookEngine,
+    datagram: &[u8],
+    active_station_profile: Option<&StationProfile>,
+    refresh: bool,
+) -> Result<AdifImportSummary, String> {
+    let Some(adif_payload) = extract_wsjtx_logged_adif(datagram)? else {
+        return Ok(AdifImportSummary {
+            records_skipped: 1,
+            ..AdifImportSummary::default()
+        });
+    };
+    Box::pin(ingest_adif_payload(
+        logbook_engine,
+        &adif_payload,
+        active_station_profile,
+        refresh,
+    ))
     .await
 }
 
@@ -79,17 +106,18 @@ pub async fn ingest_wsjtx_adif_tail(
         return Ok(AdifImportSummary::default());
     };
 
-    let summary = ingest_adif_payload(
+    let summary = Box::pin(ingest_adif_payload(
         logbook_engine,
         complete_payload,
         active_station_profile,
         refresh,
-    )
+    ))
     .await?;
     *cursor = start.saturating_add(complete_len);
     Ok(summary)
 }
 
+#[cfg(test)]
 fn extract_adif_payload(datagram: &[u8]) -> Result<Option<Vec<u8>>, String> {
     if read_be_u32(datagram, 0)?.is_some_and(|magic| magic == WSJTX_MAGIC) {
         return extract_wsjtx_logged_adif(datagram);
@@ -203,8 +231,7 @@ async fn ingest_adif_payload(
         return Ok(AdifImportSummary::default());
     }
 
-    logbook_engine
-        .import_adif_qsos(qsos, active_station_profile, refresh)
+    Box::pin(logbook_engine.import_adif_qsos(qsos, active_station_profile, refresh))
         .await
         .map_err(format_wsjtx_error)
 }
@@ -221,18 +248,79 @@ fn format_wsjtx_error(error: LogbookError) -> String {
 }
 
 fn complete_adif_prefix_len(bytes: &[u8]) -> Option<usize> {
-    let marker = b"<eor>";
     let mut last_end = None;
-    for (index, window) in bytes.windows(marker.len()).enumerate() {
-        if window
-            .iter()
-            .zip(marker)
-            .all(|(left, right)| left.to_ascii_lowercase() == *right)
-        {
-            last_end = Some(index + marker.len());
+    let mut cursor = 0;
+    while cursor < bytes.len() {
+        let Some(remaining) = bytes.get(cursor..) else {
+            break;
+        };
+        let Some(tag_start_offset) = remaining.iter().position(|byte| *byte == b'<') else {
+            break;
+        };
+        let tag_start = cursor + tag_start_offset;
+        let Some(tag_and_rest) = bytes.get(tag_start..) else {
+            break;
+        };
+        let Some(tag_end_offset) = tag_and_rest.iter().position(|byte| *byte == b'>') else {
+            break;
+        };
+        let tag_end = tag_start + tag_end_offset;
+        let Some(tag_body) = bytes.get(tag_start + 1..tag_end) else {
+            break;
+        };
+        let field_name = adif_tag_name(tag_body);
+        cursor = tag_end + 1;
+
+        if field_name.eq_ignore_ascii_case(b"eor") {
+            last_end = Some(cursor);
+            continue;
+        }
+
+        if let Some(field_len) = adif_field_len(tag_body) {
+            let Some(next_cursor) = cursor_after_utf8_chars(bytes, cursor, field_len) else {
+                break;
+            };
+            cursor = next_cursor;
         }
     }
     last_end
+}
+
+fn cursor_after_utf8_chars(bytes: &[u8], start: usize, char_count: usize) -> Option<usize> {
+    let remaining = std::str::from_utf8(bytes.get(start..)?).ok()?;
+    let mut end_offset = 0;
+    for _ in 0..char_count {
+        let (offset, ch) = remaining.get(end_offset..)?.char_indices().next()?;
+        end_offset = end_offset.checked_add(offset)?.checked_add(ch.len_utf8())?;
+    }
+    start.checked_add(end_offset)
+}
+
+fn adif_tag_name(tag_body: &[u8]) -> &[u8] {
+    let end = tag_body
+        .iter()
+        .position(|byte| *byte == b':' || byte.is_ascii_whitespace())
+        .unwrap_or(tag_body.len());
+    tag_body.get(..end).unwrap_or(tag_body)
+}
+
+fn adif_field_len(tag_body: &[u8]) -> Option<usize> {
+    let colon = tag_body.iter().position(|byte| *byte == b':')?;
+    let mut length = 0_usize;
+    let mut saw_digit = false;
+    for byte in tag_body.get(colon + 1..)? {
+        if *byte == b':' {
+            break;
+        }
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+        saw_digit = true;
+        length = length
+            .checked_mul(10)?
+            .checked_add(usize::from(*byte - b'0'))?;
+    }
+    saw_digit.then_some(length)
 }
 
 #[cfg(test)]
@@ -243,7 +331,7 @@ mod tests {
         ingest_wsjtx_udp_datagram, WSJTX_LOGGED_ADIF_MESSAGE_TYPE, WSJTX_MAGIC,
     };
     use crate::application::logbook::{AdifImportSummary, LogbookEngine};
-    use crate::proto::qsoripper::domain::QsoRecord;
+    use crate::proto::qsoripper::domain::{QsoRecord, SyncStatus};
     use crate::storage::{
         EngineStorage, LogbookCounts, LogbookStore, LookupSnapshot, LookupSnapshotStore,
         QsoHistoryPage, QsoListQuery, StorageError, SyncMetadata,
@@ -295,6 +383,30 @@ mod tests {
         async fn update_qso(&self, qso: &QsoRecord) -> Result<bool, StorageError> {
             let mut qsos = self.qsos.write().await;
             Ok(qsos.insert(qso.local_id.clone(), qso.clone()).is_some())
+        }
+
+        async fn update_qrz_sync_metadata(
+            &self,
+            local_id: &str,
+            expected_updated_at: Option<&prost_types::Timestamp>,
+            qrz_logid: &str,
+        ) -> Result<Option<QsoRecord>, StorageError> {
+            let mut qsos = self.qsos.write().await;
+            let Some(record) = qsos.get_mut(local_id) else {
+                return Ok(None);
+            };
+
+            let unchanged_since_upload_started = record.updated_at.as_ref() == expected_updated_at;
+            record.qrz_logid = Some(qrz_logid.to_string());
+            record.sync_status = if unchanged_since_upload_started {
+                SyncStatus::Synced as i32
+            } else if record.sync_status == SyncStatus::Conflict as i32 {
+                record.sync_status
+            } else {
+                SyncStatus::Modified as i32
+            };
+
+            Ok(Some(record.clone()))
         }
 
         async fn delete_qso(&self, local_id: &str) -> Result<bool, StorageError> {
@@ -523,7 +635,8 @@ mod tests {
 
     #[tokio::test]
     async fn ingest_wsjtx_udp_datagram_refreshes_changed_duplicate_but_skips_exact_replay() {
-        let engine = LogbookEngine::new(Arc::new(TestStorage::new()));
+        let storage = Arc::new(TestStorage::new());
+        let engine = LogbookEngine::new(storage.clone());
         let first_payload = wsjtx_frame(
             WSJTX_LOGGED_ADIF_MESSAGE_TYPE,
             std::str::from_utf8(&sample_adif_with_rst_sent("-10")).expect("sample adif"),
@@ -539,6 +652,17 @@ mod tests {
         let replay = ingest_wsjtx_udp_datagram(&engine, &first_payload, None, true)
             .await
             .expect("exact replay");
+        let mut synced_qso = engine
+            .list_qsos(&QsoListQuery::default())
+            .await
+            .expect("qsos")
+            .into_iter()
+            .next()
+            .expect("imported qso");
+        synced_qso.sync_status = SyncStatus::Synced as i32;
+        synced_qso.qrz_logid = Some("remote-1".to_string());
+        storage.update_qso(&synced_qso).await.expect("mark synced");
+
         let changed = ingest_wsjtx_udp_datagram(&engine, &changed_payload, None, true)
             .await
             .expect("changed import");
@@ -556,6 +680,8 @@ mod tests {
             qso.rst_sent.as_ref().map(|rst| rst.raw.as_str()),
             Some("-05")
         );
+        assert_eq!(qso.sync_status, SyncStatus::Modified as i32);
+        assert_eq!(qso.qrz_logid.as_deref(), Some("remote-1"));
     }
 
     #[tokio::test]
@@ -604,6 +730,41 @@ mod tests {
         assert_eq!(cursor, partial.len());
     }
 
+    #[tokio::test]
+    async fn ingest_wsjtx_adif_tail_replay_matches_original_import_after_local_edit_and_delete() {
+        let storage = Arc::new(TestStorage::new());
+        let engine = LogbookEngine::new(storage.clone());
+        let file = NamedTempFile::new().expect("temp file");
+        let path = file.path().to_path_buf();
+        fs::write(&path, sample_adif()).expect("write initial record");
+
+        let mut cursor = 0;
+        let first = ingest_wsjtx_adif_tail(&engine, &path, None, false, &mut cursor)
+            .await
+            .expect("first import");
+        let mut edited = first.affected_qsos.first().expect("affected qso").clone();
+        edited.worked_callsign = "K7EDIT".to_string();
+        edited.deleted_at = Some(millis_to_timestamp(1_700_000_500_000));
+        storage.update_qso(&edited).await.expect("operator edit");
+
+        cursor = 0;
+        let replay = ingest_wsjtx_adif_tail(&engine, &path, None, false, &mut cursor)
+            .await
+            .expect("replay import");
+        let stored = storage.qsos.read().await;
+
+        assert_eq!(first.records_imported, 1);
+        assert_eq!(replay.records_imported, 0);
+        assert_eq!(replay.records_skipped, 1);
+        assert_eq!(stored.len(), 1);
+        assert!(stored
+            .values()
+            .next()
+            .expect("stored qso")
+            .deleted_at
+            .is_some());
+    }
+
     #[test]
     fn complete_adif_prefix_len_returns_last_complete_eor_end() {
         let payload = b"<CALL:3>AAA <EOR><CALL:3>BBB";
@@ -612,5 +773,19 @@ mod tests {
             complete_adif_prefix_len(payload),
             Some(b"<CALL:3>AAA <EOR>".len())
         );
+    }
+
+    #[test]
+    fn complete_adif_prefix_len_ignores_eor_inside_field_value() {
+        let payload = b"<CALL:4>W1AW<COMMENT:11>abc<EOR>def";
+
+        assert_eq!(complete_adif_prefix_len(payload), None);
+    }
+
+    #[test]
+    fn complete_adif_prefix_len_counts_adif_field_lengths_as_utf8_characters() {
+        let payload = "<COMMENT:11>éééééé<EOR>".as_bytes();
+
+        assert_eq!(complete_adif_prefix_len(payload), None);
     }
 }

--- a/src/rust/qsoripper-core/src/wsjtx.rs
+++ b/src/rust/qsoripper-core/src/wsjtx.rs
@@ -7,6 +7,10 @@ use serde_json::Value;
 use std::fs;
 use std::path::Path;
 
+const WSJTX_MAGIC: u32 = 0xadbc_cbda;
+const WSJTX_LOGGED_ADIF_MESSAGE_TYPE: u32 = 12;
+const WSJTX_NULL_STRING_LENGTH: u32 = u32::MAX;
+
 /// Import a WSJT-X UDP datagram by extracting any embedded ADIF payload and
 /// feeding it through the normal logbook import path.
 ///
@@ -24,7 +28,12 @@ pub async fn ingest_wsjtx_udp_datagram(
     active_station_profile: Option<&StationProfile>,
     refresh: bool,
 ) -> Result<AdifImportSummary, String> {
-    let adif_payload = extract_adif_payload(datagram)?;
+    let Some(adif_payload) = extract_adif_payload(datagram)? else {
+        return Ok(AdifImportSummary {
+            records_skipped: 1,
+            ..AdifImportSummary::default()
+        });
+    };
     ingest_adif_payload(
         logbook_engine,
         &adif_payload,
@@ -52,26 +61,47 @@ pub async fn ingest_wsjtx_adif_tail(
 ) -> Result<AdifImportSummary, String> {
     let bytes =
         fs::read(path).map_err(|error| format!("failed to read {}: {error}", path.display()))?;
-    if *cursor >= bytes.len() {
+    if *cursor > bytes.len() {
+        *cursor = 0;
+    }
+    if *cursor == bytes.len() {
         return Ok(AdifImportSummary::default());
     }
 
-    let Some(appended) = bytes.get(*cursor..) else {
+    let start = *cursor;
+    let Some(appended) = bytes.get(start..) else {
         return Ok(AdifImportSummary::default());
     };
-    let appended = appended.to_vec();
-    *cursor = bytes.len();
-    ingest_adif_payload(logbook_engine, &appended, active_station_profile, refresh).await
+    let Some(complete_len) = complete_adif_prefix_len(appended) else {
+        return Ok(AdifImportSummary::default());
+    };
+    let Some(complete_payload) = appended.get(..complete_len) else {
+        return Ok(AdifImportSummary::default());
+    };
+
+    let summary = ingest_adif_payload(
+        logbook_engine,
+        complete_payload,
+        active_station_profile,
+        refresh,
+    )
+    .await?;
+    *cursor = start.saturating_add(complete_len);
+    Ok(summary)
 }
 
-fn extract_adif_payload(datagram: &[u8]) -> Result<Vec<u8>, String> {
+fn extract_adif_payload(datagram: &[u8]) -> Result<Option<Vec<u8>>, String> {
+    if read_be_u32(datagram, 0)?.is_some_and(|magic| magic == WSJTX_MAGIC) {
+        return extract_wsjtx_logged_adif(datagram);
+    }
+
     if let Ok(value) = serde_json::from_slice::<Value>(datagram) {
         if let Some(adif) = value.get("adif").and_then(Value::as_str).map(str::to_owned) {
-            return Ok(adif.into_bytes());
+            return Ok(Some(adif.into_bytes()));
         }
 
         if let Some(adif) = value.get("qsos").and_then(Value::as_str).map(str::to_owned) {
-            return Ok(adif.into_bytes());
+            return Ok(Some(adif.into_bytes()));
         }
 
         if let Some(adif) = value
@@ -79,7 +109,7 @@ fn extract_adif_payload(datagram: &[u8]) -> Result<Vec<u8>, String> {
             .and_then(Value::as_str)
             .map(str::to_owned)
         {
-            return Ok(adif.into_bytes());
+            return Ok(Some(adif.into_bytes()));
         }
     }
 
@@ -87,10 +117,76 @@ fn extract_adif_payload(datagram: &[u8]) -> Result<Vec<u8>, String> {
         .iter()
         .any(|byte| *byte == b'<' || *byte == b'>' || *byte == b'\n')
     {
-        return Ok(datagram.to_vec());
+        return Ok(Some(datagram.to_vec()));
     }
 
     Err("WSJT-X datagram does not contain a usable ADIF payload".to_string())
+}
+
+fn extract_wsjtx_logged_adif(datagram: &[u8]) -> Result<Option<Vec<u8>>, String> {
+    let Some(magic) = read_be_u32(datagram, 0)? else {
+        return Ok(None);
+    };
+    if magic != WSJTX_MAGIC {
+        return Ok(None);
+    }
+
+    let Some(_schema) = read_be_u32(datagram, 4)? else {
+        return Err("WSJT-X datagram is missing schema field".to_string());
+    };
+    let Some(message_type) = read_be_u32(datagram, 8)? else {
+        return Err("WSJT-X datagram is missing message type field".to_string());
+    };
+    if message_type != WSJTX_LOGGED_ADIF_MESSAGE_TYPE {
+        return Ok(None);
+    }
+
+    let mut cursor = 12;
+    let _id = read_wsjtx_utf8(datagram, &mut cursor)?;
+    let adif = read_wsjtx_utf8(datagram, &mut cursor)?;
+    if adif.trim().is_empty() {
+        return Err("WSJT-X Logged ADIF datagram has an empty ADIF payload".to_string());
+    }
+
+    Ok(Some(adif.into_bytes()))
+}
+
+fn read_be_u32(bytes: &[u8], offset: usize) -> Result<Option<u32>, String> {
+    let Some(end) = offset.checked_add(4) else {
+        return Err("WSJT-X datagram offset overflow".to_string());
+    };
+    let Some(slice) = bytes.get(offset..end) else {
+        return Ok(None);
+    };
+    let value = u32::from_be_bytes(
+        slice
+            .try_into()
+            .map_err(|_| "WSJT-X datagram u32 field had invalid length".to_string())?,
+    );
+    Ok(Some(value))
+}
+
+fn read_wsjtx_utf8(bytes: &[u8], cursor: &mut usize) -> Result<String, String> {
+    let Some(length) = read_be_u32(bytes, *cursor)? else {
+        return Err("WSJT-X datagram is missing string length".to_string());
+    };
+    *cursor = cursor
+        .checked_add(4)
+        .ok_or_else(|| "WSJT-X datagram cursor overflow".to_string())?;
+    if length == WSJTX_NULL_STRING_LENGTH {
+        return Ok(String::new());
+    }
+    let length = usize::try_from(length)
+        .map_err(|_| "WSJT-X datagram string length is not addressable".to_string())?;
+    let end = cursor
+        .checked_add(length)
+        .ok_or_else(|| "WSJT-X datagram string length overflow".to_string())?;
+    let Some(slice) = bytes.get(*cursor..end) else {
+        return Err("WSJT-X datagram string extends past packet end".to_string());
+    };
+    *cursor = end;
+    String::from_utf8(slice.to_vec())
+        .map_err(|error| format!("WSJT-X datagram string is not UTF-8: {error}"))
 }
 
 async fn ingest_adif_payload(
@@ -124,11 +220,29 @@ fn format_wsjtx_error(error: LogbookError) -> String {
     }
 }
 
+fn complete_adif_prefix_len(bytes: &[u8]) -> Option<usize> {
+    let marker = b"<eor>";
+    let mut last_end = None;
+    for (index, window) in bytes.windows(marker.len()).enumerate() {
+        if window
+            .iter()
+            .zip(marker)
+            .all(|(left, right)| left.to_ascii_lowercase() == *right)
+        {
+            last_end = Some(index + marker.len());
+        }
+    }
+    last_end
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
-    use super::{extract_adif_payload, ingest_wsjtx_adif_tail, ingest_wsjtx_udp_datagram};
-    use crate::application::logbook::LogbookEngine;
+    use super::{
+        complete_adif_prefix_len, extract_adif_payload, ingest_wsjtx_adif_tail,
+        ingest_wsjtx_udp_datagram, WSJTX_LOGGED_ADIF_MESSAGE_TYPE, WSJTX_MAGIC,
+    };
+    use crate::application::logbook::{AdifImportSummary, LogbookEngine};
     use crate::proto::qsoripper::domain::QsoRecord;
     use crate::storage::{
         EngineStorage, LogbookCounts, LogbookStore, LookupSnapshot, LookupSnapshotStore,
@@ -292,13 +406,63 @@ mod tests {
         b"<STATION_CALLSIGN:4>W1AW <CALL:5>K7ABC <QSO_DATE:8>20250101 <TIME_ON:4>1200 <BAND:3>20M <MODE:3>FT8 <RST_SENT:3>-10 <RST_RCVD:3>-12 <EOR>"
     }
 
+    fn sample_adif_with_rst_sent(rst_sent: &str) -> Vec<u8> {
+        format!(
+            "<STATION_CALLSIGN:4>W1AW <CALL:5>K7ABC <QSO_DATE:8>20250101 <TIME_ON:4>1200 <BAND:3>20M <MODE:3>FT8 <RST_SENT:{}>{rst_sent} <RST_RCVD:3>-12 <EOR>",
+            rst_sent.len()
+        )
+        .into_bytes()
+    }
+
+    fn wsjtx_frame(message_type: u32, adif: &str) -> Vec<u8> {
+        let mut frame = Vec::new();
+        append_be_u32(&mut frame, WSJTX_MAGIC);
+        append_be_u32(&mut frame, 2);
+        append_be_u32(&mut frame, message_type);
+        append_wsjtx_utf8(&mut frame, "WSJT-X");
+        append_wsjtx_utf8(&mut frame, adif);
+        frame
+    }
+
+    fn append_be_u32(target: &mut Vec<u8>, value: u32) {
+        target.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn append_wsjtx_utf8(target: &mut Vec<u8>, value: &str) {
+        let len = u32::try_from(value.len()).expect("test string length");
+        append_be_u32(target, len);
+        target.extend_from_slice(value.as_bytes());
+    }
+
     #[test]
     fn extract_adif_payload_accepts_json_wrapped_adif() {
         let payload = br#"{"type":"logged_qso","adif":"<CALL:5>K7ABC <EOR>"}"#;
 
-        let extracted = extract_adif_payload(payload).expect("payload");
+        let extracted = extract_adif_payload(payload)
+            .expect("payload")
+            .expect("adif");
 
         assert_eq!(String::from_utf8(extracted).unwrap(), "<CALL:5>K7ABC <EOR>");
+    }
+
+    #[test]
+    fn wsjtx_logged_adif_frame_extracts_adif_payload() {
+        let payload = wsjtx_frame(WSJTX_LOGGED_ADIF_MESSAGE_TYPE, "<CALL:5>K7ABC <EOR>");
+
+        let extracted = extract_adif_payload(&payload)
+            .expect("payload")
+            .expect("logged adif");
+
+        assert_eq!(String::from_utf8(extracted).unwrap(), "<CALL:5>K7ABC <EOR>");
+    }
+
+    #[test]
+    fn wsjtx_non_logged_frame_is_ignored() {
+        let payload = wsjtx_frame(0, "<CALL:5>K7ABC <EOR>");
+
+        let extracted = extract_adif_payload(&payload).expect("payload");
+
+        assert_eq!(extracted, None);
     }
 
     #[tokio::test]
@@ -322,6 +486,79 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ingest_wsjtx_udp_datagram_imports_qso_from_logged_adif_frame() {
+        let engine = LogbookEngine::new(Arc::new(TestStorage::new()));
+        let payload = wsjtx_frame(
+            WSJTX_LOGGED_ADIF_MESSAGE_TYPE,
+            std::str::from_utf8(sample_adif()).expect("sample adif"),
+        );
+
+        let summary = ingest_wsjtx_udp_datagram(&engine, &payload, None, false)
+            .await
+            .expect("import succeeded");
+
+        assert_eq!(summary.records_imported, 1);
+        assert_eq!(summary.records_skipped, 0);
+    }
+
+    #[tokio::test]
+    async fn ingest_wsjtx_udp_datagram_skips_duplicate_logged_adif_frame() {
+        let engine = LogbookEngine::new(Arc::new(TestStorage::new()));
+        let payload = wsjtx_frame(
+            WSJTX_LOGGED_ADIF_MESSAGE_TYPE,
+            std::str::from_utf8(sample_adif()).expect("sample adif"),
+        );
+
+        let first = ingest_wsjtx_udp_datagram(&engine, &payload, None, false)
+            .await
+            .expect("first import");
+        let second = ingest_wsjtx_udp_datagram(&engine, &payload, None, false)
+            .await
+            .expect("second import");
+
+        assert_eq!(first.records_imported, 1);
+        assert_eq!(second.records_imported, 0);
+        assert_eq!(second.records_skipped, 1);
+    }
+
+    #[tokio::test]
+    async fn ingest_wsjtx_udp_datagram_refreshes_changed_duplicate_but_skips_exact_replay() {
+        let engine = LogbookEngine::new(Arc::new(TestStorage::new()));
+        let first_payload = wsjtx_frame(
+            WSJTX_LOGGED_ADIF_MESSAGE_TYPE,
+            std::str::from_utf8(&sample_adif_with_rst_sent("-10")).expect("sample adif"),
+        );
+        let changed_payload = wsjtx_frame(
+            WSJTX_LOGGED_ADIF_MESSAGE_TYPE,
+            std::str::from_utf8(&sample_adif_with_rst_sent("-05")).expect("changed adif"),
+        );
+
+        let first = ingest_wsjtx_udp_datagram(&engine, &first_payload, None, true)
+            .await
+            .expect("first import");
+        let replay = ingest_wsjtx_udp_datagram(&engine, &first_payload, None, true)
+            .await
+            .expect("exact replay");
+        let changed = ingest_wsjtx_udp_datagram(&engine, &changed_payload, None, true)
+            .await
+            .expect("changed import");
+        let qsos = engine
+            .list_qsos(&QsoListQuery::default())
+            .await
+            .expect("qsos");
+
+        assert_eq!(first.records_imported, 1);
+        assert_eq!(replay.records_skipped, 1);
+        assert_eq!(changed.records_updated, 1);
+        assert_eq!(qsos.len(), 1);
+        let qso = qsos.first().expect("single qso");
+        assert_eq!(
+            qso.rst_sent.as_ref().map(|rst| rst.raw.as_str()),
+            Some("-05")
+        );
+    }
+
+    #[tokio::test]
     async fn ingest_wsjtx_adif_tail_imports_appended_records() {
         let engine = LogbookEngine::new(Arc::new(TestStorage::new()));
         let file = NamedTempFile::new().expect("temp file");
@@ -338,5 +575,42 @@ mod tests {
         let metadata_len =
             usize::try_from(fs::metadata(&path).unwrap().len()).expect("metadata len");
         assert_eq!(cursor, metadata_len);
+    }
+
+    #[tokio::test]
+    async fn ingest_wsjtx_adif_tail_waits_for_complete_record_before_advancing_cursor() {
+        let engine = LogbookEngine::new(Arc::new(TestStorage::new()));
+        let file = NamedTempFile::new().expect("temp file");
+        let path = file.path().to_path_buf();
+        let mut partial = sample_adif().to_vec();
+        partial.truncate(partial.len() - "<EOR>".len());
+        fs::write(&path, &partial).expect("write partial record");
+
+        let mut cursor = 0;
+        let partial_summary = ingest_wsjtx_adif_tail(&engine, &path, None, true, &mut cursor)
+            .await
+            .expect("partial tail import");
+
+        assert_eq!(partial_summary, AdifImportSummary::default());
+        assert_eq!(cursor, 0);
+
+        partial.extend_from_slice(b"<EOR>");
+        fs::write(&path, &partial).expect("complete record");
+        let complete_summary = ingest_wsjtx_adif_tail(&engine, &path, None, true, &mut cursor)
+            .await
+            .expect("complete tail import");
+
+        assert_eq!(complete_summary.records_imported, 1);
+        assert_eq!(cursor, partial.len());
+    }
+
+    #[test]
+    fn complete_adif_prefix_len_returns_last_complete_eor_end() {
+        let payload = b"<CALL:3>AAA <EOR><CALL:3>BBB";
+
+        assert_eq!(
+            complete_adif_prefix_len(payload),
+            Some(b"<CALL:3>AAA <EOR>".len())
+        );
     }
 }

--- a/src/rust/qsoripper-core/src/wsjtx.rs
+++ b/src/rust/qsoripper-core/src/wsjtx.rs
@@ -1,0 +1,342 @@
+//! WSJT-X ingestion helpers that feed the existing ADIF import pipeline.
+
+use crate::adif::parse_adi_qsos_without_header_detection;
+use crate::application::logbook::{AdifImportSummary, LogbookEngine, LogbookError};
+use crate::proto::qsoripper::domain::StationProfile;
+use serde_json::Value;
+use std::fs;
+use std::path::Path;
+
+/// Import a WSJT-X UDP datagram by extracting any embedded ADIF payload and
+/// feeding it through the normal logbook import path.
+///
+/// The parser accepts both raw ADIF text and lightweight JSON envelopes such as
+/// `{"type":"logged_qso","adif":"<CALL:...>"}` that WSJT-X integrations often
+/// emit when forwarding QSO events to downstream tooling.
+///
+/// # Errors
+///
+/// Returns an error when the datagram has no usable ADIF payload or when the
+/// import pipeline rejects the parsed QSO records.
+pub async fn ingest_wsjtx_udp_datagram(
+    logbook_engine: &LogbookEngine,
+    datagram: &[u8],
+    active_station_profile: Option<&StationProfile>,
+    refresh: bool,
+) -> Result<AdifImportSummary, String> {
+    let adif_payload = extract_adif_payload(datagram)?;
+    ingest_adif_payload(
+        logbook_engine,
+        &adif_payload,
+        active_station_profile,
+        refresh,
+    )
+    .await
+}
+
+/// Import any newly appended ADIF data from a WSJT-X log file.
+///
+/// The current implementation keeps a simple byte offset cursor so the caller can
+/// replay appended records without re-importing the full file every time.
+///
+/// # Errors
+///
+/// Returns an error when the file cannot be read or when the ADIF import path
+/// rejects the newly appended records.
+pub async fn ingest_wsjtx_adif_tail(
+    logbook_engine: &LogbookEngine,
+    path: &Path,
+    active_station_profile: Option<&StationProfile>,
+    refresh: bool,
+    cursor: &mut usize,
+) -> Result<AdifImportSummary, String> {
+    let bytes =
+        fs::read(path).map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    if *cursor >= bytes.len() {
+        return Ok(AdifImportSummary::default());
+    }
+
+    let Some(appended) = bytes.get(*cursor..) else {
+        return Ok(AdifImportSummary::default());
+    };
+    let appended = appended.to_vec();
+    *cursor = bytes.len();
+    ingest_adif_payload(logbook_engine, &appended, active_station_profile, refresh).await
+}
+
+fn extract_adif_payload(datagram: &[u8]) -> Result<Vec<u8>, String> {
+    if let Ok(value) = serde_json::from_slice::<Value>(datagram) {
+        if let Some(adif) = value.get("adif").and_then(Value::as_str).map(str::to_owned) {
+            return Ok(adif.into_bytes());
+        }
+
+        if let Some(adif) = value.get("qsos").and_then(Value::as_str).map(str::to_owned) {
+            return Ok(adif.into_bytes());
+        }
+
+        if let Some(adif) = value
+            .get("payload")
+            .and_then(Value::as_str)
+            .map(str::to_owned)
+        {
+            return Ok(adif.into_bytes());
+        }
+    }
+
+    if datagram
+        .iter()
+        .any(|byte| *byte == b'<' || *byte == b'>' || *byte == b'\n')
+    {
+        return Ok(datagram.to_vec());
+    }
+
+    Err("WSJT-X datagram does not contain a usable ADIF payload".to_string())
+}
+
+async fn ingest_adif_payload(
+    logbook_engine: &LogbookEngine,
+    adif_payload: &[u8],
+    active_station_profile: Option<&StationProfile>,
+    refresh: bool,
+) -> Result<AdifImportSummary, String> {
+    let qsos = parse_adi_qsos_without_header_detection(adif_payload)
+        .await
+        .map_err(|error| format!("failed to parse ADIF payload: {error}"))?;
+
+    if qsos.is_empty() {
+        return Ok(AdifImportSummary::default());
+    }
+
+    logbook_engine
+        .import_adif_qsos(qsos, active_station_profile, refresh)
+        .await
+        .map_err(format_wsjtx_error)
+}
+
+fn format_wsjtx_error(error: LogbookError) -> String {
+    match error {
+        LogbookError::Validation(message) => format!("WSJT-X import validation failed: {message}"),
+        LogbookError::NotFound(message) => format!("WSJT-X import failed to find QSO: {message}"),
+        LogbookError::AlreadyDeleted(message) => {
+            format!("WSJT-X import failed because QSO is deleted: {message}")
+        }
+        LogbookError::Storage(error) => format!("WSJT-X import storage failed: {error}"),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::{extract_adif_payload, ingest_wsjtx_adif_tail, ingest_wsjtx_udp_datagram};
+    use crate::application::logbook::LogbookEngine;
+    use crate::proto::qsoripper::domain::QsoRecord;
+    use crate::storage::{
+        EngineStorage, LogbookCounts, LogbookStore, LookupSnapshot, LookupSnapshotStore,
+        QsoHistoryPage, QsoListQuery, StorageError, SyncMetadata,
+    };
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::sync::Arc;
+    use tempfile::NamedTempFile;
+    use tokio::sync::RwLock;
+
+    #[derive(Default)]
+    struct TestStorage {
+        qsos: RwLock<BTreeMap<String, QsoRecord>>,
+        sync_metadata: RwLock<SyncMetadata>,
+        lookup_snapshots: RwLock<BTreeMap<String, LookupSnapshot>>,
+    }
+
+    impl TestStorage {
+        fn new() -> Self {
+            Self::default()
+        }
+    }
+
+    impl EngineStorage for TestStorage {
+        fn logbook(&self) -> &dyn LogbookStore {
+            self
+        }
+
+        fn lookup_snapshots(&self) -> &dyn LookupSnapshotStore {
+            self
+        }
+
+        fn backend_name(&self) -> &'static str {
+            "test"
+        }
+    }
+
+    #[tonic::async_trait]
+    impl LogbookStore for TestStorage {
+        async fn insert_qso(&self, qso: &QsoRecord) -> Result<(), StorageError> {
+            let mut qsos = self.qsos.write().await;
+            if qsos.contains_key(&qso.local_id) {
+                return Err(StorageError::duplicate("qso", &qso.local_id));
+            }
+            qsos.insert(qso.local_id.clone(), qso.clone());
+            Ok(())
+        }
+
+        async fn update_qso(&self, qso: &QsoRecord) -> Result<bool, StorageError> {
+            let mut qsos = self.qsos.write().await;
+            Ok(qsos.insert(qso.local_id.clone(), qso.clone()).is_some())
+        }
+
+        async fn delete_qso(&self, local_id: &str) -> Result<bool, StorageError> {
+            Ok(self.qsos.write().await.remove(local_id).is_some())
+        }
+
+        async fn soft_delete_qso(
+            &self,
+            local_id: &str,
+            deleted_at_ms: i64,
+            pending_remote_delete: bool,
+        ) -> Result<bool, StorageError> {
+            let mut qsos = self.qsos.write().await;
+            let Some(record) = qsos.get_mut(local_id) else {
+                return Ok(false);
+            };
+            record.deleted_at = Some(millis_to_timestamp(deleted_at_ms));
+            record.pending_remote_delete = pending_remote_delete;
+            Ok(true)
+        }
+
+        async fn restore_qso(&self, local_id: &str) -> Result<bool, StorageError> {
+            let mut qsos = self.qsos.write().await;
+            let Some(record) = qsos.get_mut(local_id) else {
+                return Ok(false);
+            };
+            record.deleted_at = None;
+            record.pending_remote_delete = false;
+            Ok(true)
+        }
+
+        async fn get_qso(&self, local_id: &str) -> Result<Option<QsoRecord>, StorageError> {
+            Ok(self.qsos.read().await.get(local_id).cloned())
+        }
+
+        async fn list_qsos(&self, _query: &QsoListQuery) -> Result<Vec<QsoRecord>, StorageError> {
+            Ok(self.qsos.read().await.values().cloned().collect())
+        }
+
+        async fn list_qso_history(
+            &self,
+            _worked_callsign: &str,
+            _limit: u32,
+        ) -> Result<QsoHistoryPage, StorageError> {
+            Ok(QsoHistoryPage::default())
+        }
+
+        async fn qso_counts(&self) -> Result<LogbookCounts, StorageError> {
+            Ok(LogbookCounts::default())
+        }
+
+        async fn get_sync_metadata(&self) -> Result<SyncMetadata, StorageError> {
+            Ok(self.sync_metadata.read().await.clone())
+        }
+
+        async fn upsert_sync_metadata(&self, metadata: &SyncMetadata) -> Result<(), StorageError> {
+            *self.sync_metadata.write().await = metadata.clone();
+            Ok(())
+        }
+
+        async fn purge_deleted_qsos(
+            &self,
+            _local_ids: &[String],
+            _older_than_ms: Option<i64>,
+        ) -> Result<u32, StorageError> {
+            Ok(0)
+        }
+    }
+
+    #[tonic::async_trait]
+    impl LookupSnapshotStore for TestStorage {
+        async fn get_lookup_snapshot(
+            &self,
+            callsign: &str,
+        ) -> Result<Option<LookupSnapshot>, StorageError> {
+            Ok(self.lookup_snapshots.read().await.get(callsign).cloned())
+        }
+
+        async fn upsert_lookup_snapshot(
+            &self,
+            snapshot: &LookupSnapshot,
+        ) -> Result<(), StorageError> {
+            self.lookup_snapshots
+                .write()
+                .await
+                .insert(snapshot.callsign.clone(), snapshot.clone());
+            Ok(())
+        }
+
+        async fn delete_lookup_snapshot(&self, callsign: &str) -> Result<bool, StorageError> {
+            Ok(self
+                .lookup_snapshots
+                .write()
+                .await
+                .remove(callsign)
+                .is_some())
+        }
+    }
+
+    fn millis_to_timestamp(millis: i64) -> prost_types::Timestamp {
+        let seconds = millis.div_euclid(1_000);
+        let nanos = i32::try_from(millis.rem_euclid(1_000))
+            .unwrap_or(0)
+            .saturating_mul(1_000_000);
+        prost_types::Timestamp { seconds, nanos }
+    }
+
+    fn sample_adif() -> &'static [u8] {
+        b"<STATION_CALLSIGN:4>W1AW <CALL:5>K7ABC <QSO_DATE:8>20250101 <TIME_ON:4>1200 <BAND:3>20M <MODE:3>FT8 <RST_SENT:3>-10 <RST_RCVD:3>-12 <EOR>"
+    }
+
+    #[test]
+    fn extract_adif_payload_accepts_json_wrapped_adif() {
+        let payload = br#"{"type":"logged_qso","adif":"<CALL:5>K7ABC <EOR>"}"#;
+
+        let extracted = extract_adif_payload(payload).expect("payload");
+
+        assert_eq!(String::from_utf8(extracted).unwrap(), "<CALL:5>K7ABC <EOR>");
+    }
+
+    #[tokio::test]
+    async fn ingest_wsjtx_udp_datagram_imports_qso_from_json_payload() {
+        let engine = LogbookEngine::new(Arc::new(TestStorage::new()));
+        let payload = br#"{"type":"logged_qso","adif":"<STATION_CALLSIGN:4>W1AW <CALL:5>K7ABC <QSO_DATE:8>20250101 <TIME_ON:4>1200 <BAND:3>20M <MODE:3>FT8 <RST_SENT:3>-10 <RST_RCVD:3>-12 <EOR>"}"#;
+
+        let summary = ingest_wsjtx_udp_datagram(&engine, payload, None, false)
+            .await
+            .expect("import succeeded");
+
+        assert_eq!(summary.records_imported, 1);
+        assert_eq!(
+            engine
+                .list_qsos(&QsoListQuery::default())
+                .await
+                .expect("qsos")
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn ingest_wsjtx_adif_tail_imports_appended_records() {
+        let engine = LogbookEngine::new(Arc::new(TestStorage::new()));
+        let file = NamedTempFile::new().expect("temp file");
+        let path = file.path().to_path_buf();
+
+        fs::write(&path, sample_adif()).expect("write initial record");
+
+        let mut cursor = 0;
+        let summary = ingest_wsjtx_adif_tail(&engine, &path, None, false, &mut cursor)
+            .await
+            .expect("tail import");
+
+        assert_eq!(summary.records_imported, 1);
+        let metadata_len =
+            usize::try_from(fs::metadata(&path).unwrap().len()).expect("metadata len");
+        assert_eq!(cursor, metadata_len);
+    }
+}

--- a/src/rust/qsoripper-launcher/src/sync.rs
+++ b/src/rust/qsoripper-launcher/src/sync.rs
@@ -170,6 +170,7 @@ pub(crate) fn save_request_from_status(status: &SetupStatus) -> SaveSetupRequest
         sync_config: status.sync_config,
         rig_control: status.rig_control.clone(),
         cat_hub: None,
+        wsjtx_ingest: status.wsjtx_ingest.clone(),
         persistence_values,
     }
 }

--- a/src/rust/qsoripper-server/Cargo.toml
+++ b/src/rust/qsoripper-server/Cargo.toml
@@ -24,6 +24,7 @@ tonic = { workspace = true }
 
 [dev-dependencies]
 qsoripper-cathub = { path = "../qsoripper-cathub", version = "0.1.0" }
+tempfile = "3"
 
 [lints]
 workspace = true

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -26,6 +26,7 @@ use qsoripper_core::storage::{
 };
 use qsoripper_storage_memory::MemoryStorage;
 use qsoripper_storage_sqlite::SqliteStorageBuilder;
+use tokio::sync::Mutex;
 use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
@@ -95,29 +96,11 @@ where
     );
     let background_services = start_background_services(runtime_config.clone());
 
-    // One-shot QRZ logid backfill + duplicate collapse. Older builds never
-    // mapped APP_QRZLOG_LOGID into qrz_logid, so QRZ pulls produced rows
-    // that subsequent syncs duplicated whenever fuzzy matching missed.
-    // Repair is idempotent — clean stores are a no-op.
-    {
-        let logbook_engine = runtime_config.logbook_engine().await;
-        match repair::backfill_qrz_logids(logbook_engine.logbook_store()).await {
-            Ok(report) => {
-                if !report.is_no_op() {
-                    eprintln!(
-                        "[repair] QRZ logid backfill: backfilled={}, duplicates_removed={}, merged_groups={}",
-                        report.backfilled, report.duplicates_removed, report.merged_groups,
-                    );
-                }
-            }
-            Err(err) => {
-                eprintln!("[repair] QRZ logid backfill failed (continuing startup): {err}");
-            }
-        }
-    }
+    run_startup_repairs(&runtime_config).await;
     let logbook_service = DeveloperLogbookService::new(
         runtime_config.clone(),
         background_services.sync_scheduler.clone(),
+        background_services.qrz_upload_lock.clone(),
     );
     let lookup_service = DeveloperLookupService::new(runtime_config.clone());
     let engine_service = EngineControlSurface;
@@ -196,9 +179,31 @@ where
     Ok(())
 }
 
+async fn run_startup_repairs(runtime_config: &Arc<RuntimeConfigManager>) {
+    // One-shot QRZ logid backfill + duplicate collapse. Older builds never
+    // mapped APP_QRZLOG_LOGID into qrz_logid, so QRZ pulls produced rows
+    // that subsequent syncs duplicated whenever fuzzy matching missed.
+    // Repair is idempotent — clean stores are a no-op.
+    let logbook_engine = runtime_config.logbook_engine().await;
+    match repair::backfill_qrz_logids(logbook_engine.logbook_store()).await {
+        Ok(report) => {
+            if !report.is_no_op() {
+                eprintln!(
+                    "[repair] QRZ logid backfill: backfilled={}, duplicates_removed={}, merged_groups={}",
+                    report.backfilled, report.duplicates_removed, report.merged_groups,
+                );
+            }
+        }
+        Err(err) => {
+            eprintln!("[repair] QRZ logid backfill failed (continuing startup): {err}");
+        }
+    }
+}
+
 struct BackgroundServices {
     sync_scheduler: Arc<sync_scheduler::SyncScheduler>,
     wsjtx_ingest: Arc<wsjtx_ingest::WsjtxIngestSupervisor>,
+    qrz_upload_lock: Arc<Mutex<()>>,
 }
 
 impl BackgroundServices {
@@ -209,13 +214,17 @@ impl BackgroundServices {
 }
 
 fn start_background_services(runtime_config: Arc<RuntimeConfigManager>) -> BackgroundServices {
-    let sync_scheduler = Arc::new(sync_scheduler::SyncScheduler::new());
+    let qrz_upload_lock = Arc::new(Mutex::new(()));
+    let sync_scheduler = Arc::new(sync_scheduler::SyncScheduler::new(qrz_upload_lock.clone()));
     sync_scheduler.start(runtime_config.clone());
-    let wsjtx_ingest = Arc::new(wsjtx_ingest::WsjtxIngestSupervisor::new());
+    let wsjtx_ingest = Arc::new(wsjtx_ingest::WsjtxIngestSupervisor::with_qrz_sync_lock(
+        qrz_upload_lock.clone(),
+    ));
     wsjtx_ingest.start(runtime_config);
     BackgroundServices {
         sync_scheduler,
         wsjtx_ingest,
+        qrz_upload_lock,
     }
 }
 
@@ -341,16 +350,19 @@ fn find_dotenv_path() -> io::Result<Option<PathBuf>> {
 struct DeveloperLogbookService {
     runtime_config: Arc<RuntimeConfigManager>,
     sync_scheduler: Arc<sync_scheduler::SyncScheduler>,
+    qrz_upload_lock: Arc<Mutex<()>>,
 }
 
 impl DeveloperLogbookService {
     fn new(
         runtime_config: Arc<RuntimeConfigManager>,
         sync_scheduler: Arc<sync_scheduler::SyncScheduler>,
+        qrz_upload_lock: Arc<Mutex<()>>,
     ) -> Self {
         Self {
             runtime_config,
             sync_scheduler,
+            qrz_upload_lock,
         }
     }
 
@@ -410,6 +422,7 @@ impl DeveloperLogbookService {
             .unwrap_or_default();
         let book_owner = sync::resolve_book_owner_for_upload(&client, &cached_metadata).await;
 
+        let _upload_guard = self.qrz_upload_lock.lock().await;
         match sync::sync_single_qso(
             &client,
             engine.logbook_store(),
@@ -648,8 +661,10 @@ impl LogbookService for DeveloperLogbookService {
 
         let engine = self.runtime_config.logbook_engine().await;
         let (tx, rx) = tokio::sync::mpsc::channel(16);
+        let qrz_upload_lock = self.qrz_upload_lock.clone();
 
         tokio::spawn(async move {
+            let _upload_guard = qrz_upload_lock.lock().await;
             let store = engine.logbook_store();
             sync::execute_sync(&client, store, request.full_sync, conflict_policy, &tx).await;
         });
@@ -707,10 +722,10 @@ impl LogbookService for DeveloperLogbookService {
         let qsos = parse_adi_qsos(&adif_bytes)
             .await
             .map_err(Status::invalid_argument)?;
-        let summary = engine
-            .import_adif_qsos(qsos, active_station_profile.as_ref(), refresh)
-            .await
-            .map_err(map_logbook_error)?;
+        let summary =
+            Box::pin(engine.import_adif_qsos(qsos, active_station_profile.as_ref(), refresh))
+                .await
+                .map_err(map_logbook_error)?;
 
         Ok(Response::new(ImportAdifResponse {
             records_imported: summary.records_imported,
@@ -1638,11 +1653,17 @@ mod tests {
     }
 
     fn test_sync_scheduler() -> Arc<sync_scheduler::SyncScheduler> {
-        Arc::new(sync_scheduler::SyncScheduler::new())
+        Arc::new(sync_scheduler::SyncScheduler::new(Arc::new(
+            tokio::sync::Mutex::new(()),
+        )))
     }
 
     fn test_logbook_service(config: Arc<RuntimeConfigManager>) -> DeveloperLogbookService {
-        DeveloperLogbookService::new(config, test_sync_scheduler())
+        DeveloperLogbookService::new(
+            config,
+            test_sync_scheduler(),
+            Arc::new(tokio::sync::Mutex::new(())),
+        )
     }
 
     fn test_runtime_config() -> Arc<RuntimeConfigManager> {

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -6,6 +6,7 @@ mod setup;
 mod station_profile_support;
 mod sync;
 mod sync_scheduler;
+mod wsjtx_ingest;
 
 use std::{
     fs,
@@ -92,8 +93,7 @@ where
             &options.runtime_config_cli_storage_overrides(),
         )?,
     );
-    let sync_scheduler = Arc::new(sync_scheduler::SyncScheduler::new());
-    sync_scheduler.start(runtime_config.clone());
+    let background_services = start_background_services(runtime_config.clone());
 
     // One-shot QRZ logid backfill + duplicate collapse. Older builds never
     // mapped APP_QRZLOG_LOGID into qrz_logid, so QRZ pulls produced rows
@@ -115,12 +115,15 @@ where
             }
         }
     }
-    let logbook_service =
-        DeveloperLogbookService::new(runtime_config.clone(), sync_scheduler.clone());
+    let logbook_service = DeveloperLogbookService::new(
+        runtime_config.clone(),
+        background_services.sync_scheduler.clone(),
+    );
     let lookup_service = DeveloperLookupService::new(runtime_config.clone());
     let engine_service = EngineControlSurface;
     let developer_control_service = DeveloperControlSurface::new(runtime_config.clone());
-    let setup_service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
+    let setup_service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone())
+        .with_wsjtx_ingest_status(background_services.wsjtx_ingest.status_handle());
     let station_profile_service =
         StationProfileControlSurface::new(setup_state.clone(), runtime_config.clone());
     let contest_calendar_service = ContestCalendarControlSurface::new(runtime_config.clone());
@@ -182,13 +185,38 @@ where
         signal_result = &mut shutdown_signal => {
             signal_result?;
             println!("Shutting down.");
-            sync_scheduler.stop();
+            background_services.stop();
             let _ = shutdown_sender.send(());
             server.await?;
         }
     }
 
+    background_services.stop();
+
     Ok(())
+}
+
+struct BackgroundServices {
+    sync_scheduler: Arc<sync_scheduler::SyncScheduler>,
+    wsjtx_ingest: Arc<wsjtx_ingest::WsjtxIngestSupervisor>,
+}
+
+impl BackgroundServices {
+    fn stop(&self) {
+        self.sync_scheduler.stop();
+        self.wsjtx_ingest.stop();
+    }
+}
+
+fn start_background_services(runtime_config: Arc<RuntimeConfigManager>) -> BackgroundServices {
+    let sync_scheduler = Arc::new(sync_scheduler::SyncScheduler::new());
+    sync_scheduler.start(runtime_config.clone());
+    let wsjtx_ingest = Arc::new(wsjtx_ingest::WsjtxIngestSupervisor::new());
+    wsjtx_ingest.start(runtime_config);
+    BackgroundServices {
+        sync_scheduler,
+        wsjtx_ingest,
+    }
 }
 
 fn setup_completion_label(setup_complete: bool) -> &'static str {

--- a/src/rust/qsoripper-server/src/runtime_config.rs
+++ b/src/rust/qsoripper-server/src/runtime_config.rs
@@ -67,11 +67,23 @@ pub(crate) const QRZ_LOGBOOK_BASE_URL_ENV_VAR: &str = "QSORIPPER_QRZ_LOGBOOK_BAS
 pub(crate) const SYNC_AUTO_ENABLED_ENV_VAR: &str = "QSORIPPER_SYNC_AUTO_ENABLED";
 pub(crate) const SYNC_INTERVAL_SECONDS_ENV_VAR: &str = "QSORIPPER_SYNC_INTERVAL_SECONDS";
 pub(crate) const SYNC_CONFLICT_POLICY_ENV_VAR: &str = "QSORIPPER_SYNC_CONFLICT_POLICY";
+pub(crate) const WSJTX_INGEST_ENABLED_ENV_VAR: &str = "QSORIPPER_WSJTX_INGEST_ENABLED";
+pub(crate) const WSJTX_INGEST_UDP_ENABLED_ENV_VAR: &str = "QSORIPPER_WSJTX_INGEST_UDP_ENABLED";
+pub(crate) const WSJTX_INGEST_UDP_BIND_ENV_VAR: &str = "QSORIPPER_WSJTX_INGEST_UDP_BIND";
+pub(crate) const WSJTX_INGEST_ADIF_TAIL_ENABLED_ENV_VAR: &str =
+    "QSORIPPER_WSJTX_INGEST_ADIF_TAIL_ENABLED";
+pub(crate) const WSJTX_INGEST_ADIF_TAIL_PATH_ENV_VAR: &str =
+    "QSORIPPER_WSJTX_INGEST_ADIF_TAIL_PATH";
+pub(crate) const WSJTX_INGEST_POLL_INTERVAL_MS_ENV_VAR: &str =
+    "QSORIPPER_WSJTX_INGEST_POLL_INTERVAL_MS";
+pub(crate) const WSJTX_INGEST_SYNC_TO_QRZ_ENV_VAR: &str = "QSORIPPER_WSJTX_INGEST_SYNC_TO_QRZ";
 
 pub(crate) const DEFAULT_QRZ_LOGBOOK_BASE_URL: &str = "https://logbook.qrz.com/api";
 const DEFAULT_SYNC_AUTO_ENABLED: &str = "false";
 const DEFAULT_SYNC_INTERVAL_SECONDS: &str = "300";
 const DEFAULT_SYNC_CONFLICT_POLICY: &str = "last_write_wins";
+pub(crate) const DEFAULT_WSJTX_INGEST_UDP_BIND: &str = "127.0.0.1:2237";
+pub(crate) const DEFAULT_WSJTX_INGEST_POLL_INTERVAL_MS: &str = "1000";
 
 const DEFAULT_STORAGE_BACKEND: &str = "memory";
 const DEFAULT_SQLITE_PATH: &str = "qsoripper.db";
@@ -599,6 +611,69 @@ const SUPPORTED_FIELDS: &[ConfigFieldSpec] = &[
         default_value: Some(DEFAULT_SYNC_CONFLICT_POLICY),
     },
     ConfigFieldSpec {
+        key: WSJTX_INGEST_ENABLED_ENV_VAR,
+        label: "WSJT-X ingest enabled",
+        description: "Enable automatic ingestion of QSOs logged by WSJT-X.",
+        kind: RuntimeConfigValueKind::Boolean,
+        secret: false,
+        allowed_values: BOOLEAN_ALLOWED_VALUES,
+        default_value: Some("false"),
+    },
+    ConfigFieldSpec {
+        key: WSJTX_INGEST_UDP_ENABLED_ENV_VAR,
+        label: "WSJT-X UDP ingest enabled",
+        description: "Listen for WSJT-X real-time Logged ADIF UDP messages.",
+        kind: RuntimeConfigValueKind::Boolean,
+        secret: false,
+        allowed_values: BOOLEAN_ALLOWED_VALUES,
+        default_value: Some("true"),
+    },
+    ConfigFieldSpec {
+        key: WSJTX_INGEST_UDP_BIND_ENV_VAR,
+        label: "WSJT-X UDP bind",
+        description: "Local host:port for the WSJT-X UDP listener.",
+        kind: RuntimeConfigValueKind::String,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some(DEFAULT_WSJTX_INGEST_UDP_BIND),
+    },
+    ConfigFieldSpec {
+        key: WSJTX_INGEST_ADIF_TAIL_ENABLED_ENV_VAR,
+        label: "WSJT-X ADIF tail enabled",
+        description: "Poll WSJT-X's wsjtx_log.adi file for recovery ingestion.",
+        kind: RuntimeConfigValueKind::Boolean,
+        secret: false,
+        allowed_values: BOOLEAN_ALLOWED_VALUES,
+        default_value: Some("false"),
+    },
+    ConfigFieldSpec {
+        key: WSJTX_INGEST_ADIF_TAIL_PATH_ENV_VAR,
+        label: "WSJT-X ADIF tail path",
+        description: "Path to WSJT-X's wsjtx_log.adi file.",
+        kind: RuntimeConfigValueKind::Path,
+        secret: false,
+        allowed_values: &[],
+        default_value: None,
+    },
+    ConfigFieldSpec {
+        key: WSJTX_INGEST_POLL_INTERVAL_MS_ENV_VAR,
+        label: "WSJT-X ADIF poll interval",
+        description: "Polling interval for WSJT-X ADIF tail recovery, in milliseconds.",
+        kind: RuntimeConfigValueKind::Integer,
+        secret: false,
+        allowed_values: &[],
+        default_value: Some(DEFAULT_WSJTX_INGEST_POLL_INTERVAL_MS),
+    },
+    ConfigFieldSpec {
+        key: WSJTX_INGEST_SYNC_TO_QRZ_ENV_VAR,
+        label: "WSJT-X sync to QRZ",
+        description: "Immediately upload imported WSJT-X QSOs to QRZ Logbook.",
+        kind: RuntimeConfigValueKind::Boolean,
+        secret: false,
+        allowed_values: BOOLEAN_ALLOWED_VALUES,
+        default_value: Some("false"),
+    },
+    ConfigFieldSpec {
         key: CONTEST_CALENDAR_ENABLED_ENV_VAR,
         label: "Contest calendar enabled",
         description: "Enable live contest calendar fetching.",
@@ -816,14 +891,8 @@ fn normalize_value(key: &'static str, raw_value: &str) -> Result<String, String>
         parse_storage_backend(trimmed)
             .map_err(|error| error.to_string())
             .map(|_| trimmed.to_ascii_lowercase())
-    } else if key == QRZ_XML_CAPTURE_ONLY_ENV_VAR {
-        parse_bool(trimmed).map(|value| {
-            if value {
-                "true".to_string()
-            } else {
-                "false".to_string()
-            }
-        })
+    } else if is_boolean_key(key) {
+        normalize_bool_value(trimmed)
     } else if key == QRZ_HTTP_TIMEOUT_SECONDS_ENV_VAR {
         trimmed
             .parse::<u64>()
@@ -844,28 +913,12 @@ fn normalize_value(key: &'static str, raw_value: &str) -> Result<String, String>
             .parse::<u64>()
             .map(|value| value.to_string())
             .map_err(|_| format!("'{key}' expects an integer value."))
-    } else if key == NOAA_SPACE_WEATHER_ENABLED_ENV_VAR {
-        parse_bool(trimmed).map(|value| {
-            if value {
-                "true".to_string()
-            } else {
-                "false".to_string()
-            }
-        })
     } else if is_station_positive_integer_key(key) {
         parse_positive_integer(key, trimmed).map(|value| value.to_string())
     } else if key == STATION_LATITUDE_ENV_VAR {
         parse_bounded_f64(key, trimmed, -90.0, 90.0).map(|value| value.to_string())
     } else if key == STATION_LONGITUDE_ENV_VAR {
         parse_bounded_f64(key, trimmed, -180.0, 180.0).map(|value| value.to_string())
-    } else if key == SYNC_AUTO_ENABLED_ENV_VAR {
-        parse_bool(trimmed).map(|value| {
-            if value {
-                "true".to_string()
-            } else {
-                "false".to_string()
-            }
-        })
     } else if key == SYNC_INTERVAL_SECONDS_ENV_VAR {
         trimmed
             .parse::<u32>()
@@ -881,14 +934,6 @@ fn normalize_value(key: &'static str, raw_value: &str) -> Result<String, String>
                 CONFLICT_POLICY_ALLOWED_VALUES.join(", ")
             ))
         }
-    } else if key == RIGCTLD_ENABLED_ENV_VAR {
-        parse_bool(trimmed).map(|value| {
-            if value {
-                "true".to_string()
-            } else {
-                "false".to_string()
-            }
-        })
     } else if matches!(
         key,
         RIGCTLD_PORT_ENV_VAR | RIGCTLD_READ_TIMEOUT_MS_ENV_VAR | RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR
@@ -897,9 +942,37 @@ fn normalize_value(key: &'static str, raw_value: &str) -> Result<String, String>
             .parse::<u64>()
             .map(|value| value.to_string())
             .map_err(|_| format!("'{key}' expects an integer value."))
+    } else if key == WSJTX_INGEST_UDP_BIND_ENV_VAR {
+        validate_host_port(trimmed, key).map(|()| trimmed.to_string())
+    } else if key == WSJTX_INGEST_POLL_INTERVAL_MS_ENV_VAR {
+        parse_positive_integer(key, trimmed).map(|value| value.to_string())
     } else {
         Ok(trimmed.to_string())
     }
+}
+
+fn is_boolean_key(key: &str) -> bool {
+    matches!(
+        key,
+        QRZ_XML_CAPTURE_ONLY_ENV_VAR
+            | NOAA_SPACE_WEATHER_ENABLED_ENV_VAR
+            | SYNC_AUTO_ENABLED_ENV_VAR
+            | RIGCTLD_ENABLED_ENV_VAR
+            | WSJTX_INGEST_ENABLED_ENV_VAR
+            | WSJTX_INGEST_UDP_ENABLED_ENV_VAR
+            | WSJTX_INGEST_ADIF_TAIL_ENABLED_ENV_VAR
+            | WSJTX_INGEST_SYNC_TO_QRZ_ENV_VAR
+    )
+}
+
+fn normalize_bool_value(raw_value: &str) -> Result<String, String> {
+    parse_bool(raw_value).map(|value| {
+        if value {
+            "true".to_string()
+        } else {
+            "false".to_string()
+        }
+    })
 }
 
 fn parse_bool(raw_value: &str) -> Result<bool, String> {
@@ -933,6 +1006,22 @@ fn parse_bounded_f64(key: &str, raw_value: &str, min: f64, max: f64) -> Result<f
         return Err(format!("'{key}' must be between {min} and {max}."));
     }
     Ok(value)
+}
+
+fn validate_host_port(bind: &str, label: &str) -> Result<(), String> {
+    let (host, port) = bind
+        .rsplit_once(':')
+        .ok_or_else(|| format!("'{label}' must be in host:port form."))?;
+    if host.trim().is_empty() {
+        return Err(format!("'{label}' must include a host."));
+    }
+    let port: u32 = port
+        .parse()
+        .map_err(|_| format!("'{label}' port is not a number."))?;
+    if port == 0 || port > u32::from(u16::MAX) {
+        return Err(format!("'{label}' port must be between 1 and 65535."));
+    }
+    Ok(())
 }
 
 fn is_station_positive_integer_key(key: &str) -> bool {
@@ -977,6 +1066,7 @@ fn station_profile_override_values(profile: Option<&StationProfile>) -> BTreeMap
 }
 
 fn build_runtime_bindings(values: &BTreeMap<String, String>) -> Result<RuntimeBindings, String> {
+    validate_wsjtx_ingest_values(values)?;
     let storage = build_storage(
         &parse_storage_options_from_values(values).map_err(|error| error.to_string())?,
     )
@@ -1004,6 +1094,29 @@ fn build_runtime_bindings(values: &BTreeMap<String, String>) -> Result<RuntimeBi
         lookup_provider_summary,
         active_station_profile,
     })
+}
+
+fn validate_wsjtx_ingest_values(values: &BTreeMap<String, String>) -> Result<(), String> {
+    for key in [
+        WSJTX_INGEST_ENABLED_ENV_VAR,
+        WSJTX_INGEST_UDP_ENABLED_ENV_VAR,
+        WSJTX_INGEST_ADIF_TAIL_ENABLED_ENV_VAR,
+        WSJTX_INGEST_SYNC_TO_QRZ_ENV_VAR,
+    ] {
+        if let Some(value) = values.get(key) {
+            parse_bool(value)?;
+        }
+    }
+
+    if let Some(bind) = values.get(WSJTX_INGEST_UDP_BIND_ENV_VAR) {
+        validate_host_port(bind, WSJTX_INGEST_UDP_BIND_ENV_VAR)?;
+    }
+
+    if let Some(interval) = values.get(WSJTX_INGEST_POLL_INTERVAL_MS_ENV_VAR) {
+        parse_positive_integer(WSJTX_INGEST_POLL_INTERVAL_MS_ENV_VAR, interval)?;
+    }
+
+    Ok(())
 }
 
 fn build_active_station_profile(

--- a/src/rust/qsoripper-server/src/setup.rs
+++ b/src/rust/qsoripper-server/src/setup.rs
@@ -26,7 +26,7 @@ use qsoripper_core::proto::qsoripper::services::{
     SetupFieldValidation, SetupStatus, SetupWizardStep, SetupWizardStepStatus,
     StationProfileRecord, StorageBackend, TestQrzCredentialsRequest, TestQrzCredentialsResponse,
     TestQrzLogbookCredentialsRequest, TestQrzLogbookCredentialsResponse, ValidateSetupStepRequest,
-    ValidateSetupStepResponse,
+    ValidateSetupStepResponse, WsjtxIngestSettings, WsjtxIngestStatus,
 };
 use qsoripper_core::qrz_logbook::{QrzLogbookClient, QrzLogbookConfig};
 use qsoripper_core::rig_control::{
@@ -34,13 +34,17 @@ use qsoripper_core::rig_control::{
     RIGCTLD_READ_TIMEOUT_MS_ENV_VAR, RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR,
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tonic::{Request, Response, Status};
 
 use crate::runtime_config::{
     RuntimeConfigManager, DEFAULT_QRZ_LOGBOOK_BASE_URL, QRZ_LOGBOOK_API_KEY_ENV_VAR,
     QRZ_LOGBOOK_BASE_URL_ENV_VAR, SQLITE_PATH_ENV_VAR, STORAGE_BACKEND_ENV_VAR,
     SYNC_AUTO_ENABLED_ENV_VAR, SYNC_CONFLICT_POLICY_ENV_VAR, SYNC_INTERVAL_SECONDS_ENV_VAR,
+    WSJTX_INGEST_ADIF_TAIL_ENABLED_ENV_VAR, WSJTX_INGEST_ADIF_TAIL_PATH_ENV_VAR,
+    WSJTX_INGEST_ENABLED_ENV_VAR, WSJTX_INGEST_POLL_INTERVAL_MS_ENV_VAR,
+    WSJTX_INGEST_SYNC_TO_QRZ_ENV_VAR, WSJTX_INGEST_UDP_BIND_ENV_VAR,
+    WSJTX_INGEST_UDP_ENABLED_ENV_VAR,
 };
 use crate::station_profile_support::{
     insert_station_profile_runtime_values, normalize_station_profile as normalize_profile_payload,
@@ -59,6 +63,7 @@ const PERSISTENCE_STEP_LABEL: &str = "Log storage";
 pub(crate) struct SetupControlSurface {
     state: Arc<SetupState>,
     runtime_config: Arc<RuntimeConfigManager>,
+    wsjtx_ingest_status: Option<Arc<Mutex<WsjtxIngestStatus>>>,
 }
 
 impl SetupControlSurface {
@@ -66,7 +71,23 @@ impl SetupControlSurface {
         Self {
             state,
             runtime_config,
+            wsjtx_ingest_status: None,
         }
+    }
+
+    pub(crate) fn with_wsjtx_ingest_status(
+        mut self,
+        status: Arc<Mutex<WsjtxIngestStatus>>,
+    ) -> Self {
+        self.wsjtx_ingest_status = Some(status);
+        self
+    }
+
+    async fn attach_wsjtx_status(&self, mut status: SetupStatus) -> SetupStatus {
+        if let Some(wsjtx_status) = &self.wsjtx_ingest_status {
+            status.wsjtx_ingest_status = Some(wsjtx_status.lock().await.clone());
+        }
+        status
     }
 }
 
@@ -91,8 +112,9 @@ impl SetupService for SetupControlSurface {
         &self,
         _request: Request<GetSetupStatusRequest>,
     ) -> Result<Response<GetSetupStatusResponse>, Status> {
+        let status = self.attach_wsjtx_status(self.state.status().await).await;
         Ok(Response::new(GetSetupStatusResponse {
-            status: Some(self.state.status().await),
+            status: Some(status),
         }))
     }
 
@@ -105,6 +127,7 @@ impl SetupService for SetupControlSurface {
             .save_setup(request.into_inner(), &self.runtime_config)
             .await
             .map_err(Status::invalid_argument)?;
+        let status = self.attach_wsjtx_status(status).await;
         Ok(Response::new(SaveSetupResponse {
             status: Some(status),
         }))
@@ -541,6 +564,8 @@ struct PersistedSetupConfig {
     sync: PersistedSyncConfig,
     #[serde(default, skip_serializing_if = "PersistedRigControlConfig::is_empty")]
     rig_control: PersistedRigControlConfig,
+    #[serde(default, skip_serializing_if = "PersistedWsjtxIngestConfig::is_empty")]
+    wsjtx_ingest: PersistedWsjtxIngestConfig,
 }
 
 impl PersistedSetupConfig {
@@ -644,6 +669,9 @@ impl PersistedSetupConfig {
         if let Some(ref rig_control) = request.rig_control {
             config.rig_control = PersistedRigControlConfig::from_proto(rig_control)?;
         }
+        if let Some(ref wsjtx_ingest) = request.wsjtx_ingest {
+            config.wsjtx_ingest = PersistedWsjtxIngestConfig::from_proto(wsjtx_ingest)?;
+        }
 
         config.sync_active_station_profile();
 
@@ -729,6 +757,10 @@ impl PersistedSetupConfig {
                 RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR.to_string(),
                 stale_threshold_ms.to_string(),
             );
+        }
+
+        if !PersistedWsjtxIngestConfig::is_empty(&self.wsjtx_ingest) {
+            self.wsjtx_ingest.insert_runtime_values(&mut values);
         }
 
         values
@@ -1227,6 +1259,122 @@ impl PersistedRigControlConfig {
     }
 }
 
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+struct PersistedWsjtxIngestConfig {
+    enabled: Option<bool>,
+    udp_enabled: Option<bool>,
+    udp_bind: Option<String>,
+    adif_tail_enabled: Option<bool>,
+    adif_tail_path: Option<String>,
+    poll_interval_ms: Option<u32>,
+    sync_to_qrz: Option<bool>,
+}
+
+impl PersistedWsjtxIngestConfig {
+    fn is_empty(config: &Self) -> bool {
+        config.enabled.is_none()
+            && config.udp_enabled.is_none()
+            && normalize_optional_string(config.udp_bind.as_deref()).is_none()
+            && config.adif_tail_enabled.is_none()
+            && normalize_optional_string(config.adif_tail_path.as_deref()).is_none()
+            && config.poll_interval_ms.is_none()
+            && config.sync_to_qrz.is_none()
+    }
+
+    fn from_proto(settings: &WsjtxIngestSettings) -> Result<Self, String> {
+        let udp_bind = normalize_optional_string(Some(&settings.udp_bind))
+            .unwrap_or_else(|| crate::runtime_config::DEFAULT_WSJTX_INGEST_UDP_BIND.to_string());
+        validate_host_port(&udp_bind, "WSJT-X UDP bind")?;
+        let poll_interval_ms = if settings.poll_interval_ms == 0 {
+            crate::runtime_config::DEFAULT_WSJTX_INGEST_POLL_INTERVAL_MS
+                .parse()
+                .unwrap_or(1_000)
+        } else {
+            settings.poll_interval_ms
+        };
+        let adif_tail_path = normalize_optional_string(settings.adif_tail_path.as_deref());
+        if settings.adif_tail_enabled && adif_tail_path.is_none() {
+            return Err(
+                "WSJT-X ADIF tail path is required when ADIF tailing is enabled.".to_string(),
+            );
+        }
+
+        Ok(Self {
+            enabled: Some(settings.enabled),
+            udp_enabled: Some(settings.udp_enabled.unwrap_or(true)),
+            udp_bind: Some(udp_bind),
+            adif_tail_enabled: Some(settings.adif_tail_enabled),
+            adif_tail_path,
+            poll_interval_ms: Some(poll_interval_ms),
+            sync_to_qrz: Some(settings.sync_to_qrz),
+        })
+    }
+
+    fn to_proto(&self) -> Option<WsjtxIngestSettings> {
+        if Self::is_empty(self) {
+            return None;
+        }
+
+        Some(WsjtxIngestSettings {
+            enabled: self.enabled.unwrap_or(false),
+            udp_enabled: Some(self.udp_enabled.unwrap_or(true)),
+            udp_bind: normalize_optional_string(self.udp_bind.as_deref()).unwrap_or_else(|| {
+                crate::runtime_config::DEFAULT_WSJTX_INGEST_UDP_BIND.to_string()
+            }),
+            adif_tail_enabled: self.adif_tail_enabled.unwrap_or(false),
+            adif_tail_path: normalize_optional_string(self.adif_tail_path.as_deref()),
+            poll_interval_ms: self.poll_interval_ms.unwrap_or_else(|| {
+                crate::runtime_config::DEFAULT_WSJTX_INGEST_POLL_INTERVAL_MS
+                    .parse()
+                    .unwrap_or(1_000)
+            }),
+            sync_to_qrz: self.sync_to_qrz.unwrap_or(false),
+        })
+    }
+
+    fn insert_runtime_values(&self, values: &mut BTreeMap<String, String>) {
+        if let Some(enabled) = self.enabled {
+            values.insert(
+                WSJTX_INGEST_ENABLED_ENV_VAR.to_string(),
+                enabled.to_string(),
+            );
+        }
+        if let Some(udp_enabled) = self.udp_enabled {
+            values.insert(
+                WSJTX_INGEST_UDP_ENABLED_ENV_VAR.to_string(),
+                udp_enabled.to_string(),
+            );
+        }
+        if let Some(udp_bind) = normalize_optional_string(self.udp_bind.as_deref()) {
+            values.insert(WSJTX_INGEST_UDP_BIND_ENV_VAR.to_string(), udp_bind);
+        }
+        if let Some(adif_tail_enabled) = self.adif_tail_enabled {
+            values.insert(
+                WSJTX_INGEST_ADIF_TAIL_ENABLED_ENV_VAR.to_string(),
+                adif_tail_enabled.to_string(),
+            );
+        }
+        if let Some(adif_tail_path) = normalize_optional_string(self.adif_tail_path.as_deref()) {
+            values.insert(
+                WSJTX_INGEST_ADIF_TAIL_PATH_ENV_VAR.to_string(),
+                adif_tail_path,
+            );
+        }
+        if let Some(poll_interval_ms) = self.poll_interval_ms {
+            values.insert(
+                WSJTX_INGEST_POLL_INTERVAL_MS_ENV_VAR.to_string(),
+                poll_interval_ms.to_string(),
+            );
+        }
+        if let Some(sync_to_qrz) = self.sync_to_qrz {
+            values.insert(
+                WSJTX_INGEST_SYNC_TO_QRZ_ENV_VAR.to_string(),
+                sync_to_qrz.to_string(),
+            );
+        }
+    }
+}
+
 /// Mirror of the cathub daemon's `[cat_hub.radio]` table. Every field is optional
 /// so the engine only writes what the wizard supplied and the daemon fills in the
 /// rest from its own defaults.
@@ -1665,6 +1813,22 @@ fn validate_cat_hub_bind(bind: &str, name: &str) -> Result<(), String> {
     Ok(())
 }
 
+fn validate_host_port(bind: &str, label: &str) -> Result<(), String> {
+    let (host, port) = bind
+        .rsplit_once(':')
+        .ok_or_else(|| format!("{label} must be in host:port form."))?;
+    if host.trim().is_empty() {
+        return Err(format!("{label} must include a host."));
+    }
+    let port: u32 = port
+        .parse()
+        .map_err(|_| format!("{label} port is not a number."))?;
+    if port == 0 || port > u32::from(u16::MAX) {
+        return Err(format!("{label} port must be between 1 and 65535."));
+    }
+    Ok(())
+}
+
 fn first_duplicate<'a>(values: &[&'a str]) -> Option<&'a str> {
     let mut seen: Vec<&str> = Vec::with_capacity(values.len());
     for value in values {
@@ -1764,7 +1928,7 @@ fn load_persisted_config(config_path: &Path) -> Result<Option<PersistedSetupConf
 /// caller supplies a complete replacement (see `write_persisted_config`). Every other
 /// unknown top-level table (for example `[launcher]` written by the launcher) is always
 /// preserved untouched so the unified `config.toml` can be shared across all components.
-const ENGINE_OWNED_CONFIG_KEYS: [&str; 8] = [
+const ENGINE_OWNED_CONFIG_KEYS: [&str; 9] = [
     "logbook",
     "storage",
     "station_profile",
@@ -1773,6 +1937,7 @@ const ENGINE_OWNED_CONFIG_KEYS: [&str; 8] = [
     "qrz_logbook",
     "sync",
     "rig_control",
+    "wsjtx_ingest",
 ];
 
 fn write_persisted_config(
@@ -1920,6 +2085,8 @@ fn build_status(
         sync_config: persisted_config.map(|config| config.sync.to_proto()),
         rig_control: persisted_config.and_then(|config| config.rig_control.to_proto()),
         cat_hub: cat_hub.and_then(PersistedCatHubConfig::to_proto),
+        wsjtx_ingest: persisted_config.and_then(|config| config.wsjtx_ingest.to_proto()),
+        wsjtx_ingest_status: None,
         persistence_step_enabled: true,
         persistence_label: PERSISTENCE_STEP_LABEL.to_string(),
         persistence_description: PERSISTENCE_STEP_DESCRIPTION.to_string(),
@@ -2430,7 +2597,7 @@ mod tests {
         ListStationProfilesRequest, RigControlSettings, SaveSetupRequest,
         SaveStationProfileRequest, SetActiveStationProfileRequest,
         SetSessionStationProfileOverrideRequest, SetupWizardStep, StorageBackend,
-        ValidateSetupStepRequest,
+        ValidateSetupStepRequest, WsjtxIngestSettings,
     };
 
     fn unique_config_path() -> std::path::PathBuf {
@@ -3534,6 +3701,130 @@ station_callsign = "K7RND"
             runtime_values
                 .get(RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR)
                 .map(String::as_str)
+        );
+
+        drop(service);
+        drop(runtime_config);
+        drop(setup_state);
+
+        let config_directory = config_path.parent().expect("config directory");
+        let _ = fs::remove_dir_all(config_directory);
+    }
+
+    #[tokio::test]
+    async fn save_setup_persists_wsjtx_ingest_and_round_trips() {
+        let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "wsjtx-ingest.db");
+        let adif_tail_path = absolute_log_file_path(&config_path, "wsjtx_log.adi");
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
+
+        let response = SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file_path),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                wsjtx_ingest: Some(WsjtxIngestSettings {
+                    enabled: true,
+                    udp_enabled: Some(true),
+                    udp_bind: "127.0.0.1:2237".to_string(),
+                    adif_tail_enabled: true,
+                    adif_tail_path: Some(adif_tail_path.clone()),
+                    poll_interval_ms: 1500,
+                    sync_to_qrz: true,
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("save setup")
+        .into_inner();
+
+        let status = response.status.expect("status payload");
+        let wsjtx = status.wsjtx_ingest.expect("wsjtx settings");
+        assert!(wsjtx.enabled);
+        assert_eq!(Some(true), wsjtx.udp_enabled);
+        assert_eq!("127.0.0.1:2237", wsjtx.udp_bind);
+        assert!(wsjtx.adif_tail_enabled);
+        assert_eq!(
+            Some(adif_tail_path.as_str()),
+            wsjtx.adif_tail_path.as_deref()
+        );
+        assert_eq!(1500, wsjtx.poll_interval_ms);
+        assert!(wsjtx.sync_to_qrz);
+
+        let saved_toml = fs::read_to_string(&config_path).expect("read config");
+        assert!(
+            saved_toml.contains("[wsjtx_ingest]"),
+            "wsjtx_ingest table: {saved_toml}"
+        );
+        let parsed =
+            toml::from_str::<PersistedSetupConfig>(&saved_toml).expect("parse saved config");
+        assert_eq!(Some(true), parsed.wsjtx_ingest.enabled);
+        assert_eq!(
+            Some("127.0.0.1:2237"),
+            parsed.wsjtx_ingest.udp_bind.as_deref()
+        );
+
+        let runtime_values = setup_state.runtime_config_values().await;
+        assert_eq!(
+            Some("true"),
+            runtime_values
+                .get(crate::runtime_config::WSJTX_INGEST_ENABLED_ENV_VAR)
+                .map(String::as_str)
+        );
+        assert_eq!(
+            Some(adif_tail_path.as_str()),
+            runtime_values
+                .get(crate::runtime_config::WSJTX_INGEST_ADIF_TAIL_PATH_ENV_VAR)
+                .map(String::as_str)
+        );
+
+        drop(service);
+        drop(runtime_config);
+        drop(setup_state);
+
+        let config_directory = config_path.parent().expect("config directory");
+        let _ = fs::remove_dir_all(config_directory);
+    }
+
+    #[tokio::test]
+    async fn save_setup_rejects_wsjtx_adif_tail_without_path() {
+        let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "wsjtx-invalid.db");
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
+
+        let error = SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file_path),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                wsjtx_ingest: Some(WsjtxIngestSettings {
+                    enabled: true,
+                    udp_enabled: Some(false),
+                    adif_tail_enabled: true,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect_err("ADIF tail without path should fail");
+
+        assert!(
+            error
+                .message()
+                .contains("WSJT-X ADIF tail path is required"),
+            "unexpected error: {error}"
         );
 
         drop(service);

--- a/src/rust/qsoripper-server/src/setup.rs
+++ b/src/rust/qsoripper-server/src/setup.rs
@@ -348,7 +348,13 @@ impl SetupState {
             .as_ref()
             .map(PersistedCatHubConfig::from_proto)
             .transpose()?;
-        write_persisted_config(self.config_path.as_path(), &config, cat_hub_update.as_ref())?;
+        let wsjtx_ingest_update = request.wsjtx_ingest.as_ref().map(|_| &config.wsjtx_ingest);
+        write_persisted_config(
+            self.config_path.as_path(),
+            &config,
+            cat_hub_update.as_ref(),
+            wsjtx_ingest_update,
+        )?;
 
         {
             let mut persisted_config = self.persisted_config.write().await;
@@ -534,7 +540,7 @@ impl SetupState {
         runtime_config
             .preview_config_file_values(runtime_values.clone())
             .await?;
-        write_persisted_config(self.config_path.as_path(), &next, None)?;
+        write_persisted_config(self.config_path.as_path(), &next, None, None)?;
         {
             let mut persisted_config = self.persisted_config.write().await;
             *persisted_config = Some(next);
@@ -1923,12 +1929,13 @@ fn load_persisted_config(config_path: &Path) -> Result<Option<PersistedSetupConf
 }
 
 /// Top-level TOML keys owned by the engine setup config. On save these are replaced
-/// wholesale. The `[cat_hub]` section is CONDITIONALLY engine-managed: it is preserved
-/// verbatim when a save does not touch it, and only removed-and-rewritten when the
-/// caller supplies a complete replacement (see `write_persisted_config`). Every other
+/// wholesale. The `[cat_hub]` and `[wsjtx_ingest]` sections are CONDITIONALLY
+/// engine-managed: they are preserved verbatim when a save does not touch them, and
+/// only removed-and-rewritten when the caller supplies a complete replacement (see
+/// `write_persisted_config`). Every other
 /// unknown top-level table (for example `[launcher]` written by the launcher) is always
 /// preserved untouched so the unified `config.toml` can be shared across all components.
-const ENGINE_OWNED_CONFIG_KEYS: [&str; 9] = [
+const ENGINE_OWNED_CONFIG_KEYS: [&str; 8] = [
     "logbook",
     "storage",
     "station_profile",
@@ -1937,13 +1944,13 @@ const ENGINE_OWNED_CONFIG_KEYS: [&str; 9] = [
     "qrz_logbook",
     "sync",
     "rig_control",
-    "wsjtx_ingest",
 ];
 
 fn write_persisted_config(
     config_path: &Path,
     config: &PersistedSetupConfig,
     cat_hub_update: Option<&PersistedCatHubConfig>,
+    wsjtx_ingest_update: Option<&PersistedWsjtxIngestConfig>,
 ) -> Result<(), String> {
     if let Some(parent) = config_path.parent() {
         fs::create_dir_all(parent).map_err(|error| {
@@ -1992,6 +1999,9 @@ fn write_persisted_config(
         doc.remove(key);
     }
     for (key, item) in owned_doc.iter() {
+        if key == "wsjtx_ingest" {
+            continue;
+        }
         doc.insert(key, item.clone());
     }
 
@@ -2000,6 +2010,9 @@ fn write_persisted_config(
     if let Some(cat_hub) = cat_hub_update {
         splice_cat_hub_section(&mut doc, cat_hub, config_path)?;
     }
+    if let Some(wsjtx_ingest) = wsjtx_ingest_update {
+        splice_wsjtx_ingest_section(&mut doc, wsjtx_ingest, config_path)?;
+    }
 
     fs::write(config_path, doc.to_string()).map_err(|error| {
         format!(
@@ -2007,6 +2020,34 @@ fn write_persisted_config(
             config_path.display()
         )
     })
+}
+
+fn splice_wsjtx_ingest_section(
+    doc: &mut toml_edit::DocumentMut,
+    wsjtx_ingest: &PersistedWsjtxIngestConfig,
+    config_path: &Path,
+) -> Result<(), String> {
+    let owned_text = toml::to_string_pretty(&PersistedSetupConfig {
+        wsjtx_ingest: wsjtx_ingest.clone(),
+        ..PersistedSetupConfig::default()
+    })
+    .map_err(|error| {
+        format!(
+            "Failed to serialize WSJT-X ingest config '{}': {error}",
+            config_path.display()
+        )
+    })?;
+    let owned_doc: toml_edit::DocumentMut = owned_text.parse().map_err(|error| {
+        format!(
+            "Failed to re-parse WSJT-X ingest config '{}': {error}",
+            config_path.display()
+        )
+    })?;
+    doc.remove("wsjtx_ingest");
+    if let Some(item) = owned_doc.get("wsjtx_ingest") {
+        doc.insert("wsjtx_ingest", item.clone());
+    }
+    Ok(())
 }
 
 #[derive(Serialize)]
@@ -3793,6 +3834,59 @@ station_callsign = "K7RND"
     }
 
     #[tokio::test]
+    async fn save_setup_without_wsjtx_ingest_preserves_existing_wsjtx_section_verbatim() {
+        let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "wsjtx-preserve.db");
+        fs::create_dir_all(config_path.parent().expect("config directory"))
+            .expect("create config directory");
+        fs::write(
+            &config_path,
+            format!(
+                r#"
+[wsjtx_ingest]
+# keep operator comment
+enabled = true
+future_key = "preserve-me"
+
+[logbook]
+file_path = "{}"
+"#,
+                log_file_path.replace('\\', "\\\\")
+            ),
+        )
+        .expect("seed config");
+        let setup_state = Arc::new(SetupState::load(config_path.clone()).expect("setup state"));
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state.clone(), runtime_config.clone());
+        let replacement_log = absolute_log_file_path(&config_path, "replacement.db");
+
+        let _ = SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(replacement_log),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("save setup");
+
+        let saved_toml = fs::read_to_string(&config_path).expect("read config");
+        assert!(saved_toml.contains("# keep operator comment"));
+        assert!(saved_toml.contains("future_key = \"preserve-me\""));
+
+        drop(service);
+        drop(runtime_config);
+        drop(setup_state);
+
+        let config_directory = config_path.parent().expect("config directory");
+        let _ = fs::remove_dir_all(config_directory);
+    }
+
+    #[tokio::test]
     async fn save_setup_rejects_wsjtx_adif_tail_without_path() {
         let config_path = unique_config_path();
         let log_file_path = absolute_log_file_path(&config_path, "wsjtx-invalid.db");
@@ -4205,7 +4299,7 @@ engines = [1]
         .expect("seed config");
 
         let config = PersistedSetupConfig::default();
-        write_persisted_config(&config_path, &config, None).expect("write");
+        write_persisted_config(&config_path, &config, None, None).expect("write");
 
         let saved = fs::read_to_string(&config_path).expect("read");
         assert!(saved.contains("[cat_hub.radio]"), "cat_hub.radio: {saved}");
@@ -4246,7 +4340,7 @@ backend = "ts590"
         .expect("seed config");
 
         let config = PersistedSetupConfig::default();
-        write_persisted_config(&config_path, &config, None).expect("write");
+        write_persisted_config(&config_path, &config, None, None).expect("write");
 
         let saved = fs::read_to_string(&config_path).expect("read");
         assert!(
@@ -4467,7 +4561,7 @@ tcp_port = 99999
         let cat_hub =
             PersistedCatHubConfig::from_proto(&valid_cat_hub_settings()).expect("valid settings");
         let engine_config = PersistedSetupConfig::default();
-        write_persisted_config(&config_path, &engine_config, Some(&cat_hub)).expect("write");
+        write_persisted_config(&config_path, &engine_config, Some(&cat_hub), None).expect("write");
 
         let saved = fs::read_to_string(&config_path).expect("read");
         assert!(saved.contains("[cat_hub.radio]"), "radio: {saved}");
@@ -4476,7 +4570,7 @@ tcp_port = 99999
         qsoripper_cathub::validate_cat_hub_toml(&saved).expect("daemon-valid cat_hub");
 
         // Second write WITHOUT a CAT hub update must leave the section untouched.
-        write_persisted_config(&config_path, &engine_config, None).expect("second write");
+        write_persisted_config(&config_path, &engine_config, None, None).expect("second write");
         let preserved = fs::read_to_string(&config_path).expect("read again");
         assert!(
             preserved.contains("[cat_hub.radio]"),

--- a/src/rust/qsoripper-server/src/sync.rs
+++ b/src/rust/qsoripper-server/src/sync.rs
@@ -710,6 +710,69 @@ pub(crate) async fn sync_single_qso(
     qso: &QsoRecord,
     book_owner: Option<&str>,
 ) -> Result<SyncOutcome, String> {
+    sync_single_qso_with_metadata_patch(client, store, qso, book_owner).await
+}
+
+pub(crate) async fn sync_single_qso_metadata_only(
+    client: &dyn QrzLogbookApi,
+    store: &dyn LogbookStore,
+    qso: &QsoRecord,
+    book_owner: Option<&str>,
+) -> Result<SyncOutcome, String> {
+    sync_single_qso_with_metadata_patch(client, store, qso, book_owner).await
+}
+
+async fn sync_single_qso_with_metadata_patch(
+    client: &dyn QrzLogbookApi,
+    store: &dyn LogbookStore,
+    qso: &QsoRecord,
+    book_owner: Option<&str>,
+) -> Result<SyncOutcome, String> {
+    let current = store
+        .get_qso(&qso.local_id)
+        .await
+        .map_err(|err| format!("QRZ sync failed to read current local QSO: {err}"))?
+        .ok_or_else(|| {
+            format!(
+                "QRZ sync skipped because local QSO '{}' no longer exists.",
+                qso.local_id
+            )
+        })?;
+    if current.deleted_at.is_some() {
+        return Err(format!(
+            "QRZ sync skipped because local QSO '{}' is deleted.",
+            current.local_id
+        ));
+    }
+    let expected_updated_at = current.updated_at;
+    let (result, was_duplicate_replace) = upload_single_qso(client, &current, book_owner).await?;
+
+    let patched = store
+        .update_qrz_sync_metadata(
+            &current.local_id,
+            expected_updated_at.as_ref(),
+            result.logid.as_str(),
+        )
+        .await
+        .map_err(|err| format!("QRZ upload succeeded but local metadata update failed: {err}"))?
+        .ok_or_else(|| {
+            format!(
+                "QRZ upload succeeded but local QSO '{}' no longer exists.",
+                current.local_id
+            )
+        })?;
+
+    Ok(SyncOutcome {
+        qso: patched,
+        was_duplicate_replace,
+    })
+}
+
+async fn upload_single_qso(
+    client: &dyn QrzLogbookApi,
+    qso: &QsoRecord,
+    book_owner: Option<&str>,
+) -> Result<(QrzUploadResult, bool), String> {
     let existing_logid = qso.qrz_logid.clone().filter(|s| !s.is_empty());
 
     let result = match existing_logid.as_deref() {
@@ -741,19 +804,7 @@ pub(crate) async fn sync_single_qso(
     };
     let result = result?;
 
-    let mut synced = qso.clone();
-    synced.qrz_logid = Some(result.logid);
-    synced.sync_status = SyncStatus::Synced as i32;
-
-    store
-        .update_qso(&synced)
-        .await
-        .map_err(|err| format!("QRZ upload succeeded but local update failed: {err}"))?;
-
-    Ok(SyncOutcome {
-        qso: synced,
-        was_duplicate_replace,
-    })
+    Ok((result, was_duplicate_replace))
 }
 
 /// Check whether a QRZ API error reason indicates a duplicate QSO.
@@ -1274,11 +1325,154 @@ mod tests {
         Band, ConflictPolicy, Mode, QsoRecord, SyncStatus,
     };
     use qsoripper_core::qrz_logbook::{QrzLogbookError, QrzLogbookStatus, QrzUploadResult};
-    use qsoripper_core::storage::{DeletedRecordsFilter, LogbookStore, QsoListQuery, SyncMetadata};
+    use qsoripper_core::storage::{
+        DeletedRecordsFilter, LogbookCounts, LogbookStore, QsoHistoryPage, QsoListQuery,
+        SyncMetadata,
+    };
     use qsoripper_storage_memory::MemoryStorage;
     use tokio::sync::mpsc;
 
-    use super::{execute_sync, sync_single_qso, QrzLogbookApi};
+    use super::{execute_sync, sync_single_qso, sync_single_qso_metadata_only, QrzLogbookApi};
+
+    struct EditAfterReadStorage {
+        inner: MemoryStorage,
+        injected: Mutex<bool>,
+    }
+
+    impl EditAfterReadStorage {
+        fn new() -> Self {
+            Self {
+                inner: MemoryStorage::new(),
+                injected: Mutex::new(false),
+            }
+        }
+    }
+
+    #[tonic::async_trait]
+    impl LogbookStore for EditAfterReadStorage {
+        async fn insert_qso(
+            &self,
+            qso: &QsoRecord,
+        ) -> Result<(), qsoripper_core::storage::StorageError> {
+            self.inner.insert_qso(qso).await
+        }
+
+        async fn update_qso(
+            &self,
+            qso: &QsoRecord,
+        ) -> Result<bool, qsoripper_core::storage::StorageError> {
+            self.inner.update_qso(qso).await
+        }
+
+        async fn update_qrz_sync_metadata(
+            &self,
+            local_id: &str,
+            expected_updated_at: Option<&Timestamp>,
+            qrz_logid: &str,
+        ) -> Result<Option<QsoRecord>, qsoripper_core::storage::StorageError> {
+            self.inner
+                .update_qrz_sync_metadata(local_id, expected_updated_at, qrz_logid)
+                .await
+        }
+
+        async fn delete_qso(
+            &self,
+            local_id: &str,
+        ) -> Result<bool, qsoripper_core::storage::StorageError> {
+            self.inner.delete_qso(local_id).await
+        }
+
+        async fn soft_delete_qso(
+            &self,
+            local_id: &str,
+            deleted_at_ms: i64,
+            pending_remote_delete: bool,
+        ) -> Result<bool, qsoripper_core::storage::StorageError> {
+            self.inner
+                .soft_delete_qso(local_id, deleted_at_ms, pending_remote_delete)
+                .await
+        }
+
+        async fn restore_qso(
+            &self,
+            local_id: &str,
+        ) -> Result<bool, qsoripper_core::storage::StorageError> {
+            self.inner.restore_qso(local_id).await
+        }
+
+        async fn get_qso(
+            &self,
+            local_id: &str,
+        ) -> Result<Option<QsoRecord>, qsoripper_core::storage::StorageError> {
+            let record = self.inner.get_qso(local_id).await?;
+            let should_inject = {
+                let mut injected = self.injected.lock().unwrap();
+                if *injected {
+                    false
+                } else {
+                    *injected = true;
+                    true
+                }
+            };
+            if should_inject {
+                if let Some(mut edited) = record.clone() {
+                    edited.notes = Some("operator edit after QRZ readback".into());
+                    edited.updated_at = Some(Timestamp {
+                        seconds: edited
+                            .updated_at
+                            .as_ref()
+                            .map_or(1, |stamp| stamp.seconds + 1),
+                        nanos: 0,
+                    });
+                    edited.sync_status = SyncStatus::Modified as i32;
+                    self.inner.update_qso(&edited).await?;
+                }
+            }
+            Ok(record)
+        }
+
+        async fn list_qsos(
+            &self,
+            query: &QsoListQuery,
+        ) -> Result<Vec<QsoRecord>, qsoripper_core::storage::StorageError> {
+            self.inner.list_qsos(query).await
+        }
+
+        async fn list_qso_history(
+            &self,
+            worked_callsign: &str,
+            limit: u32,
+        ) -> Result<QsoHistoryPage, qsoripper_core::storage::StorageError> {
+            self.inner.list_qso_history(worked_callsign, limit).await
+        }
+
+        async fn qso_counts(&self) -> Result<LogbookCounts, qsoripper_core::storage::StorageError> {
+            self.inner.qso_counts().await
+        }
+
+        async fn get_sync_metadata(
+            &self,
+        ) -> Result<SyncMetadata, qsoripper_core::storage::StorageError> {
+            self.inner.get_sync_metadata().await
+        }
+
+        async fn upsert_sync_metadata(
+            &self,
+            metadata: &SyncMetadata,
+        ) -> Result<(), qsoripper_core::storage::StorageError> {
+            self.inner.upsert_sync_metadata(metadata).await
+        }
+
+        async fn purge_deleted_qsos(
+            &self,
+            local_ids: &[String],
+            older_than_ms: Option<i64>,
+        ) -> Result<u32, qsoripper_core::storage::StorageError> {
+            self.inner
+                .purge_deleted_qsos(local_ids, older_than_ms)
+                .await
+        }
+    }
 
     // -- Mock API -----------------------------------------------------------
 
@@ -1715,6 +1909,217 @@ mod tests {
         let saved = store.get_qso(&q.local_id).await.unwrap().unwrap();
         assert_eq!(saved.sync_status, SyncStatus::LocalOnly as i32);
         assert!(saved.qrz_logid.is_none());
+    }
+
+    #[tokio::test]
+    async fn sync_single_qso_uses_current_logid_before_upload() {
+        let store = MemoryStorage::new();
+        let mut stale_snapshot =
+            make_qso("W1AW", "K7SYNC", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        stale_snapshot.qrz_logid = None;
+        stale_snapshot.sync_status = SyncStatus::LocalOnly as i32;
+        stale_snapshot.updated_at = Some(Timestamp {
+            seconds: 1_700_000_010,
+            nanos: 0,
+        });
+        store.insert_qso(&stale_snapshot).await.unwrap();
+
+        let mut current = stale_snapshot.clone();
+        current.qrz_logid = Some("QRZ-SYNC".into());
+        current.sync_status = SyncStatus::Modified as i32;
+        current.updated_at = Some(Timestamp {
+            seconds: 1_700_000_011,
+            nanos: 0,
+        });
+        store.update_qso(&current).await.unwrap();
+
+        let api = MockQrzApi::new(Ok(vec![]), vec![]);
+        let outcome = sync_single_qso(&api, &store, &stale_snapshot, None)
+            .await
+            .expect("sync should use current row");
+
+        assert_eq!(outcome.qso.qrz_logid.as_deref(), Some("QRZ-SYNC"));
+        assert_eq!(api.upload_calls.lock().unwrap().len(), 0);
+        let replace_calls = api.replace_calls.lock().unwrap().clone();
+        assert_eq!(replace_calls.len(), 1);
+        assert_eq!(replace_calls[0].0, "QRZ-SYNC");
+    }
+
+    #[tokio::test]
+    async fn sync_single_qso_does_not_overwrite_edit_between_read_and_write() {
+        let store = EditAfterReadStorage::new();
+        let mut imported = make_qso("W1AW", "K7SYNC2", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        imported.qrz_logid = None;
+        imported.sync_status = SyncStatus::LocalOnly as i32;
+        imported.updated_at = Some(Timestamp {
+            seconds: 1_700_000_010,
+            nanos: 0,
+        });
+        store.insert_qso(&imported).await.unwrap();
+
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![Ok(QrzUploadResult {
+                logid: "QRZ-SYNC2".into(),
+            })],
+        );
+
+        let outcome = sync_single_qso(&api, &store, &imported, None)
+            .await
+            .expect("sync should preserve concurrent edit");
+
+        assert_eq!(
+            outcome.qso.notes.as_deref(),
+            Some("operator edit after QRZ readback")
+        );
+        assert_eq!(outcome.qso.qrz_logid.as_deref(), Some("QRZ-SYNC2"));
+        assert_eq!(outcome.qso.sync_status, SyncStatus::Modified as i32);
+    }
+
+    #[tokio::test]
+    async fn sync_single_qso_metadata_only_preserves_newer_local_edits() {
+        let store = MemoryStorage::new();
+        let mut imported = make_qso("W1AW", "K7RACE", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        imported.qrz_logid = None;
+        imported.sync_status = SyncStatus::LocalOnly as i32;
+        imported.updated_at = Some(Timestamp {
+            seconds: 1_700_000_010,
+            nanos: 0,
+        });
+        store.insert_qso(&imported).await.unwrap();
+
+        let mut edited = imported.clone();
+        edited.notes = Some("operator corrected note".into());
+        edited.updated_at = Some(Timestamp {
+            seconds: imported.updated_at.as_ref().unwrap().seconds + 1,
+            nanos: 0,
+        });
+        edited.sync_status = SyncStatus::Modified as i32;
+        store.update_qso(&edited).await.unwrap();
+
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![Ok(QrzUploadResult {
+                logid: "QRZ-RACE".into(),
+            })],
+        );
+
+        let outcome = sync_single_qso_metadata_only(&api, &store, &imported, None)
+            .await
+            .expect("metadata-only sync should succeed");
+        assert_eq!(
+            outcome.qso.notes.as_deref(),
+            Some("operator corrected note")
+        );
+        assert_eq!(outcome.qso.qrz_logid.as_deref(), Some("QRZ-RACE"));
+        assert_eq!(outcome.qso.sync_status, SyncStatus::Synced as i32);
+
+        let saved = store.get_qso(&imported.local_id).await.unwrap().unwrap();
+        assert_eq!(saved.notes.as_deref(), Some("operator corrected note"));
+        assert_eq!(saved.qrz_logid.as_deref(), Some("QRZ-RACE"));
+        assert_eq!(saved.sync_status, SyncStatus::Synced as i32);
+    }
+
+    #[tokio::test]
+    async fn sync_single_qso_metadata_only_uses_current_logid_before_upload() {
+        let store = MemoryStorage::new();
+        let mut stale_snapshot =
+            make_qso("W1AW", "K7CURRENT", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        stale_snapshot.qrz_logid = None;
+        stale_snapshot.sync_status = SyncStatus::LocalOnly as i32;
+        stale_snapshot.updated_at = Some(Timestamp {
+            seconds: 1_700_000_010,
+            nanos: 0,
+        });
+        store.insert_qso(&stale_snapshot).await.unwrap();
+
+        let mut current = stale_snapshot.clone();
+        current.qrz_logid = Some("QRZ-CURRENT".into());
+        current.sync_status = SyncStatus::Modified as i32;
+        current.updated_at = Some(Timestamp {
+            seconds: 1_700_000_011,
+            nanos: 0,
+        });
+        store.update_qso(&current).await.unwrap();
+
+        let api = MockQrzApi::new(Ok(vec![]), vec![]);
+        let outcome = sync_single_qso_metadata_only(&api, &store, &stale_snapshot, None)
+            .await
+            .expect("metadata-only sync should use current row");
+
+        assert_eq!(outcome.qso.qrz_logid.as_deref(), Some("QRZ-CURRENT"));
+        assert_eq!(api.upload_calls.lock().unwrap().len(), 0);
+        let replace_calls = api.replace_calls.lock().unwrap().clone();
+        assert_eq!(replace_calls.len(), 1);
+        assert_eq!(replace_calls[0].0, "QRZ-CURRENT");
+    }
+
+    #[tokio::test]
+    async fn sync_single_qso_metadata_only_does_not_overwrite_edit_between_read_and_write() {
+        let store = EditAfterReadStorage::new();
+        let mut imported = make_qso("W1AW", "K7CAS", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        imported.qrz_logid = None;
+        imported.sync_status = SyncStatus::LocalOnly as i32;
+        imported.updated_at = Some(Timestamp {
+            seconds: 1_700_000_010,
+            nanos: 0,
+        });
+        store.insert_qso(&imported).await.unwrap();
+
+        let api = MockQrzApi::new(
+            Ok(vec![]),
+            vec![Ok(QrzUploadResult {
+                logid: "QRZ-CAS".into(),
+            })],
+        );
+
+        let outcome = sync_single_qso_metadata_only(&api, &store, &imported, None)
+            .await
+            .expect("metadata-only sync should preserve concurrent edit");
+
+        assert_eq!(
+            outcome.qso.notes.as_deref(),
+            Some("operator edit after QRZ readback")
+        );
+        assert_eq!(outcome.qso.qrz_logid.as_deref(), Some("QRZ-CAS"));
+        assert_eq!(outcome.qso.sync_status, SyncStatus::Modified as i32);
+
+        let saved = store.get_qso(&imported.local_id).await.unwrap().unwrap();
+        assert_eq!(
+            saved.notes.as_deref(),
+            Some("operator edit after QRZ readback")
+        );
+        assert_eq!(saved.qrz_logid.as_deref(), Some("QRZ-CAS"));
+        assert_eq!(saved.sync_status, SyncStatus::Modified as i32);
+    }
+
+    #[tokio::test]
+    async fn sync_single_qso_skips_deleted_current_row_without_uploading() {
+        let store = MemoryStorage::new();
+        let mut imported = make_qso("W1AW", "K7DEL1", Band::Band20m, Mode::Ft8, 1_700_000_000);
+        imported.sync_status = SyncStatus::Modified as i32;
+        store.insert_qso(&imported).await.unwrap();
+        store
+            .soft_delete_qso(&imported.local_id, 1_700_000_500_000, false)
+            .await
+            .unwrap();
+        let api = MockQrzApi::new(
+            Ok(Vec::new()),
+            vec![Ok(QrzUploadResult {
+                logid: "QRZ-DEL1".into(),
+            })],
+        );
+
+        let err = sync_single_qso(&api, &store, &imported, None)
+            .await
+            .expect_err("deleted current row should skip upload");
+
+        assert!(err.contains("deleted"), "{err}");
+        assert!(api.upload_calls.lock().unwrap().is_empty());
+        let stored = store.get_qso(&imported.local_id).await.unwrap().unwrap();
+        assert!(stored.deleted_at.is_some());
+        assert_eq!(stored.qrz_logid, None);
+        assert!(!stored.pending_remote_delete);
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-server/src/sync_scheduler.rs
+++ b/src/rust/qsoripper-server/src/sync_scheduler.rs
@@ -31,18 +31,20 @@ pub(crate) struct SyncScheduler {
     is_syncing: Arc<Mutex<bool>>,
     last_error: Arc<Mutex<Option<String>>>,
     next_sync: Arc<Mutex<Option<Timestamp>>>,
+    qrz_upload_lock: Arc<Mutex<()>>,
     cancel_tx: watch::Sender<bool>,
 }
 
 impl SyncScheduler {
     /// Create a new scheduler.  Call [`start`](Self::start) to spawn the
     /// background loop.
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(qrz_upload_lock: Arc<Mutex<()>>) -> Self {
         let (cancel_tx, _) = watch::channel(false);
         Self {
             is_syncing: Arc::new(Mutex::new(false)),
             last_error: Arc::new(Mutex::new(None)),
             next_sync: Arc::new(Mutex::new(None)),
+            qrz_upload_lock,
             cancel_tx,
         }
     }
@@ -56,6 +58,7 @@ impl SyncScheduler {
         let is_syncing = self.is_syncing.clone();
         let last_error = self.last_error.clone();
         let next_sync = self.next_sync.clone();
+        let qrz_upload_lock = self.qrz_upload_lock.clone();
         let mut cancel_rx = self.cancel_tx.subscribe();
 
         tokio::spawn(async move {
@@ -150,6 +153,7 @@ impl SyncScheduler {
                 // Use a channel that we drain immediately — the scheduler does
                 // not stream progress anywhere, it just needs the final result.
                 let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+                let _upload_guard = qrz_upload_lock.lock().await;
                 sync::execute_sync(&client, logbook_store, false, conflict_policy, &tx).await;
                 drop(tx);
 
@@ -246,7 +250,7 @@ mod tests {
 
     #[tokio::test]
     async fn scheduler_does_not_sync_when_auto_disabled() {
-        let scheduler = SyncScheduler::new();
+        let scheduler = SyncScheduler::new(Arc::new(Mutex::new(())));
         let config = make_config(&[("QSORIPPER_SYNC_AUTO_ENABLED", "false")]);
         scheduler.start(config);
 
@@ -262,7 +266,7 @@ mod tests {
 
     #[tokio::test]
     async fn scheduler_stops_on_cancel() {
-        let scheduler = SyncScheduler::new();
+        let scheduler = SyncScheduler::new(Arc::new(Mutex::new(())));
         let config = make_config(&[("QSORIPPER_SYNC_AUTO_ENABLED", "false")]);
         scheduler.start(config);
 
@@ -278,7 +282,7 @@ mod tests {
 
     #[tokio::test]
     async fn scheduler_clears_next_sync_when_no_api_key() {
-        let scheduler = SyncScheduler::new();
+        let scheduler = SyncScheduler::new(Arc::new(Mutex::new(())));
         // Auto-sync enabled but no API key.
         let config = make_config(&[("QSORIPPER_SYNC_AUTO_ENABLED", "true")]);
         scheduler.start(config);

--- a/src/rust/qsoripper-server/src/wsjtx_ingest.rs
+++ b/src/rust/qsoripper-server/src/wsjtx_ingest.rs
@@ -1,0 +1,678 @@
+//! Background WSJT-X ingestion supervisor.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use prost_types::Timestamp;
+use qsoripper_core::application::logbook::AdifImportSummary;
+use qsoripper_core::proto::qsoripper::services::WsjtxIngestStatus;
+use qsoripper_core::qrz_logbook::{QrzLogbookClient, QrzLogbookConfig};
+use qsoripper_core::wsjtx::{ingest_wsjtx_adif_tail, ingest_wsjtx_udp_datagram};
+use tokio::net::UdpSocket;
+use tokio::sync::{watch, Mutex};
+use tokio::time::{timeout, Duration};
+
+use crate::runtime_config::{
+    RuntimeConfigManager, DEFAULT_QRZ_LOGBOOK_BASE_URL, DEFAULT_WSJTX_INGEST_POLL_INTERVAL_MS,
+    DEFAULT_WSJTX_INGEST_UDP_BIND, QRZ_LOGBOOK_API_KEY_ENV_VAR, QRZ_LOGBOOK_BASE_URL_ENV_VAR,
+    WSJTX_INGEST_ADIF_TAIL_ENABLED_ENV_VAR, WSJTX_INGEST_ADIF_TAIL_PATH_ENV_VAR,
+    WSJTX_INGEST_ENABLED_ENV_VAR, WSJTX_INGEST_POLL_INTERVAL_MS_ENV_VAR,
+    WSJTX_INGEST_SYNC_TO_QRZ_ENV_VAR, WSJTX_INGEST_UDP_BIND_ENV_VAR,
+    WSJTX_INGEST_UDP_ENABLED_ENV_VAR,
+};
+use crate::sync;
+
+#[derive(Clone)]
+pub(crate) struct WsjtxIngestSupervisor {
+    status: Arc<Mutex<WsjtxIngestStatus>>,
+    import_lock: Arc<Mutex<()>>,
+    cancel_tx: watch::Sender<bool>,
+}
+
+impl WsjtxIngestSupervisor {
+    pub(crate) fn new() -> Self {
+        let (cancel_tx, _) = watch::channel(false);
+        Self {
+            status: Arc::new(Mutex::new(WsjtxIngestStatus::default())),
+            import_lock: Arc::new(Mutex::new(())),
+            cancel_tx,
+        }
+    }
+
+    pub(crate) fn status_handle(&self) -> Arc<Mutex<WsjtxIngestStatus>> {
+        self.status.clone()
+    }
+
+    pub(crate) fn start(&self, runtime_config: Arc<RuntimeConfigManager>) {
+        let udp_status = self.status.clone();
+        let udp_import_lock = self.import_lock.clone();
+        let udp_runtime = runtime_config.clone();
+        let mut udp_cancel = self.cancel_tx.subscribe();
+        tokio::spawn(async move {
+            udp_loop(udp_runtime, udp_status, udp_import_lock, &mut udp_cancel).await;
+        });
+
+        let tail_status = self.status.clone();
+        let tail_import_lock = self.import_lock.clone();
+        let mut tail_cancel = self.cancel_tx.subscribe();
+        tokio::spawn(async move {
+            adif_tail_loop(
+                runtime_config,
+                tail_status,
+                tail_import_lock,
+                &mut tail_cancel,
+            )
+            .await;
+        });
+    }
+
+    pub(crate) fn stop(&self) {
+        let _ = self.cancel_tx.send(true);
+    }
+}
+
+async fn udp_loop(
+    runtime_config: Arc<RuntimeConfigManager>,
+    status: Arc<Mutex<WsjtxIngestStatus>>,
+    import_lock: Arc<Mutex<()>>,
+    cancel_rx: &mut watch::Receiver<bool>,
+) {
+    let mut active_bind = String::new();
+    let mut socket: Option<UdpSocket> = None;
+    let mut buffer = vec![0_u8; 65_535];
+
+    loop {
+        if *cancel_rx.borrow() {
+            mark_udp_stopped(&status).await;
+            return;
+        }
+
+        let settings = WsjtxRuntimeSettings::from_values(&runtime_config.effective_values().await);
+        update_config_status(&status, &settings).await;
+
+        if !settings.enabled || !settings.udp_enabled {
+            socket = None;
+            active_bind.clear();
+            mark_udp_stopped(&status).await;
+            if wait_or_cancel(cancel_rx, Duration::from_millis(500)).await {
+                return;
+            }
+            continue;
+        }
+
+        if socket.is_none() || active_bind != settings.udp_bind {
+            match UdpSocket::bind(&settings.udp_bind).await {
+                Ok(bound) => {
+                    let local = bound
+                        .local_addr()
+                        .map_or_else(|_| settings.udp_bind.clone(), |addr| addr.to_string());
+                    active_bind.clone_from(&settings.udp_bind);
+                    socket = Some(bound);
+                    let mut guard = status.lock().await;
+                    guard.enabled = true;
+                    guard.running = true;
+                    guard.udp_running = true;
+                    guard.udp_bind = local;
+                    guard.last_error = None;
+                }
+                Err(error) => {
+                    let mut guard = status.lock().await;
+                    guard.enabled = true;
+                    guard.running = settings.adif_tail_enabled;
+                    guard.udp_running = false;
+                    guard.udp_bind.clone_from(&settings.udp_bind);
+                    guard.last_error = Some(format!(
+                        "Failed to bind WSJT-X UDP listener on {}: {error}",
+                        settings.udp_bind
+                    ));
+                    socket = None;
+                    active_bind.clear();
+                    if wait_or_cancel(cancel_rx, Duration::from_millis(1_000)).await {
+                        return;
+                    }
+                    continue;
+                }
+            }
+        }
+
+        let Some(bound) = socket.as_ref() else {
+            continue;
+        };
+        match timeout(Duration::from_millis(500), bound.recv_from(&mut buffer)).await {
+            Ok(Ok((len, _addr))) => {
+                if let Some(datagram) = buffer.get(..len) {
+                    process_datagram(
+                        &runtime_config,
+                        &status,
+                        &import_lock,
+                        datagram,
+                        settings.sync_to_qrz,
+                    )
+                    .await;
+                }
+            }
+            Ok(Err(error)) => {
+                status.lock().await.last_error =
+                    Some(format!("WSJT-X UDP receive failed: {error}"));
+                socket = None;
+                active_bind.clear();
+            }
+            Err(_) => {}
+        }
+    }
+}
+
+async fn adif_tail_loop(
+    runtime_config: Arc<RuntimeConfigManager>,
+    status: Arc<Mutex<WsjtxIngestStatus>>,
+    import_lock: Arc<Mutex<()>>,
+    cancel_rx: &mut watch::Receiver<bool>,
+) {
+    let mut cursor = 0_usize;
+    let mut active_path = PathBuf::new();
+
+    loop {
+        if *cancel_rx.borrow() {
+            mark_tail_stopped(&status).await;
+            return;
+        }
+
+        let settings = WsjtxRuntimeSettings::from_values(&runtime_config.effective_values().await);
+        update_config_status(&status, &settings).await;
+
+        if !settings.enabled || !settings.adif_tail_enabled {
+            cursor = 0;
+            active_path = PathBuf::new();
+            mark_tail_stopped(&status).await;
+            if wait_or_cancel(cancel_rx, Duration::from_millis(500)).await {
+                return;
+            }
+            continue;
+        }
+
+        let Some(path) = settings.adif_tail_path.clone() else {
+            status.lock().await.last_error =
+                Some("WSJT-X ADIF tail is enabled but no path is configured.".to_string());
+            if wait_or_cancel(cancel_rx, settings.poll_interval).await {
+                return;
+            }
+            continue;
+        };
+
+        if active_path != path {
+            cursor = 0;
+            active_path.clone_from(&path);
+        }
+
+        {
+            let mut guard = status.lock().await;
+            guard.enabled = true;
+            guard.running = true;
+            guard.adif_tail_running = true;
+            guard.adif_tail_path = Some(path.display().to_string());
+        }
+
+        let summary = {
+            let _guard = import_lock.lock().await;
+            let (engine, active_station_profile) = runtime_config.logbook_context().await;
+            ingest_wsjtx_adif_tail(
+                &engine,
+                &path,
+                active_station_profile.as_ref(),
+                true,
+                &mut cursor,
+            )
+            .await
+        };
+        match summary {
+            Ok(summary) => {
+                record_import_summary(&status, &summary).await;
+                queue_qrz_sync(&runtime_config, &status, settings.sync_to_qrz, summary);
+            }
+            Err(error) => {
+                let mut guard = status.lock().await;
+                guard.parse_errors = guard.parse_errors.saturating_add(1);
+                guard.last_error = Some(error);
+            }
+        }
+
+        if wait_or_cancel(cancel_rx, settings.poll_interval).await {
+            return;
+        }
+    }
+}
+
+async fn process_datagram(
+    runtime_config: &Arc<RuntimeConfigManager>,
+    status: &Arc<Mutex<WsjtxIngestStatus>>,
+    import_lock: &Arc<Mutex<()>>,
+    datagram: &[u8],
+    sync_to_qrz: bool,
+) {
+    let summary = {
+        let _guard = import_lock.lock().await;
+        let (engine, active_station_profile) = runtime_config.logbook_context().await;
+        ingest_wsjtx_udp_datagram(&engine, datagram, active_station_profile.as_ref(), true).await
+    };
+    match summary {
+        Ok(summary) => {
+            record_import_summary(status, &summary).await;
+            queue_qrz_sync(runtime_config, status, sync_to_qrz, summary);
+        }
+        Err(error) => {
+            let mut guard = status.lock().await;
+            guard.parse_errors = guard.parse_errors.saturating_add(1);
+            guard.last_error = Some(error);
+        }
+    }
+}
+
+fn queue_qrz_sync(
+    runtime_config: &Arc<RuntimeConfigManager>,
+    status: &Arc<Mutex<WsjtxIngestStatus>>,
+    sync_to_qrz: bool,
+    summary: AdifImportSummary,
+) {
+    if !sync_to_qrz || summary.affected_qsos.is_empty() {
+        return;
+    }
+
+    let runtime_config = runtime_config.clone();
+    let status = status.clone();
+    tokio::spawn(async move {
+        maybe_sync_to_qrz(&runtime_config, &status, true, &summary).await;
+    });
+}
+
+async fn maybe_sync_to_qrz(
+    runtime_config: &Arc<RuntimeConfigManager>,
+    status: &Arc<Mutex<WsjtxIngestStatus>>,
+    sync_to_qrz: bool,
+    summary: &AdifImportSummary,
+) {
+    if !sync_to_qrz || summary.affected_qsos.is_empty() {
+        return;
+    }
+
+    let values = runtime_config.effective_values().await;
+    let api_key = values
+        .get(QRZ_LOGBOOK_API_KEY_ENV_VAR)
+        .cloned()
+        .unwrap_or_default();
+    if api_key.trim().is_empty() {
+        let mut guard = status.lock().await;
+        guard.last_qrz_sync_success = false;
+        guard.last_qrz_sync_error = Some("QRZ Logbook API key is not configured.".to_string());
+        return;
+    }
+
+    let base_url = values
+        .get(QRZ_LOGBOOK_BASE_URL_ENV_VAR)
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_QRZ_LOGBOOK_BASE_URL.to_string());
+    let client = match QrzLogbookClient::new(QrzLogbookConfig::new(
+        api_key,
+        base_url,
+        "QsoRipper/1.0".to_string(),
+    )) {
+        Ok(client) => client,
+        Err(error) => {
+            let mut guard = status.lock().await;
+            guard.last_qrz_sync_success = false;
+            guard.last_qrz_sync_error =
+                Some(format!("Failed to create QRZ logbook client: {error}"));
+            return;
+        }
+    };
+
+    let engine = runtime_config.logbook_engine().await;
+    let cached_metadata = engine
+        .logbook_store()
+        .get_sync_metadata()
+        .await
+        .unwrap_or_default();
+    let book_owner = sync::resolve_book_owner_for_upload(&client, &cached_metadata).await;
+
+    for qso in &summary.affected_qsos {
+        match sync::sync_single_qso(&client, engine.logbook_store(), qso, book_owner.as_deref())
+            .await
+        {
+            Ok(outcome) => {
+                let mut guard = status.lock().await;
+                guard.last_qrz_sync_success = true;
+                guard.last_qrz_sync_error = None;
+                guard.last_imported_callsign = Some(outcome.qso.worked_callsign);
+                guard.last_imported_local_id = Some(outcome.qso.local_id);
+            }
+            Err(error) => {
+                let mut guard = status.lock().await;
+                guard.last_qrz_sync_success = false;
+                guard.last_qrz_sync_error = Some(error);
+            }
+        }
+    }
+}
+
+async fn record_import_summary(
+    status: &Arc<Mutex<WsjtxIngestStatus>>,
+    summary: &AdifImportSummary,
+) {
+    let mut guard = status.lock().await;
+    guard.last_event_at = Some(now_timestamp());
+    guard.records_imported = guard
+        .records_imported
+        .saturating_add(summary.records_imported);
+    guard.records_updated = guard
+        .records_updated
+        .saturating_add(summary.records_updated);
+    guard.records_skipped = guard
+        .records_skipped
+        .saturating_add(summary.records_skipped);
+    guard.duplicates_skipped = guard
+        .duplicates_skipped
+        .saturating_add(count_duplicate_warnings(summary));
+    if let Some(qso) = summary.affected_qsos.last() {
+        guard.last_imported_callsign = Some(qso.worked_callsign.clone());
+        guard.last_imported_local_id = Some(qso.local_id.clone());
+    }
+    guard.last_error = summary.warnings.last().cloned();
+}
+
+fn count_duplicate_warnings(summary: &AdifImportSummary) -> u32 {
+    u32::try_from(
+        summary
+            .warnings
+            .iter()
+            .filter(|warning| warning.contains("duplicate skipped"))
+            .count(),
+    )
+    .unwrap_or(u32::MAX)
+}
+
+async fn update_config_status(
+    status: &Arc<Mutex<WsjtxIngestStatus>>,
+    settings: &WsjtxRuntimeSettings,
+) {
+    let mut guard = status.lock().await;
+    guard.enabled = settings.enabled;
+    guard.udp_bind.clone_from(&settings.udp_bind);
+    guard.adif_tail_path = settings
+        .adif_tail_path
+        .as_ref()
+        .map(|path| path.display().to_string());
+    guard.running = settings.enabled && (guard.udp_running || guard.adif_tail_running);
+}
+
+async fn mark_udp_stopped(status: &Arc<Mutex<WsjtxIngestStatus>>) {
+    let mut guard = status.lock().await;
+    guard.udp_running = false;
+    guard.running = guard.enabled && guard.adif_tail_running;
+}
+
+async fn mark_tail_stopped(status: &Arc<Mutex<WsjtxIngestStatus>>) {
+    let mut guard = status.lock().await;
+    guard.adif_tail_running = false;
+    guard.running = guard.enabled && guard.udp_running;
+}
+
+async fn wait_or_cancel(cancel_rx: &mut watch::Receiver<bool>, duration: Duration) -> bool {
+    tokio::select! {
+        () = tokio::time::sleep(duration) => false,
+        result = cancel_rx.changed() => result.is_ok() && *cancel_rx.borrow(),
+    }
+}
+
+fn now_timestamp() -> Timestamp {
+    let now = chrono::Utc::now();
+    Timestamp {
+        seconds: now.timestamp(),
+        nanos: i32::try_from(now.timestamp_subsec_nanos()).unwrap_or(0),
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "WSJT-X settings mirror protobuf/TOML boolean toggles."
+)]
+struct WsjtxRuntimeSettings {
+    enabled: bool,
+    udp_enabled: bool,
+    udp_bind: String,
+    adif_tail_enabled: bool,
+    adif_tail_path: Option<PathBuf>,
+    poll_interval: Duration,
+    sync_to_qrz: bool,
+}
+
+impl WsjtxRuntimeSettings {
+    fn from_values(values: &BTreeMap<String, String>) -> Self {
+        let enabled = bool_value(values, WSJTX_INGEST_ENABLED_ENV_VAR, false);
+        Self {
+            enabled,
+            udp_enabled: bool_value(values, WSJTX_INGEST_UDP_ENABLED_ENV_VAR, true),
+            udp_bind: values
+                .get(WSJTX_INGEST_UDP_BIND_ENV_VAR)
+                .filter(|value| !value.trim().is_empty())
+                .cloned()
+                .unwrap_or_else(|| DEFAULT_WSJTX_INGEST_UDP_BIND.to_string()),
+            adif_tail_enabled: bool_value(values, WSJTX_INGEST_ADIF_TAIL_ENABLED_ENV_VAR, false),
+            adif_tail_path: values
+                .get(WSJTX_INGEST_ADIF_TAIL_PATH_ENV_VAR)
+                .filter(|value| !value.trim().is_empty())
+                .map(PathBuf::from),
+            poll_interval: Duration::from_millis(
+                values
+                    .get(WSJTX_INGEST_POLL_INTERVAL_MS_ENV_VAR)
+                    .and_then(|value| value.parse::<u64>().ok())
+                    .filter(|value| *value > 0)
+                    .unwrap_or_else(|| {
+                        DEFAULT_WSJTX_INGEST_POLL_INTERVAL_MS
+                            .parse()
+                            .unwrap_or(1_000)
+                    }),
+            ),
+            sync_to_qrz: bool_value(values, WSJTX_INGEST_SYNC_TO_QRZ_ENV_VAR, false),
+        }
+    }
+}
+
+fn bool_value(values: &BTreeMap<String, String>, key: &str, default: bool) -> bool {
+    values.get(key).map_or(default, |value| {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "y" | "on" => true,
+            "0" | "false" | "no" | "n" | "off" => false,
+            _ => default,
+        }
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::{WsjtxIngestSupervisor, WsjtxRuntimeSettings};
+    use crate::runtime_config::{
+        RuntimeConfigManager, WSJTX_INGEST_ADIF_TAIL_ENABLED_ENV_VAR,
+        WSJTX_INGEST_ADIF_TAIL_PATH_ENV_VAR, WSJTX_INGEST_ENABLED_ENV_VAR,
+        WSJTX_INGEST_SYNC_TO_QRZ_ENV_VAR, WSJTX_INGEST_UDP_BIND_ENV_VAR,
+    };
+    use qsoripper_core::storage::QsoListQuery;
+    use std::collections::BTreeMap;
+    use std::fs;
+    use std::sync::Arc;
+    use tempfile::NamedTempFile;
+    use tokio::net::UdpSocket;
+    use tokio::time::{sleep, Duration};
+
+    fn append_be_u32(target: &mut Vec<u8>, value: u32) {
+        target.extend_from_slice(&value.to_be_bytes());
+    }
+
+    fn append_wsjtx_utf8(target: &mut Vec<u8>, value: &str) {
+        append_be_u32(
+            target,
+            u32::try_from(value.len()).expect("test string length"),
+        );
+        target.extend_from_slice(value.as_bytes());
+    }
+
+    fn wsjtx_logged_adif_frame(adif: &str) -> Vec<u8> {
+        let mut frame = Vec::new();
+        append_be_u32(&mut frame, 0xadbc_cbda);
+        append_be_u32(&mut frame, 2);
+        append_be_u32(&mut frame, 12);
+        append_wsjtx_utf8(&mut frame, "WSJT-X");
+        append_wsjtx_utf8(&mut frame, adif);
+        frame
+    }
+
+    fn sample_adif(callsign: &str) -> String {
+        format!(
+            "<STATION_CALLSIGN:4>W1AW <CALL:{}>{callsign} <QSO_DATE:8>20250101 <TIME_ON:4>1200 <BAND:3>20M <MODE:3>FT8 <RST_SENT:3>-10 <RST_RCVD:3>-12 <EOR>",
+            callsign.len()
+        )
+    }
+
+    fn free_udp_bind() -> String {
+        let socket = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind probe");
+        socket.local_addr().expect("local addr").to_string()
+    }
+
+    #[tokio::test]
+    async fn wsjtx_udp_supervisor_imports_logged_adif_datagram() {
+        let bind = free_udp_bind();
+        let mut values = BTreeMap::new();
+        values.insert(WSJTX_INGEST_ENABLED_ENV_VAR.to_string(), "true".to_string());
+        values.insert(WSJTX_INGEST_UDP_BIND_ENV_VAR.to_string(), bind.clone());
+        let runtime = Arc::new(RuntimeConfigManager::new(values).expect("runtime"));
+        let supervisor = WsjtxIngestSupervisor::new();
+        supervisor.start(runtime.clone());
+
+        sleep(Duration::from_millis(100)).await;
+        let sender = UdpSocket::bind("127.0.0.1:0").await.expect("sender");
+        sender
+            .send_to(&wsjtx_logged_adif_frame(&sample_adif("K7UDP")), &bind)
+            .await
+            .expect("send datagram");
+
+        let mut imported = false;
+        for _ in 0..20 {
+            let qsos = runtime
+                .logbook_engine()
+                .await
+                .list_qsos(&QsoListQuery::default())
+                .await
+                .expect("list qsos");
+            if qsos.iter().any(|qso| qso.worked_callsign == "K7UDP") {
+                imported = true;
+                break;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        supervisor.stop();
+        assert!(imported, "WSJT-X UDP datagram was not imported");
+    }
+
+    #[tokio::test]
+    async fn wsjtx_adif_tail_supervisor_imports_existing_log_file() {
+        let file = NamedTempFile::new().expect("temp file");
+        fs::write(file.path(), sample_adif("K7TAIL")).expect("write adif");
+
+        let mut values = BTreeMap::new();
+        values.insert(WSJTX_INGEST_ENABLED_ENV_VAR.to_string(), "true".to_string());
+        values.insert(
+            WSJTX_INGEST_ADIF_TAIL_ENABLED_ENV_VAR.to_string(),
+            "true".to_string(),
+        );
+        values.insert(
+            WSJTX_INGEST_ADIF_TAIL_PATH_ENV_VAR.to_string(),
+            file.path().display().to_string(),
+        );
+        let runtime = Arc::new(RuntimeConfigManager::new(values).expect("runtime"));
+        let supervisor = WsjtxIngestSupervisor::new();
+        supervisor.start(runtime.clone());
+
+        let mut imported = false;
+        for _ in 0..20 {
+            let qsos = runtime
+                .logbook_engine()
+                .await
+                .list_qsos(&QsoListQuery::default())
+                .await
+                .expect("list qsos");
+            if qsos.iter().any(|qso| qso.worked_callsign == "K7TAIL") {
+                imported = true;
+                break;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        supervisor.stop();
+        assert!(imported, "WSJT-X ADIF tail file was not imported");
+    }
+
+    #[tokio::test]
+    async fn wsjtx_sync_to_qrz_records_missing_key_without_losing_local_qso() {
+        let bind = free_udp_bind();
+        let mut values = BTreeMap::new();
+        values.insert(WSJTX_INGEST_ENABLED_ENV_VAR.to_string(), "true".to_string());
+        values.insert(WSJTX_INGEST_UDP_BIND_ENV_VAR.to_string(), bind.clone());
+        values.insert(
+            WSJTX_INGEST_SYNC_TO_QRZ_ENV_VAR.to_string(),
+            "true".to_string(),
+        );
+        let runtime = Arc::new(RuntimeConfigManager::new(values).expect("runtime"));
+        let supervisor = WsjtxIngestSupervisor::new();
+        let status = supervisor.status_handle();
+        supervisor.start(runtime.clone());
+
+        sleep(Duration::from_millis(100)).await;
+        let sender = UdpSocket::bind("127.0.0.1:0").await.expect("sender");
+        sender
+            .send_to(&wsjtx_logged_adif_frame(&sample_adif("K7QRZ")), &bind)
+            .await
+            .expect("send datagram");
+
+        let mut recorded = false;
+        for _ in 0..20 {
+            let qsos = runtime
+                .logbook_engine()
+                .await
+                .list_qsos(&QsoListQuery::default())
+                .await
+                .expect("list qsos");
+            let snapshot = status.lock().await.clone();
+            if qsos.iter().any(|qso| qso.worked_callsign == "K7QRZ")
+                && snapshot.last_qrz_sync_error.is_some()
+            {
+                assert!(!snapshot.last_qrz_sync_success);
+                assert_eq!(
+                    Some("QRZ Logbook API key is not configured."),
+                    snapshot.last_qrz_sync_error.as_deref()
+                );
+                recorded = true;
+                break;
+            }
+            sleep(Duration::from_millis(100)).await;
+        }
+
+        supervisor.stop();
+        assert!(
+            recorded,
+            "WSJT-X QRZ missing-key diagnostic was not recorded"
+        );
+    }
+
+    #[test]
+    fn wsjtx_runtime_settings_default_udp_enabled_when_ingest_enabled() {
+        let mut values = BTreeMap::new();
+        values.insert(WSJTX_INGEST_ENABLED_ENV_VAR.to_string(), "true".to_string());
+
+        let settings = WsjtxRuntimeSettings::from_values(&values);
+
+        assert!(settings.enabled);
+        assert!(settings.udp_enabled);
+    }
+}

--- a/src/rust/qsoripper-server/src/wsjtx_ingest.rs
+++ b/src/rust/qsoripper-server/src/wsjtx_ingest.rs
@@ -8,7 +8,7 @@ use prost_types::Timestamp;
 use qsoripper_core::application::logbook::AdifImportSummary;
 use qsoripper_core::proto::qsoripper::services::WsjtxIngestStatus;
 use qsoripper_core::qrz_logbook::{QrzLogbookClient, QrzLogbookConfig};
-use qsoripper_core::wsjtx::{ingest_wsjtx_adif_tail, ingest_wsjtx_udp_datagram};
+use qsoripper_core::wsjtx::{ingest_wsjtx_adif_tail, ingest_wsjtx_logged_adif_datagram};
 use tokio::net::UdpSocket;
 use tokio::sync::{watch, Mutex};
 use tokio::time::{timeout, Duration};
@@ -27,15 +27,22 @@ use crate::sync;
 pub(crate) struct WsjtxIngestSupervisor {
     status: Arc<Mutex<WsjtxIngestStatus>>,
     import_lock: Arc<Mutex<()>>,
+    qrz_sync_lock: Arc<Mutex<()>>,
     cancel_tx: watch::Sender<bool>,
 }
 
 impl WsjtxIngestSupervisor {
+    #[cfg(test)]
     pub(crate) fn new() -> Self {
+        Self::with_qrz_sync_lock(Arc::new(Mutex::new(())))
+    }
+
+    pub(crate) fn with_qrz_sync_lock(qrz_sync_lock: Arc<Mutex<()>>) -> Self {
         let (cancel_tx, _) = watch::channel(false);
         Self {
             status: Arc::new(Mutex::new(WsjtxIngestStatus::default())),
             import_lock: Arc::new(Mutex::new(())),
+            qrz_sync_lock,
             cancel_tx,
         }
     }
@@ -47,20 +54,30 @@ impl WsjtxIngestSupervisor {
     pub(crate) fn start(&self, runtime_config: Arc<RuntimeConfigManager>) {
         let udp_status = self.status.clone();
         let udp_import_lock = self.import_lock.clone();
+        let udp_qrz_sync_lock = self.qrz_sync_lock.clone();
         let udp_runtime = runtime_config.clone();
         let mut udp_cancel = self.cancel_tx.subscribe();
         tokio::spawn(async move {
-            udp_loop(udp_runtime, udp_status, udp_import_lock, &mut udp_cancel).await;
+            udp_loop(
+                udp_runtime,
+                udp_status,
+                udp_import_lock,
+                udp_qrz_sync_lock,
+                &mut udp_cancel,
+            )
+            .await;
         });
 
         let tail_status = self.status.clone();
         let tail_import_lock = self.import_lock.clone();
+        let tail_qrz_sync_lock = self.qrz_sync_lock.clone();
         let mut tail_cancel = self.cancel_tx.subscribe();
         tokio::spawn(async move {
             adif_tail_loop(
                 runtime_config,
                 tail_status,
                 tail_import_lock,
+                tail_qrz_sync_lock,
                 &mut tail_cancel,
             )
             .await;
@@ -76,6 +93,7 @@ async fn udp_loop(
     runtime_config: Arc<RuntimeConfigManager>,
     status: Arc<Mutex<WsjtxIngestStatus>>,
     import_lock: Arc<Mutex<()>>,
+    qrz_sync_lock: Arc<Mutex<()>>,
     cancel_rx: &mut watch::Receiver<bool>,
 ) {
     let mut active_bind = String::new();
@@ -146,6 +164,7 @@ async fn udp_loop(
                         &runtime_config,
                         &status,
                         &import_lock,
+                        &qrz_sync_lock,
                         datagram,
                         settings.sync_to_qrz,
                     )
@@ -167,6 +186,7 @@ async fn adif_tail_loop(
     runtime_config: Arc<RuntimeConfigManager>,
     status: Arc<Mutex<WsjtxIngestStatus>>,
     import_lock: Arc<Mutex<()>>,
+    qrz_sync_lock: Arc<Mutex<()>>,
     cancel_rx: &mut watch::Receiver<bool>,
 ) {
     let mut cursor = 0_usize;
@@ -220,7 +240,7 @@ async fn adif_tail_loop(
                 &engine,
                 &path,
                 active_station_profile.as_ref(),
-                true,
+                false,
                 &mut cursor,
             )
             .await
@@ -228,7 +248,13 @@ async fn adif_tail_loop(
         match summary {
             Ok(summary) => {
                 record_import_summary(&status, &summary).await;
-                queue_qrz_sync(&runtime_config, &status, settings.sync_to_qrz, summary);
+                queue_qrz_sync(
+                    &runtime_config,
+                    &status,
+                    &qrz_sync_lock,
+                    settings.sync_to_qrz,
+                    summary,
+                );
             }
             Err(error) => {
                 let mut guard = status.lock().await;
@@ -247,18 +273,20 @@ async fn process_datagram(
     runtime_config: &Arc<RuntimeConfigManager>,
     status: &Arc<Mutex<WsjtxIngestStatus>>,
     import_lock: &Arc<Mutex<()>>,
+    qrz_sync_lock: &Arc<Mutex<()>>,
     datagram: &[u8],
     sync_to_qrz: bool,
 ) {
     let summary = {
         let _guard = import_lock.lock().await;
         let (engine, active_station_profile) = runtime_config.logbook_context().await;
-        ingest_wsjtx_udp_datagram(&engine, datagram, active_station_profile.as_ref(), true).await
+        ingest_wsjtx_logged_adif_datagram(&engine, datagram, active_station_profile.as_ref(), true)
+            .await
     };
     match summary {
         Ok(summary) => {
             record_import_summary(status, &summary).await;
-            queue_qrz_sync(runtime_config, status, sync_to_qrz, summary);
+            queue_qrz_sync(runtime_config, status, qrz_sync_lock, sync_to_qrz, summary);
         }
         Err(error) => {
             let mut guard = status.lock().await;
@@ -271,6 +299,7 @@ async fn process_datagram(
 fn queue_qrz_sync(
     runtime_config: &Arc<RuntimeConfigManager>,
     status: &Arc<Mutex<WsjtxIngestStatus>>,
+    qrz_sync_lock: &Arc<Mutex<()>>,
     sync_to_qrz: bool,
     summary: AdifImportSummary,
 ) {
@@ -280,7 +309,9 @@ fn queue_qrz_sync(
 
     let runtime_config = runtime_config.clone();
     let status = status.clone();
+    let qrz_sync_lock = qrz_sync_lock.clone();
     tokio::spawn(async move {
+        let _guard = qrz_sync_lock.lock().await;
         maybe_sync_to_qrz(&runtime_config, &status, true, &summary).await;
     });
 }
@@ -335,8 +366,13 @@ async fn maybe_sync_to_qrz(
     let book_owner = sync::resolve_book_owner_for_upload(&client, &cached_metadata).await;
 
     for qso in &summary.affected_qsos {
-        match sync::sync_single_qso(&client, engine.logbook_store(), qso, book_owner.as_deref())
-            .await
+        match sync::sync_single_qso_metadata_only(
+            &client,
+            engine.logbook_store(),
+            qso,
+            book_owner.as_deref(),
+        )
+        .await
         {
             Ok(outcome) => {
                 let mut guard = status.lock().await;
@@ -376,7 +412,7 @@ async fn record_import_summary(
         guard.last_imported_callsign = Some(qso.worked_callsign.clone());
         guard.last_imported_local_id = Some(qso.local_id.clone());
     }
-    guard.last_error = summary.warnings.last().cloned();
+    guard.last_error = None;
 }
 
 fn count_duplicate_warnings(summary: &AdifImportSummary) -> u32 {
@@ -491,12 +527,16 @@ fn bool_value(values: &BTreeMap<String, String>, key: &str, default: bool) -> bo
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
-    use super::{WsjtxIngestSupervisor, WsjtxRuntimeSettings};
+    use super::{
+        process_datagram, record_import_summary, WsjtxIngestSupervisor, WsjtxRuntimeSettings,
+    };
     use crate::runtime_config::{
         RuntimeConfigManager, WSJTX_INGEST_ADIF_TAIL_ENABLED_ENV_VAR,
         WSJTX_INGEST_ADIF_TAIL_PATH_ENV_VAR, WSJTX_INGEST_ENABLED_ENV_VAR,
         WSJTX_INGEST_SYNC_TO_QRZ_ENV_VAR, WSJTX_INGEST_UDP_BIND_ENV_VAR,
     };
+    use qsoripper_core::application::logbook::AdifImportSummary;
+    use qsoripper_core::proto::qsoripper::services::WsjtxIngestStatus;
     use qsoripper_core::storage::QsoListQuery;
     use std::collections::BTreeMap;
     use std::fs;
@@ -573,6 +613,54 @@ mod tests {
 
         supervisor.stop();
         assert!(imported, "WSJT-X UDP datagram was not imported");
+    }
+
+    #[tokio::test]
+    async fn record_import_summary_does_not_treat_warnings_as_errors() {
+        let status = Arc::new(tokio::sync::Mutex::new(WsjtxIngestStatus::default()));
+        let summary = AdifImportSummary {
+            records_skipped: 1,
+            warnings: vec!["Record 1 duplicate skipped".to_string()],
+            ..AdifImportSummary::default()
+        };
+
+        record_import_summary(&status, &summary).await;
+
+        let guard = status.lock().await;
+        assert_eq!(guard.records_skipped, 1);
+        assert_eq!(guard.duplicates_skipped, 1);
+        assert!(guard.last_error.is_none());
+    }
+
+    #[tokio::test]
+    async fn process_datagram_rejects_raw_adif_on_production_udp_path() {
+        let mut values = BTreeMap::new();
+        values.insert(WSJTX_INGEST_ENABLED_ENV_VAR.to_string(), "true".to_string());
+        let runtime = Arc::new(RuntimeConfigManager::new(values).expect("runtime"));
+        let status = Arc::new(tokio::sync::Mutex::new(WsjtxIngestStatus::default()));
+        let import_lock = Arc::new(tokio::sync::Mutex::new(()));
+        let qrz_sync_lock = Arc::new(tokio::sync::Mutex::new(()));
+
+        process_datagram(
+            &runtime,
+            &status,
+            &import_lock,
+            &qrz_sync_lock,
+            sample_adif("K7RAW").as_bytes(),
+            false,
+        )
+        .await;
+
+        let qsos = runtime
+            .logbook_engine()
+            .await
+            .list_qsos(&QsoListQuery::default())
+            .await
+            .expect("list qsos");
+        let guard = status.lock().await;
+        assert!(qsos.is_empty());
+        assert_eq!(guard.records_skipped, 1);
+        assert_eq!(guard.parse_errors, 0);
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-storage-memory/src/lib.rs
+++ b/src/rust/qsoripper-storage-memory/src/lib.rs
@@ -2,7 +2,7 @@
 
 use qsoripper_core::application::logbook::is_pending_sync_status;
 use qsoripper_core::domain::lookup::normalize_callsign;
-use qsoripper_core::proto::qsoripper::domain::QsoRecord;
+use qsoripper_core::proto::qsoripper::domain::{QsoRecord, SyncStatus};
 use qsoripper_core::storage::{
     DeletedRecordsFilter, EngineStorage, LogbookCounts, LogbookStore, LookupSnapshot,
     LookupSnapshotStore, QsoHistoryPage, QsoListQuery, QsoSortOrder, StorageError, SyncMetadata,
@@ -66,6 +66,37 @@ impl LogbookStore for MemoryStorage {
 
         state.qsos.insert(qso.local_id.clone(), qso.clone());
         Ok(true)
+    }
+
+    async fn update_qrz_sync_metadata(
+        &self,
+        local_id: &str,
+        expected_updated_at: Option<&prost_types::Timestamp>,
+        qrz_logid: &str,
+    ) -> Result<Option<QsoRecord>, StorageError> {
+        let mut state = self.state.write().await;
+        let Some(record) = state.qsos.get_mut(local_id) else {
+            return Ok(None);
+        };
+
+        let unchanged_since_upload_started = record.updated_at.as_ref() == expected_updated_at;
+        record.qrz_logid = Some(qrz_logid.to_string());
+        if record.deleted_at.is_some() {
+            record.pending_remote_delete = true;
+            if record.sync_status != SyncStatus::Conflict as i32 {
+                record.sync_status = SyncStatus::Modified as i32;
+            }
+            return Ok(Some(record.clone()));
+        }
+        record.sync_status = if unchanged_since_upload_started {
+            SyncStatus::Synced as i32
+        } else if record.sync_status == SyncStatus::Conflict as i32 {
+            record.sync_status
+        } else {
+            SyncStatus::Modified as i32
+        };
+
+        Ok(Some(record.clone()))
     }
 
     async fn delete_qso(&self, local_id: &str) -> Result<bool, StorageError> {
@@ -632,6 +663,41 @@ mod tests {
         let fetched = storage.get_qso(&local_id).await.unwrap().unwrap();
         assert!(fetched.deleted_at.is_none());
         assert!(!fetched.pending_remote_delete);
+    }
+
+    #[tokio::test]
+    async fn memory_storage_qrz_metadata_patch_on_deleted_row_queues_remote_delete() {
+        let storage = MemoryStorage::new();
+        let mut qso = QsoRecordBuilder::new("W1AW", "K7DEL")
+            .band(Band::Band20m)
+            .mode(Mode::Ft8)
+            .timestamp(Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            })
+            .build();
+        qso.sync_status = SyncStatus::Modified as i32;
+        qso.updated_at = Some(Timestamp {
+            seconds: 1_700_000_010,
+            nanos: 0,
+        });
+        let local_id = qso.local_id.clone();
+        storage.insert_qso(&qso).await.unwrap();
+        storage
+            .soft_delete_qso(&local_id, 1_700_000_500_000, false)
+            .await
+            .unwrap();
+
+        let patched = storage
+            .update_qrz_sync_metadata(&local_id, qso.updated_at.as_ref(), "QRZ-DEL")
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert!(patched.deleted_at.is_some());
+        assert!(patched.pending_remote_delete);
+        assert_eq!(patched.qrz_logid.as_deref(), Some("QRZ-DEL"));
+        assert_eq!(patched.sync_status, SyncStatus::Modified as i32);
     }
 
     #[tokio::test]

--- a/src/rust/qsoripper-storage-sqlite/src/lib.rs
+++ b/src/rust/qsoripper-storage-sqlite/src/lib.rs
@@ -91,46 +91,48 @@ impl LogbookStore for SqliteStorage {
 
     async fn update_qso(&self, qso: &QsoRecord) -> Result<bool, StorageError> {
         let connection = self.connection()?;
-        let encoded = encode_message(qso);
-        let rows = execute_statement(
+        update_qso_record(&connection, qso)
+    }
+
+    async fn update_qrz_sync_metadata(
+        &self,
+        local_id: &str,
+        expected_updated_at: Option<&prost_types::Timestamp>,
+        qrz_logid: &str,
+    ) -> Result<Option<QsoRecord>, StorageError> {
+        let connection = self.connection()?;
+        let payload = query_optional::<Vec<u8>>(
             &connection,
-            "UPDATE qsos
-             SET qrz_logid = ?,
-                 qrz_bookid = ?,
-                 station_callsign = ?,
-                 worked_callsign = ?,
-                 utc_timestamp_ms = ?,
-                 band = ?,
-                 mode = ?,
-                 contest_id = ?,
-                 created_at_ms = ?,
-                 updated_at_ms = ?,
-                 sync_status = ?,
-                 record = ?,
-                 deleted_at_ms = ?,
-                 pending_remote_delete = ?
-             WHERE local_id = ?",
-            &[
-                Value::from(qso.qrz_logid.as_deref()),
-                Value::from(qso.qrz_bookid.as_deref()),
-                Value::from(qso.station_callsign.as_str()),
-                Value::from(qso.worked_callsign.as_str()),
-                Value::from(timestamp_to_millis(qso.utc_timestamp.as_ref())),
-                Value::Integer(i64::from(qso.band)),
-                Value::Integer(i64::from(qso.mode)),
-                Value::from(qso.contest_id.as_deref()),
-                Value::from(timestamp_to_millis(qso.created_at.as_ref())),
-                Value::from(timestamp_to_millis(qso.updated_at.as_ref())),
-                Value::Integer(i64::from(qso.sync_status)),
-                Value::Binary(encoded),
-                Value::from(timestamp_to_millis(qso.deleted_at.as_ref())),
-                Value::Integer(i64::from(qso.pending_remote_delete)),
-                Value::from(qso.local_id.as_str()),
-            ],
+            "SELECT record FROM qsos WHERE local_id = ?",
+            &[Value::from(local_id)],
+            0,
         )
         .map_err(map_sqlite_error)?;
 
-        Ok(rows > 0)
+        let Some(bytes) = payload else {
+            return Ok(None);
+        };
+        let mut record = decode_qso(&bytes)?;
+        let unchanged_since_upload_started = record.updated_at.as_ref() == expected_updated_at;
+        record.qrz_logid = Some(qrz_logid.to_string());
+        if record.deleted_at.is_some() {
+            record.pending_remote_delete = true;
+            if record.sync_status != SyncStatus::Conflict as i32 {
+                record.sync_status = SyncStatus::Modified as i32;
+            }
+            update_qso_record(&connection, &record)?;
+            return Ok(Some(record));
+        }
+        record.sync_status = if unchanged_since_upload_started {
+            SyncStatus::Synced as i32
+        } else if record.sync_status == SyncStatus::Conflict as i32 {
+            record.sync_status
+        } else {
+            SyncStatus::Modified as i32
+        };
+
+        update_qso_record(&connection, &record)?;
+        Ok(Some(record))
     }
 
     async fn delete_qso(&self, local_id: &str) -> Result<bool, StorageError> {
@@ -517,6 +519,52 @@ impl LookupSnapshotStore for SqliteStorage {
     }
 }
 
+fn update_qso_record(
+    connection: &ConnectionThreadSafe,
+    qso: &QsoRecord,
+) -> Result<bool, StorageError> {
+    let encoded = encode_message(qso);
+    let rows = execute_statement(
+        connection,
+        "UPDATE qsos
+         SET qrz_logid = ?,
+             qrz_bookid = ?,
+             station_callsign = ?,
+             worked_callsign = ?,
+             utc_timestamp_ms = ?,
+             band = ?,
+             mode = ?,
+             contest_id = ?,
+             created_at_ms = ?,
+             updated_at_ms = ?,
+             sync_status = ?,
+             record = ?,
+             deleted_at_ms = ?,
+             pending_remote_delete = ?
+         WHERE local_id = ?",
+        &[
+            Value::from(qso.qrz_logid.as_deref()),
+            Value::from(qso.qrz_bookid.as_deref()),
+            Value::from(qso.station_callsign.as_str()),
+            Value::from(qso.worked_callsign.as_str()),
+            Value::from(timestamp_to_millis(qso.utc_timestamp.as_ref())),
+            Value::Integer(i64::from(qso.band)),
+            Value::Integer(i64::from(qso.mode)),
+            Value::from(qso.contest_id.as_deref()),
+            Value::from(timestamp_to_millis(qso.created_at.as_ref())),
+            Value::from(timestamp_to_millis(qso.updated_at.as_ref())),
+            Value::Integer(i64::from(qso.sync_status)),
+            Value::Binary(encoded),
+            Value::from(timestamp_to_millis(qso.deleted_at.as_ref())),
+            Value::Integer(i64::from(qso.pending_remote_delete)),
+            Value::from(qso.local_id.as_str()),
+        ],
+    )
+    .map_err(map_sqlite_error)?;
+
+    Ok(rows > 0)
+}
+
 fn encode_message<T: Message>(message: &T) -> Vec<u8> {
     message.encode_to_vec()
 }
@@ -609,7 +657,9 @@ mod tests {
     use prost_types::Timestamp;
     use qsoripper_core::application::logbook::LogbookEngine;
     use qsoripper_core::domain::qso::QsoRecordBuilder;
-    use qsoripper_core::proto::qsoripper::domain::{Band, LookupResult, LookupState, Mode};
+    use qsoripper_core::proto::qsoripper::domain::{
+        Band, LookupResult, LookupState, Mode, SyncStatus,
+    };
     use qsoripper_core::storage::{
         EngineStorage, LookupSnapshot, LookupSnapshotStore, QsoListQuery,
     };
@@ -640,6 +690,49 @@ mod tests {
         assert_eq!(loaded.worked_callsign, "K7ABC");
         assert!(loaded.created_at.is_some());
         assert!(loaded.updated_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn sqlite_storage_patches_qrz_metadata_without_replacing_current_row() {
+        let storage = SqliteStorageBuilder::new().in_memory().build().unwrap();
+        let mut qso = QsoRecordBuilder::new("W1AW", "K7PATCH")
+            .band(Band::Band20m)
+            .mode(Mode::Ft8)
+            .timestamp(Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            })
+            .build();
+        qso.notes = Some("operator edit".into());
+        qso.sync_status = SyncStatus::Modified as i32;
+        qso.updated_at = Some(Timestamp {
+            seconds: 1_700_000_010,
+            nanos: 0,
+        });
+
+        let logbook = storage.logbook();
+        logbook.insert_qso(&qso).await.unwrap();
+        let patched = logbook
+            .update_qrz_sync_metadata(
+                &qso.local_id,
+                Some(&Timestamp {
+                    seconds: 1_700_000_000,
+                    nanos: 0,
+                }),
+                "QRZ-PATCH",
+            )
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("patched qso"));
+
+        assert_eq!(patched.notes.as_deref(), Some("operator edit"));
+        assert_eq!(patched.qrz_logid.as_deref(), Some("QRZ-PATCH"));
+        assert_eq!(patched.sync_status, SyncStatus::Modified as i32);
+
+        let reloaded = logbook.get_qso(&qso.local_id).await.unwrap().unwrap();
+        assert_eq!(reloaded.notes.as_deref(), Some("operator edit"));
+        assert_eq!(reloaded.qrz_logid.as_deref(), Some("QRZ-PATCH"));
+        assert_eq!(reloaded.sync_status, SyncStatus::Modified as i32);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Implements issue #500 with Rust engine WSJT-X Logged ADIF UDP ingestion, ADIF-tail recovery, shared setup/status configuration, diagnostics, duplicate safety, and optional QRZ upload integration. The implementation routes imports through the existing ADIF/logbook path, preserves startup replay safety for local edits and deleted rows, and keeps Rust/.NET setup persistence aligned. Closes #500.