### PR TITLE
Fix .NET CI restore failure from SQLite native lib advisory

### DIFF
--- a/src/dotnet/Directory.Packages.props
+++ b/src/dotnet/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.15.0" />
     <PackageVersion Include="Roslynator.Formatting.Analyzers" Version="4.15.0" />
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.50.3" />
     <PackageVersion Include="Tomlyn" Version="0.17.0" />
     <PackageVersion Include="ToListinator" Version="0.0.10" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/src/dotnet/QsoRipper.Engine.Storage.Sqlite/QsoRipper.Engine.Storage.Sqlite.csproj
+++ b/src/dotnet/QsoRipper.Engine.Storage.Sqlite/QsoRipper.Engine.Storage.Sqlite.csproj
@@ -10,6 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite" />
+    <!-- Pin the native SQLite library above the version transitively pulled by
+         Microsoft.Data.Sqlite to pick up the SQLite 3.50.x fix for CVE-2025-6965
+         (advisory GHSA-2m69-gcr7-jv3q). -->
+    <PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The scheduled Full-Stack Quality workflow has failed every run since June 19 (last success June 18). Nothing in the repo changed around then; the break is environmental.

Root cause: NuGet started reporting advisory GHSA-2m69-gcr7-jv3q (CVE-2025-6965) against SQLitePCLRaw.lib.e_sqlite3 2.1.11, which Microsoft.Data.Sqlite 10.0.6 pulls in transitively. Because the .NET build sets TreatWarningsAsErrors, the NU1903 vulnerability warning is promoted to an error during restore. The first dotnet step in the job is "dotnet format --verify-no-changes", which does an implicit restore and crashes with "Restore operation failed" before formatting runs, so the whole .NET Quality job dies on a misleading error.

Fix: pin the transitive native library SQLitePCLRaw.lib.e_sqlite3 to 3.50.3 (bundles SQLite 3.50.3, which contains the CVE fix) while keeping the managed core/provider/bundle packages at 2.1.11. A direct PackageReference in the SQLite storage project is needed because central transitive pinning is not enabled in this repo.

Verified locally:
- dotnet restore src/dotnet/QsoRipper.slnx is clean
- dotnet list --vulnerable --include-transitive reports no vulnerable packages
- the resolved native lib is SQLitePCLRaw.lib.e_sqlite3 3.50.3
- dotnet format --verify-no-changes passes (exit 0)
- all 59 SQLite storage tests pass against the patched native library