### PR TITLE
Fix HDSDR FB click-to-tune path

### DIFF
--- a/src/rust/qsoripper-cathub/src/dialect/kenwood/ts2000.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/kenwood/ts2000.rs
@@ -63,10 +63,14 @@ impl ClientDialect for Ts2000Dialect {
                 set_freq(ctx, ctx.snapshot().rx_vfo, &payload).await
             }
             b"FB" => {
+                let snap = ctx.snapshot();
                 if read {
-                    return freq_frame(b"FB", ctx.snapshot().vfo(Vfo::B).freq_hz);
+                    return freq_frame(b"FB", snap.vfo(snap.rx_vfo).freq_hz);
                 }
-                set_freq(ctx, Vfo::B, &payload).await
+                // HDSDR can issue waterfall click-to-tune writes through FB rather than FA
+                // depending on its OmniRig VFO-sync state. Treat both as displayed-frequency
+                // writes so the panadapter cannot tune an inactive physical VFO.
+                set_freq(ctx, snap.rx_vfo, &payload).await
             }
             b"MD" => {
                 if read {
@@ -122,7 +126,6 @@ impl ClientDialect for Ts2000Dialect {
             StateChange::Freq { vfo, hz } if vfo == ctx.snapshot().rx_vfo => {
                 Some(freq_frame(b"FA", hz))
             }
-            StateChange::Freq { vfo: Vfo::B, hz } => Some(freq_frame(b"FB", hz)),
             StateChange::Mode { vfo, mode } if vfo == ctx.snapshot().rx_vfo => {
                 Some(vec![b'M', b'D', mode_to_digit(mode), b';'])
             }
@@ -375,6 +378,30 @@ mod tests {
                 hz: 14_074_000
             }],
             "HDSDR/OmniRig FA set-frequency writes express the displayed active frequency"
+        );
+    }
+
+    #[tokio::test]
+    async fn fb_write_tunes_active_vfo_a() {
+        let (ctx, backend) = ctx_with(FacePermissions::from_tokens(&["read", "write"]));
+        ctx.state.record(
+            StateChange::RxVfo { vfo: Vfo::A },
+            RadioEventSource::NativePush,
+        );
+
+        assert_eq!(
+            Ts2000Dialect::new().handle(b"FB00014052000;", &ctx).await,
+            Vec::<u8>::new()
+        );
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        assert_eq!(
+            backend.mutations(),
+            vec![StateMutation::SetVfoFreq {
+                vfo: Vfo::A,
+                hz: 14_052_000
+            }],
+            "HDSDR/OmniRig may issue waterfall click-to-tune writes through FB"
         );
     }
 

--- a/src/rust/qsoripper-cathub/src/integration.rs
+++ b/src/rust/qsoripper-cathub/src/integration.rs
@@ -224,6 +224,35 @@ async fn ts2000_face_fa_write_tunes_active_vfo_b() {
     assert!(rig.backend.passthroughs().is_empty());
 }
 
+/// HDSDR can issue waterfall click-to-tune writes through `FB` while the radio is receiving
+/// on VFO A. The TS-2000 translator must treat that as a displayed-frequency write, not as
+/// a request to silently tune inactive physical VFO B.
+#[tokio::test]
+async fn ts2000_face_fb_write_tunes_active_vfo_a() {
+    let rig = rig();
+    let mut omni = rig.face(
+        ts2000(),
+        FacePermissions::from_tokens(&["read", "write"]),
+        1,
+    );
+    rig.state.record(
+        StateChange::RxVfo { vfo: Vfo::A },
+        RadioEventSource::NativePush,
+    );
+
+    omni.write_all(b"FB00014052000;").await.expect("write");
+    tokio::time::sleep(Duration::from_millis(30)).await;
+
+    assert_eq!(
+        rig.backend.mutations(),
+        vec![StateMutation::SetVfoFreq {
+            vfo: Vfo::A,
+            hz: 14_052_000
+        }]
+    );
+    assert!(rig.backend.passthroughs().is_empty());
+}
+
 /// HDSDR/OmniRig polls `IF;`, `FA;`, and `FB;`. On active VFO B, `FA;` must report the
 /// displayed active frequency, not stale inactive VFO A, because HDSDR treats FA as its main
 /// panadapter frequency.


### PR DESCRIPTION
HDSDR waterfall clicks were reaching OmniRig, but the live trace showed they updated Rig1.FreqB while CatHub and the TS-590 active frequency stayed on VFO A. The TS-2000/HDSDR translator treated FB writes as physical VFO B writes, so click-to-tune could silently retune the inactive VFO.

This changes the TS-2000 translator so FB reads and writes mirror the active operating VFO, matching the existing FA behavior and the CatHub single-operating-VFO design for panadapter clients. HDSDR/OmniRig can now issue either FA or FB for displayed-frequency tuning without retargeting VFOs or leaving the TS-590 unchanged.

I validated this locally by rebuilding and restarting CatHub, then setting OmniRig Rig1.FreqB; the active CatHub/TS-590 frequency changed and restored correctly. I also automated HDSDR clicks on the RF display and confirmed the active frequency changed through CatHub before restoring it.