### PR TITLE
Fix QRZ remote delete request parameter

### DIFF
--- a/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzLogbookClientTests.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook.Tests/QrzLogbookClientTests.cs
@@ -285,7 +285,7 @@ public sealed class QrzLogbookClientTests
     // -- DELETE --------------------------------------------------------------
 
     [Fact]
-    public async Task Delete_sends_action_delete_with_logid()
+    public async Task Delete_sends_action_delete_with_logids()
     {
         var (client, handler) = CreateClient("RESULT=OK");
 
@@ -295,7 +295,8 @@ public sealed class QrzLogbookClientTests
         }
 
         Assert.Contains("ACTION=DELETE", handler.CapturedBody);
-        Assert.Contains("LOGID=123456", handler.CapturedBody);
+        Assert.Contains("LOGIDS=123456", handler.CapturedBody);
+        Assert.DoesNotContain("LOGID=123456", handler.CapturedBody);
     }
 
     [Fact]

--- a/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
+++ b/src/dotnet/QsoRipper.Engine.QrzLogbook/QrzLogbookClient.cs
@@ -230,7 +230,7 @@ public sealed class QrzLogbookClient : IQrzLogbookApi, IDisposable
         {
             new("ACTION", "DELETE"),
             new("KEY", _apiKey),
-            new("LOGID", logid),
+            new("LOGIDS", logid),
         };
 
         string body;

--- a/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
+++ b/src/rust/qsoripper-core/src/qrz_logbook/mod.rs
@@ -788,7 +788,7 @@ impl QrzLogbookClient {
     /// next sync just clears the local pending flag instead of looping forever.
     pub async fn delete_qso(&self, logid: &str) -> Result<(), QrzLogbookError> {
         let body = self
-            .post_form(&[("ACTION", "DELETE"), ("LOGID", logid)])
+            .post_form(&[("ACTION", "DELETE"), ("LOGIDS", logid)])
             .await?;
         let map = parse_kv_response(&body);
         match check_result(map) {
@@ -1774,7 +1774,8 @@ mod tests {
 
         let reqs = requests.lock().expect("requests");
         assert!(reqs[0].contains("ACTION=DELETE"));
-        assert!(reqs[0].contains("LOGID=123456"));
+        assert!(reqs[0].contains("LOGIDS=123456"));
+        assert!(!reqs[0].contains("LOGID=123456"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
QsoRipper sent QRZ DELETE requests with the singular LOGID parameter, but the QRZ Logbook API requires LOGIDS even when deleting one QSO. QRZ rejected every queued remote deletion with “No LOGIDS parameter,” leaving the local tombstone pending and the remote QSO intact.

This change updates both the Rust and .NET QRZ Logbook clients to send LOGIDS. The client regression tests now assert the plural parameter and explicitly reject the singular request form.

Validated with the full repository pre-push gates: `.\build.ps1 check-rust` and `.\build.ps1 check-dotnet`. Rust line coverage is 83.46%, .NET line coverage is 53.6%, and all formatting, lint, test, protobuf, dependency, and vulnerability checks passed.

Closes #547