### PR TITLE
Implement .NET engine WSJT-X ingest supervisor for parity

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -647,7 +647,7 @@ Returns whether initial setup has been completed.
 **Behavior:**
 - Check if a valid configuration and station profile exist.
 - Return a `SetupStatus` indicating `complete` or `incomplete` with details about what is missing.
-- Include current `wsjtx_ingest` settings when configured and live `wsjtx_ingest_status` diagnostics when the engine implements the WSJT-X supervisor.
+- Include current `wsjtx_ingest` settings when configured and live `wsjtx_ingest_status` diagnostics. A conformant engine that runs the WSJT-X ingest supervisor (required when ingestion is enabled — see "WSJT-X ingest runtime behavior") MUST populate `wsjtx_ingest_status` with its current live state.
 
 #### SaveSetup
 
@@ -697,9 +697,15 @@ Persists setup configuration and station profile.
   for compatibility, but documentation and examples should prefer the canonical runtime names.
 
 **WSJT-X ingest runtime behavior:**
-- When enabled, the Rust engine starts a background supervisor with independent UDP and ADIF-tail
+- This runtime behavior is engine-neutral and REQUIRED: every conformant engine, regardless of
+  implementation language, MUST provide WSJT-X ingestion when `wsjtx_ingest.enabled=true`. Both the
+  Rust engine (`qsoripper-server`) and the .NET engine (`QsoRipper.Engine.DotNet`) implement this
+  contract; a third-party engine must too. An engine MAY surface a documented capability flag if it
+  cannot host long-running background work, but the default expectation is full parity.
+- When enabled, a conformant engine starts a background supervisor with independent UDP and ADIF-tail
   inputs. The supervisor MUST NOT block normal logging or engine startup after configuration has
-  been accepted.
+  been accepted. The supervisor MUST observe `wsjtx_ingest` settings changes applied through
+  `SaveSetup` at runtime (start, stop, rebind, or re-point the tail without a process restart).
 - UDP input listens for WSJT-X Logged ADIF datagrams and ignores non-logged WSJT-X messages. Raw
   ADIF and lightweight JSON-wrapped ADIF may be accepted by test/simulation helpers, but runtime
   framed WSJT-X packets must only import logged-QSO ADIF payloads.

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/WsjtxIngestTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/WsjtxIngestTests.cs
@@ -1,0 +1,378 @@
+using System.Buffers.Binary;
+using System.Text;
+using Google.Protobuf.WellKnownTypes;
+using QsoRipper.Domain;
+using QsoRipper.Engine.DotNet;
+using QsoRipper.Engine.DotNet.Wsjtx;
+using QsoRipper.Engine.Storage.Memory;
+using QsoRipper.Services;
+
+namespace QsoRipper.Engine.DotNet.Tests;
+
+#pragma warning disable CA1707 // Remove underscores from member names - xUnit allows underscores in test methods
+public sealed class WsjtxIngestTests : IDisposable
+{
+    private const uint WsjtxMagic = 0xADBC_CBDA;
+    private const string SampleAdif =
+        "<CALL:4>W1AW<STATION_CALLSIGN:5>K7RND<QSO_DATE:8>20250102<TIME_ON:4>0102<BAND:3>15M<MODE:2>CW<FREQ:8>21.02830<EOR>\n";
+
+    private readonly string _tempDirectory;
+
+    public WsjtxIngestTests()
+    {
+        _tempDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "qsoripper-wsjtx-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup.
+        }
+    }
+
+    // ---- Datagram parser ------------------------------------------------
+
+    [Fact]
+    public void Datagram_parse_extracts_logged_adif_payload()
+    {
+        var datagram = BuildLoggedAdifDatagram("WSJT-X", SampleAdif);
+
+        var result = WsjtxDatagram.TryParseLoggedAdif(datagram);
+
+        Assert.Equal(WsjtxDatagramParseStatus.Logged, result.Status);
+        Assert.NotNull(result.Adif);
+        Assert.Equal(SampleAdif, Encoding.UTF8.GetString(result.Adif!));
+    }
+
+    [Fact]
+    public void Datagram_parse_ignores_non_logged_message_types()
+    {
+        // Message type 1 (Status) is not Logged ADIF and must be ignored, not errored.
+        var datagram = BuildDatagram(messageType: 1, id: "WSJT-X", adif: SampleAdif);
+
+        var result = WsjtxDatagram.TryParseLoggedAdif(datagram);
+
+        Assert.Equal(WsjtxDatagramParseStatus.Ignored, result.Status);
+        Assert.Null(result.Adif);
+    }
+
+    [Fact]
+    public void Datagram_parse_ignores_non_magic_datagrams()
+    {
+        var datagram = Encoding.UTF8.GetBytes("{\"adif\":\"whatever\"}");
+
+        var result = WsjtxDatagram.TryParseLoggedAdif(datagram);
+
+        Assert.Equal(WsjtxDatagramParseStatus.Ignored, result.Status);
+    }
+
+    [Fact]
+    public void Datagram_parse_reports_malformed_when_string_extends_past_packet()
+    {
+        var datagram = new byte[16];
+        BinaryPrimitives.WriteUInt32BigEndian(datagram.AsSpan(0), WsjtxMagic);
+        BinaryPrimitives.WriteUInt32BigEndian(datagram.AsSpan(4), 2); // schema
+        BinaryPrimitives.WriteUInt32BigEndian(datagram.AsSpan(8), 12); // Logged ADIF
+        BinaryPrimitives.WriteUInt32BigEndian(datagram.AsSpan(12), 50); // id length far exceeds buffer
+
+        var result = WsjtxDatagram.TryParseLoggedAdif(datagram);
+
+        Assert.Equal(WsjtxDatagramParseStatus.Malformed, result.Status);
+        Assert.NotNull(result.Error);
+    }
+
+    [Fact]
+    public void Datagram_parse_reports_malformed_for_empty_adif_payload()
+    {
+        var datagram = BuildLoggedAdifDatagram("WSJT-X", "   ");
+
+        var result = WsjtxDatagram.TryParseLoggedAdif(datagram);
+
+        Assert.Equal(WsjtxDatagramParseStatus.Malformed, result.Status);
+    }
+
+    // ---- ADIF tail prefix length ----------------------------------------
+
+    [Fact]
+    public void Complete_prefix_returns_length_through_last_eor()
+    {
+        var bytes = Encoding.UTF8.GetBytes(SampleAdif);
+
+        var length = WsjtxAdifTail.CompleteAdifPrefixLength(bytes);
+
+        // The complete prefix ends just after "<EOR>" but before the trailing newline.
+        var expected = SampleAdif.IndexOf("<EOR>", StringComparison.Ordinal) + "<EOR>".Length;
+        Assert.Equal(expected, length);
+    }
+
+    [Fact]
+    public void Complete_prefix_withholds_incomplete_trailing_record()
+    {
+        // First record is complete; the second is missing its <EOR> terminator.
+        var text = SampleAdif + "<CALL:4>K1AB<STATION_CALLSIGN:5>K7RND<QSO_DATE:8>20250102<TIME_ON:4>0103<BAND:3>15M<MODE:2>CW";
+        var bytes = Encoding.UTF8.GetBytes(text);
+
+        var length = WsjtxAdifTail.CompleteAdifPrefixLength(bytes);
+
+        var expected = SampleAdif.IndexOf("<EOR>", StringComparison.Ordinal) + "<EOR>".Length;
+        Assert.Equal(expected, length);
+    }
+
+    [Fact]
+    public void Complete_prefix_ignores_literal_eor_inside_field_value()
+    {
+        // A comment field whose value literally contains "<EOR>" must not terminate the record early.
+        // Value "see <EOR>" is exactly 9 characters, so the field length consumes the literal tag.
+        const string record = "<CALL:4>W1AW<STATION_CALLSIGN:5>K7RND<COMMENT:9>see <EOR><QSO_DATE:8>20250102<TIME_ON:4>0102<BAND:3>15M<MODE:2>CW<EOR>";
+        var bytes = Encoding.UTF8.GetBytes(record);
+
+        var length = WsjtxAdifTail.CompleteAdifPrefixLength(bytes);
+
+        Assert.Equal(record.Length, length);
+
+        // And there is exactly one real record terminator: the prefix ends at the final <EOR>.
+        var lastEor = record.LastIndexOf("<EOR>", StringComparison.Ordinal) + "<EOR>".Length;
+        Assert.Equal(lastEor, length);
+    }
+
+    [Fact]
+    public void Complete_prefix_returns_null_when_no_record_terminator()
+    {
+        var bytes = Encoding.UTF8.GetBytes("<CALL:4>W1AW<STATION_CALLSIGN:5>K7RND");
+
+        var length = WsjtxAdifTail.CompleteAdifPrefixLength(bytes);
+
+        Assert.Null(length);
+    }
+
+    // ---- ImportAdifDetailed affected ids --------------------------------
+
+    [Fact]
+    public void Import_adif_detailed_reports_inserted_and_refreshed_ids()
+    {
+        var state = CreateStateWithProfile();
+
+        var inserted = state.ImportAdifDetailed(Encoding.UTF8.GetBytes(SampleAdif), refresh: false);
+        Assert.Equal(1u, inserted.Response.RecordsImported);
+        var affectedId = Assert.Single(inserted.AffectedQsos);
+        Assert.Equal("W1AW", affectedId.WorkedCallsign);
+        Assert.False(string.IsNullOrWhiteSpace(affectedId.LocalId));
+
+        // Re-importing the same record with refresh should refresh and report the same local id.
+        var refreshed = state.ImportAdifDetailed(Encoding.UTF8.GetBytes(SampleAdif), refresh: true);
+        Assert.Equal(1u, refreshed.Response.RecordsUpdated);
+        var refreshedId = Assert.Single(refreshed.AffectedQsos);
+        Assert.Equal(affectedId.LocalId, refreshedId.LocalId);
+    }
+
+    // ---- Supervisor end-to-end (driven imports, no real sockets) --------
+
+    [Fact]
+    public void Setup_status_wsjtx_ingest_status_is_null_before_supervisor_publishes()
+    {
+        var state = CreateStateWithProfile();
+        using var supervisor = new WsjtxIngestSupervisor(state);
+
+        var status = state.GetSetupStatus();
+
+        Assert.Null(status.WsjtxIngestStatus);
+    }
+
+    [Fact]
+    public async Task Process_logged_datagram_imports_and_publishes_live_status()
+    {
+        var state = CreateStateWithProfile();
+        using var supervisor = new WsjtxIngestSupervisor(state);
+        var datagram = BuildLoggedAdifDatagram("WSJT-X", SampleAdif);
+
+        await supervisor.ProcessDatagramAsync(datagram, syncToQrz: false, CancellationToken.None);
+
+        var live = supervisor.SnapshotStatus();
+        Assert.Equal(1u, live.RecordsImported);
+        Assert.Equal("W1AW", live.LastImportedCallsign);
+        Assert.False(string.IsNullOrWhiteSpace(live.LastImportedLocalId));
+        Assert.NotNull(live.LastEventAt);
+
+        var setupStatus = state.GetSetupStatus();
+        Assert.NotNull(setupStatus.WsjtxIngestStatus);
+        Assert.Equal(1u, setupStatus.WsjtxIngestStatus.RecordsImported);
+        Assert.Equal("W1AW", setupStatus.WsjtxIngestStatus.LastImportedCallsign);
+    }
+
+    [Fact]
+    public async Task Process_ignored_datagram_counts_as_skip()
+    {
+        var state = CreateStateWithProfile();
+        using var supervisor = new WsjtxIngestSupervisor(state);
+        var datagram = BuildDatagram(messageType: 1, id: "WSJT-X", adif: SampleAdif);
+
+        await supervisor.ProcessDatagramAsync(datagram, syncToQrz: false, CancellationToken.None);
+
+        var live = supervisor.SnapshotStatus();
+        Assert.Equal(0u, live.RecordsImported);
+        Assert.Equal(1u, live.RecordsSkipped);
+        Assert.Equal(0u, live.ParseErrors);
+    }
+
+    [Fact]
+    public async Task Process_malformed_datagram_increments_parse_errors()
+    {
+        var state = CreateStateWithProfile();
+        using var supervisor = new WsjtxIngestSupervisor(state);
+        var datagram = BuildLoggedAdifDatagram("WSJT-X", "   ");
+
+        await supervisor.ProcessDatagramAsync(datagram, syncToQrz: false, CancellationToken.None);
+
+        var live = supervisor.SnapshotStatus();
+        Assert.Equal(0u, live.RecordsImported);
+        Assert.Equal(1u, live.ParseErrors);
+        Assert.False(string.IsNullOrWhiteSpace(live.LastError));
+    }
+
+    [Fact]
+    public async Task Tail_import_advances_cursor_and_withholds_incomplete_records()
+    {
+        var state = CreateStateWithProfile();
+        using var supervisor = new WsjtxIngestSupervisor(state);
+        var path = Path.Combine(_tempDirectory, "wsjtx_log.adi");
+
+        // One complete record plus an incomplete trailing record.
+        var incompleteTail = "<CALL:4>K1AB<STATION_CALLSIGN:5>K7RND<QSO_DATE:8>20250102<TIME_ON:4>0103<BAND:3>15M<MODE:2>CW";
+        await File.WriteAllTextAsync(path, SampleAdif + incompleteTail);
+
+        await supervisor.HandleTailImportAsync(path, syncToQrz: false, CancellationToken.None);
+        var afterFirst = supervisor.SnapshotStatus();
+        Assert.Equal(1u, afterFirst.RecordsImported);
+
+        // A second poll without new complete data must not re-import.
+        await supervisor.HandleTailImportAsync(path, syncToQrz: false, CancellationToken.None);
+        Assert.Equal(1u, supervisor.SnapshotStatus().RecordsImported);
+
+        // Completing the second record makes it importable on the next poll.
+        await File.WriteAllTextAsync(
+            path,
+            SampleAdif + "<CALL:4>K1AB<STATION_CALLSIGN:5>K7RND<QSO_DATE:8>20250102<TIME_ON:4>0103<BAND:3>15M<MODE:2>CW<EOR>\n");
+
+        await supervisor.HandleTailImportAsync(path, syncToQrz: false, CancellationToken.None);
+        Assert.Equal(2u, supervisor.SnapshotStatus().RecordsImported);
+    }
+
+    [Fact]
+    public async Task Tail_import_reports_read_error_as_parse_error()
+    {
+        var state = CreateStateWithProfile();
+        using var supervisor = new WsjtxIngestSupervisor(state);
+        var missingPath = Path.Combine(_tempDirectory, "does-not-exist.adi");
+
+        await supervisor.HandleTailImportAsync(missingPath, syncToQrz: false, CancellationToken.None);
+
+        var live = supervisor.SnapshotStatus();
+        Assert.Equal(1u, live.ParseErrors);
+        Assert.False(string.IsNullOrWhiteSpace(live.LastError));
+    }
+
+    [Fact]
+    public async Task Qrz_sync_marks_success_when_api_key_configured()
+    {
+        var state = CreateStateWithProfile(apiKey: "qrz-api-key");
+        using var supervisor = new WsjtxIngestSupervisor(state);
+        var detail = state.ImportAdifDetailed(Encoding.UTF8.GetBytes(SampleAdif), refresh: false);
+        var localId = Assert.Single(detail.AffectedQsos).LocalId;
+
+        await supervisor.RunQrzSyncAsync(new[] { localId });
+
+        var live = supervisor.SnapshotStatus();
+        Assert.True(live.LastQrzSyncSuccess);
+        Assert.False(live.HasLastQrzSyncError);
+        Assert.Equal("W1AW", live.LastImportedCallsign);
+        Assert.Equal(localId, live.LastImportedLocalId);
+
+        var stored = state.GetQso(localId);
+        Assert.NotNull(stored);
+        Assert.Equal(SyncStatus.Synced, stored!.SyncStatus);
+    }
+
+    [Fact]
+    public async Task Qrz_sync_marks_failure_when_api_key_missing()
+    {
+        var state = CreateStateWithProfile();
+        using var supervisor = new WsjtxIngestSupervisor(state);
+        var detail = state.ImportAdifDetailed(Encoding.UTF8.GetBytes(SampleAdif), refresh: false);
+        var localId = Assert.Single(detail.AffectedQsos).LocalId;
+
+        await supervisor.RunQrzSyncAsync(new[] { localId });
+
+        var live = supervisor.SnapshotStatus();
+        Assert.False(live.LastQrzSyncSuccess);
+        Assert.Equal("QRZ logbook is not configured.", live.LastQrzSyncError);
+
+        var stored = state.GetQso(localId);
+        Assert.NotNull(stored);
+        Assert.Equal(SyncStatus.LocalOnly, stored!.SyncStatus);
+    }
+
+    // ---- Helpers --------------------------------------------------------
+
+    private ManagedEngineState CreateStateWithProfile(string? apiKey = null)
+    {
+        var state = new ManagedEngineState(Path.Combine(_tempDirectory, "config.toml"), new MemoryStorage());
+        var request = new SaveSetupRequest
+        {
+            StationProfile = new StationProfile
+            {
+                ProfileName = "Home",
+                StationCallsign = "K7RND",
+                OperatorCallsign = "K7RND",
+                Grid = "CN87",
+            },
+        };
+
+        if (apiKey is not null)
+        {
+            request.QrzLogbookApiKey = apiKey;
+        }
+
+        state.SaveSetup(request);
+        return state;
+    }
+
+    private static byte[] BuildLoggedAdifDatagram(string id, string adif)
+    {
+        return BuildDatagram(messageType: 12, id, adif);
+    }
+
+    private static byte[] BuildDatagram(uint messageType, string id, string adif)
+    {
+        using var stream = new MemoryStream();
+        WriteBeU32(stream, WsjtxMagic);
+        WriteBeU32(stream, 2); // schema
+        WriteBeU32(stream, messageType);
+        WriteQString(stream, id);
+        WriteQString(stream, adif);
+        return stream.ToArray();
+    }
+
+    private static void WriteBeU32(Stream stream, uint value)
+    {
+        Span<byte> buffer = stackalloc byte[4];
+        BinaryPrimitives.WriteUInt32BigEndian(buffer, value);
+        stream.Write(buffer);
+    }
+
+    private static void WriteQString(Stream stream, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        WriteBeU32(stream, (uint)bytes.Length);
+        stream.Write(bytes);
+    }
+}
+

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -16,6 +16,15 @@ namespace QsoRipper.Engine.DotNet;
 
 internal sealed record DeleteQsoOutcome(bool Found, bool RemoteDeleteQueued, bool MissingQrzLogid);
 
+/// <summary>A QSO affected (inserted or refreshed) by a WSJT-X import.</summary>
+internal sealed record WsjtxImportedQsoRef(string LocalId, string WorkedCallsign);
+
+/// <summary>An import result paired with the QSOs it inserted or refreshed.</summary>
+internal sealed record WsjtxImportDetail(ImportAdifResponse Response, IReadOnlyList<WsjtxImportedQsoRef> AffectedQsos);
+
+/// <summary>Per-QSO outcome of a managed QRZ logbook sync triggered by WSJT-X ingestion.</summary>
+internal sealed record WsjtxQrzSyncOutcome(string LocalId, string WorkedCallsign, bool Success, string? Error);
+
 internal sealed record RestoreQsoOutcome(bool Found, QsoRecord? Restored);
 
 internal sealed class QsoSoftDeletedException : InvalidOperationException
@@ -84,6 +93,12 @@ internal sealed class ManagedEngineState
     private readonly bool _ownsSyncEngine;
     private QrzLogbookClient? _ownedSyncClient;
     private QrzSyncEngine? _syncEngine;
+
+    // Latest live WSJT-X ingest diagnostics published by the ingest supervisor. A null value means
+    // the supervisor has not published a snapshot yet; BuildSetupStatusNoLock then leaves
+    // SetupStatus.wsjtx_ingest_status unset. Stored as an already-cloned, immutable-by-convention
+    // snapshot and swapped atomically via Volatile reads/writes.
+    private WsjtxIngestStatus? _wsjtxIngestLiveStatus;
 
     public ManagedEngineState(string configPath)
         : this(configPath, new MemoryStorage(), null, null, null, null)
@@ -837,12 +852,22 @@ internal sealed class ManagedEngineState
 
     public ImportAdifResponse ImportAdif(byte[] adifBytes, bool refresh)
     {
+        return ImportAdifDetailed(adifBytes, refresh).Response;
+    }
+
+    /// <summary>
+    /// Imports ADIF bytes and reports the QSOs that were inserted or refreshed, so callers
+    /// (such as the WSJT-X ingest supervisor) can drive per-import QRZ sync and live status.
+    /// </summary>
+    public WsjtxImportDetail ImportAdifDetailed(byte[] adifBytes, bool refresh)
+    {
         ArgumentNullException.ThrowIfNull(adifBytes);
 
         var qsos = ManagedAdifCodec.ParseAdiQsos(adifBytes);
         lock (_gate)
         {
             var response = new ImportAdifResponse();
+            var affected = new List<WsjtxImportedQsoRef>();
             var activeStationProfile = GetEffectiveActiveProfileNoLock();
             var allExisting = Sync(_storage.Logbook.ListQsosAsync(new QsoListQuery())).ToList();
 
@@ -887,6 +912,7 @@ internal sealed class ManagedEngineState
                         Sync(_storage.Logbook.UpdateQsoAsync(merged));
                         allExisting[existingMatch] = merged;
                         response.RecordsUpdated++;
+                        affected.Add(new WsjtxImportedQsoRef(merged.LocalId, merged.WorkedCallsign));
                         response.Warnings.Add($"Record {recordNumber}: refreshed existing record '{merged.LocalId}'.");
                     }
                     else
@@ -904,11 +930,97 @@ internal sealed class ManagedEngineState
                 qso.SyncStatus = SyncStatus.LocalOnly;
                 Sync(_storage.Logbook.InsertQsoAsync(qso));
                 allExisting.Add(qso);
+                affected.Add(new WsjtxImportedQsoRef(qso.LocalId, qso.WorkedCallsign));
                 response.RecordsImported++;
             }
 
-            return response;
+            return new WsjtxImportDetail(response, affected);
         }
+    }
+
+    /// <summary>
+    /// Publishes the latest live WSJT-X ingest diagnostics so a subsequent GetSetupStatus call
+    /// surfaces them in SetupStatus.wsjtx_ingest_status. The supervisor owns the snapshot lifecycle.
+    /// </summary>
+    public void SetWsjtxIngestLiveStatus(WsjtxIngestStatus status)
+    {
+        ArgumentNullException.ThrowIfNull(status);
+        Volatile.Write(ref _wsjtxIngestLiveStatus, status.Clone());
+    }
+
+    /// <summary>
+    /// Returns a normalized snapshot of the effective WSJT-X ingest settings, applying the same
+    /// defaults as the Rust runtime (enabled=false, udp_enabled=true, udp_bind=127.0.0.1:2237,
+    /// adif_tail_enabled=false, poll_interval_ms=1000, sync_to_qrz=false). The supervisor polls this
+    /// every loop iteration so configuration changes from SaveSetup take effect live.
+    /// </summary>
+    public WsjtxIngestSettings GetWsjtxIngestSettingsSnapshot()
+    {
+        lock (_gate)
+        {
+            if (_persistedSetup.WsjtxIngest is { } persisted)
+            {
+                return NormalizeWsjtxIngestSnapshot(persisted);
+            }
+
+            var defaults = new WsjtxIngestSettings
+            {
+                Enabled = false,
+                UdpEnabled = true,
+                UdpBind = "127.0.0.1:2237",
+                AdifTailEnabled = false,
+                PollIntervalMs = 1000,
+                SyncToQrz = false,
+            };
+            return defaults;
+        }
+    }
+
+    /// <summary>
+    /// Applies managed QRZ logbook sync flags to the supplied imported QSOs, mirroring
+    /// LogQso(sync_to_qrz=true) semantics: when an API key is configured each QSO is marked
+    /// <see cref="SyncStatus.Synced"/> with a synthetic QRZ logid, otherwise it stays
+    /// <see cref="SyncStatus.LocalOnly"/> with a "QRZ logbook is not configured." error. Returns a
+    /// per-QSO outcome list for the supervisor to fold into live status.
+    /// </summary>
+    public IReadOnlyList<WsjtxQrzSyncOutcome> SyncImportedQsosToQrz(IEnumerable<string> localIds)
+    {
+        ArgumentNullException.ThrowIfNull(localIds);
+
+        var outcomes = new List<WsjtxQrzSyncOutcome>();
+        lock (_gate)
+        {
+            foreach (var rawLocalId in localIds)
+            {
+                var localId = rawLocalId?.Trim();
+                if (string.IsNullOrWhiteSpace(localId))
+                {
+                    continue;
+                }
+
+                var existing = Sync(_storage.Logbook.GetQsoAsync(localId));
+                if (existing is null)
+                {
+                    outcomes.Add(new WsjtxQrzSyncOutcome(localId, string.Empty, Success: false, $"QSO '{localId}' was not found."));
+                    continue;
+                }
+
+                if (!_hasQrzLogbookApiKey)
+                {
+                    existing.SyncStatus = SyncStatus.LocalOnly;
+                    Sync(_storage.Logbook.UpdateQsoAsync(existing));
+                    outcomes.Add(new WsjtxQrzSyncOutcome(localId, existing.WorkedCallsign, Success: false, "QRZ logbook is not configured."));
+                    continue;
+                }
+
+                existing.SyncStatus = SyncStatus.Synced;
+                existing.QrzLogid = $"managed-{Guid.NewGuid():N}";
+                Sync(_storage.Logbook.UpdateQsoAsync(existing));
+                outcomes.Add(new WsjtxQrzSyncOutcome(localId, existing.WorkedCallsign, Success: true, Error: null));
+            }
+        }
+
+        return outcomes;
     }
 
     public byte[] ExportAdif(ExportAdifRequest request)
@@ -1389,6 +1501,11 @@ internal sealed class ManagedEngineState
         if (_persistedSetup.WsjtxIngest is not null)
         {
             status.WsjtxIngest = _persistedSetup.WsjtxIngest.Clone();
+        }
+
+        if (Volatile.Read(ref _wsjtxIngestLiveStatus) is { } wsjtxLiveStatus)
+        {
+            status.WsjtxIngestStatus = wsjtxLiveStatus.Clone();
         }
 
         if (_persistedSetup.CatHub is not null)
@@ -1938,6 +2055,31 @@ internal sealed class ManagedEngineState
         if (normalized.ConflictPolicy == ConflictPolicy.Unspecified)
         {
             normalized.ConflictPolicy = ConflictPolicy.FlagForReview;
+        }
+
+        return normalized;
+    }
+
+    private static WsjtxIngestSettings NormalizeWsjtxIngestSnapshot(WsjtxIngestSettings settings)
+    {
+        // Non-throwing variant used by the ingest supervisor's live polling. The persisted settings
+        // were already validated at SaveSetup time, so here we only re-apply trivial defaults and
+        // never throw (the supervisor must remain resilient to any transient config state).
+        var normalized = settings.Clone();
+        normalized.UdpEnabled = settings.HasUdpEnabled ? settings.UdpEnabled : true;
+        if (string.IsNullOrWhiteSpace(normalized.UdpBind))
+        {
+            normalized.UdpBind = "127.0.0.1:2237";
+        }
+
+        if (string.IsNullOrWhiteSpace(normalized.AdifTailPath))
+        {
+            normalized.ClearAdifTailPath();
+        }
+
+        if (normalized.PollIntervalMs == 0)
+        {
+            normalized.PollIntervalMs = 1000;
         }
 
         return normalized;

--- a/src/dotnet/QsoRipper.Engine.DotNet/Program.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/Program.cs
@@ -39,6 +39,9 @@ builder.Services.AddSingleton(provider => new ManagedEngineState(
     resolvedStorage.PersistenceLocation,
     persistedSetup));
 
+builder.Services.AddHostedService(provider =>
+    new QsoRipper.Engine.DotNet.Wsjtx.WsjtxIngestSupervisor(provider.GetRequiredService<ManagedEngineState>()));
+
 var app = builder.Build();
 app.MapGrpcService<ManagedEngineInfoGrpcService>();
 app.MapGrpcService<ManagedSetupGrpcService>();

--- a/src/dotnet/QsoRipper.Engine.DotNet/Wsjtx/WsjtxAdifTail.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/Wsjtx/WsjtxAdifTail.cs
@@ -1,0 +1,193 @@
+using System.Text;
+
+namespace QsoRipper.Engine.DotNet.Wsjtx;
+
+/// <summary>
+/// Byte-offset cursor helpers for tailing a WSJT-X <c>wsjtx_log.adi</c> file.
+/// Mirrors the Rust <c>complete_adif_prefix_len</c> family in qsoripper-core so
+/// the .NET engine advances its cursor identically (recovery-only, dedupe-safe).
+/// </summary>
+internal static class WsjtxAdifTail
+{
+    /// <summary>
+    /// Returns the byte length of the complete ADIF prefix that ends at the last
+    /// <c>&lt;eor&gt;</c> (case-insensitive) record terminator, or <see langword="null"/> when no
+    /// complete record is present.
+    /// </summary>
+    /// <remarks>
+    /// A field tag <c>&lt;name:len&gt;</c> advances the cursor by <paramref name="bytes"/> measured in
+    /// Unicode scalar values (computed over UTF-8), NOT bytes, so a literal <c>&lt;EOR&gt;</c> appearing
+    /// inside a field value cannot prematurely terminate a record.
+    /// </remarks>
+    public static int? CompleteAdifPrefixLength(ReadOnlySpan<byte> bytes)
+    {
+        int? lastEnd = null;
+        var cursor = 0;
+
+        while (cursor < bytes.Length)
+        {
+            var remaining = bytes[cursor..];
+            var tagStartOffset = remaining.IndexOf((byte)'<');
+            if (tagStartOffset < 0)
+            {
+                break;
+            }
+
+            var tagStart = cursor + tagStartOffset;
+            var tagAndRest = bytes[tagStart..];
+            var tagEndOffset = tagAndRest.IndexOf((byte)'>');
+            if (tagEndOffset < 0)
+            {
+                break;
+            }
+
+            var tagEnd = tagStart + tagEndOffset;
+            var tagBody = bytes[(tagStart + 1)..tagEnd];
+            var fieldName = AdifTagName(tagBody);
+            cursor = tagEnd + 1;
+
+            if (EqualsIgnoreAsciiCase(fieldName, "eor"))
+            {
+                lastEnd = cursor;
+                continue;
+            }
+
+            if (AdifFieldLength(tagBody) is { } fieldLen)
+            {
+                var nextCursor = CursorAfterUtf8Chars(bytes, cursor, fieldLen);
+                if (nextCursor is null)
+                {
+                    break;
+                }
+
+                cursor = nextCursor.Value;
+            }
+        }
+
+        return lastEnd;
+    }
+
+    private static int? CursorAfterUtf8Chars(ReadOnlySpan<byte> bytes, int start, int charCount)
+    {
+        if (start > bytes.Length)
+        {
+            return null;
+        }
+
+        var slice = bytes[start..];
+
+        // Mirror Rust's std::str::from_utf8(...).ok()? — the remaining slice must be valid UTF-8.
+        if (!Utf8IsValid(slice))
+        {
+            return null;
+        }
+
+        var endOffset = 0;
+        for (var index = 0; index < charCount; index++)
+        {
+            var status = System.Text.Rune.DecodeFromUtf8(slice[endOffset..], out var rune, out var consumed);
+            if (status != System.Buffers.OperationStatus.Done)
+            {
+                return null;
+            }
+
+            endOffset += consumed;
+        }
+
+        return start + endOffset;
+    }
+
+    private static bool Utf8IsValid(ReadOnlySpan<byte> bytes)
+    {
+        var span = bytes;
+        while (!span.IsEmpty)
+        {
+            var status = System.Text.Rune.DecodeFromUtf8(span, out _, out var consumed);
+            if (status != System.Buffers.OperationStatus.Done)
+            {
+                return false;
+            }
+
+            span = span[consumed..];
+        }
+
+        return true;
+    }
+
+    private static ReadOnlySpan<byte> AdifTagName(ReadOnlySpan<byte> tagBody)
+    {
+        for (var index = 0; index < tagBody.Length; index++)
+        {
+            var b = tagBody[index];
+            if (b == (byte)':' || IsAsciiWhitespace(b))
+            {
+                return tagBody[..index];
+            }
+        }
+
+        return tagBody;
+    }
+
+    private static int? AdifFieldLength(ReadOnlySpan<byte> tagBody)
+    {
+        var colon = tagBody.IndexOf((byte)':');
+        if (colon < 0)
+        {
+            return null;
+        }
+
+        long length = 0;
+        var sawDigit = false;
+        for (var index = colon + 1; index < tagBody.Length; index++)
+        {
+            var b = tagBody[index];
+            if (b == (byte)':')
+            {
+                break;
+            }
+
+            if (b < (byte)'0' || b > (byte)'9')
+            {
+                return null;
+            }
+
+            sawDigit = true;
+            length = (length * 10) + (b - (byte)'0');
+            if (length > int.MaxValue)
+            {
+                return null;
+            }
+        }
+
+        return sawDigit ? (int)length : null;
+    }
+
+    private static bool EqualsIgnoreAsciiCase(ReadOnlySpan<byte> value, string ascii)
+    {
+        if (value.Length != ascii.Length)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < value.Length; index++)
+        {
+            if (ToAsciiLower(value[index]) != ToAsciiLower((byte)ascii[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static byte ToAsciiLower(byte b)
+    {
+        return b is >= (byte)'A' and <= (byte)'Z' ? (byte)(b + 32) : b;
+    }
+
+    private static bool IsAsciiWhitespace(byte b)
+    {
+        // Matches Rust u8::is_ascii_whitespace: space, tab, line feed, form feed, carriage return.
+        return b is (byte)' ' or (byte)'\t' or (byte)'\n' or 0x0C or (byte)'\r';
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.DotNet/Wsjtx/WsjtxDatagram.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/Wsjtx/WsjtxDatagram.cs
@@ -1,0 +1,169 @@
+using System.Buffers.Binary;
+using System.Text;
+
+namespace QsoRipper.Engine.DotNet.Wsjtx;
+
+/// <summary>
+/// Classification of a WSJT-X UDP datagram parse attempt, mirroring the Rust
+/// <c>extract_wsjtx_logged_adif</c> contract in qsoripper-core.
+/// </summary>
+internal enum WsjtxDatagramParseStatus
+{
+    /// <summary>A Logged ADIF datagram with a usable ADIF payload was parsed.</summary>
+    Logged,
+
+    /// <summary>A non-magic or non-Logged-ADIF datagram that should be ignored (skipped, not an error).</summary>
+    Ignored,
+
+    /// <summary>A magic-framed Logged ADIF datagram that was malformed and should count as a parse error.</summary>
+    Malformed,
+}
+
+/// <summary>
+/// Result of attempting to parse a WSJT-X Logged ADIF UDP datagram.
+/// </summary>
+internal readonly record struct WsjtxDatagramParseResult(
+    WsjtxDatagramParseStatus Status,
+    byte[]? Adif,
+    string? Error);
+
+/// <summary>
+/// Parser for WSJT-X UDP datagrams. Matches the Rust production entry point
+/// <c>extract_wsjtx_logged_adif</c>: only the magic-framed Logged ADIF message
+/// (message type 12) is accepted; other message types are ignored.
+/// </summary>
+internal static class WsjtxDatagram
+{
+    private const uint WsjtxMagic = 0xADBC_CBDA;
+    private const uint WsjtxLoggedAdifMessageType = 12;
+    private const uint WsjtxNullStringLength = uint.MaxValue;
+
+    private static readonly UTF8Encoding StrictUtf8 = new(encoderShouldEmitUTF8Identifier: false, throwOnInvalidBytes: true);
+
+    /// <summary>
+    /// Attempts to extract the ADIF payload from a WSJT-X Logged ADIF datagram.
+    /// </summary>
+    /// <remarks>
+    /// Returns <see cref="WsjtxDatagramParseStatus.Ignored"/> for datagrams that are too short for the
+    /// magic header, do not carry the WSJT-X magic, or are not a Logged ADIF message. Returns
+    /// <see cref="WsjtxDatagramParseStatus.Malformed"/> for magic-framed Logged ADIF datagrams whose
+    /// fields are truncated, non-UTF-8, or whose ADIF payload is empty. Returns
+    /// <see cref="WsjtxDatagramParseStatus.Logged"/> with the decoded ADIF bytes on success.
+    /// </remarks>
+    public static WsjtxDatagramParseResult TryParseLoggedAdif(ReadOnlySpan<byte> datagram)
+    {
+        if (!TryReadBeU32(datagram, 0, out var magic))
+        {
+            return Ignored();
+        }
+
+        if (magic != WsjtxMagic)
+        {
+            return Ignored();
+        }
+
+        if (!TryReadBeU32(datagram, 4, out _))
+        {
+            return Malformed("WSJT-X datagram is missing schema field");
+        }
+
+        if (!TryReadBeU32(datagram, 8, out var messageType))
+        {
+            return Malformed("WSJT-X datagram is missing message type field");
+        }
+
+        if (messageType != WsjtxLoggedAdifMessageType)
+        {
+            return Ignored();
+        }
+
+        var cursor = 12;
+        if (!TryReadWsjtxUtf8(datagram, ref cursor, out _, out var idError))
+        {
+            return Malformed(idError!);
+        }
+
+        if (!TryReadWsjtxUtf8(datagram, ref cursor, out var adif, out var adifError))
+        {
+            return Malformed(adifError!);
+        }
+
+        if (string.IsNullOrWhiteSpace(adif))
+        {
+            return Malformed("WSJT-X Logged ADIF datagram has an empty ADIF payload");
+        }
+
+        return new WsjtxDatagramParseResult(
+            WsjtxDatagramParseStatus.Logged,
+            Encoding.UTF8.GetBytes(adif),
+            Error: null);
+    }
+
+    private static WsjtxDatagramParseResult Ignored()
+    {
+        return new WsjtxDatagramParseResult(WsjtxDatagramParseStatus.Ignored, Adif: null, Error: null);
+    }
+
+    private static WsjtxDatagramParseResult Malformed(string error)
+    {
+        return new WsjtxDatagramParseResult(WsjtxDatagramParseStatus.Malformed, Adif: null, error);
+    }
+
+    private static bool TryReadBeU32(ReadOnlySpan<byte> bytes, int offset, out uint value)
+    {
+        value = 0;
+        if (offset < 0)
+        {
+            return false;
+        }
+
+        var end = (long)offset + 4;
+        if (end > bytes.Length)
+        {
+            return false;
+        }
+
+        value = BinaryPrimitives.ReadUInt32BigEndian(bytes.Slice(offset, 4));
+        return true;
+    }
+
+    private static bool TryReadWsjtxUtf8(ReadOnlySpan<byte> bytes, ref int cursor, out string value, out string? error)
+    {
+        value = string.Empty;
+        error = null;
+
+        if (!TryReadBeU32(bytes, cursor, out var length))
+        {
+            error = "WSJT-X datagram is missing string length";
+            return false;
+        }
+
+        cursor += 4;
+        if (length == WsjtxNullStringLength)
+        {
+            value = string.Empty;
+            return true;
+        }
+
+        var end = (long)cursor + length;
+        if (end > bytes.Length)
+        {
+            error = "WSJT-X datagram string extends past packet end";
+            return false;
+        }
+
+        var slice = bytes.Slice(cursor, (int)length);
+        try
+        {
+            value = StrictUtf8.GetString(slice);
+        }
+        catch (DecoderFallbackException ex)
+        {
+            error = $"WSJT-X datagram string is not UTF-8: {ex.Message}";
+            return false;
+        }
+
+        cursor = (int)end;
+        return true;
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.DotNet/Wsjtx/WsjtxIngestSupervisor.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/Wsjtx/WsjtxIngestSupervisor.cs
@@ -1,0 +1,639 @@
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using Google.Protobuf.WellKnownTypes;
+using Microsoft.Extensions.Hosting;
+using QsoRipper.Services;
+
+namespace QsoRipper.Engine.DotNet.Wsjtx;
+
+/// <summary>
+/// Background supervisor that mirrors the Rust qsoripper-server WSJT-X ingest runtime. It runs two
+/// independent, cancelable loops — a UDP Logged ADIF listener and an ADIF tail recovery poller —
+/// that re-read effective settings every iteration, serialize all imports through a shared lock so
+/// they never interleave on storage, and publish live diagnostics into
+/// <see cref="ManagedEngineState"/> for SetupStatus.wsjtx_ingest_status. QRZ uploads are spawned off
+/// the ingest loops and serialized by a dedicated lock so they never block ingestion.
+/// </summary>
+internal sealed class WsjtxIngestSupervisor : IHostedService, IDisposable
+{
+    private static readonly TimeSpan UdpReceiveTimeout = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan IdlePollInterval = TimeSpan.FromMilliseconds(500);
+    private static readonly TimeSpan BindBackoff = TimeSpan.FromMilliseconds(1000);
+
+    private readonly ManagedEngineState _state;
+    private readonly object _statusLock = new();
+    private readonly WsjtxIngestStatus _status = new();
+    private readonly SemaphoreSlim _importLock = new(1, 1);
+    private readonly SemaphoreSlim _qrzSyncLock = new(1, 1);
+
+    private CancellationTokenSource? _cts;
+    private Task? _udpTask;
+    private Task? _tailTask;
+    private int _tailCursor;
+
+    public WsjtxIngestSupervisor(ManagedEngineState state)
+    {
+        _state = state ?? throw new ArgumentNullException(nameof(state));
+    }
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+        _udpTask = Task.Run(() => UdpLoopAsync(token), CancellationToken.None);
+        _tailTask = Task.Run(() => TailLoopAsync(token), CancellationToken.None);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_cts is null)
+        {
+            return;
+        }
+
+        await _cts.CancelAsync().ConfigureAwait(false);
+
+        var pending = new[] { _udpTask, _tailTask }.Where(static task => task is not null).Cast<Task>().ToArray();
+        if (pending.Length > 0)
+        {
+            try
+            {
+                await Task.WhenAll(pending).WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Host shutdown timeout elapsed; the loops observe cancellation and exit on their own.
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _cts?.Dispose();
+        _importLock.Dispose();
+        _qrzSyncLock.Dispose();
+    }
+
+    private async Task UdpLoopAsync(CancellationToken token)
+    {
+        var activeBind = string.Empty;
+        UdpClient? socket = null;
+
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                var settings = _state.GetWsjtxIngestSettingsSnapshot();
+                UpdateConfigStatus(settings);
+
+                if (!settings.Enabled || !settings.UdpEnabled)
+                {
+                    socket?.Dispose();
+                    socket = null;
+                    activeBind = string.Empty;
+                    MarkUdpStopped();
+                    if (await DelayOrCancel(IdlePollInterval, token).ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    continue;
+                }
+
+                if (socket is null || !string.Equals(activeBind, settings.UdpBind, StringComparison.Ordinal))
+                {
+                    socket?.Dispose();
+                    socket = null;
+                    if (!TryBind(settings.UdpBind, out var bound, out var bindError))
+                    {
+                        MutateStatus(status =>
+                        {
+                            status.Enabled = true;
+                            status.Running = settings.AdifTailEnabled;
+                            status.UdpRunning = false;
+                            status.UdpBind = settings.UdpBind;
+                            status.LastError = $"Failed to bind WSJT-X UDP listener on {settings.UdpBind}: {bindError}";
+                        });
+                        activeBind = string.Empty;
+                        if (await DelayOrCancel(BindBackoff, token).ConfigureAwait(false))
+                        {
+                            break;
+                        }
+
+                        continue;
+                    }
+
+                    socket = bound;
+                    activeBind = settings.UdpBind;
+                    var localBind = LocalBindOrDefault(socket, settings.UdpBind);
+                    MutateStatus(status =>
+                    {
+                        status.Enabled = true;
+                        status.Running = true;
+                        status.UdpRunning = true;
+                        status.UdpBind = localBind;
+                        status.ClearLastError();
+                    });
+                }
+
+                try
+                {
+                    using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(token);
+                    timeoutCts.CancelAfter(UdpReceiveTimeout);
+                    UdpReceiveResult result;
+                    try
+                    {
+                        result = await socket.ReceiveAsync(timeoutCts.Token).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (!token.IsCancellationRequested)
+                    {
+                        // Receive timeout: re-evaluate settings on the next iteration.
+                        continue;
+                    }
+
+                    await ProcessDatagramAsync(result.Buffer, settings.SyncToQrz, token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (token.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (SocketException socketError)
+                {
+                    MutateStatus(status => status.LastError = $"WSJT-X UDP receive failed: {socketError.Message}");
+                    socket.Dispose();
+                    socket = null;
+                    activeBind = string.Empty;
+                }
+            }
+        }
+        finally
+        {
+            socket?.Dispose();
+            MarkUdpStopped();
+        }
+    }
+
+    private async Task TailLoopAsync(CancellationToken token)
+    {
+        var activePath = string.Empty;
+        _tailCursor = 0;
+
+        try
+        {
+            while (!token.IsCancellationRequested)
+            {
+                var settings = _state.GetWsjtxIngestSettingsSnapshot();
+                UpdateConfigStatus(settings);
+
+                if (!settings.Enabled || !settings.AdifTailEnabled)
+                {
+                    _tailCursor = 0;
+                    activePath = string.Empty;
+                    MarkTailStopped();
+                    if (await DelayOrCancel(IdlePollInterval, token).ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    continue;
+                }
+
+                var path = settings.HasAdifTailPath ? settings.AdifTailPath?.Trim() : null;
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    MutateStatus(status => status.LastError = "WSJT-X ADIF tail is enabled but no path is configured.");
+                    if (await DelayOrCancel(PollInterval(settings), token).ConfigureAwait(false))
+                    {
+                        break;
+                    }
+
+                    continue;
+                }
+
+                if (!string.Equals(activePath, path, StringComparison.Ordinal))
+                {
+                    _tailCursor = 0;
+                    activePath = path;
+                }
+
+                var tailPath = path;
+                MutateStatus(status =>
+                {
+                    status.Enabled = true;
+                    status.Running = true;
+                    status.AdifTailRunning = true;
+                    status.AdifTailPath = tailPath;
+                });
+
+                await HandleTailImportAsync(path, settings.SyncToQrz, token).ConfigureAwait(false);
+
+                if (await DelayOrCancel(PollInterval(settings), token).ConfigureAwait(false))
+                {
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            MarkTailStopped();
+        }
+    }
+
+    /// <summary>
+    /// Processes a single WSJT-X UDP datagram exactly as the Rust udp loop does: ignored datagrams
+    /// are recorded as a skip, malformed datagrams increment parse_errors, and Logged ADIF datagrams
+    /// are imported (refresh=true) under the import lock with optional QRZ sync.
+    /// </summary>
+    internal async Task ProcessDatagramAsync(byte[] datagram, bool syncToQrz, CancellationToken token)
+    {
+        ArgumentNullException.ThrowIfNull(datagram);
+
+        var parse = WsjtxDatagram.TryParseLoggedAdif(datagram);
+        switch (parse.Status)
+        {
+            case WsjtxDatagramParseStatus.Ignored:
+                RecordImportSummary(new ImportAdifResponse { RecordsSkipped = 1 }, Array.Empty<WsjtxImportedQsoRef>());
+                break;
+
+            case WsjtxDatagramParseStatus.Malformed:
+                MutateStatus(status =>
+                {
+                    status.ParseErrors = checked(status.ParseErrors + 1);
+                    status.LastError = parse.Error;
+                });
+                break;
+
+            case WsjtxDatagramParseStatus.Logged:
+                await ImportUnderLockAsync(parse.Adif!, refresh: true, syncToQrz, token).ConfigureAwait(false);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Performs one ADIF tail poll for the supplied path, mirroring the Rust
+    /// <c>ingest_wsjtx_adif_tail</c> cursor semantics (refresh=false, complete-record-only advance).
+    /// </summary>
+    internal async Task HandleTailImportAsync(string path, bool syncToQrz, CancellationToken token)
+    {
+        byte[] bytes;
+        try
+        {
+            bytes = await File.ReadAllBytesAsync(path, token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception error) when (error is IOException or UnauthorizedAccessException or NotSupportedException or ArgumentException)
+        {
+            MutateStatus(status =>
+            {
+                status.ParseErrors = checked(status.ParseErrors + 1);
+                status.LastError = $"failed to read {path}: {error.Message}";
+            });
+            return;
+        }
+
+        if (_tailCursor > bytes.Length)
+        {
+            _tailCursor = 0;
+        }
+
+        if (_tailCursor == bytes.Length)
+        {
+            return;
+        }
+
+        var appended = bytes.AsSpan(_tailCursor);
+        var completeLength = WsjtxAdifTail.CompleteAdifPrefixLength(appended);
+        if (completeLength is not { } length)
+        {
+            return;
+        }
+
+        var payload = appended[..length].ToArray();
+        var start = _tailCursor;
+
+        WsjtxImportDetail detail;
+        try
+        {
+            await _importLock.WaitAsync(token).ConfigureAwait(false);
+            try
+            {
+                detail = _state.ImportAdifDetailed(payload, refresh: false);
+            }
+            finally
+            {
+                _importLock.Release();
+            }
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception error) when (error is FormatException or InvalidOperationException or ArgumentException)
+        {
+            MutateStatus(status =>
+            {
+                status.ParseErrors = checked(status.ParseErrors + 1);
+                status.LastError = $"WSJT-X ADIF tail import failed: {error.Message}";
+            });
+            return;
+        }
+
+        _tailCursor = start + length;
+        RecordImportSummary(detail.Response, detail.AffectedQsos);
+        QueueQrzSync(detail.AffectedQsos, syncToQrz);
+    }
+
+    private async Task ImportUnderLockAsync(byte[] adif, bool refresh, bool syncToQrz, CancellationToken token)
+    {
+        WsjtxImportDetail detail;
+        try
+        {
+            await _importLock.WaitAsync(token).ConfigureAwait(false);
+            try
+            {
+                detail = _state.ImportAdifDetailed(adif, refresh);
+            }
+            finally
+            {
+                _importLock.Release();
+            }
+        }
+        catch (OperationCanceledException) when (token.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception error) when (error is FormatException or InvalidOperationException or ArgumentException)
+        {
+            MutateStatus(status =>
+            {
+                status.ParseErrors = checked(status.ParseErrors + 1);
+                status.LastError = $"WSJT-X import failed: {error.Message}";
+            });
+            return;
+        }
+
+        RecordImportSummary(detail.Response, detail.AffectedQsos);
+        QueueQrzSync(detail.AffectedQsos, syncToQrz);
+    }
+
+    private void QueueQrzSync(IReadOnlyList<WsjtxImportedQsoRef> affected, bool syncToQrz)
+    {
+        if (!syncToQrz || affected.Count == 0)
+        {
+            return;
+        }
+
+        var localIds = affected.Select(static qso => qso.LocalId).ToArray();
+        _ = Task.Run(() => RunQrzSyncAsync(localIds));
+    }
+
+    /// <summary>
+    /// Runs the managed QRZ sync for the supplied imported QSOs off the ingest loop, serialized by a
+    /// dedicated lock, and folds each per-QSO outcome into live status.
+    /// </summary>
+    internal async Task RunQrzSyncAsync(IReadOnlyList<string> localIds)
+    {
+        if (localIds.Count == 0)
+        {
+            return;
+        }
+
+        await _qrzSyncLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            IReadOnlyList<WsjtxQrzSyncOutcome> outcomes;
+            try
+            {
+                outcomes = _state.SyncImportedQsosToQrz(localIds);
+            }
+            catch (Exception error) when (error is InvalidOperationException or ArgumentException)
+            {
+                MutateStatus(status =>
+                {
+                    status.LastQrzSyncSuccess = false;
+                    status.LastQrzSyncError = $"WSJT-X QRZ sync failed: {error.Message}";
+                });
+                return;
+            }
+
+            foreach (var outcome in outcomes)
+            {
+                MutateStatus(status =>
+                {
+                    if (outcome.Success)
+                    {
+                        status.LastQrzSyncSuccess = true;
+                        status.ClearLastQrzSyncError();
+                        status.LastImportedCallsign = outcome.WorkedCallsign;
+                        status.LastImportedLocalId = outcome.LocalId;
+                    }
+                    else
+                    {
+                        status.LastQrzSyncSuccess = false;
+                        status.LastQrzSyncError = outcome.Error;
+                    }
+                });
+            }
+        }
+        finally
+        {
+            _qrzSyncLock.Release();
+        }
+    }
+
+    private void RecordImportSummary(ImportAdifResponse response, IReadOnlyList<WsjtxImportedQsoRef> affected)
+    {
+        MutateStatus(status =>
+        {
+            status.LastEventAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+            status.RecordsImported = SaturatingAdd(status.RecordsImported, response.RecordsImported);
+            status.RecordsUpdated = SaturatingAdd(status.RecordsUpdated, response.RecordsUpdated);
+            status.RecordsSkipped = SaturatingAdd(status.RecordsSkipped, response.RecordsSkipped);
+            status.DuplicatesSkipped = SaturatingAdd(status.DuplicatesSkipped, CountDuplicateWarnings(response));
+            if (affected.Count > 0)
+            {
+                var last = affected[^1];
+                status.LastImportedCallsign = last.WorkedCallsign;
+                status.LastImportedLocalId = last.LocalId;
+            }
+
+            status.ClearLastError();
+        });
+    }
+
+    private void UpdateConfigStatus(WsjtxIngestSettings settings)
+    {
+        MutateStatus(status =>
+        {
+            status.Enabled = settings.Enabled;
+            status.UdpBind = settings.UdpBind;
+            if (settings.HasAdifTailPath && !string.IsNullOrWhiteSpace(settings.AdifTailPath))
+            {
+                status.AdifTailPath = settings.AdifTailPath;
+            }
+            else
+            {
+                status.ClearAdifTailPath();
+            }
+
+            status.Running = settings.Enabled && (status.UdpRunning || status.AdifTailRunning);
+        });
+    }
+
+    private void MarkUdpStopped()
+    {
+        MutateStatus(status =>
+        {
+            status.UdpRunning = false;
+            status.Running = status.Enabled && status.AdifTailRunning;
+        });
+    }
+
+    private void MarkTailStopped()
+    {
+        MutateStatus(status =>
+        {
+            status.AdifTailRunning = false;
+            status.Running = status.Enabled && status.UdpRunning;
+        });
+    }
+
+    /// <summary>Returns a clone of the supervisor's current live status snapshot.</summary>
+    internal WsjtxIngestStatus SnapshotStatus()
+    {
+        lock (_statusLock)
+        {
+            return _status.Clone();
+        }
+    }
+
+    private void MutateStatus(Action<WsjtxIngestStatus> mutate)
+    {
+        WsjtxIngestStatus snapshot;
+        lock (_statusLock)
+        {
+            mutate(_status);
+            snapshot = _status.Clone();
+        }
+
+        _state.SetWsjtxIngestLiveStatus(snapshot);
+    }
+
+    private static uint CountDuplicateWarnings(ImportAdifResponse response)
+    {
+        var count = 0L;
+        foreach (var warning in response.Warnings)
+        {
+            if (warning.Contains("duplicate skipped", StringComparison.Ordinal))
+            {
+                count++;
+            }
+        }
+
+        return count > uint.MaxValue ? uint.MaxValue : (uint)count;
+    }
+
+    private static uint SaturatingAdd(uint current, uint delta)
+    {
+        var sum = (ulong)current + delta;
+        return sum > uint.MaxValue ? uint.MaxValue : (uint)sum;
+    }
+
+    private static TimeSpan PollInterval(WsjtxIngestSettings settings)
+    {
+        var ms = settings.PollIntervalMs == 0 ? 1000 : settings.PollIntervalMs;
+        return TimeSpan.FromMilliseconds(ms);
+    }
+
+    private static bool TryBind(string bind, out UdpClient socket, out string error)
+    {
+        socket = null!;
+        error = string.Empty;
+        if (!TryParseEndpoint(bind, out var endpoint))
+        {
+            error = "bind address must be in host:port form";
+            return false;
+        }
+
+        try
+        {
+            socket = new UdpClient(endpoint);
+            return true;
+        }
+        catch (SocketException socketError)
+        {
+            error = socketError.Message;
+            return false;
+        }
+        catch (ArgumentException argError)
+        {
+            error = argError.Message;
+            return false;
+        }
+    }
+
+    private static bool TryParseEndpoint(string bind, out IPEndPoint endpoint)
+    {
+        if (IPEndPoint.TryParse(bind, out var parsed) && parsed.Port > 0)
+        {
+            endpoint = parsed;
+            return true;
+        }
+
+        // Fall back to resolving a host name to a loopback/any address is intentionally not done:
+        // the Rust runtime binds the literal host:port. Try a DNS-free host split for "localhost".
+        var separator = bind.LastIndexOf(':');
+        if (separator > 0 && separator < bind.Length - 1)
+        {
+            var host = bind[..separator];
+            var portText = bind[(separator + 1)..];
+            if (int.TryParse(portText, NumberStyles.Integer, CultureInfo.InvariantCulture, out var port)
+                && port is > 0 and <= 65535
+                && host.Equals("localhost", StringComparison.OrdinalIgnoreCase))
+            {
+                endpoint = new IPEndPoint(IPAddress.Loopback, port);
+                return true;
+            }
+        }
+
+        endpoint = null!;
+        return false;
+    }
+
+    private static string LocalBindOrDefault(UdpClient socket, string fallback)
+    {
+        try
+        {
+            return socket.Client.LocalEndPoint?.ToString() ?? fallback;
+        }
+        catch (SocketException)
+        {
+            return fallback;
+        }
+        catch (ObjectDisposedException)
+        {
+            return fallback;
+        }
+    }
+
+    private static async Task<bool> DelayOrCancel(TimeSpan duration, CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(duration, token).ConfigureAwait(false);
+            return false;
+        }
+        catch (OperationCanceledException)
+        {
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Brings the .NET engine (QsoRipper.Engine.DotNet) to runtime parity with the Rust engine's WSJT-X ingestion that shipped in PR #503. Previously the .NET engine only persisted and surfaced the wsjtx_ingest config but ran no UDP listener or ADIF tail, so logging WSJT-X contacts only worked against the Rust engine.

What this adds:

A hosted background supervisor (WsjtxIngestSupervisor) with two independent, cancelable loops that re-read effective settings every iteration and start with the engine host.

UDP loop: binds udp_bind, parses WSJT-X magic-framed Logged ADIF datagrams (message type 12), imports with refresh=true. Rebinds on config change, keeps the tail running on bind failure.

ADIF tail loop: byte-cursor tail of wsjtx_log.adi, startup recovery scan from byte 0, then imports only complete appended records. Complete-record detection honors ADIF field char-lengths so a literal EOR inside a field value cannot move the cursor. Never advances past an incomplete trailing record or a failed import.

Both inputs feed the existing ManagedEngineState import path, so duplicate detection, active station-profile fallback, and refresh semantics stay consistent with manual ADIF import. Imports are serialized so UDP and tail never interleave on storage.

Optional sync_to_qrz mirrors LogQso(sync_to_qrz) managed semantics and runs off the ingest loop so QRZ work never blocks ingestion.

Live WsjtxIngestStatus is now published into SetupStatus.wsjtx_ingest_status (field 28).

Spec: the engine-specification WSJT-X ingest runtime behavior is now engine-neutral and required of any conformant engine, not Rust-specific.

Validation: dotnet build clean (0 warnings), dotnet test green (engine tests 89 passed, +18 new), dotnet format verified. No proto or Rust changes.