### PR TITLE
Fix NU1903: pin SQLitePCLRaw.lib.e_sqlite3 to 3.50.3

### DIFF
--- a/src/dotnet/Directory.Build.props
+++ b/src/dotnet/Directory.Build.props
@@ -5,6 +5,10 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <!-- Allow pinning transitive package versions centrally so security advisories
+         in transitive dependencies (e.g. SQLitePCLRaw.lib.e_sqlite3) can be patched
+         without waiting for the direct dependency to float to a fixed version. -->
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <AnalysisLevel>latest-All</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>

--- a/src/dotnet/Directory.Packages.props
+++ b/src/dotnet/Directory.Packages.props
@@ -14,6 +14,11 @@
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
+    <!-- Transitive pin: Microsoft.Data.Sqlite 10.0.x pulls SQLitePCLRaw.lib.e_sqlite3 2.1.11,
+         which has high-severity advisory GHSA-2m69-gcr7-jv3q (NU1903). Pin the native SQLite
+         library to the patched 3.50.3 build. Only Microsoft.Data.Sqlite 11.0-preview moves off
+         2.1.11, so a stable Microsoft.Data.Sqlite bump cannot resolve this. -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Tomlyn" Version="0.17.0" />
     <PackageVersion Include="ToListinator" Version="0.0.10" />


### PR DESCRIPTION
The scheduled Full-Stack Quality run on main started failing on 06-19. Root cause is a new NuGet security advisory, not a code change.

Microsoft.Data.Sqlite 10.0.x transitively depends on SQLitePCLRaw.lib.e_sqlite3 2.1.11, which now carries high-severity advisory GHSA-2m69-gcr7-jv3q (NU1903). Because the .NET projects build with TreatWarningsAsErrors, the audit warning becomes an error during restore. The dotnet format step runs first in CI and does an implicit restore, so it crashed with a generic Restore operation failed message.

This change enables CentralPackageTransitivePinningEnabled and pins the native SQLitePCLRaw.lib.e_sqlite3 package to the patched 3.50.3 build. The native package has no managed dependencies and the SQLite C ABI is stable, so pinning it while the provider stays on 2.1.11 is safe. Only Microsoft.Data.Sqlite 11.0-preview moves off 2.1.11, so a stable provider bump cannot resolve this.

Verified locally: restore clears NU1903, full build succeeds, all 59 SQLite storage tests pass against 3.50.3, and dotnet format --verify-no-changes passes.