### PR TITLE
Bump quick-xml to 0.41 to clear cargo-deny RustSec advisories

### DIFF
--- a/src/rust/qsoripper-core/Cargo.toml
+++ b/src/rust/qsoripper-core/Cargo.toml
@@ -17,7 +17,7 @@ difa = "0.1"
 thiserror = "2"
 chrono = "0.4"
 futures = "0.3"
-quick-xml = { version = "0.37", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
The scheduled Full-Stack Quality run on main is failing at the Rust cargo-deny step because of two RustSec advisories published against quick-xml 0.37.5:

RUSTSEC-2026-0194 - quadratic complexity in the duplicate-attribute check.
RUSTSEC-2026-0195 - unbounded namespace allocation in NsReader (memory-exhaustion DoS).

Both are fixed in quick-xml 0.41.0, so this bumps the qsoripper-core requirement from 0.37 to 0.41. quick-xml is only used for serde deserialization (QRZ XML lookups and the WA7BNM contest calendar RSS); there was no API breakage and all qsoripper-core tests pass on 0.41.

A concurrent advisory, RUSTSEC-2026-0190 (anyhow soundness issue, fixed in 1.0.103), also cleared. anyhow is pinned as "1" and Cargo.lock is not committed to the repo, so a fresh dependency resolution on CI already picks up 1.0.103 with no manifest change.

Validated locally: cargo fmt, cargo clippy -D warnings, cargo test, and cargo deny check (advisories, bans, licenses, sources) are all green. A from-scratch lockfile regeneration confirms fresh resolution selects quick-xml 0.41.0 and anyhow 1.0.103.