### PR TITLE
Fix WSJT-X TS-590 band mode recall

### DIFF
--- a/src/rust/qsoripper-cathub/src/dialect/mod.rs
+++ b/src/rust/qsoripper-cathub/src/dialect/mod.rs
@@ -109,7 +109,7 @@ impl FaceContext {
         // Idempotent suppression: never re-send a value the radio already holds. This keeps
         // the hub as quiet on the wire as a native Hamlib driver and avoids the TS-590
         // PC-control beep that fires on every redundant set. PTT is never redundant.
-        if self.state.snapshot().is_redundant(&mutation) {
+        if self.state.is_redundant(&mutation) {
             return ApplyOutcome::Ok;
         }
         match (class, mutation) {

--- a/src/rust/qsoripper-cathub/src/hamlib_net.rs
+++ b/src/rust/qsoripper-cathub/src/hamlib_net.rs
@@ -844,6 +844,44 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn set_freq_then_same_pktusb_reasserts_mode_after_band_memory_recall() {
+        // The TS-590 recalls MD and DA from per-band memory as soon as FA/FB crosses a band
+        // boundary. Before its AI/poll updates arrive, the cache still contains the old
+        // PKTUSB value. WSJT-X then sends M PKTUSB; that re-assertion must reach the radio
+        // instead of being incorrectly deduped against the stale pre-tune cache.
+        let (ctx, backend, state) = ctx_with(FacePermissions::from_tokens(&["read", "write"]));
+        state.record(
+            StateChange::DataMode {
+                vfo: Vfo::A,
+                on: true,
+            },
+            RadioEventSource::PollDiff,
+        );
+
+        assert_eq!(reply_of("F 28074000", &ctx).await, RPRT_OK.to_vec());
+        assert_eq!(reply_of("M PKTUSB 0", &ctx).await, RPRT_OK.to_vec());
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        assert_eq!(
+            backend.mutations(),
+            vec![
+                StateMutation::SetVfoFreq {
+                    vfo: Vfo::A,
+                    hz: 28_074_000,
+                },
+                StateMutation::SetMode {
+                    vfo: Vfo::A,
+                    mode: Mode::Usb,
+                },
+                StateMutation::SetDataMode {
+                    vfo: Vfo::A,
+                    on: true,
+                },
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn set_mode_plain_clears_data_flag() {
         // Switching from a data mode to a plain mode must emit DA0. Prime DATA on, then send
         // plain USB: the base mode is unchanged (deduped) but the DATA-off write lands.

--- a/src/rust/qsoripper-cathub/src/state.rs
+++ b/src/rust/qsoripper-cathub/src/state.rs
@@ -14,6 +14,15 @@ use tokio::sync::broadcast;
 
 use crate::model::{Field, Mode, RadioEventSource, StateChange, StateMutation, Vfo};
 
+/// A cached mode fact that may have been invalidated by a frequency change. The TS-590
+/// recalls mode and DATA independently from its per-band memory, so both facts must be
+/// re-asserted after tuning even when the pre-tune snapshot already held the requested mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum ModeFact {
+    Base(Vfo),
+    Data(Vfo),
+}
+
 /// Default IF passband reported for a VFO (Hz). Real backends may refine this; the default
 /// matches the canonical Hamlib `get_mode` second line.
 const DEFAULT_PASSBAND_HZ: u32 = 2_400;
@@ -213,6 +222,7 @@ pub(crate) enum RadioEvent {
 struct Inner {
     snapshot: RwLock<Snapshot>,
     covered: Mutex<HashSet<Field>>,
+    uncertain_mode: Mutex<HashSet<ModeFact>>,
     tx: broadcast::Sender<RadioEvent>,
 }
 
@@ -234,6 +244,7 @@ impl StateHandle {
             inner: Arc::new(Inner {
                 snapshot: RwLock::new(Snapshot::default()),
                 covered: Mutex::new(HashSet::new()),
+                uncertain_mode: Mutex::new(HashSet::new()),
                 tx,
             }),
         }
@@ -258,6 +269,34 @@ impl StateHandle {
                 .unwrap_or_else(PoisonError::into_inner);
             apply_change(&mut snap, change)
         };
+
+        // A TS-590 frequency set can cross a band boundary and synchronously recall that
+        // band's stored MD/DA settings. Until fresh MD and DA facts arrive, the old cached
+        // mode must not suppress a client's immediately following mode re-assertion (the
+        // normal WSJT-X band-change sequence is F then M). Each fact becomes certain again
+        // as soon as it is observed or successfully written, even when its value compares
+        // equal and therefore produced no broadcast change.
+        let mut uncertain = self
+            .inner
+            .uncertain_mode
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        match change {
+            StateChange::Freq { vfo, .. }
+                if changed && source == RadioEventSource::OptimisticWrite =>
+            {
+                uncertain.insert(ModeFact::Base(vfo));
+                uncertain.insert(ModeFact::Data(vfo));
+            }
+            StateChange::Mode { vfo, .. } => {
+                uncertain.remove(&ModeFact::Base(vfo));
+            }
+            StateChange::DataMode { vfo, .. } => {
+                uncertain.remove(&ModeFact::Data(vfo));
+            }
+            _ => {}
+        }
+        drop(uncertain);
         if changed {
             // A send error only means there are no subscribers; that is fine.
             let _ = self.inner.tx.send(RadioEvent::Change(change));
@@ -287,6 +326,25 @@ impl StateHandle {
             .snapshot
             .read()
             .unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Whether a modeled write is safely redundant against the current cache.
+    ///
+    /// Mode facts invalidated by an optimistic frequency change are deliberately treated as
+    /// non-redundant until the radio reports them or a client re-asserts them. Other fields
+    /// retain the snapshot's ordinary idempotent suppression.
+    pub(crate) fn is_redundant(&self, mutation: &StateMutation) -> bool {
+        let uncertain = self
+            .inner
+            .uncertain_mode
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        let invalidated = match *mutation {
+            StateMutation::SetMode { vfo, .. } => uncertain.contains(&ModeFact::Base(vfo)),
+            StateMutation::SetDataMode { vfo, .. } => uncertain.contains(&ModeFact::Data(vfo)),
+            _ => false,
+        };
+        !invalidated && self.snapshot().is_redundant(mutation)
     }
 
     /// Subscribe to the radio-output event stream (for a face's auto-info fan-out).


### PR DESCRIPTION
## What changed

- invalidate cached base-mode and DATA facts after an optimistic frequency change
- force WSJT-X's next mode assertion through after a TS-590 band-memory recall
- preserve ordinary duplicate-mode suppression once fresh mode facts are observed or written
- add a regression test for the WSJT-X `F` then `M PKTUSB` band-change sequence

## Root cause

The TS-590 can synchronously recall per-band `MD` and `DA` settings when a frequency command crosses a band boundary. CatHub optimistically updated frequency while retaining its pre-tune PKTUSB cache. When WSJT-X immediately followed with `M PKTUSB`, CatHub could incorrectly classify it as redundant before the radio's recalled CW state arrived, leaving the rig in CW instead of USB+DATA.

## Impact

WSJT-X band selections now reliably reassert USB+DATA on the TS-590 without bringing back noisy repeated mode writes during steady-state polling.

## Validation

- full Release build completed for Rust, .NET, Win32, CW decoder, and published artifacts
- CI-equivalent Rust formatting, Clippy, coverage, and quality checks passed
- full test suite passed with Visual Studio 2022: 2,128 passed, 0 failed
- direct live CatHub check confirmed `M PKTUSB` completes and reads back correctly
