### PR TITLE
Fix QRZ replacement uploads

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -227,7 +227,7 @@ The sync follows a three-phase lifecycle:
 
 1. **Download phase** — Fetch all QSOs from the QRZ logbook API via ADIF. Parse the ADIF response. For each remote QSO, attempt to match it against local records using fuzzy matching on callsign + timestamp + band + mode. Filter out ghost/duplicate records. Insert new remote-only records and update local records that have newer remote data (per the configured `ConflictPolicy`).
 
-2. **Upload phase** — Find all local QSOs with `sync_status` of `SYNC_STATUS_NOT_SYNCED` or `SYNC_STATUS_MODIFIED`. For each, serialize to ADIF and upload via the QRZ logbook API. On success, update `sync_status` to `SYNC_STATUS_SYNCED` and record the `qrz_logid` returned by QRZ.
+2. **Upload phase** — Find all local QSOs with `sync_status` of `SYNC_STATUS_NOT_SYNCED` or `SYNC_STATUS_MODIFIED`. For each, serialize to ADIF and upload via the QRZ logbook API. New records use a normal INSERT. Modified records use the documented `OPTION=REPLACE` value exactly; engines must not append a `LOGID` selector to that option. QRZ matches the duplicate from the ADIF identity fields and returns the affected `qrz_logid`. On success, update `sync_status` to `SYNC_STATUS_SYNCED` and record that returned value.
 
    **Previous-callsign rewrite (issue #337).** QRZ logbooks are bound to a single callsign and reject ADIF whose `STATION_CALLSIGN` does not match the logbook owner. Operators who have changed callsigns (e.g. KB7QOP → AE7XI) keep historical QSOs locally with the old call. To avoid those rejections, engines MUST:
 
@@ -1505,7 +1505,7 @@ The QRZ logbook sync is a multi-phase operation:
 
 #### Phase 0.5: Push local corrections before download
 
-Before fetching remote QSOs, engines MUST resolve the QRZ logbook owner callsign (via `STATUS`, falling back to cached metadata on transient failure) and push local rows with `sync_status = MODIFIED` and a non-empty `qrz_logid` when the effective conflict policy is `CONFLICT_POLICY_FLAG_FOR_REVIEW` or `CONFLICT_POLICY_UNSPECIFIED`. This uses the documented replace form `ACTION=INSERT&OPTION=REPLACE,LOGID:<logid>`.
+Before fetching remote QSOs, engines MUST resolve the QRZ logbook owner callsign (via `STATUS`, falling back to cached metadata on transient failure) and push local rows with `sync_status = MODIFIED` and a non-empty `qrz_logid` when the effective conflict policy is `CONFLICT_POLICY_FLAG_FOR_REVIEW` or `CONFLICT_POLICY_UNSPECIFIED`. This uses the documented replace form `ACTION=INSERT&OPTION=REPLACE`. QRZ identifies the existing record from the ADIF identity fields.
 
 This pre-download upload prevents a stale QRZ copy from being downloaded first and converting a normal local correction into `CONFLICT` before the upload phase can update QRZ. Engines MUST remember the `qrz_logid` values successfully uploaded during this phase and ignore matching remote rows returned by the same sync's subsequent `FETCH`, because QRZ may briefly return the stale pre-replace copy.
 
@@ -1531,7 +1531,7 @@ This pre-download upload prevents a stale QRZ copy from being downloaded first a
 1. Query local QSOs with `sync_status` in (`NOT_SYNCED`, `MODIFIED`). Soft-deleted rows MUST NOT be uploaded as inserts/updates regardless of `sync_status`; they are handled by Phase 2.5.
 2. For each QSO, serialize to ADIF and call the QRZ logbook API:
    - If `sync_status = NOT_SYNCED` (new record, no `qrz_logid`), use `ACTION=INSERT`.
-   - If `sync_status = MODIFIED` and the record has a `qrz_logid`, use the documented replace form `ACTION=INSERT&OPTION=REPLACE,LOGID:<logid>`. Engines MUST NOT use the undocumented `ACTION=REPLACE` form, which can silently produce duplicate inserts on the remote logbook.
+   - If `sync_status = MODIFIED` and the record has a `qrz_logid`, use the documented replace form `ACTION=INSERT&OPTION=REPLACE`. QRZ identifies the existing record from the ADIF identity fields. Engines MUST NOT append a `LOGID` selector to `OPTION` or use the undocumented `ACTION=REPLACE` form.
    - If `sync_status = MODIFIED` but no `qrz_logid` is available (e.g., first sync after upgrading from an engine that didn't persist the logid), fall back to `ACTION=INSERT`. Engines SHOULD additionally run the repair pass described in §7.7 before the first sync so modified-without-logid rows are rare.
 3. Accept both `RESULT=OK` (insert) and `RESULT=REPLACE` (update) as success indicators when parsing the QRZ response.
 4. On success, set `sync_status = SYNCED` and store the returned `LOGID` (or the supplied one for a REPLACE that echoes nothing) in `qrz_logid`.
@@ -1561,7 +1561,7 @@ This pre-download upload prevents a stale QRZ copy from being downloaded first a
 When `LogQso.sync_to_qrz=true` or `UpdateQso.sync_to_qrz=true`, engines MUST attempt to push the affected row to QRZ immediately after the local persist. This is independent of the bulk sync flow (`SyncWithQrz`) and lets clients log a QSO and get an authoritative QRZ logid back in a single round-trip.
 
 **Selection rule (mirrors Phase 2):**
-- If the local row has a non-empty `qrz_logid`, REPLACE in place (`ACTION=INSERT&OPTION=REPLACE,LOGID:<logid>`).
+- If the local row has a non-empty `qrz_logid`, replace it using `ACTION=INSERT&OPTION=REPLACE`; QRZ identifies the existing record from the ADIF identity fields.
 - Otherwise INSERT (`ACTION=INSERT`).
 
 **Success path:** adopt the QRZ-assigned `LOGID`, set `sync_status=SYNC_STATUS_SYNCED`, write the row back to local storage, and populate the response's `sync_success=true` (and `qrz_logid` for `LogQsoResponse`).

--- a/docs/integrations/qrz-logbook-api.md
+++ b/docs/integrations/qrz-logbook-api.md
@@ -135,6 +135,9 @@ RESULT=OK&LOGID=130877825&COUNT=1
 **Implementation warnings:**
 
 - The `REPLACE` option **will overwrite confirmed QSOs** with the supplied unconfirmed QSO data until QRZ re-verifies the match. Treat this as a high-risk operation requiring explicit user intent.
+- Send the option as exactly `REPLACE`. Do not append a `LOGID` selector to the
+  `OPTION` value. QRZ matches the duplicate from the supplied ADIF record and
+  returns the affected `LOGID`.
 
 ---
 
@@ -308,4 +311,3 @@ Use these environment variables (see `.env.example`):
 | `QSORIPPER_QRZ_USER_AGENT` | User-Agent header value (e.g. `QsoRipper/0.1.0 (YOURCALL)`) |
 | `QSORIPPER_QRZ_HTTP_TIMEOUT_SECONDS` | HTTP request timeout |
 | `QSORIPPER_QRZ_MAX_RETRIES` | Maximum retry count for transient failures |
-

--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -263,7 +263,7 @@ fn parse_status_response(map: &HashMap<String, String>) -> QrzLogbookStatus {
 fn check_result(map: HashMap<String, String>) -> Result<HashMap<String, String>, QrzLogbookError> {
     match map.get("RESULT").map(String::as_str) {
         // QRZ returns RESULT=OK for INSERT/FETCH/STATUS/DELETE successes and
-        // RESULT=REPLACE for `INSERT&OPTION=REPLACE,LOGID:...` successes.
+        // RESULT=REPLACE for `INSERT&OPTION=REPLACE` successes.
         // Treat both as success per docs/integrations/qrz-logbook-api.md.
         Some("OK" | "REPLACE") => Ok(map),
         Some("FAIL") => {
@@ -727,10 +727,10 @@ impl QrzLogbookClient {
     /// Replace an existing QSO on the QRZ Logbook in place.
     ///
     /// Per the QRZ Logbook API contract this is `ACTION=INSERT` with
-    /// `OPTION=REPLACE,LOGID:<id>`. The server keeps the same `LOGID`
-    /// rather than minting a new one. Modified QSOs that already have a
-    /// `qrz_logid` MUST go through this path instead of `upload_qso` to
-    /// avoid creating duplicate rows on QRZ.
+    /// `OPTION=REPLACE`. QRZ matches the duplicate from the ADIF identity
+    /// fields and returns its `LOGID`. Modified QSOs that already have a
+    /// `qrz_logid` must go through this path instead of `upload_qso` to avoid
+    /// creating duplicate rows on QRZ.
     ///
     /// # Errors
     ///
@@ -749,12 +749,11 @@ impl QrzLogbookClient {
             ));
         }
         let adif_record = qso_to_qrz_adif(qso, book_owner);
-        let option = format!("REPLACE,LOGID:{logid}");
 
         let body = self
             .post_form(&[
                 ("ACTION", "INSERT"),
-                ("OPTION", option.as_str()),
+                ("OPTION", "REPLACE"),
                 ("ADIF", &adif_record),
             ])
             .await?;
@@ -1702,13 +1701,14 @@ mod tests {
     // -- delete_qso integration ---------------------------------------------
 
     #[tokio::test]
-    async fn replace_qso_sends_replace_option_with_logid() {
+    async fn replace_qso_sends_documented_replace_option() {
         let (base_url, requests) =
             spawn_logbook_server(&[("text/plain", "RESULT=REPLACE&LOGID=555444333")]).await;
         let client = QrzLogbookClient::new(test_config(base_url)).expect("client");
 
         let qso = QsoRecord {
             worked_callsign: "W1AW".to_string(),
+            qrz_logid: Some("555444333".to_string()),
             ..Default::default()
         };
         let result = client
@@ -1723,16 +1723,21 @@ mod tests {
 
         let body = &requests.lock().expect("requests")[0];
         assert!(body.contains("ACTION=INSERT"));
-        // OPTION=REPLACE,LOGID:555444333 — the comma and colon are URL-encoded
-        // so we just verify the discriminating substrings are present.
         assert!(
-            body.contains("OPTION=REPLACE"),
-            "missing OPTION=REPLACE: {body}"
+            body.contains("OPTION=REPLACE&"),
+            "OPTION must be exactly REPLACE: {body}"
         );
-        assert!(body.contains("LOGID"), "missing logid in OPTION: {body}");
+        assert!(
+            !body.contains("OPTION=REPLACE%2C"),
+            "OPTION must not embed a LOGID selector: {body}"
+        );
+        assert!(
+            body.contains("APP_QRZLOG_LOGID"),
+            "ADIF must carry the existing logid: {body}"
+        );
         assert!(
             body.contains("555444333"),
-            "missing logid value in OPTION: {body}"
+            "missing logid value in ADIF: {body}"
         );
     }
 


### PR DESCRIPTION
QRZ replacement uploads were sending `OPTION=REPLACE,LOGID:<id>`, but the QRZ API requires the option value to be exactly `REPLACE`. QRZ interpreted the malformed request as a new insert and rejected modified contacts as duplicates.

This change sends the documented option, preserves the existing QRZ log ID in the ADIF payload, adds a regression test for the encoded request body, and updates the integration and engine-contract documentation.

Validated with the 68 QRZ client tests, 49 server sync tests, the Rust quality gate, a full Release build, and a live forced sync. The live sync uploaded both pending contacts with zero errors and restored the affected N7NWT contact to synced status under its existing QRZ log ID.
