### PR TITLE
Add CatHub architecture report

### DIFF
--- a/docs/architecture/cathub/index.html
+++ b/docs/architecture/cathub/index.html
@@ -1,0 +1,437 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="An engineering explanation of how QsoRipper CatHub brokers shared access to a radio and WinKeyer hardware across existing software interfaces.">
+  <title>CatHub: shared radio control | QsoRipper</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --page: #f7f7f5;
+      --paper: #ffffff;
+      --ink: #17201d;
+      --muted: #52605b;
+      --faint: #6c7873;
+      --line: #ccd3cf;
+      --line-strong: #9eaaa4;
+      --hub: #195f49;
+      --hub-soft: #e8f2ed;
+      --client: #215d83;
+      --client-soft: #eaf2f7;
+      --hardware: #815718;
+      --hardware-soft: #f7f0e4;
+      --caution: #765300;
+      --caution-soft: #fff7dc;
+      --code: #f2f4f3;
+      --max: 1120px;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      background: var(--page);
+      font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 16px;
+      line-height: 1.62;
+    }
+    a { color: #145a80; text-underline-offset: 0.16em; }
+    a:hover { text-decoration-thickness: 2px; }
+    code, .mono {
+      font-family: "Cascadia Mono", "SFMono-Regular", Consolas, monospace;
+      font-size: 0.91em;
+    }
+    code { padding: 0.1em 0.3em; background: var(--code); border-radius: 3px; }
+    h1, h2, h3, p { margin-top: 0; }
+    h1, h2, h3 { line-height: 1.2; letter-spacing: -0.015em; }
+    h1 { max-width: 820px; margin-bottom: 20px; font-size: clamp(2.3rem, 5vw, 4.35rem); font-weight: 680; }
+    h2 { margin-bottom: 16px; font-size: clamp(1.7rem, 3vw, 2.45rem); font-weight: 650; }
+    h3 { margin-bottom: 8px; font-size: 1.08rem; }
+    p { max-width: 76ch; }
+
+    .shell { width: min(calc(100% - 40px), var(--max)); margin-inline: auto; }
+    .skip-link { position: fixed; top: -60px; left: 12px; z-index: 20; padding: 9px 12px; color: #fff; background: var(--hub); }
+    .skip-link:focus { top: 12px; }
+    .site-header { border-bottom: 1px solid var(--line); background: rgba(255, 255, 255, 0.95); }
+    .header-inner { min-height: 58px; display: flex; align-items: center; justify-content: space-between; gap: 24px; }
+    .brand { color: var(--ink); font-weight: 650; text-decoration: none; }
+    .brand span { color: var(--faint); font-weight: 450; }
+    .nav { display: flex; flex-wrap: wrap; gap: 20px; font-size: 0.86rem; }
+    .nav a { color: var(--muted); text-decoration: none; }
+    .nav a:hover, .nav a:focus-visible { color: var(--ink); text-decoration: underline; }
+
+    .hero { padding-block: 82px 68px; border-bottom: 1px solid var(--line); background: var(--paper); }
+    .label { margin-bottom: 15px; color: var(--hub); font: 650 0.75rem "Cascadia Mono", Consolas, monospace; letter-spacing: 0.08em; text-transform: uppercase; }
+    .lede { max-width: 800px; margin-bottom: 27px; color: var(--muted); font-size: clamp(1.08rem, 2vw, 1.3rem); }
+    .answer {
+      max-width: 900px;
+      padding: 19px 22px;
+      border-left: 4px solid var(--hub);
+      background: var(--hub-soft);
+    }
+    .answer strong { color: var(--hub); }
+    .answer p:last-child { margin-bottom: 0; }
+
+    main section { padding-block: 68px; border-bottom: 1px solid var(--line); }
+    .section-head { display: grid; grid-template-columns: minmax(0, 0.75fr) minmax(320px, 1.25fr); gap: 56px; margin-bottom: 30px; align-items: start; }
+    .section-head p { margin: 5px 0 0; color: var(--muted); }
+
+    .terms { display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid var(--line); background: var(--paper); }
+    .term { padding: 22px; }
+    .term + .term { border-left: 1px solid var(--line); }
+    .term p { margin: 0; color: var(--muted); font-size: 0.93rem; }
+    .term-tag { display: inline-block; margin-bottom: 12px; color: var(--faint); font: 650 0.72rem "Cascadia Mono", Consolas, monospace; text-transform: uppercase; }
+
+    .comparison { overflow-x: auto; border: 1px solid var(--line); background: var(--paper); }
+    table { width: 100%; min-width: 760px; border-collapse: collapse; }
+    th, td { padding: 14px 16px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    tr:last-child td { border-bottom: 0; }
+    th { color: var(--faint); background: #f2f4f3; font-size: 0.76rem; letter-spacing: 0.05em; text-transform: uppercase; }
+    td { font-size: 0.91rem; }
+    td:first-child { font-weight: 620; }
+
+    .diagram { overflow-x: auto; padding: 26px; border: 1px solid var(--line-strong); background: var(--paper); }
+    .diagram-grid { min-width: 1040px; display: grid; grid-template-columns: 1.1fr 38px 1.05fr 38px 1.2fr 38px 0.95fr; gap: 8px; align-items: stretch; }
+    .diagram-heading { grid-row: 1; padding: 0 12px 10px; color: var(--faint); font: 650 0.72rem "Cascadia Mono", Consolas, monospace; letter-spacing: 0.05em; text-transform: uppercase; }
+    .diagram-heading.center { text-align: center; }
+    .lane { display: contents; }
+    .box { min-height: 108px; padding: 16px; border: 1px solid var(--line); background: var(--paper); }
+    .box.client { border-color: #aec4d2; background: var(--client-soft); }
+    .box.interface { border-color: #aec4d2; }
+    .box.hub { border-color: #96b8aa; background: var(--hub-soft); }
+    .box.hardware { border-color: #cdbb9d; background: var(--hardware-soft); }
+    .box strong { display: block; margin-bottom: 5px; }
+    .box small { display: block; color: var(--muted); line-height: 1.45; }
+    .box .port { margin-top: 8px; color: var(--faint); font: 0.76rem "Cascadia Mono", Consolas, monospace; }
+    .arrow-cell { display: grid; place-items: center; color: var(--line-strong); font-size: 1.45rem; }
+    .program-col { grid-column: 1; }
+    .program-arrow { grid-column: 2; }
+    .interface-col { grid-column: 3; }
+    .interface-arrow { grid-column: 4; }
+    .radio-one { grid-row: 2; }
+    .radio-two { grid-row: 3; }
+    .radio-three { grid-row: 4; }
+    .keyer-one { grid-row: 5; margin-top: 22px; }
+    .keyer-two { grid-row: 6; }
+    .keyer-three { grid-row: 7; }
+    .hub-core { grid-column: 5; min-height: 348px; display: flex; flex-direction: column; justify-content: center; border: 2px solid var(--hub); background: var(--hub-soft); }
+    .hub-core strong { color: var(--hub); font-size: 1.24rem; }
+    .hub-core ul { margin: 12px 0 0; padding-left: 19px; color: var(--muted); font-size: 0.88rem; }
+    .hub-domain { display: inline-block; margin-bottom: 10px; color: var(--faint); font: 650 0.7rem "Cascadia Mono", Consolas, monospace; letter-spacing: 0.05em; text-transform: uppercase; }
+    .radio-hub { grid-row: 2 / span 3; }
+    .keyer-hub { grid-row: 5 / span 3; margin-top: 22px; }
+    .hardware-core { grid-column: 7; min-height: 348px; display: flex; flex-direction: column; justify-content: center; }
+    .radio-core { grid-row: 2 / span 3; }
+    .keyer-core { grid-row: 5 / span 3; margin-top: 22px; }
+    .core-arrow { grid-column: 6; }
+    .radio-core-arrow { grid-row: 2 / span 3; }
+    .keyer-core-arrow { grid-row: 5 / span 3; margin-top: 22px; }
+    .diagram-note { margin: 18px 0 0; color: var(--muted); font-size: 0.88rem; }
+    .legend { display: flex; flex-wrap: wrap; gap: 18px; margin-bottom: 14px; color: var(--muted); font-size: 0.8rem; }
+    .legend span { display: inline-flex; align-items: center; gap: 7px; }
+    .legend i { width: 12px; height: 12px; border: 1px solid var(--line); }
+    .legend .client-key i { background: var(--client-soft); border-color: #aec4d2; }
+    .legend .hub-key i { background: var(--hub-soft); border-color: #96b8aa; }
+    .legend .hardware-key i { background: var(--hardware-soft); border-color: #cdbb9d; }
+
+    .routes { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+    .subsection-head { margin: 38px 0 16px; padding-top: 30px; border-top: 1px solid var(--line); }
+    .subsection-head p { margin-bottom: 0; color: var(--muted); }
+    .flow-heading { margin: 28px 0 10px; color: var(--muted); font-size: 0.92rem; font-weight: 650; }
+    .route { padding: 21px; border: 1px solid var(--line); background: var(--paper); }
+    .route-number { color: var(--hub); font: 650 0.76rem "Cascadia Mono", Consolas, monospace; }
+    .route ol { margin: 15px 0 0; padding-left: 20px; }
+    .route li { margin-bottom: 9px; color: var(--muted); font-size: 0.9rem; }
+    .route li:last-child { margin-bottom: 0; }
+
+    .two-column { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+    .plain-card { padding: 23px; border: 1px solid var(--line); background: var(--paper); }
+    .plain-card ul { margin: 15px 0 0; padding-left: 20px; }
+    .plain-card li { margin-bottom: 10px; color: var(--muted); }
+    .plain-card li:last-child { margin-bottom: 0; }
+    .caution { margin-top: 18px; padding: 17px 19px; border-left: 4px solid #b08018; color: #543c06; background: var(--caution-soft); }
+    .caution p:last-child { margin-bottom: 0; }
+
+    .connection-flow { display: flex; align-items: center; gap: 10px; overflow-x: auto; padding: 24px; border: 1px solid var(--line); background: var(--paper); }
+    .connection-flow .node { flex: 1 0 150px; min-height: 96px; padding: 15px; border: 1px solid var(--line); }
+    .connection-flow .node.app { background: var(--client-soft); border-color: #aec4d2; }
+    .connection-flow .node.hub { background: var(--hub-soft); border-color: #96b8aa; }
+    .connection-flow .node.hardware { background: var(--hardware-soft); border-color: #cdbb9d; }
+    .connection-flow strong, .connection-flow small { display: block; }
+    .connection-flow small { margin-top: 5px; color: var(--muted); line-height: 1.4; }
+    .connection-flow .flow-arrow { flex: 0 0 auto; color: var(--line-strong); font-size: 1.35rem; }
+
+    .implementation-list { display: grid; grid-template-columns: 1fr 1fr; gap: 0 34px; margin: 0; padding-left: 21px; }
+    .implementation-list li { margin-bottom: 12px; padding-left: 4px; color: var(--muted); }
+    .implementation-list strong { color: var(--ink); }
+
+    .sources { margin: 0; padding-left: 21px; }
+    .sources li { margin-bottom: 11px; color: var(--muted); }
+    .sources li:last-child { margin-bottom: 0; }
+    footer { padding-block: 28px; color: var(--faint); font-size: 0.82rem; }
+
+    @media (max-width: 820px) {
+      .header-inner { align-items: flex-start; flex-direction: column; padding-block: 15px; }
+      .section-head, .two-column { grid-template-columns: 1fr; gap: 13px; }
+      .terms, .routes { grid-template-columns: 1fr; }
+      .term + .term { border-left: 0; border-top: 1px solid var(--line); }
+      .implementation-list { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 560px) {
+      .shell { width: min(calc(100% - 28px), var(--max)); }
+      .hero { padding-block: 54px 48px; }
+      main section { padding-block: 50px; }
+      .nav { gap: 12px; }
+    }
+    @media print {
+      :root { --page: #fff; }
+      .site-header { position: static; }
+      .nav { display: none; }
+      main section { break-inside: avoid; }
+      a { color: inherit; }
+    }
+  </style>
+</head>
+<body>
+  <a class="skip-link" href="#content">Skip to content</a>
+  <header class="site-header">
+    <div class="shell header-inner">
+      <a class="brand" href="#top">QsoRipper <span>/ CatHub architecture note</span></a>
+      <nav class="nav" aria-label="Page sections">
+        <a href="#model">Model</a>
+        <a href="#architecture">Architecture</a>
+        <a href="#routes">Routes</a>
+        <a href="#boundaries">Boundaries</a>
+        <a href="#sources">Sources</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="hero" id="top">
+    <div class="shell">
+      <p class="label">Engineering note</p>
+      <h1>Shared control of a radio and WinKeyer</h1>
+      <p class="lede">CatHub brokers access to two stateful station devices: a transceiver controlled through computer-aided transceiver (CAT) interfaces, and a hardware WinKeyer used for CW transmission.</p>
+      <div class="answer">
+        <p><strong>The interoperability problem:</strong> established tools such as OmniRig and Hamlib's <code>rigctld</code> can each let compatible programs share a radio. Other programs require a native CAT serial port. CW applications may also expect direct access to the station's WinKeyer. These interfaces do not coordinate with one another.</p>
+        <p>CatHub becomes the sole owner of both physical devices. It presents separate, familiar interfaces to existing applications and coordinates the resulting radio operations, CW jobs, maintenance sessions, and transmit requests.</p>
+      </div>
+    </div>
+  </div>
+
+  <main id="content">
+    <section id="model" aria-labelledby="model-heading">
+      <div class="shell">
+        <div class="section-head">
+          <div><p class="label">Terms</p><h2 id="model-heading">Transport, protocol, and coordinator are different things</h2></div>
+          <p>These layers are often grouped together as a radio-control "language." Keeping them separate makes each connection path easier to trace.</p>
+        </div>
+        <div class="terms">
+          <article class="term">
+            <span class="term-tag">Transport</span>
+            <h3>How bytes move</h3>
+            <p>A physical COM port, a virtual COM pair, or a TCP socket. "Direct serial" describes this layer. It does not say which CAT commands are in the byte stream.</p>
+          </article>
+          <article class="term">
+            <span class="term-tag">Protocol</span>
+            <h3>What the bytes mean</h3>
+            <p>Examples include Kenwood TS-590 CAT, Kenwood TS-2000 CAT, Hamlib NET, and WinKeyer's stateful host protocol.</p>
+          </article>
+          <article class="term">
+            <span class="term-tag">Coordinator</span>
+            <h3>Who owns shared state</h3>
+            <p>OmniRig and rigctld coordinate compatible radio clients. CatHub coordinates mixed radio interfaces and a separate set of WinKeyer clients.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section aria-labelledby="comparison-heading">
+      <div class="shell">
+        <div class="section-head">
+          <div><p class="label">Established solutions</p><h2 id="comparison-heading">Each interface works within its own client group</h2></div>
+          <p>OmniRig and rigctld already solve multi-client radio access. Their boundary is client compatibility. Neither can directly absorb a program that only supports another interface.</p>
+        </div>
+        <div class="comparison">
+          <table>
+            <thead><tr><th>Approach</th><th>What works</th><th>Compatibility boundary</th><th>Place in a CatHub station</th></tr></thead>
+            <tbody>
+              <tr><td>OmniRig</td><td>Several programs that use the OmniRig automation API can share one configured radio.</td><td>Programs that only know Hamlib NET or native serial CAT cannot use the OmniRig API without an adapter.</td><td>OmniRig remains the coordinator for its clients. Its configured "radio" is a private CatHub serial face.</td></tr>
+              <tr><td>Hamlib <code>rigctld</code></td><td>Several Hamlib NET clients can use a common TCP radio-control protocol.</td><td>Programs that require a COM port or a vendor CAT dialect cannot connect to a rigctld socket.</td><td>Hamlib-aware programs connect to separate rigctld-compatible CatHub endpoints.</td></tr>
+              <tr><td>Direct serial CAT</td><td>A program can control a radio through a COM port using a supported vendor command set.</td><td>Windows serial ports are normally exclusive, and independent command streams cannot be merged safely.</td><td>Each serial program receives a private virtual COM pair backed by a CatHub CAT face.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section id="architecture" aria-labelledby="architecture-heading">
+      <div class="shell">
+        <div class="section-head">
+          <div><p class="label">Broker architecture</p><h2 id="architecture-heading">Two hardware brokers, one station boundary</h2></div>
+          <p>The radio and WinKeyer paths remain separate inside CatHub because they use different protocols and scheduling rules. They share station-wide transmit arbitration.</p>
+        </div>
+        <div class="legend" aria-label="Diagram legend">
+          <span class="client-key"><i></i> Application or existing interface</span>
+          <span class="hub-key"><i></i> CatHub</span>
+          <span class="hardware-key"><i></i> Physical hardware</span>
+        </div>
+        <div class="diagram" role="img" aria-label="Radio applications converge through OmniRig, Hamlib NET, and serial CAT on the CatHub radio broker, while CW applications converge through virtual WinKeyer serial and gRPC interfaces on the CatHub WinKeyer broker">
+          <div class="diagram-grid">
+            <div class="diagram-heading program-col">Programs</div><div class="diagram-heading interface-col center">Interface they use</div><div class="diagram-heading" style="grid-column:5;text-align:center">CatHub broker</div><div class="diagram-heading" style="grid-column:7;text-align:center">Hardware</div>
+
+            <div class="box client program-col radio-one"><strong>HDSDR and other OmniRig clients</strong><small>Use the OmniRig automation API.</small></div>
+            <div class="arrow-cell program-arrow radio-one" aria-hidden="true">→</div>
+            <div class="box interface interface-col radio-one"><strong>OmniRig</strong><small>Configured as a TS-2000 on its own virtual COM port.</small><span class="port">COM11</span></div>
+            <div class="arrow-cell interface-arrow radio-one" aria-hidden="true">→</div>
+
+            <div class="box client program-col radio-two"><strong>WSJT-X, JS8Call, Log4OM, QsoRipper</strong><small>Use Hamlib's NET rigctl model.</small></div>
+            <div class="arrow-cell program-arrow radio-two" aria-hidden="true">→</div>
+            <div class="box interface interface-col radio-two"><strong>Hamlib NET / rigctld protocol</strong><small>Each client connects to a CatHub TCP endpoint.</small><span class="port">127.0.0.1:4532-4535</span></div>
+            <div class="arrow-cell interface-arrow radio-two" aria-hidden="true">→</div>
+
+            <div class="box client program-col radio-three"><strong>N1MM, ARCP-590, native CAT clients</strong><small>Open a COM port as though a radio were attached.</small></div>
+            <div class="arrow-cell program-arrow radio-three" aria-hidden="true">→</div>
+            <div class="box interface interface-col radio-three"><strong>Dedicated serial CAT face</strong><small>A virtual COM pair carries an implemented CAT dialect.</small><span class="port">COM21 ⇄ COM20</span></div>
+            <div class="arrow-cell interface-arrow radio-three" aria-hidden="true">→</div>
+
+            <div class="box hub hub-core radio-hub"><span class="hub-domain">Radio control</span><strong>CatHub radio broker</strong><small>Owns the physical CAT connection.</small><ul><li>parses each client dialect</li><li>maintains shared radio state</li><li>serializes reads and writes</li><li>applies endpoint permissions</li><li>leases PTT ownership</li></ul></div>
+            <div class="arrow-cell core-arrow radio-core-arrow" aria-hidden="true">⇄</div>
+            <div class="box hardware hardware-core radio-core"><strong>Transceiver</strong><small>One physical serial or network CAT connection.</small><span class="port">TS-590 on COM4</span></div>
+
+            <div class="box client program-col keyer-one"><strong>N1MM Logger+</strong><small>Uses a WinKeyer-compatible serial port.</small></div>
+            <div class="arrow-cell program-arrow keyer-one" aria-hidden="true">→</div>
+            <div class="box interface interface-col keyer-one"><strong>Virtual WinKeyer serial face</strong><small>Unmodified WinKeyer byte protocol over a private COM pair.</small><span class="port">COM41 ⇄ COM40</span></div>
+            <div class="arrow-cell interface-arrow keyer-one" aria-hidden="true">→</div>
+
+            <div class="box client program-col keyer-two"><strong>QsoRipper CW clients</strong><small>Submit named or expanded CW work.</small></div>
+            <div class="arrow-cell program-arrow keyer-two" aria-hidden="true">→</div>
+            <div class="box interface interface-col keyer-two"><strong>Typed WinKeyer gRPC service</strong><small>Named clients submit atomic text jobs and receive status.</small><span class="port">127.0.0.1:50071</span></div>
+            <div class="arrow-cell interface-arrow keyer-two" aria-hidden="true">→</div>
+
+            <div class="box client program-col keyer-three"><strong>WKTools</strong><small>Performs keyer configuration and diagnostics.</small></div>
+            <div class="arrow-cell program-arrow keyer-three" aria-hidden="true">→</div>
+            <div class="box interface interface-col keyer-three"><strong>Maintenance serial face</strong><small>Exclusive, permission-gated access on a separate virtual pair.</small><span class="port">COM43 ⇄ COM42</span></div>
+            <div class="arrow-cell interface-arrow keyer-three" aria-hidden="true">→</div>
+
+            <div class="box hub hub-core keyer-hub"><span class="hub-domain">CW keying</span><strong>CatHub WinKeyer broker</strong><small>Owns the physical keyer session.</small><ul><li>keeps client profiles separate</li><li>queues complete CW jobs</li><li>prevents byte interleaving</li><li>fans out device status</li><li>grants exclusive maintenance</li></ul></div>
+            <div class="arrow-cell core-arrow keyer-core-arrow" aria-hidden="true">⇄</div>
+            <div class="box hardware hardware-core keyer-core"><strong>WinKeyer</strong><small>One physical 1200 baud, 8-N-2 serial connection.</small><span class="port">WinKeyer on COM3</span></div>
+          </div>
+          <p class="diagram-note">The port numbers show one station configuration. Every serial client receives a separate virtual pair. CatHub opens the hub side; the application or OmniRig opens the other side. Only CatHub opens COM4 and COM3.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="routes" aria-labelledby="routes-heading">
+      <div class="shell">
+        <div class="section-head">
+          <div><p class="label">Radio request paths</p><h2 id="routes-heading">Three interfaces, one radio actor</h2></div>
+          <p>OmniRig, Hamlib NET, and serial CAT are client-side choices. After CatHub parses a request, every allowed operation enters the same radio scheduler and shared state model.</p>
+        </div>
+        <div class="routes">
+          <article class="route"><span class="route-number">01 / OmniRig route</span><h3>Application → OmniRig → CatHub</h3><ol><li>The application calls OmniRig.</li><li>OmniRig emits the CAT dialect configured for its virtual radio.</li><li>A virtual COM pair delivers those bytes to CatHub's TS-2000 face.</li><li>CatHub maps the request to shared radio state and the physical radio.</li></ol></article>
+          <article class="route"><span class="route-number">02 / Hamlib route</span><h3>Application → CatHub TCP endpoint</h3><ol><li>The application selects Hamlib's NET rigctl model.</li><li>It sends rigctld protocol commands to a CatHub listener.</li><li>CatHub returns state in the form the client expects.</li><li>Allowed writes go through the same radio actor as every other route.</li></ol></article>
+          <article class="route"><span class="route-number">03 / Serial route</span><h3>Application → virtual COM → CatHub</h3><ol><li>The application selects a supported radio model and its assigned COM port.</li><li>The paired port delivers its CAT frames to CatHub.</li><li>CatHub parses or transparently mirrors supported commands according to the face configuration.</li><li>The physical radio still has only one owner.</li></ol></article>
+        </div>
+        <div class="subsection-head">
+          <p class="label">WinKeyer request paths</p>
+          <h2>Two operating interfaces and one maintenance path</h2>
+          <p>WinKeyer is a stateful byte protocol, not a CAT dialect. CatHub gives it a separate broker and physical-device actor.</p>
+        </div>
+        <div class="routes">
+          <article class="route"><span class="route-number">01 / Legacy serial</span><h3>N1MM → virtual WinKeyer face</h3><ol><li>N1MM opens its assigned virtual COM port.</li><li>CatHub tracks that client's Host Open state, speed, mode, and permissions.</li><li>Complete sends enter the broker queue without interleaving another client's bytes.</li><li>Physical busy, idle, speed-pot, and error status return through the virtual face.</li></ol></article>
+          <article class="route"><span class="route-number">02 / Typed service</span><h3>QsoRipper → WinKeyer gRPC</h3><ol><li>A named QsoRipper client submits text, speed, or cancellation through the loopback service.</li><li>The broker records the work as an atomic job.</li><li>The selected client profile is applied before transmission.</li><li>Completion, cancellation, and error events return as typed messages.</li></ol></article>
+          <article class="route"><span class="route-number">03 / Maintenance</span><h3>WKTools → exclusive serial face</h3><ol><li>WKTools opens its dedicated virtual COM port.</li><li>Permission-gated maintenance commands acquire exclusive access.</li><li>Private device replies return only to the maintenance client.</li><li>Normal transmission remains blocked until maintenance releases the keyer.</li></ol></article>
+        </div>
+      </div>
+    </section>
+
+    <section aria-labelledby="value-heading">
+      <div class="shell">
+        <div class="section-head">
+          <div><p class="label">Engineering effect</p><h2 id="value-heading">Brokering is more than copying bytes</h2></div>
+          <p>Both devices carry bidirectional, stateful control traffic. A safe broker must interpret operations, preserve client context, and decide who may transmit or change configuration.</p>
+        </div>
+        <div class="two-column">
+          <article class="plain-card"><h3>Radio control broker</h3><ul><li>Translates supported client dialects into one shared radio model.</li><li>Serves routine reads from current state instead of multiplying hardware polls.</li><li>Orders writes, maintains native push state, and applies per-endpoint permissions.</li><li>Provides compatibility views such as single-VFO presentation without changing the physical radio state.</li></ul></article>
+          <article class="plain-card"><h3>WinKeyer broker</h3><ul><li>Maintains one physical Host Open session and separate state for each virtual client.</li><li>Queues complete CW jobs so commands and text from different clients do not interleave.</li><li>Returns device status to clients and restores the primary operating profile between jobs.</li><li>Separates normal sending from exclusive configuration and diagnostic work.</li></ul></article>
+        </div>
+        <div class="caution"><p><strong>Shared transmit boundary:</strong> radio CAT PTT and WinKeyer transmission use one station-wide PTT lease. A transmit-time ceiling and disconnect handling return the station to receive when a client or hardware path fails.</p></div>
+      </div>
+    </section>
+
+    <section aria-labelledby="ports-heading">
+      <div class="shell">
+        <div class="section-head">
+          <div><p class="label">Serial examples</p><h2 id="ports-heading">CAT and WinKeyer clients each receive private COM pairs</h2></div>
+          <p>A com0com pair acts like a null-modem cable between two programs. It connects one application endpoint to one CatHub endpoint; it does not make a single COM port shareable.</p>
+        </div>
+        <p class="flow-heading">OmniRig radio-control path</p>
+        <div class="connection-flow" aria-label="OmniRig COM11 connects through a virtual pair to CatHub COM10, which controls the radio on COM4">
+          <div class="node app"><strong>OmniRig</strong><small>Opens application side</small><span class="mono">COM11</span></div>
+          <span class="flow-arrow" aria-hidden="true">⇄</span>
+          <div class="node"><strong>com0com pair</strong><small>Bytes written at one end appear at the other.</small></div>
+          <span class="flow-arrow" aria-hidden="true">⇄</span>
+          <div class="node hub"><strong>CatHub serial face</strong><small>Opens hub side</small><span class="mono">COM10</span></div>
+          <span class="flow-arrow" aria-hidden="true">⇄</span>
+          <div class="node hardware"><strong>Physical radio</strong><small>Opened only by CatHub</small><span class="mono">COM4</span></div>
+        </div>
+        <p class="flow-heading">N1MM WinKeyer path</p>
+        <div class="connection-flow" aria-label="N1MM COM41 connects through a virtual pair to the CatHub WinKeyer face on COM40, which controls the physical WinKeyer on COM3">
+          <div class="node app"><strong>N1MM Logger+</strong><small>Opens application side</small><span class="mono">COM41</span></div>
+          <span class="flow-arrow" aria-hidden="true">⇄</span>
+          <div class="node"><strong>com0com pair</strong><small>Carries WinKeyer's 1200 baud, 8-N-2 byte protocol.</small></div>
+          <span class="flow-arrow" aria-hidden="true">⇄</span>
+          <div class="node hub"><strong>CatHub WinKeyer face</strong><small>Opens hub side</small><span class="mono">COM40</span></div>
+          <span class="flow-arrow" aria-hidden="true">⇄</span>
+          <div class="node hardware"><strong>Physical WinKeyer</strong><small>Opened only by CatHub</small><span class="mono">COM3</span></div>
+        </div>
+        <div class="caution"><p>The application side and hub side are not interchangeable. In these examples, OmniRig opens COM11 and CatHub opens COM10; N1MM opens COM41 and CatHub opens COM40. Only CatHub opens the physical device ports, COM4 and COM3.</p></div>
+      </div>
+    </section>
+
+    <section id="boundaries" aria-labelledby="boundaries-heading">
+      <div class="shell">
+        <div class="section-head">
+          <div><p class="label">Current implementation</p><h2 id="boundaries-heading">Supported interfaces and limits</h2></div>
+          <p>The architecture is general, but the present CatHub implementation has explicit backends and dialects.</p>
+        </div>
+        <ul class="implementation-list">
+          <li><strong>Radio backends:</strong> the current configuration accepts native TS-590 control, an upstream rigctld backend, or a loopback test backend.</li>
+          <li><strong>Serial faces:</strong> the current implementation exposes TS-590, transparent TS-590, and TS-2000 client dialects.</li>
+          <li><strong>Network faces:</strong> CatHub exposes rigctld-compatible Hamlib NET endpoints, including per-endpoint permissions and compatibility policy.</li>
+          <li><strong>OmniRig:</strong> CatHub does not replace OmniRig for programs that use its automation API. OmniRig becomes one CatHub client through a virtual serial face.</li>
+          <li><strong>Direct serial:</strong> this means a program sends a supported CAT dialect over its own virtual pair. It does not mean every arbitrary serial protocol is accepted.</li>
+          <li><strong>Physical WinKeyer:</strong> CatHub maintains the single hardware session at 1200 baud and enforces a separate transmit-time ceiling.</li>
+          <li><strong>Virtual WinKeyer faces:</strong> unmodified serial clients receive private 8-N-2 COM pairs with explicit status, send, control, PTT, and configuration permissions.</li>
+          <li><strong>Typed WinKeyer service:</strong> QsoRipper clients use a loopback gRPC API for status, text jobs, speed, cancellation, abort, and event streaming.</li>
+          <li><strong>Maintenance:</strong> configuration tools use an exclusive face whose private replies are not broadcast to ordinary clients.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section id="sources" aria-labelledby="sources-heading">
+      <div class="shell">
+        <div class="section-head">
+          <div><p class="label">Verification</p><h2 id="sources-heading">Technical basis</h2></div>
+          <p>This architecture note is based on the current implementation and primary documentation for the interfaces CatHub composes.</p>
+        </div>
+        <ol class="sources">
+          <li><a href="https://github.com/treitforge/qsoripper/blob/main/docs/architecture/engine-specification.md">QsoRipper engine specification</a>, especially the CAT hub behavior, endpoint, dialect, state, and PTT sections.</li>
+          <li><a href="https://github.com/treitforge/qsoripper/blob/main/docs/design/cathub-multi-client-cat-hub.md">Multi-client CAT hub design</a> and <a href="https://github.com/treitforge/qsoripper/blob/main/docs/design/cathub-winkeyer-broker.md">multi-client WinKeyer broker design</a>, which define the two physical-device actors, client-facing interfaces, scheduling, and shared transmit boundary.</li>
+          <li><a href="https://www.dxatlas.com/OmniRig/">OmniRig product documentation</a>, which describes its COM component and support for several programs controlling one radio.</li>
+          <li><a href="https://hamlib.sourceforge.net/html/rigctld.1.html">Hamlib rigctld manual</a>, which defines the TCP daemon and notes its multiple-program sharing behavior and compatibility qualifications.</li>
+          <li><a href="https://learn.microsoft.com/en-us/windows/win32/devio/communications-resource-handles">Microsoft: Communications Resource Handles</a>, which documents exclusive opening of Windows communications resources.</li>
+          <li><a href="https://com0com.sourceforge.net/">com0com project documentation</a>, which defines a virtual COM pair and its bidirectional byte flow.</li>
+          <li>Implementation files: <a href="https://github.com/treitforge/qsoripper/blob/main/src/rust/qsoripper-cathub/src/serial_face.rs"><code>serial_face.rs</code></a>, <a href="https://github.com/treitforge/qsoripper/blob/main/src/rust/qsoripper-cathub/src/hamlib_net.rs"><code>hamlib_net.rs</code></a>, the radio <a href="https://github.com/treitforge/qsoripper/tree/main/src/rust/qsoripper-cathub/src/dialect"><code>dialect</code> modules</a>, and the <a href="https://github.com/treitforge/qsoripper/tree/main/src/rust/qsoripper-cathub/src/winkeyer"><code>winkeyer</code> broker modules</a>.</li>
+        </ol>
+      </div>
+    </section>
+  </main>
+
+  <footer><div class="shell">QsoRipper CatHub architecture note. Examples describe the current TS-590 station configuration.</div></footer>
+</body>
+</html>


### PR DESCRIPTION
Adds the standalone CatHub architecture report under docs/architecture/cathub.

The report explains how established OmniRig, Hamlib NET, and native serial CAT clients share one radio through CatHub, and how CatHub separately brokers WinKeyer serial, typed gRPC, and maintenance clients. It documents transport and protocol boundaries, physical and virtual COM ownership, scheduling, permissions, PTT arbitration, implementation limits, and primary technical sources.

This checks the previously untracked report into the QsoRipper repository so its canonical content and source history live with the implementation it describes.

Validation covered all internal anchors, portable HTTPS links, repository style rules, staged whitespace checks, and HTTP 200 responses from all eleven external technical references.
