### PR TITLE
Apply STE documentation guidance and improve CatHub discovery

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,5 +1,11 @@
 # GitHub Copilot Instructions
 
+## Documentation and reports
+
+Follow `.github/instructions/documentation.instructions.md` for
+documentation, reports, plans, reviews, issue text, pull request text, and
+release notes.
+
 Use the root `AGENTS.md` file as the canonical repository guidance for
 QsoRipper.
 

--- a/.github/instructions/documentation.instructions.md
+++ b/.github/instructions/documentation.instructions.md
@@ -1,0 +1,11 @@
+---
+applyTo: "**/*.md,**/*.txt,**/*.rst,**/*.adoc,**/*.html,**/*.htm"
+---
+
+# Documentation and reports
+
+Follow the `Documentation and Reports` section in the root `AGENTS.md` file.
+That section is the canonical repository rule for documentation and reports.
+
+Use `docs/documentation-style.md` for the full review checklist and the
+controlled project terms.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,31 @@ Primary goals:
   sentences.
 - Keep comments focused on why something exists, not what each line does.
 
+## Documentation and Reports
+
+- Use ASD-STE100 Simplified Technical English, Issue 9, for all
+  documentation and reports unless the user requests a different style.
+- This rule applies to new text and to text that you change.
+- Use approved words only with their approved meanings and parts of speech.
+- Use established project terms as technical nouns or technical verbs. Use
+  each term consistently.
+- Use American English spelling.
+- Keep a multi-word noun to three words or fewer.
+- Use only the verb forms that Issue 9 permits.
+- Use active voice when the agent is known.
+- Do not use contractions, Latin abbreviations, or semicolons.
+- Put only one instruction in each sentence unless actions occur at the same
+  time.
+- Use no more than 20 words in a procedural sentence.
+- Use no more than 25 words in a descriptive sentence.
+- Use no more than six sentences in one paragraph.
+- Keep code, identifiers, commands, paths, protocol fields, quoted text, and
+  legal text exact.
+- Do not claim STE conformance unless you checked the text against the Issue 9
+  rules and dictionary.
+- Reference:
+  [ASD-STE100 Issue 9](https://www.asd-ste100.org/assets/files/ASD-STE100_ISSUE9.pdf).
+
 ## Development Environment
 
 - This repo is normally worked on from Windows.
@@ -102,7 +127,8 @@ Local Win32 CMake validation uses Visual Studio Build Tools 2026
 ## Architecture Direction
 
 - Keep the log engine independent from any specific UI.
-- The engine exposes a gRPC API; UX implementations are independent consumers.
+- The engine exposes a gRPC API.
+- UX implementations are independent consumers.
 - No specific UI technology is required or privileged.
 - Keep third-party integrations isolated behind interfaces.
 - Make offline logging resilient, even when network integrations fail.
@@ -135,8 +161,8 @@ Local Win32 CMake validation uses Visual Studio Build Tools 2026
   incompatible schema changes.
 - ADIF is for external interchange, such as QRZ API and file I/O, only.
   Internal IPC uses protobuf.
-- Keep shared proto messages discoverable in the Debug Host Protobuf Lab; prefer
-  auto-discovered message catalogs over hand-maintained UI enums or lists.
+- Keep shared proto messages discoverable in the Debug Host Protobuf Lab.
+- Prefer auto-discovered message catalogs over hand-maintained UI enums or lists.
 - In .NET UI and DebugHost surfaces, do not hand-format generated proto enum
   names with `ToString()` and string replacement. Use shared display helpers
   such as `src\dotnet\QsoRipper.DebugHost\Utilities\ProtoEnumDisplay.cs` so
@@ -239,9 +265,9 @@ issue bodies, review comments, or other repository comments:
   autocomplete behavior.
 - Squash is the only allowed merge method on `main`. Always pass `--squash` to
   `gh pr merge`.
-- Do not click or invoke "Update branch" on PRs. Branch protection no longer
-  requires PRs to be up to date with `main` before merging; the merge queue
-  handles speculative-merge testing automatically.
+- Do not click or invoke "Update branch" on PRs.
+- Branch protection does not require PRs to be current with `main`.
+- The merge queue handles speculative-merge testing automatically.
 - When a PR implements only part of a GitHub issue, do not reference the parent
   issue with a closing keyword such as `Closes`, `Fixes`, or `Resolves`.
   Instead, create a sub-issue scoped to the work in the PR, reference that

--- a/EXPERIMENT_REPORT.md
+++ b/EXPERIMENT_REPORT.md
@@ -5,23 +5,32 @@
 **Source corpus:** `C:\Users\randy\Git\qsoripper-experiments\arrl-corpus-fast\data\cw-samples\arrl-archive` (1,576 chunks, 17.84 h, median CER 1.6 %)
 **Decoder:** `C:\Users\randy\Git\qsoripper-experiments\viterbi\experiments\cw-decoder\target\release\cw-decoder.exe`
 
-## TL;DR
+## TL.DR
 
-The pristine ARRL Code Practice corpus is too clean to train against — it
-collapses adaptive σ floors and pulls decision boundaries inward, regressing
-real OTA performance. This experiment delivers a deterministic, parametric
-augmentation pipeline that can synthesize ~30× variants per chunk under
-realistic HF-channel conditions: Watterson 2-tap (ITU-R F.1487 profiles), QSB,
-QRM, AGC pumping, rough-fist timing jitter, pitch shift / drift, VFO chirp,
-pink noise, and impulses.
+The original ARRL Code Practice corpus is too clean for training.
+It collapses adaptive σ floors and moves decision boundaries inward.
+These changes reduce real OTA performance.
+This experiment supplies a repeatable augmentation pipeline.
+The pipeline can make approximately 30 variants for each chunk.
+It applies realistic HF-channel conditions:
+
+- Watterson 2-tap profiles from ITU-R F.1487
+- QSB and QRM
+- AGC pumping
+- Rough-fist timing jitter
+- Pitch shift and drift
+- VFO chirp
+- Pink noise and impulses
 
 A **6,000-variant validation render** (200 chunks × 30 variants, ~107 h
-audio) is included as a reproducible representative sample. The full
-**47,280-variant** render (1,576 × 30) is supported by `augment_arrl.run` but
-deferred to a follow-up bulk job — measured throughput on the 36-core dev
-machine is ~3.6 v/s, so the full render takes ≈ 220 min. Storage is
-~50 GB at 8 kHz / 16-bit, which we keep gitignored under
-`data/cw-samples/arrl-augmented/`.
+audio) is a repeatable representative sample.
+`augment_arrl.run` supports the full **47,280-variant** render.
+A later bulk job will create this render.
+The measured rate on the 36-core development machine is approximately 3.6 variants each second.
+Thus, the full render takes approximately 220 minutes.
+
+The 8 kHz, 16-bit output uses approximately 50 GB.
+Git ignores output below `data/cw-samples/arrl-augmented/`.
 
 ## Deliverables
 
@@ -57,7 +66,7 @@ real audio
     ▼  + AWGN at chosen SNR
     ▼  + pink (1/f) noise
     ▼  + Poisson impulses
-    ▼  + birdies (CW carriers ±50–200 Hz)
+    ▼  + birdies (CW carriers ±50-200 Hz)
     ▼  AGC pump (one-pole attack/release)
     ▼  peak normalize
 output.wav
@@ -76,26 +85,26 @@ that side-input is reproducible.
 
 ## Impairment-by-impairment validation
 
-All 15 impairments from the spec are implemented and exercised:
+The generator implements all 15 specified impairments. The tests exercise each impairment:
 
 | # | Impairment | Implementation | Coverage in 6 k sample |
 |---|---|---|---:|
-| 1 | WPM scale | `wpm_scale_map` (linear time-warp, 0.7–1.5×) | 100.0 % |
-| 2 | Farnsworth ratio | `farnsworth_stretch_map` (gap-only stretch, 1.2–3.0×) | 19.9 % |
+| 1 | WPM scale | `wpm_scale_map` (linear time-warp, 0.7-1.5×) | 100.0 % |
+| 2 | Farnsworth ratio | `farnsworth_stretch_map` (gap-only stretch, 1.2-3.0×) | 19.9 % |
 | 3 | WPM drift | `wpm_drift_map` (∫1/(1+ε·sin) dt, ε≤0.10, f∈[0.01,0.1] Hz) | 100.0 % |
 | 4 | Per-element jitter | `per_element_jitter_map` (LogNormal σ ∈ {0.05, 0.10, 0.20}) | 100.0 % |
 | 5 | Pitch shift | `from_baseband` (carrier ±50 Hz) | 100.0 % |
 | 6 | Pitch drift | `pitch_drift_curve` (linear ±20 Hz/min) | 30.4 % |
-| 7 | VFO chirp | `vfo_chirp_curve` (decaying ±5–10 Hz at each rising edge) | 30.7 % |
+| 7 | VFO chirp | `vfo_chirp_curve` (decaying ±5-10 Hz at each rising edge) | 30.7 % |
 | 8 | **Watterson 2-tap** | `watterson_channel` (Jakes sum-of-sinusoids, ITU-R F.1487 profiles `good`/`moderate`/`poor`) | 64.9 % |
 | 9 | QSB (slow fade) | `qsb_envelope` (1−d/2 + d/2·cos, f∈[0.1,2] Hz) | 56.0 % |
 | 10 | AWGN | `add_awgn` (SNR ∈ {0,5,10,15,20,30} dB) | 100.0 % |
 | 11 | Pink noise | `add_pink_noise` (FFT 1/√f shaping) | 45.9 % |
-| 12 | Atmospheric impulses | `add_impulses` (Poisson 0.5–3 Hz, exponential decay) | 1.0 % |
+| 12 | Atmospheric impulses | `add_impulses` (Poisson 0.5-3 Hz, exponential decay) | 1.0 % |
 | 13 | QRM (interfering CW) | `add_qrm` (partner chunk @ Δpitch ∈ [-100,100] Hz, S/QRM ∈ [-6,6] dB) | 29.8 % |
-| 14 | Receiver birdies | `add_birdies` (1–2 carriers at ±50–200 Hz) | 5.2 % |
+| 14 | Receiver birdies | `add_birdies` (1-2 carriers at ±50-200 Hz) | 5.2 % |
 | 15 | AGC pumping | `agc_pump` (one-pole attack 10 ms / release 200 ms) | 9.5 % |
-| 16 | Mixed degradations | Each variant samples 5–10 of the above (always-on + Bernoulli draw) | 5–10 per variant |
+| 16 | Mixed degradations | Each variant samples 5-10 of the above (always-on + Bernoulli draw) | 5-10 per variant |
 
 ### Watterson model notes
 
@@ -112,17 +121,18 @@ power. Profiles match ITU-R F.1487 / CCIR:
 | moderate | 1.0 | 0.5 |
 | poor | 2.0 | 1.0 |
 
-**Performance trick:** the tap process is band-limited to f_d ≤ 1 Hz, so we
-synthesize `h(t)` at 50 Hz internally and linearly interpolate up to 8 kHz.
-Cost drops from ~1 s per tap to <5 ms per tap with no loss of fidelity at
-audio bandwidths.
+**Performance optimization:** The tap process is band-limited to f_d ≤ 1 Hz.
+Thus, the pipeline makes `h(t)` at 50 Hz.
+It uses linear interpolation to increase the rate to 8 kHz.
+The processing time decreases from approximately one second to less than 5 ms for each tap.
+This change does not decrease fidelity at audio bandwidths.
 
 ## CER-vs-SNR validation
 
-98 random variants decoded with `cw-decoder.exe stream-region --no-realtime`
-(2 hit the 90 s timeout because Farnsworth × WPM-scale 1.5 stretched the
-clip past the cutoff — these are real edge cases the augmenter is meant to
-produce).
+The decoder processed 98 random variants with `cw-decoder.exe stream-region --no-realtime`.
+Two variants reached the 90-second limit.
+Farnsworth timing and a 1.5 WPM scale extended these clips beyond the cutoff.
+The augmenter must produce these valid edge conditions.
 
 ![CER vs SNR](experiments/cw-decoder/scripts/augment_cer_vs_snr.png)
 
@@ -131,16 +141,18 @@ Stratified medians (n=98 total):
 | condition | n | SNR ↗ behaviour |
 |---|---:|---|
 | noise-only (Watterson off, no QRM) | 24 | CER **drops** monotonically from ~0.27 (5 dB) to ~0.12 (10 dB clean), as expected |
-| Watterson channel applied | 33 | CER stays in 0.4–0.7 even at high SNR — channel-limited, not noise-limited |
-| QRM applied | 22 | CER plateaus near 0.5 — interference dominates |
-| all variants (random mix) | 98 | non-monotonic; the 30 dB bin happens to draw more Watterson-poor + QRM samples in this n=98 sample |
+| Watterson channel applied | 33 | CER stays in 0.4-0.7 even at high SNR - channel-limited, not noise-limited |
+| QRM applied | 22 | CER plateaus near 0.5 - interference dominates |
+| all variants (random mix) | 98 | non-monotonic. The 30 dB bin happens to draw more Watterson-poor + QRM samples in this n=98 sample |
 
-Take-away: **CER is monotonic in SNR for noise-only variants** (the spec's
-acceptance criterion), but the augmented corpus is intentionally designed
-so most variants are channel/QRM-limited rather than noise-limited. That's
-the entire point — the ARRL baseline already achieves CER 1.6 % at infinite
-SNR, so adding only noise wouldn't broaden the training distribution
-enough to fix the σ-collapse problem.
+**Result:** CER changes monotonically with SNR for noise-only variants.
+This result meets the specification acceptance criterion.
+The channel or QRM limits most augmented variants.
+They are not limited only by noise.
+The ARRL baseline already has a 1.6 percent CER at infinite SNR.
+
+Thus, noise alone does not make the training distribution sufficiently broad.
+The other impairments are necessary to correct the σ-collapse problem.
 
 ## Distribution match vs real OTA
 
@@ -152,15 +164,16 @@ the path documented in `bench.py`) on every measured axis:
 
 | metric | real OTA median | augmented median | real range | augmented range | bracketed? |
 |---|---:|---:|---|---|---|
-| element duration | 91 ms | 66 ms | [47, 247] ms | [4, 1256] ms | ✅ |
-| inter-element gap | 250 ms | 350 ms | [41, 6190] ms | [3, 44184] ms | ✅ |
-| dominant pitch | 750 Hz | 747 Hz | [573, 767] Hz | [504, 887] Hz | ✅ |
-| in-band/off-band SNR estimate | 107 dB | 10 dB | [51, 109] dB | [2, 28] dB | ✅ (intentionally harder) |
+| element duration | 91 ms | 66 ms | [47, 247] ms | [4, 1256] ms | Yes |
+| inter-element gap | 250 ms | 350 ms | [41, 6190] ms | [3, 44184] ms | Yes |
+| dominant pitch | 750 Hz | 747 Hz | [573, 767] Hz | [504, 887] Hz | Yes |
+| in-band/off-band SNR estimate | 107 dB | 10 dB | [51, 109] dB | [2, 28] dB | Yes (intentionally harder) |
 
-The element/gap distributions for augmented samples include long tails
-beyond the OTA — those come from Farnsworth stretches and from chunks where
-WPM-scaling × Farnsworth pushes envelope features into seconds-long
-regions. Downstream consumers can filter these out with
+The element and gap distributions include long tails beyond the OTA data.
+Farnsworth timing causes some of these tails.
+Combined WPM scaling and Farnsworth timing cause the other tails.
+They can extend envelope features for several seconds.
+Downstream consumers can filter them with
 `row["params"]["farnsworth_ratio"] is None` if they want a tighter timing
 distribution.
 
@@ -280,24 +293,21 @@ print(hashlib.sha256(open("v.wav","rb").read()).hexdigest())
 
 ## Known limitations
 
-1. **Source WPM is an estimate**: the per-element jitter sigma uses a
-   nominal 60 ms dit length (i.e. ~20 wpm) regardless of the source
-   chunk's actual speed. For 30 wpm chunks the absolute jitter is too
-   large; for 15 wpm it's too small. Acceptable for the
-   `(LogNormal σ_rel × dit)` interpretation but worth tightening if a
-   future trainer needs precise rough-fist statistics.
+1. **Source WPM is an estimate.** The element jitter sigma uses a nominal 60 ms dit length for each source speed.
+   This value is approximately 20 WPM. Thus, 30 WPM chunks have excessive jitter.
+   The 15 WPM chunks have insufficient jitter. The value is acceptable for the `(LogNormal σ_rel × dit)` interpretation.
+   A future trainer can use a more exact value.
 2. **Watterson sum-of-sinusoids is sub-Nyquist for f_d=0.1 Hz at
-   coarse_sr=50 Hz** — fine in practice (still accurate Doppler
-   PSD shape) but not a strict-Watterson implementation. The
-   `pyhfchannel` / `gr-fcdproplus` LP-FIR variant would be more
-   academically pure; we picked Jakes for speed.
-3. **Farnsworth applies on the audio envelope rather than at synthesis
-   time.** Real Farnsworth stretches inter-character gaps proportional
-   to the WPM ratio — we approximate by stretching every detected gap
-   by the same factor. Visible in the long-tail gap distribution.
-4. **Validation render covers 200 of 1,576 chunks.** All 4 WPM buckets
-   are represented (the source manifest is sorted by date, not WPM, so
-   the first 200 chunks span all of 15/20/25/30 WPM proportionally).
+   coarse_sr=50 Hz.** It gives an accurate Doppler PSD shape, but it is not a strict Watterson implementation.
+   The `pyhfchannel` or `gr-fcdproplus` LP-FIR variant is more exact.
+   We selected Jakes for speed.
+3. **Farnsworth applies to the audio envelope, not during synthesis.**
+   Real Farnsworth changes character gaps in proportion to the WPM ratio.
+   This experiment changes each detected gap by the same factor. The gap distribution shows this difference.
+4. **Validation render covers 200 of 1,576 chunks.**
+   The validation set contains all four WPM groups.
+   The source manifest sorts chunks by date, not by WPM.
+   Thus, the first 200 chunks contain proportional samples at 15, 20, 25, and 30 WPM.
    Full corpus render is a single command:
    `py -m augment_arrl.run --workers 24` (≈ 4 h wall, ~50 GB disk).
 
@@ -315,9 +325,9 @@ print(hashlib.sha256(open("v.wav","rb").read()).hexdigest())
 - **Total augmented audio generated:** 106.95 h (validation render of 6 k variants)
 - **Full-corpus projection:** ~535 h (47,280 variants)
 - **Wall time (validation):** 27.6 min render + 36 min eval ≈ 64 min total
-- **Distribution-match assessment:** ✅ — augmented corpus brackets the
-  real-OTA distribution on element duration, gap, pitch, and SNR; channel
+- **Distribution-match assessment:** Pass. The augmented corpus includes the
+  real-OTA distribution on element duration, gap, pitch, and SNR. Channel
   conditions go strictly beyond the real bench (which is ARRL-clean).
-- **Pipeline ready for training jobs:** yes — the on-demand renderer
+- **Pipeline ready for training jobs:** yes - the on-demand renderer
   (`render_on_demand.py`) means downstream trainers can stream variants
   without paying the 50 GB storage cost.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ High-performance ham radio logging platform built around shared gRPC/protobuf co
 
 ## Architecture
 
-QsoRipper is a **gRPC/protobuf-first** project. The stable core is the contract in `proto/`, not any single process implementation. An engine host implements those services. A client consumes them. Because both sides meet at the same protobuf/gRPC seam, engines and clients can be mixed and matched across languages without changing the contract.
+QsoRipper is a **gRPC/protobuf-first** project. The contract in `proto/` is the stable core. An engine host implements the services. A client uses them. Projects can combine engines and clients from different languages without a contract change.
 
 ```
 ┌─────────────────────────────────────────────┐
@@ -46,12 +46,15 @@ No engine host or client is privileged. The protobuf/gRPC contract is the only s
 
 ### Protocol Buffers
 
-Proto files under `proto/` are the **single source of truth** for all shared types (`QsoRecord`, `CallsignRecord`, `LookupResult`, bands, modes, etc.). Code can be generated for any consuming language -- zero hand-duplicated types:
+Proto files under `proto/` are the **single source of truth** for all shared types. Tools can generate code for any client language:
 
 - **Rust** (engine): `prost` + `tonic-build` generate structs and gRPC server stubs
-- **Any client language**: standard protobuf/gRPC tooling generates client stubs (e.g., `Grpc.Tools` for C#, `protoc-gen-go` for Go, `grpc-web` for browsers)
+- **Any client language**: standard protobuf/gRPC tooling generates client stubs (for example, `Grpc.Tools` for C#, `protoc-gen-go` for Go, `grpc-web` for browsers)
 - **Schema quality**: `buf lint` and `buf breaking` enforce conventions and backward compatibility
-- **Contract shape**: protobuf 1-1-1 is the default — one top-level entity per file, service files that contain only the `service`, and unique `XxxRequest` / `XxxResponse` envelopes for every RPC
+- **Contract shape**: Protobuf 1-1-1 is the default.
+  Each file has one top-level entity.
+  A service file contains only the `service`.
+  Each RPC has unique `XxxRequest` and `XxxResponse` envelopes.
 
 ### gRPC Services
 
@@ -65,13 +68,15 @@ Proto files under `proto/` are the **single source of truth** for all shared typ
 | **DeveloperControlService** | Developer-only runtime config inspection and mutation |
 | **SpaceWeatherService** | Current NOAA SWPC snapshot reads and explicit refresh for engine clients |
 
-The built-in engine hosts advertise fine-grained lookup capabilities (`lookup-callsign`, `lookup-stream`, `lookup-cache`) so discovery matches the actually implemented surface. `BatchLookup` and DXCC lookup by code are implemented in both Rust and .NET hosts; DXCC lookup by prefix still returns `UNIMPLEMENTED`.
+The built-in engine hosts advertise detailed lookup capabilities. Thus, discovery matches the implemented surface. Both Rust and .NET implement `BatchLookup` and DXCC code lookup. DXCC prefix lookup returns `UNIMPLEMENTED`.
 
-**Building a client or a new engine host?** See the [Engine API Documentation](docs/api/README.md) for the shared contract reference, stub generation guidance, transport notes, and implementation-status details.
+**Building a client or a new engine host?**
+See the [Engine API Documentation](docs/api/README.md).
+It gives contract, stub generation, transport, and implementation information.
 
 ### ADIF
 
-ADIF (Amateur Data Interchange Format) is used **only at the edges** -- QRZ API calls and file I/O. Internal communication always uses protobuf. Engine-specific ADIF adapters convert to/from proto types at the boundary, with an `extra_fields` map for lossless round-tripping.
+QsoRipper uses ADIF **only at the edges** for QRZ API calls and file I/O. Internal communication uses protobuf. Engine ADIF adapters convert boundary data. The `extra_fields` map keeps unrecognized data.
 
 ## Getting Started
 
@@ -109,7 +114,7 @@ winget install OpenJS.NodeJS.LTS
 sudo apt install nodejs npm
 ```
 
-Node 22 LTS is the safest default for local UI automation work. A newer globally installed Node is fine as long as `npm` is available; `capture-tui.ps1` bootstraps its own repo-local Node 22 runtime for Terminalizer.
+Node 22 LTS is the safest default for local UI automation work. A newer globally installed Node is fine as long as `npm` is available. `capture-tui.ps1` bootstraps its own repo-local Node 22 runtime for Terminalizer.
 
 **PowerShell 7** -- required for the repo automation scripts under `scripts/`, including Avalonia and terminal capture:
 
@@ -131,7 +136,7 @@ sudo apt install protobuf-compiler
 sudo dnf install protobuf-compiler
 ```
 
-**C compiler** -- required for the native FFI libraries under `src/c/`. On Windows, install the "Desktop development with C++" workload in Visual Studio or the [Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). On Linux, `gcc` or `clang` is typically already available; install with `sudo apt install build-essential` if needed. The `cc` crate finds the compiler automatically on both platforms.
+**C compiler** -- required for the native FFI libraries under `src/c/`. On Windows, install the "Desktop development with C++" workload in Visual Studio or the [Build Tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/). On Linux, `gcc` or `clang` is typically already available. Install with `sudo apt install build-essential` if needed. The `cc` crate finds the compiler automatically on both platforms.
 
 **buf** (optional) -- for linting and breaking change detection on proto files:
 
@@ -172,7 +177,7 @@ If `cppcheck` is not installed, `.\build.ps1` still builds the Win32 app and ski
 
 By default, `.\build.ps1` builds the Rust workspace in **Release**, publishes the Native AOT CLI to `artifacts\publish\qsoripper-cli\Release\`, and publishes the desktop GUI to `artifacts\publish\qsoripper-gui\Release\`. Use `-Configuration Debug` to switch the Rust build and both .NET publish outputs to `Debug`.
 
-Use `.\test.ps1` to run the Rust, .NET, Win32 CTest, and Pester suites without the heavier formatting, coverage, and vulnerability gates from `.\build.ps1 check`. Use `.\build-and-test.ps1` when you want to build first and then run the full test script. Local Win32 CMake tests use Visual Studio Build Tools 2026 (`Visual Studio 18 2026`).
+Use `.\test.ps1` to run the Rust, .NET, Win32 CTest, and Pester suites. This command does not run the additional gates from `.\build.ps1 check`. Use `.\build-and-test.ps1` when you want to build first and then run the full test script. Local Win32 CMake tests use Visual Studio Build Tools 2026 (`Visual Studio 18 2026`).
 
 For engine-neutral local validation, use the split checks plus the shared conformance harness:
 
@@ -213,7 +218,7 @@ npx playwright install chromium
 - `npm install` restores the root TypeScript and Playwright tooling used by `scripts\capture-web.ts` and `scripts\capture-web-diff.ts`.
 - The same repo-local Node toolchain now also drives `scripts\drive-tui.ts`, browser-rendered terminal snapshots, and the sample terminal fixture used for TUI automation smoke coverage.
 - `npx playwright install chromium` installs the browser binary used for web captures.
-- `scripts\capture-tui.ps1` is currently **Windows-only**. It does **not** require a global Terminalizer install; on first run it bootstraps a repo-local Node 22 + Terminalizer runtime under `tools\terminalizer-bootstrap\` and `tools\terminalizer-runtime\`.
+- `scripts\capture-tui.ps1` is currently **Windows-only**. It does **not** require a global Terminalizer install. On first run it bootstraps a repo-local Node 22 + Terminalizer runtime under `tools\terminalizer-bootstrap\` and `tools\terminalizer-runtime\`.
 - `scripts\drive-avalonia.ps1` is **Windows-only** and needs an interactive desktop session because it uses Windows UI Automation APIs. It does not require WinAppDriver.
 
 Common entry points:
@@ -236,7 +241,7 @@ npm run ux:drive:tui -- --action-script .\scripts\automation\tui-sample-smoke.js
 .\scripts\capture-tui.ps1 -Scenario cli-help
 ```
 
-Artifacts are written under `artifacts\ux\current\`, `artifacts\ux\baseline\`, and `artifacts\ux\diff\`.
+The tools write artifacts under `artifacts\ux\current\`, `artifacts\ux\baseline\`, and `artifacts\ux\diff\`.
 
 For the full dependency matrix and per-lane setup notes, see `docs\development\ui-inspection.md`.
 
@@ -253,7 +258,18 @@ cd src\rust
 cargo run -p qsoripper-launcher --release
 ```
 
-`qsoripper-launcher` is a fast-starting ratatui app that lists available engines (Rust on 50051, .NET on 50052) and UIs (Avalonia GUI, DebugHost, CW Scope, Rust TUI), and lets you toggle which to start with `Space`, bind each UI to a specific engine in the third column, and `Enter` to launch. `S` stops launcher-managed processes. Selections persist under `[launcher]` in `config.toml`. The launcher does not build artifacts — run `.\build.ps1` first.
+`qsoripper-launcher` is a fast-starting ratatui application.
+It lists the available engines and user interfaces.
+Rust uses port 50051, and .NET uses port 50052.
+Press `Space` to select an item.
+Use the third column to bind each user interface to an engine.
+Press `Enter` to start the selected items.
+
+Press `S` to stop launcher-managed processes.
+
+Selections persist below `[launcher]` in `config.toml`.
+The launcher does not build artifacts.
+Run `.\build.ps1` first.
 
 **Local engine launcher (recommended):**
 
@@ -269,7 +285,14 @@ Built-in local profiles:
 | `local-rust` | `rust-tonic` | `http://127.0.0.1:50051` | `sqlite` |
 | `local-dotnet` | `dotnet-aspnet` | `http://127.0.0.1:50052` | `memory` |
 
-`start-qsoripper.ps1` is the clean local abstraction for those profiles. It imports `.env`, builds the selected engine if needed, starts it in the background from the repository root, and records process state plus stdout/stderr logs under `artifacts\run\`. `-ForceRestart` only restarts the requested profile, so `local-rust` and `local-dotnet` can run side-by-side on their default ports.
+`start-qsoripper.ps1` is the local interface for these profiles.
+It imports `.env`.
+It builds the selected engine when necessary.
+Then it starts the engine in the background from the repository root.
+It records process state and output logs below `artifacts\run\`.
+`-ForceRestart` restarts only the requested profile.
+
+Thus, both local profiles can run on their default ports.
 
 **Direct engine host launch:**
 
@@ -286,7 +309,7 @@ cargo run -p qsoripper-server
 dotnet run --project src/dotnet/QsoRipper.Engine.DotNet/QsoRipper.Engine.DotNet.csproj
 ```
 
-Those start the built-in engine hosts directly. The Rust host defaults to `127.0.0.1:50051`; the .NET host defaults to `127.0.0.1:50052`.
+Those start the built-in engine hosts directly. The Rust host defaults to `127.0.0.1:50051`. The .NET host defaults to `127.0.0.1:50052`.
 
 The server can now swap storage implementations at startup:
 
@@ -345,7 +368,11 @@ cd src\rust
 cargo run -p qsoripper-stress-tui
 ```
 
-The stress host listens on `127.0.0.1:50061` by default and exposes a developer-only gRPC control surface for starting, stopping, and monitoring long-haul stress runs. The TUI connects to that endpoint, renders per-vector activity, shows rolling calls-per-second plus process CPU and memory, and keeps a bounded recent-event log with representative sample inputs from the active vectors.
+The stress host listens on `127.0.0.1:50061` by default.
+It supplies a developer-only gRPC control service for stress runs.
+The TUI connects to this endpoint.
+It shows activity for each vector, calls per second, CPU use, and memory use.
+It also keeps a limited recent-event log with representative inputs.
 
 Built-in stress profiles use a dedicated engine endpoint at `127.0.0.1:55051`. When the harness auto-starts that engine it points it at a separate stress-owned SQLite file under `artifacts\stress\storage\`. Stress runs do not reuse or mutate your normal logbook.
 
@@ -368,7 +395,12 @@ Use `cargo run -p qsoripper-stress -- --help` and `cargo run -p qsoripper-stress
 
 ### Avalonia GUI automation
 
-For repeatable desktop UX inspection, the Avalonia GUI now supports a fixture-backed live inspection mode plus a Windows automation driver. The driver builds the GUI into a per-run output folder under `artifacts\ux\automation-bin\`, launches it with deterministic fixture data, performs scripted UI actions, and saves screenshots plus UI tree dumps under `artifacts\ux\current\`.
+The Avalonia GUI supports repeatable desktop UX inspection.
+It has a fixture-backed inspection mode and a Windows automation driver.
+The driver builds the GUI below `artifacts\ux\automation-bin\`.
+It starts the GUI with repeatable fixture data.
+Then it performs scripted UI actions.
+It saves screenshots and UI tree data below `artifacts\ux\current\`.
 
 The inspection harness supports `MainWindow`, `Settings`, and `Wizard` surfaces. Scenarios can select a surface with `inspectSurface` in the action JSON, or you can override it with `-Surface` on `drive-avalonia.ps1`.
 
@@ -387,10 +419,10 @@ The repo also includes a first-class PTY-backed terminal automation lane for int
 - `scripts\drive-tui.ts` drives a live terminal session from a JSON action script.
 - It writes artifacts under `artifacts\ux\current\<scenario>\`.
 - Snapshot actions save:
-  - `*.screen.png` — rendered terminal image for the visible viewport
-  - `*.screen.txt` — visible viewport text
-  - `*.screen.json` — viewport metadata and lines
-  - `*.ansi.txt` — serialized ANSI screen content
+  - `*.screen.png` - rendered terminal image for the visible viewport
+  - `*.screen.txt` - visible viewport text
+  - `*.screen.json` - viewport metadata and lines
+  - `*.ansi.txt` - serialized ANSI screen content
 - Every run also writes `transcript.txt` plus `report.json`.
 
 Today's built-in fixture is `sample-tui`, a deterministic menu/filter/list/details demo used to validate the harness before a production TUI exists.
@@ -424,9 +456,9 @@ The QRZ credentials are easy to mix up, so keep this split in mind:
 | `QSORIPPER_QRZ_XML_PASSWORD` | Your **actual QRZ account password** for the XML lookup service |
 | `QSORIPPER_QRZ_LOGBOOK_API_KEY` | Your separate **QRZ Logbook API access key** from the QRZ website |
 
-**Important:** `QSORIPPER_QRZ_XML_PASSWORD` and `QSORIPPER_QRZ_LOGBOOK_API_KEY` are **not** the same value and are **not** interchangeable. Using the logbook API key as the XML password will cause QRZ XML login failures and may trigger a temporary lockout.
+**Important:** `QSORIPPER_QRZ_XML_PASSWORD` and `QSORIPPER_QRZ_LOGBOOK_API_KEY` are **not** the same value and are **not** interchangeable. The incorrect XML password causes login failures and can cause a temporary lockout.
 
-Current space weather can also be enabled for engine clients through the NOAA SWPC-backed service:
+Engine clients can also enable current space weather through the NOAA SWPC service:
 
 ```powershell
 QSORIPPER_NOAA_SPACE_WEATHER_ENABLED=true
@@ -447,9 +479,32 @@ In capture mode, QsoRipper builds the outgoing QRZ XML request and returns redac
 
 You can also set `QSORIPPER_STATION_*` values in `.env` to define the active station profile that the Rust engine snapshots into newly logged QSOs.
 
-Engine-backed CW keying defaults to the non-transmitting `null` backend. Persist station settings under `[cw_keying]` in the shared `config.toml`; matching `QSORIPPER_CW_*` environment variables provide per-key startup overrides. Use direct `winkeyer` for a single client, or the optional standalone [CatHub](https://github.com/treitforge/cathub) backend when QsoRipper and N1MM share one physical keyer through typed and virtual-COM endpoints. CatHub is installed and versioned independently, and ordinary QsoRipper logging does not require it. Configure and probe with the transmit gate off first, then enable hardware transmission only after `qsoripper cw status` reports the expected broker/port and firmware revision. See [CatHub integration](docs/integrations/cathub-setup.md) and [CW keying setup](docs/integrations/cw-keying.md) for the complete safety-first workflow.
+Engine-backed CW keying uses the non-transmitting `null` backend by default.
+Save station settings below `[cw_keying]` in the shared `config.toml`.
+Matching `QSORIPPER_CW_*` environment variables supply startup overrides.
+Use direct `winkeyer` for one client.
+Use [CatHub](https://github.com/treitforge/cathub) when QsoRipper and N1MM share one physical keyer.
+CatHub supplies typed and virtual COM endpoints.
 
-For the bootstrap and shared engine-settings surface, `SetupService` persists the engine's log file path, initial station profile, optional QRZ XML credentials, QRZ sync settings, and shared rig-control defaults to `config.toml`, then hot-applies those persisted values to the running engine. Setup wizards can guide the common first-run subset, while settings screens can edit the broader shared engine configuration through the same service. After setup, `StationProfileService` manages additional station profiles, persisted active-profile selection, and bounded in-memory session overrides for portable or event operation. The Debug Host `/engine` page now exposes setup and station-profile editor forms for these contract surfaces, so local bootstrap/profile lifecycle testing no longer requires `grpcurl`.
+CatHub has an independent installation and release.
+
+Normal QsoRipper logging does not require CatHub.
+
+First, configure and probe with the transmit gate off.
+Enable transmission only after `qsoripper cw status` reports the correct broker, port, and firmware.
+See [CatHub integration](docs/integrations/cathub-setup.md) and [CW keying setup](docs/integrations/cw-keying.md).
+
+`SetupService` saves shared engine settings in `config.toml`.
+These settings include the log path, initial station profile, QRZ settings, and rig-control defaults.
+The service applies the saved values to the running engine.
+Setup wizards guide the common first-run tasks.
+Settings screens use the same service for the complete shared configuration.
+After setup, `StationProfileService` manages additional station profiles.
+
+It also manages active-profile selection and limited in-memory session overrides.
+
+The Debug Host `/engine` page supplies setup and station-profile editor forms.
+Thus, local setup and profile tests do not require `grpcurl`.
 
 ### Local lookup debug workflow
 
@@ -526,7 +581,7 @@ This builds the shared .NET workspace, including the developer debug host and th
 
 ### Code Coverage
 
-Both the Rust engine and .NET components are instrumented for coverage on every CI run. Coverage reports are uploaded as workflow artifacts.
+CI measures coverage for the Rust engine and .NET components during each run. It uploads coverage reports as workflow artifacts.
 
 **Thresholds:**
 
@@ -535,7 +590,7 @@ Both the Rust engine and .NET components are instrumented for coverage on every 
 | Rust     | cargo-llvm-cov   | 80% lines | ~86% lines        |
 | .NET     | Coverlet         | 8% lines  | ~10% lines        |
 
-> **Note:** The .NET threshold is intentionally low because coverage is currently skewed by auto-generated protobuf/gRPC stubs which have no direct unit tests. The hand-written service and model code has significantly higher coverage. Ratchet the threshold up incrementally as tests are added and generated code is excluded.
+> **Note:** Generated protobuf and gRPC stubs reduce the .NET coverage value. These stubs have no direct unit tests. Service and model code has higher coverage. Increase the threshold when tests increase and coverage excludes generated code.
 
 **Run Rust coverage locally** (requires `llvm-tools-preview` component and `cargo-llvm-cov`):
 
@@ -601,7 +656,17 @@ Or publish the Native AOT build and run the produced executable:
 .\artifacts\publish\qsoripper-cli\Release\QsoRipper.Cli.exe status
 ```
 
-The CLI generates client stubs from the shared proto contracts at build time and currently includes commands for status, lookup, and local logbook operations over gRPC.
+The CLI generates client stubs from the shared proto contracts during the build.
+It includes commands for status, lookup, and local gRPC logbook operations.
+
+## Documentation
+
+- [Documentation standard](docs/documentation-style.md)
+- [Engine specification](docs/architecture/engine-specification.md)
+- [Data model](docs/architecture/data-model.md)
+- [API documentation](docs/api/README.md)
+- [Keyboard shortcuts](docs/keyboard-shortcuts.md)
+- [CatHub setup](docs/integrations/cathub-setup.md)
 
 ## Project Structure
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,8 +1,13 @@
 # QsoRipper Engine API
 
-This is the canonical entry point for anyone integrating with the shared QsoRipper gRPC/protobuf surface — whether you are building a client or implementing a new engine host.
+This document is the main reference for the shared QsoRipper gRPC and protobuf interface.
+Use it to build a client or a new engine host.
 
-QsoRipper is **contract-first**. `proto/` is the stable seam. Engine hosts implement it. Clients consume it. The repository already uses that model in both directions: Rust and .NET engine hosts sit behind the same contracts, and the Rust TUI plus the .NET CLI/GUI/DebugHost consume those contracts as independent clients.
+QsoRipper is **contract-first**.
+`proto/` is the stable interface.
+Engine hosts implement it, and clients use it.
+The Rust and .NET engine hosts implement the same contracts.
+The Rust TUI and the .NET clients use these contracts independently.
 
 ## Services
 
@@ -11,7 +16,7 @@ QsoRipper is **contract-first**. `proto/` is the stable seam. Engine hosts imple
 | **EngineService** | Engine identity, version, and runtime capability discovery | [`proto/services/engine_service.proto`](../../proto/services/engine_service.proto) |
 | **SetupService** | First-run setup, persisted config status, bootstrap storage/station defaults | [setup-service.md](setup-service.md) |
 | **StationProfileService** | Persisted station profile CRUD, active selection, bounded session override state | [station-profile-service.md](station-profile-service.md) |
-| **LookupService** | Callsign lookups — single, streaming, batch, cached, DXCC | [lookup-service.md](lookup-service.md) |
+| **LookupService** | Callsign lookups - single, streaming, batch, cached, DXCC | [lookup-service.md](lookup-service.md) |
 | **LogbookService** | QSO CRUD, QRZ logbook sync, ADIF import/export | [logbook-service.md](logbook-service.md) |
 | **DeveloperControlService** | Developer-only runtime config overrides and diagnostics | [`proto/services/developer_control_service.proto`](../../proto/services/developer_control_service.proto) |
 | **SpaceWeatherService** | Current space-weather snapshot plus explicit refresh | [`proto/services/space_weather_service.proto`](../../proto/services/space_weather_service.proto) |
@@ -19,7 +24,7 @@ QsoRipper is **contract-first**. `proto/` is the stable seam. Engine hosts imple
 
 ## Contract Source of Truth
 
-All service and domain types are defined in `proto/`. QsoRipper treats protobuf 1-1-1 and per-RPC envelopes as an architectural rule:
+The files in `proto/` define all service and domain types. QsoRipper uses protobuf 1-1-1 and one envelope for each RPC:
 
 ```
 proto/
@@ -44,8 +49,8 @@ proto/
 Rules of thumb:
 
 - Every RPC uses a unique `XxxRequest` and `XxxResponse` envelope, including streaming RPCs.
-- Shared business payloads live in dedicated domain or service support messages and are nested inside envelopes.
-- Service files contain only the `service`; request/response/support messages live beside them as their own files.
+- Dedicated domain or service messages contain shared business payloads. RPC envelopes contain those messages.
+- Service files contain only the `service`. Request/response/support messages live beside them as their own files.
 
 The `.proto` files are the durable reference source. Comments inside them document individual field and RPC semantics. The reference docs in this directory provide higher-level integration guidance and implementation-status tables on top of those definitions.
 
@@ -63,28 +68,35 @@ Built-in local engine profiles:
 | Client type | Recommended transport | Notes |
 |---|---|---|
 | **Native desktop / TUI / CLI** | Native gRPC (HTTP/2) | Any gRPC client library works directly |
-| **Browser / web** | gRPC-Web via proxy | Browsers cannot issue raw HTTP/2 gRPC frames — see [client-integration.md](client-integration.md#browser-and-web-clients) |
+| **Browser / web** | gRPC-Web via proxy | Browsers cannot issue raw HTTP/2 gRPC frames - see [client-integration.md](client-integration.md#browser-and-web-clients) |
 
-> **Browser clients** require an intermediate proxy or gateway (e.g., Envoy with the gRPC-Web filter, or a gRPC-Web-aware reverse proxy). Direct raw gRPC from a browser is not supported without this layer. See the integration guide for details.
+> **Browser clients** require an intermediate proxy or gateway (for example, Envoy with the gRPC-Web filter, or a gRPC-Web-aware reverse proxy). Direct raw gRPC from a browser is not supported without this layer. See the integration guide for details.
 
 ## Implementation Status
 
-Not every contract entry is implemented by every current engine host. The reference docs for each service include per-RPC status tables, and `EngineService.GetEngineInfo` exposes capability strings so clients can inspect what a running host actually supports.
+Current engine hosts do not implement every contract entry. Each service document contains an RPC status table. `EngineService.GetEngineInfo` supplies host capability strings.
 
 In general:
 
-- Both built-in engine hosts implement the common first slice used by the conformance harness: engine info, setup, station profiles, runtime config, logbook CRUD, sync status, ADIF import/export, rig status, space weather, contest calendar lookup, and callsign lookup via unary/stream/cache RPCs.
+- Both built-in engine hosts implement the common conformance features.
+  These features include engine information, setup, station profiles, runtime configuration, and logbook CRUD.
+  They also include sync status, ADIF import/export, rig status, space weather, and contest calendar lookup.
+  Callsign lookup supports unary, stream, and cache RPCs.
 - Both built-in hosts also implement `LookupService.BatchLookup` and `LookupService.GetDxccEntity` for the `dxcc_code` query case. The `prefix` query case of `GetDxccEntity` still returns `UNIMPLEMENTED` in both hosts.
 - The built-in engine hosts report fine-grained lookup capabilities (`lookup-callsign`, `lookup-stream`, `lookup-cache`) instead of a broad `lookup` bucket so discovery matches the actually implemented surface.
 
-The current proto contract should now be treated as the stable **post-1-1-1 baseline**. PR [#74](https://github.com/rtreit/qsoripper/pull/74) was a deliberate breaking-contract cutover while the project is still early. From this baseline forward, additive changes are preferred and client code generated from the current proto files should continue to compile as new fields and RPCs are added. See [client-integration.md](client-integration.md#schema-evolution-and-compatibility) for field tolerance guidance.
+Treat the current proto contract as the stable **post-1-1-1 baseline**.
+PR [#74](https://github.com/rtreit/qsoripper/pull/74) intentionally changed the contract.
+Prefer additive changes after this baseline.
+Generated client code must compile after a schema adds fields or RPCs.
+See [client-integration.md](client-integration.md#schema-evolution-and-compatibility) for field tolerance guidance.
 
 ## Quick Links
 
-- [Client Integration Guide](client-integration.md) — generating stubs, connecting, browser transport
-- [Workflow Examples](workflows.md) — request/response shapes for common flows
+- [Client Integration Guide](client-integration.md) - generating stubs, connecting, browser transport
+- [Workflow Examples](workflows.md) - request/response shapes for common flows
 - [SetupService Reference](setup-service.md)
 - [StationProfileService Reference](station-profile-service.md)
 - [LookupService Reference](lookup-service.md)
 - [LogbookService Reference](logbook-service.md)
-- [Data Model Architecture](../architecture/data-model.md) — architecture-oriented context for domain types
+- [Data Model Architecture](../architecture/data-model.md) - architecture-oriented context for domain types

--- a/docs/api/client-integration.md
+++ b/docs/api/client-integration.md
@@ -1,6 +1,7 @@
 # Client Integration Guide
 
-This guide covers everything you need to connect a client application to a QsoRipper engine host over gRPC, or to stand up another engine implementation that honors the same contracts.
+This guide explains how to connect a client to a QsoRipper engine with gRPC.
+It also explains how to implement a conformant engine.
 
 ## Endpoint Defaults
 
@@ -29,7 +30,9 @@ All .NET clients use the shared selector rules from `QsoRipper.EngineSelection`:
 3. `QSORIPPER_ENDPOINT`
 4. built-in profile defaults
 
-Local running-engine discovery is based on launcher state under `artifacts\run\` (`qsoripper-*.state.json` plus legacy `qsoripper-engine*.json`) and validates entries with PID + transport checks before presenting them as active.
+Local engine discovery reads launcher state below `artifacts\run\`.
+It reads `qsoripper-*.state.json` and legacy `qsoripper-engine*.json` files.
+It checks each PID and transport before it shows an engine as active.
 
 Current client behavior:
 
@@ -62,9 +65,14 @@ QSORIPPER_SERVER_ADDR=0.0.0.0:50051 cargo run -p qsoripper-server
 
 ## Generating Client Stubs
 
-The proto files under `proto/` are the authoritative contract. Use standard protobuf/gRPC tooling for your language to generate stubs from that contract rather than hand-writing client or server shapes.
+The proto files under `proto/` are the authoritative contract. Use standard protobuf/gRPC tools for your language to generate stubs from that contract. Do not write the client or server shapes manually.
 
-QsoRipper follows protobuf 1-1-1 by default: one top-level entity per file, service files that contain only the `service`, and method-specific `XxxRequest` / `XxxResponse` envelopes for every RPC. Your code generation step therefore needs to include the split service support files, not just the `*service.proto` declarations.
+QsoRipper uses protobuf 1-1-1 by default.
+Each file has one top-level entity.
+A service file contains only the `service`.
+Each RPC has method-specific `XxxRequest` and `XxxResponse` envelopes.
+Include all split service support files in code generation.
+Do not include only the `*service.proto` declarations.
 
 ### Prerequisites
 
@@ -245,7 +253,10 @@ println!("State: {:?}", result.state);
 
 ## Browser and Web Clients
 
-Browsers cannot issue native gRPC (HTTP/2 + binary framing) requests due to browser networking constraints. Web clients must use **gRPC-Web**, which is a modified protocol that works over standard HTTP/1.1 or HTTP/2 in a way browsers can handle.
+Browsers cannot send native gRPC requests.
+Their network interfaces do not supply the necessary HTTP/2 binary framing.
+Web clients must use **gRPC-Web**.
+This modified protocol works with standard browser HTTP/1.1 or HTTP/2 connections.
 
 The QsoRipper engine exposes native gRPC only. To connect a browser or web client, you need an intermediate proxy or gateway.
 
@@ -277,7 +288,7 @@ grpcwebproxy \
 
 **Option 3: connect-go / connect-web**
 
-The [Connect protocol](https://connectrpc.com/) is compatible with gRPC and adds HTTP/JSON support for browser clients without a separate proxy. This would require the engine server to add Connect support (not currently implemented).
+The [Connect protocol](https://connectrpc.com/) is compatible with gRPC. It adds HTTP/JSON support for browser clients without a separate proxy. The engine server requires Connect support for this option.
 
 ### Generating Browser Client Stubs
 
@@ -296,7 +307,10 @@ Or use `@connectrpc/protoc-gen-connect-es` with `@bufbuild/protoc-gen-es` if you
 
 ### Important: No Native Browser gRPC
 
-Do not attempt to connect a browser-side JavaScript client directly to `http://localhost:50051` with a standard gRPC client library — it will fail. The browser HTTP stack does not support the HTTP/2 framing that native gRPC requires. Always route browser traffic through a gRPC-Web–aware proxy.
+Do not connect browser JavaScript directly to `http://localhost:50051` with a standard gRPC library.
+This connection will fail.
+The browser HTTP stack does not support native gRPC HTTP/2 framing.
+Always send browser traffic through a gRPC-Web-aware proxy.
 
 ## Schema Evolution and Compatibility
 
@@ -304,15 +318,17 @@ The current QsoRipper proto contract follows standard proto3 additive evolution 
 
 > PR [#74](https://github.com/rtreit/qsoripper/pull/74) was a deliberate breaking-contract cleanup performed while the project is still early. Clients pinned to older pre-1-1-1 revisions must regenerate against the current `proto/` surface rather than assuming wire compatibility across that cutover.
 
-- **New optional fields** may be added to any message in future releases without breaking existing clients.
-- **New RPCs** may be added to existing services. Old clients will not call them.
-- **Enum values** may be added. Clients should handle unknown enum integer values gracefully (proto3 preserves unknown enum values as their integer form).
-- **Field numbers and types** should not be changed within the current published baseline. `buf breaking` is the guardrail for future changes against that baseline.
+- Future releases can add **new optional fields** to any message without breaking existing clients.
+- Existing services can add **new RPCs**. Old clients will not call them.
+- Schemas can add **enum values**. Clients must accept unknown enum integer values. Proto3 keeps unknown enum values in integer form.
+- Do not change **field numbers and types** within the current published baseline. `buf breaking` protects future changes against that baseline.
 
 **Client tolerance recommendations:**
-- Ignore unknown fields in responses — proto3 decoders do this by default.
+- Ignore unknown fields in responses - proto3 decoders do this by default.
 - Use a `default` or fallback branch when switching on enum values so new values are handled gracefully.
-- Do not rely on zero values to mean "absent" for `optional` fields in proto3 — use `has_*` checks (in languages that support them) or check for explicit presence.
+- Do not use a zero value to mean "absent" for an `optional` proto3 field.
+- Use `has_*` when the language supports it.
+- Otherwise, test for explicit presence.
 
 ## Buf for Schema Validation
 

--- a/docs/api/logbook-service.md
+++ b/docs/api/logbook-service.md
@@ -12,15 +12,15 @@ Service envelopes and support types live in their own files under `proto/service
 
 | RPC | Status | Notes |
 |---|---|---|
-| `LogQso` | ✅ Implemented | Saves locally through the configured backend; QRZ sync still reports unimplemented when requested |
-| `UpdateQso` | ✅ Implemented | Updates local storage; QRZ sync still reports unimplemented when requested |
-| `DeleteQso` | ✅ Implemented | Deletes from local storage; QRZ delete still reports unimplemented when requested |
-| `GetQso` | ✅ Implemented | Loads a single local QSO by `local_id` |
-| `ListQsos` | ✅ Implemented | Streams locally stored QSOs with filters, sorting, limit, and offset |
-| `SyncWithQrz` | ⚠️ Planned | Contract defined; returns `UNIMPLEMENTED` |
-| `GetSyncStatus` | ✅ Implemented | Returns live local counts from storage; QRZ-specific fields remain zero/absent until sync is implemented |
-| `ImportAdif` | ✅ Implemented | Streams ADIF in, imports after client close, reports duplicates/fallback warnings |
-| `ExportAdif` | ✅ Implemented | Streams filtered ADIF out in chronological order |
+| `LogQso` | Implemented | Saves locally through the configured backend. QRZ sync still reports unimplemented when requested |
+| `UpdateQso` | Implemented | Updates local storage. QRZ sync still reports unimplemented when requested |
+| `DeleteQso` | Implemented | Deletes from local storage. QRZ delete still reports unimplemented when requested |
+| `GetQso` | Implemented | Loads a single local QSO by `local_id` |
+| `ListQsos` | Implemented | Streams locally stored QSOs with filters, sorting, limit, and offset |
+| `SyncWithQrz` | Planned | Contract defined. Returns `UNIMPLEMENTED` |
+| `GetSyncStatus` | Implemented | Returns live local counts from storage. QRZ fields remain zero or absent until the engine implements sync. |
+| `ImportAdif` | Implemented | Streams ADIF in, imports after client close, reports duplicates/fallback warnings |
+| `ExportAdif` | Implemented | Streams filtered ADIF out in chronological order |
 
 ## RPCs
 
@@ -32,13 +32,13 @@ Log a new QSO (contact). Optionally syncs the new record to QRZ immediately.
 rpc LogQso(LogQsoRequest) returns (LogQsoResponse)
 ```
 
-> ✅ **Status:** Implemented for local storage.
+> **Status:** Implemented for local storage.
 
 **Request:** `LogQsoRequest`
 
 | Field | Type | Description |
 |---|---|---|
-| `qso` | `QsoRecord` | The QSO to log. `local_id` should be empty; the engine assigns a UUID. |
+| `qso` | `QsoRecord` | The QSO to log. Keep `local_id` empty. The engine assigns a UUID. |
 | `sync_to_qrz` | `bool` | If `true`, also upload to QRZ logbook immediately after logging locally. |
 
 **Response:** `LogQsoResponse`
@@ -47,18 +47,19 @@ rpc LogQso(LogQsoRequest) returns (LogQsoResponse)
 |---|---|---|
 | `local_id` | `string` | Engine-assigned UUID for the new QSO |
 | `qrz_logid` | `string` (optional) | QRZ logbook record ID, set only when `sync_to_qrz` was `true` and sync succeeded |
-| `sync_success` | `bool` | `true` when the local save completed and no QRZ request failed; `false` when QRZ work was requested but is not yet implemented |
+| `sync_success` | `bool` | `true` after a local save without a QRZ failure. `false` when the request includes QRZ work without an implementation. |
 | `sync_error` | `string` (optional) | Human-readable sync error message when `sync_to_qrz == true` and the QRZ step failed |
 
 **Behavior:**
 - The engine always assigns a new `local_id` (UUID). Do not set `QsoRecord.local_id` in the request.
 - Required user input is `worked_callsign`, `utc_timestamp`, `band`, and `mode`, plus `station_callsign` unless the effective active station context already supplies the local station identity.
-- When active station context is available, the server materializes `station_snapshot` from that context and uses it as the source of default local-station values for the new record.
-- If `sync_to_qrz == false`, the QSO is logged locally only. `sync_success` will be `true` and QRZ fields remain absent.
-- A QRZ sync failure does not cause the local log to fail. The QSO is logged locally regardless. Check `sync_success` and `sync_error` to determine the QRZ outcome.
+- When active station context is available, the server creates `station_snapshot` from it.
+  The snapshot supplies default local-station values for the new record.
+- If `sync_to_qrz == false`, the engine logs the QSO locally only. `sync_success` is `true`, and QRZ fields remain absent.
+- A QRZ sync failure does not cause a local log failure. The engine keeps the local QSO. Check `sync_success` and `sync_error`.
 
 **Notable status codes:**
-- `INVALID_ARGUMENT` — missing required fields or invalid enum values.
+- `INVALID_ARGUMENT` - missing required fields or invalid enum values.
 
 ---
 
@@ -70,7 +71,7 @@ Update an existing QSO identified by `local_id`.
 rpc UpdateQso(UpdateQsoRequest) returns (UpdateQsoResponse)
 ```
 
-> ✅ **Status:** Implemented for local storage.
+> **Status:** Implemented for local storage.
 
 **Request:** `UpdateQsoRequest`
 
@@ -89,8 +90,8 @@ rpc UpdateQso(UpdateQsoRequest) returns (UpdateQsoResponse)
 | `sync_error` | `string` (optional) | Sync error message |
 
 **Notable status codes:**
-- `NOT_FOUND` — `local_id` does not exist in the local logbook.
-- `INVALID_ARGUMENT` — the request is missing `local_id` or other required fields.
+- `NOT_FOUND` - `local_id` does not exist in the local logbook.
+- `INVALID_ARGUMENT` - the request is missing `local_id` or other required fields.
 
 ---
 
@@ -102,7 +103,7 @@ Delete a QSO from the local logbook. Optionally also deletes it from QRZ logbook
 rpc DeleteQso(DeleteQsoRequest) returns (DeleteQsoResponse)
 ```
 
-> ✅ **Status:** Implemented for local storage.
+> **Status:** Implemented for local storage.
 
 **Request:** `DeleteQsoRequest`
 
@@ -120,11 +121,11 @@ rpc DeleteQso(DeleteQsoRequest) returns (DeleteQsoResponse)
 | `qrz_delete_success` | `bool` | Whether the optional QRZ delete succeeded |
 | `qrz_delete_error` | `string` (optional) | QRZ delete error message |
 
-> ⚠️ **Warning:** Setting `delete_from_qrz = true` is **permanent and irreversible** on the QRZ side. Prompt the user to confirm before calling this with `delete_from_qrz = true`.
+> **Warning:** Setting `delete_from_qrz = true` is **permanent and irreversible** on the QRZ side. Prompt the user to confirm before calling this with `delete_from_qrz = true`.
 
 **Notable status codes:**
-- `NOT_FOUND` — `local_id` does not exist.
-- `INVALID_ARGUMENT` — `local_id` is blank.
+- `NOT_FOUND` - `local_id` does not exist.
+- `INVALID_ARGUMENT` - `local_id` is blank.
 
 ---
 
@@ -136,7 +137,7 @@ Retrieve a single QSO by its local UUID.
 rpc GetQso(GetQsoRequest) returns (GetQsoResponse)
 ```
 
-> ✅ **Status:** Implemented for local storage.
+> **Status:** Implemented for local storage.
 
 **Request:** `GetQsoRequest`
 
@@ -151,8 +152,8 @@ rpc GetQso(GetQsoRequest) returns (GetQsoResponse)
 | `qso` | `QsoRecord` | The retrieved QSO record |
 
 **Notable status codes:**
-- `NOT_FOUND` — `local_id` does not exist.
-- `INVALID_ARGUMENT` — `local_id` is blank.
+- `NOT_FOUND` - `local_id` does not exist.
+- `INVALID_ARGUMENT` - `local_id` is blank.
 
 ---
 
@@ -164,7 +165,7 @@ List QSOs with optional filters, returning results as a server-streaming respons
 rpc ListQsos(ListQsosRequest) returns (stream ListQsosResponse)
 ```
 
-> ✅ **Status:** Implemented for local storage.
+> **Status:** Implemented for local storage.
 
 **Request:** `ListQsosRequest`
 
@@ -176,7 +177,7 @@ rpc ListQsos(ListQsosRequest) returns (stream ListQsosResponse)
 | `band_filter` | `Band` (optional) | Filter by band |
 | `mode_filter` | `Mode` (optional) | Filter by mode |
 | `contest_id` | `string` (optional) | Filter by contest ID |
-| `limit` | `uint32` | Maximum records to return; `0` means no limit |
+| `limit` | `uint32` | Maximum records to return. `0` means no limit |
 | `offset` | `uint32` | Skip this many records (for pagination) |
 | `sort` | `QsoSortOrder` | `QSO_SORT_ORDER_NEWEST_FIRST` (default) or `QSO_SORT_ORDER_OLDEST_FIRST` |
 
@@ -187,29 +188,29 @@ rpc ListQsos(ListQsosRequest) returns (stream ListQsosResponse)
 | `qso` | `QsoRecord` | One matched QSO per streamed envelope |
 
 **Behavior:**
-- Results are streamed as they are produced, rather than buffered and returned in a single message. Clients should consume incrementally.
-- All filter fields are optional; omitting all filters returns all QSOs (subject to `limit`/`offset`).
+- The engine streams each result when it produces the result. Clients must process each result.
+- All filter fields are optional. Omitting all filters returns all QSOs (subject to `limit`/`offset`).
 
 **Notable status codes:**
-- `OK` — zero or more `ListQsosResponse` envelopes streamed back.
+- `OK` - zero or more `ListQsosResponse` envelopes streamed back.
 
 ---
 
 ### SyncWithQrz
 
-Trigger a full or incremental sync with the QRZ logbook. Progress is streamed back to the client.
+Start a full or incremental sync with the QRZ logbook. The engine streams progress to the client.
 
 ```
 rpc SyncWithQrz(SyncWithQrzRequest) returns (stream SyncWithQrzResponse)
 ```
 
-> ⚠️ **Status:** Planned. Currently returns `UNIMPLEMENTED`.
+> **Status:** Planned. Currently returns `UNIMPLEMENTED`.
 
 **Request:** `SyncWithQrzRequest`
 
 | Field | Type | Description |
 |---|---|---|
-| `full_sync` | `bool` | `true` = re-fetch all records from QRZ; `false` = incremental (changes since last sync) |
+| `full_sync` | `bool` | `true` = re-fetch all records from QRZ. `false` = incremental (changes since last sync) |
 
 **Response stream:** One or more `SyncWithQrzResponse` messages, terminated by a message with `complete == true`.
 
@@ -223,17 +224,17 @@ rpc SyncWithQrz(SyncWithQrzRequest) returns (stream SyncWithQrzResponse)
 | `downloaded_records` | `uint32` | Records fetched from QRZ |
 | `conflict_records` | `uint32` | Records with local/remote divergence |
 | `current_action` | `string` (optional) | Human-readable status message |
-| `complete` | `bool` | `true` on the final message — stream ends after this |
+| `complete` | `bool` | `true` on the final message - stream ends after this |
 | `error` | `string` (optional) | Error message if sync failed |
 
 **Behavior:**
 - The server closes the stream after sending a message with `complete == true`.
-- Clients should update progress UI on each received message.
+- Clients must update the progress display after each message.
 - A QRZ credentials error will produce an early terminal message with `complete == true` and `error` set.
 
 **Notable status codes:**
-- `UNIMPLEMENTED` — current server response.
-- `UNAUTHENTICATED` — future: QRZ credentials not configured or invalid.
+- `UNIMPLEMENTED` - current server response.
+- `UNAUTHENTICATED` - future: QRZ credentials not configured or invalid.
 
 ---
 
@@ -245,9 +246,9 @@ Get the current sync state and logbook statistics.
 rpc GetSyncStatus(GetSyncStatusRequest) returns (GetSyncStatusResponse)
 ```
 
-> ✅ **Status:** Implemented for local storage counts. QRZ metadata remains zero/absent until QRZ sync is implemented.
+> **Status:** The engine implements local storage counts. QRZ metadata remains zero or absent until the engine implements QRZ sync.
 
-**Request:** `GetSyncStatusRequest` — empty message, no fields.
+**Request:** `GetSyncStatusRequest` - empty message, no fields.
 
 **Response:** `GetSyncStatusResponse`
 
@@ -259,22 +260,22 @@ rpc GetSyncStatus(GetSyncStatusRequest) returns (GetSyncStatusResponse)
 | `last_sync` | `Timestamp` (optional) | Timestamp of the most recent successful sync |
 | `qrz_logbook_owner` | `string` (optional) | QRZ logbook owner callsign |
 
-**Current behavior:** `local_qso_count` and `pending_upload` are derived from current storage contents. Until QRZ sync exists, `qrz_qso_count` remains `0`, `last_sync` is absent, and `qrz_logbook_owner` is absent.
+**Current behavior:** The engine calculates `local_qso_count` and `pending_upload` from storage. Until QRZ sync exists, the other QRZ fields remain empty.
 
 **Notable status codes:**
-- `OK` — always returned; check field values for substantive data.
+- `OK` - always returned. Check field values for substantive data.
 
 ---
 
 ### ImportAdif
 
-Import QSOs from ADIF data. The client streams chunks of raw ADIF bytes; the server parses and imports them.
+Import QSOs from ADIF data. The client streams chunks of raw ADIF bytes. The server parses and imports them.
 
 ```
 rpc ImportAdif(stream ImportAdifRequest) returns (ImportAdifResponse)
 ```
 
-> ✅ **Status:** Implemented for local ADIF migration import.
+> **Status:** Implemented for local ADIF migration import.
 
 **Request stream:** One or more `ImportAdifRequest` messages, each containing one `AdifChunk`.
 
@@ -283,12 +284,15 @@ rpc ImportAdif(stream ImportAdifRequest) returns (ImportAdifResponse)
 | `chunk` | `AdifChunk` | Wrapper envelope for one raw ADIF byte slice |
 
 **Behavior:**
-- Clients may split large ADIF files into multiple chunks to avoid large single messages.
+- Clients can split large ADIF files into multiple chunks to prevent large messages.
 - The server accumulates chunks and parses the complete ADIF payload after the client closes the send side.
-- Imported `STATION_CALLSIGN`, `OPERATOR`, and `MY_*` fields are preserved through `station_snapshot`; the current active station profile does **not** overwrite imported local-station history.
-- If an ADIF record has no local-station context at all, the server uses the current active station profile as an explicit fallback and adds a warning describing that fallback.
-- Duplicate policy: a record is skipped when it matches an existing QSO on `station_callsign`, `worked_callsign`, `utc_timestamp`, `band`, `mode`, and compatible `submode` / `frequency_hz`.
-- Invalid core ADIF values such as unknown `BAND`, unknown `MODE`, or invalid `QSO_DATE` / `TIME_ON` combinations are skipped with warnings. Raw ADIF values are still retained in `extra_fields` so later exports stay predictable.
+- The engine preserves imported `STATION_CALLSIGN`, `OPERATOR`, and `MY_*` fields through `station_snapshot`. The active station profile does **not** overwrite this history.
+- If an ADIF record has no local-station context, the server uses the active station profile.
+  The server adds a warning that describes this fallback.
+- Duplicate policy: The engine skips a record that matches an existing QSO on the duplicate fields.
+  These fields are `station_callsign`, `worked_callsign`, `utc_timestamp`, `band`, `mode`, and compatible `submode` or `frequency_hz`.
+- The engine skips invalid core ADIF values and supplies warnings.
+  It keeps raw ADIF values in `extra_fields` for later exports.
 
 **Response:** `ImportAdifResponse`
 
@@ -299,9 +303,9 @@ rpc ImportAdif(stream ImportAdifRequest) returns (ImportAdifResponse)
 | `warnings` | `repeated string` | Human-readable warnings for individual record issues |
 
 **Notable status codes:**
-- `OK` — import completed; inspect counts and warnings for duplicates or skipped records.
-- `INVALID_ARGUMENT` — malformed ADIF payload that could not be parsed.
-- `INTERNAL` — storage failure during import.
+- `OK` - import completed. Inspect counts and warnings for duplicates or skipped records.
+- `INVALID_ARGUMENT` - malformed ADIF payload that the parser cannot parse.
+- `INTERNAL` - storage failure during import.
 
 ---
 
@@ -313,7 +317,7 @@ Export QSOs to ADIF format. The server streams chunks of raw ADIF bytes back to 
 rpc ExportAdif(ExportAdifRequest) returns (stream ExportAdifResponse)
 ```
 
-> ✅ **Status:** Implemented for local ADIF export.
+> **Status:** Implemented for local ADIF export.
 
 **Request:** `ExportAdifRequest`
 
@@ -331,14 +335,14 @@ rpc ExportAdif(ExportAdifRequest) returns (stream ExportAdifResponse)
 | `chunk` | `AdifChunk` | Wrapper envelope for one exported ADIF byte slice |
 
 **Behavior:**
-- Clients should concatenate received chunks to reconstruct the full ADIF payload.
+- Clients must concatenate the chunks to reconstruct the full ADIF payload.
 - Omitting all filters exports all QSOs.
 - Export order is chronological (`oldest first`) after applying the filters.
 - `include_header=true` prepends an ADIF header with version/program metadata.
 
 **Notable status codes:**
-- `OK` — export stream opened successfully.
-- `INTERNAL` — storage failure while enumerating records for export.
+- `OK` - export stream opened successfully.
+- `INTERNAL` - storage failure while enumerating records for export.
 
 ---
 
@@ -346,23 +350,23 @@ rpc ExportAdif(ExportAdifRequest) returns (stream ExportAdifResponse)
 
 | Field | Required? | Description |
 |---|---|---|
-| `local_id` | Assigned by engine | UUID — do not set in `LogQso` requests |
+| `local_id` | Assigned by engine | UUID - do not set in `LogQso` requests |
 | `station_callsign` | Required | Local operator's callsign |
 | `worked_callsign` | Required | Remote station's callsign |
 | `utc_timestamp` | Required | UTC time of the contact |
 | `utc_end_timestamp` | Optional | UTC end time of the contact when known |
 | `band` | Required | Frequency band (see `Band` enum) |
 | `mode` | Required | Operating mode (see `Mode` enum) |
-| `frequency_hz` | Optional | Precise frequency in Hz (e.g., 28075730 for 28.07573 MHz) |
-| `submode` | Optional | ADIF submode string (e.g., `"USB"`, `"PSK31"`) |
+| `frequency_hz` | Optional | Precise frequency in Hz (for example, 28075730 for 28.07573 MHz) |
+| `submode` | Optional | ADIF submode string (for example, `"USB"`, `"PSK31"`) |
 | `rst_sent` / `rst_received` | Optional | RST signal reports |
 | `sync_status` | Set by engine | `LOCAL_ONLY → SYNCED → MODIFIED → CONFLICT` |
 | `station_snapshot` | Optional | Immutable local-station metadata captured when the QSO was logged |
-| `extra_fields` | Optional | ADIF fields with no dedicated proto field — preserved for lossless round-trip |
+| `extra_fields` | Optional | ADIF fields with no dedicated proto field - preserved for lossless round-trip |
 
 ## QsoSortOrder Values
 
 | Value | Description |
 |---|---|
-| `QSO_SORT_ORDER_NEWEST_FIRST` | Default (zero value) — most recent QSOs first |
+| `QSO_SORT_ORDER_NEWEST_FIRST` | Default (zero value) - most recent QSOs first |
 | `QSO_SORT_ORDER_OLDEST_FIRST` | Oldest QSOs first |

--- a/docs/api/lookup-service.md
+++ b/docs/api/lookup-service.md
@@ -18,19 +18,19 @@ All RPCs use unique request/response envelopes. Shared domain payloads stay nest
 
 | RPC | Status | Notes |
 |---|---|---|
-| `Lookup` | ✅ Implemented | Unary callsign lookup via coordinator |
-| `StreamLookup` | ✅ Implemented | Server-streaming with `Loading → Found/Error` state transitions |
-| `GetCachedCallsign` | ✅ Implemented | L1 in-memory cache check only, no network call |
-| `GetDxccEntity` (by `dxcc_code`) | ✅ Implemented | Returns the entity for a numeric DXCC code, or `NOT_FOUND` |
-| `GetDxccEntity` (by `prefix`) | ⚠️ Unimplemented | Returns `UNIMPLEMENTED` in both hosts |
-| `BatchLookup` | ✅ Implemented | Bounded-concurrency parallel lookup over the coordinator (max 5 in-flight) |
+| `Lookup` | Implemented | Unary callsign lookup via coordinator |
+| `StreamLookup` | Implemented | Server-streaming with `Loading → Found/Error` state transitions |
+| `GetCachedCallsign` | Implemented | L1 in-memory cache check only, no network call |
+| `GetDxccEntity` (by `dxcc_code`) | Implemented | Returns the entity for a numeric DXCC code, or `NOT_FOUND` |
+| `GetDxccEntity` (by `prefix`) | Unimplemented | Returns `UNIMPLEMENTED` in both hosts |
+| `BatchLookup` | Implemented | Bounded-concurrency parallel lookup over the coordinator (max 5 in-flight) |
 
 Source-of-truth references for parity checks:
 
 - Rust: [`src/rust/qsoripper-server/src/main.rs`](../../src/rust/qsoripper-server/src/main.rs) (`get_dxcc_entity`, `batch_lookup`)
 - .NET: [`src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs`](../../src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs) (`GetDxccEntity`, `BatchLookup`)
 
-When changing or adding RPCs, update this table and the matching capability list in the engine specification in the same change. A lightweight parity test lives at [`tests/Docs.LookupParity.Tests.ps1`](../../tests/Docs.LookupParity.Tests.ps1); run `Invoke-Pester -Path tests/Docs.LookupParity.Tests.ps1` to confirm the docs above still match both the Rust and .NET hosts.
+When changing or adding RPCs, update this table and the matching capability list in the engine specification in the same change. A lightweight parity test lives at [`tests/Docs.LookupParity.Tests.ps1`](../../tests/Docs.LookupParity.Tests.ps1). Run `Invoke-Pester -Path tests/Docs.LookupParity.Tests.ps1` to confirm the docs above still match both the Rust and .NET hosts.
 
 ## RPCs
 
@@ -46,7 +46,7 @@ rpc Lookup(LookupRequest) returns (LookupResponse)
 
 | Field | Type | Description |
 |---|---|---|
-| `callsign` | `string` | Callsign to look up (e.g., `"W1AW"`) |
+| `callsign` | `string` | Callsign to look up (for example, `"W1AW"`) |
 | `skip_cache` | `bool` | If `true`, bypasses the L1 in-memory cache and forces a fresh provider fetch |
 
 **Response:** `LookupResponse`
@@ -59,7 +59,7 @@ rpc Lookup(LookupRequest) returns (LookupResponse)
 - Always returns a single `LookupResponse` envelope whose `result` field carries the lookup outcome.
 - If the provider is not configured (no QRZ credentials), returns `state == ERROR` with a configuration error message.
 - If the callsign is in the L1 cache and `skip_cache` is false, serves the cached result with `cache_hit == true`.
-- Provider-backed results may include redacted `debug_http_exchanges` entries for login and lookup HTTP calls. Cache-only responses leave this list empty.
+- Provider results can include redacted `debug_http_exchanges` entries for login and lookup HTTP calls. Cache-only responses leave this list empty.
 
 **Debug capture payload:**
 
@@ -79,11 +79,11 @@ Each `DebugHttpExchange` is an additive, provider-agnostic transport capture wit
 - `response_body` (optional)
 - `error_message` (optional)
 
-Sensitive values are redacted before the exchange is returned to clients. For QRZ XML this includes session keys, passwords, tokens, and auth/cookie-style headers.
+The engine redacts sensitive values before it returns the exchange to clients. For QRZ XML, it redacts keys, passwords, tokens, and authentication headers.
 
 **Notable status codes:**
-- `OK` — returned in all cases (including not-found); the `state` field carries the semantic outcome.
-- `INTERNAL` — unexpected server-side error (rare; most errors are expressed in `LookupResult.state`).
+- `OK` - returned in all cases (including not-found). The `state` field carries the semantic outcome.
+- `INTERNAL` - unexpected server error. The engine reports most errors in `LookupResult.state`.
 
 ---
 
@@ -99,7 +99,7 @@ rpc StreamLookup(StreamLookupRequest) returns (stream StreamLookupResponse)
 
 | Field | Type | Description |
 |---|---|---|
-| `callsign` | `string` | Callsign to look up (e.g., `"W1AW"`) |
+| `callsign` | `string` | Callsign to look up (for example, `"W1AW"`) |
 | `skip_cache` | `bool` | If `true`, bypasses the L1 in-memory cache and forces a fresh provider fetch |
 
 **Response stream:** One or more `StreamLookupResponse` messages, terminated by the server.
@@ -113,7 +113,8 @@ LOADING → (STALE)? → FOUND | NOT_FOUND | ERROR
 ```
 
 1. The server always emits a `LOADING` result first, so the client can show an in-progress indicator immediately.
-2. If a stale cached entry exists while a fresh fetch is in progress, the server may emit a `STALE` result with the cached `record` before the final result arrives.
+2. A stale cached entry can exist while the server gets fresh data.
+   The server can send the cached `record` in a `STALE` result.
 3. The stream closes after the terminal result (`FOUND`, `NOT_FOUND`, or `ERROR`).
 
 **Typical stream for a fresh lookup (no cache):**
@@ -131,8 +132,8 @@ LOADING → (STALE)? → FOUND | NOT_FOUND | ERROR
 **Use case:** TUI/GUI clients that want to show an in-progress spinner while the lookup is running. Subscribe to the stream and update the UI on each received `LookupResult`.
 
 **Notable status codes:**
-- `OK` — stream completed normally.
-- `CANCELLED` — client cancelled the stream (expected for type-ahead debounce scenarios).
+- `OK` - stream completed normally.
+- `CANCELLED` - client cancelled the stream (expected for type-ahead debounce scenarios).
 
 ---
 
@@ -158,10 +159,10 @@ rpc GetCachedCallsign(GetCachedCallsignRequest) returns (GetCachedCallsignRespon
 
 **No network calls are made.** This RPC is safe to call speculatively and at high frequency.
 
-**Use case:** Type-ahead display that first tries the cache for a zero-latency response, then optionally falls through to `StreamLookup` for a fresh result.
+**Use case:** A type-ahead display first checks the cache. It can then call `StreamLookup` for a current result.
 
 **Notable status codes:**
-- `OK` — always returned; outcome is in `LookupResult.state`.
+- `OK` - always returned. Outcome is in `LookupResult.state`.
 
 ---
 
@@ -173,14 +174,14 @@ Look up a DXCC (DX Century Club) entity by numeric code or callsign prefix.
 rpc GetDxccEntity(GetDxccEntityRequest) returns (GetDxccEntityResponse)
 ```
 
-> ✅ **Status:** Implemented for the `dxcc_code` query case. The `prefix` query case still returns `UNIMPLEMENTED` in both built-in hosts.
+> **Status:** Implemented for the `dxcc_code` query case. The `prefix` query case still returns `UNIMPLEMENTED` in both built-in hosts.
 
 **Request:** `GetDxccEntityRequest` (oneof)
 
 | Field | Type | Description |
 |---|---|---|
 | `dxcc_code` | `uint32` | Numeric DXCC entity code |
-| `prefix` | `string` | Callsign prefix — reserved for future QRZ-style 4→3→2 letter reduction; currently `UNIMPLEMENTED` |
+| `prefix` | `string` | Callsign prefix - reserved for future QRZ-style 4→3→2 letter reduction. Currently `UNIMPLEMENTED` |
 
 **Response:** `GetDxccEntityResponse`
 
@@ -189,9 +190,9 @@ rpc GetDxccEntity(GetDxccEntityRequest) returns (GetDxccEntityResponse)
 | `entity` | `DxccEntity` | The matched DXCC payload |
 
 **Notable status codes:**
-- `NOT_FOUND` — `dxcc_code` does not match any known DXCC entity.
-- `UNIMPLEMENTED` — `prefix` query case is not yet supported.
-- `INVALID_ARGUMENT` — neither `dxcc_code` nor `prefix` was supplied.
+- `NOT_FOUND` - `dxcc_code` does not match any known DXCC entity.
+- `UNIMPLEMENTED` - `prefix` query case is not yet supported.
+- `INVALID_ARGUMENT` - the request supplies neither `dxcc_code` nor `prefix`.
 
 ---
 
@@ -203,7 +204,7 @@ Look up multiple callsigns in a single request. Intended for contest prefetch sc
 rpc BatchLookup(BatchLookupRequest) returns (BatchLookupResponse)
 ```
 
-> ✅ **Status:** Implemented in both built-in hosts. Runs the supplied callsigns through the lookup coordinator in parallel with a bounded concurrency cap (currently 5 in-flight).
+> **Status:** Implemented in both built-in hosts. Runs the supplied callsigns through the lookup coordinator in parallel with a bounded concurrency cap (currently 5 in-flight).
 
 **Request:** `BatchLookupRequest`
 
@@ -217,11 +218,11 @@ rpc BatchLookup(BatchLookupRequest) returns (BatchLookupResponse)
 |---|---|---|
 | `results` | `repeated LookupResult` | One result per requested callsign, in request order |
 
-**Use case:** Pre-populate the cache before a contest session begins by looking up a list of expected callsigns in one call.
+**Use case:** Populate the cache before a contest session. Look up the expected callsigns in one call.
 
 **Notable status codes:**
-- `OK` — normal response, including the empty-input case (returns an empty `results` list).
-- `INTERNAL` — surfaced if a per-callsign worker task fails unexpectedly.
+- `OK` - normal response, including the empty-input case (returns an empty `results` list).
+- `INTERNAL` - surfaced if a per-callsign worker task fails unexpectedly.
 
 ---
 
@@ -229,17 +230,17 @@ rpc BatchLookup(BatchLookupRequest) returns (BatchLookupResponse)
 
 | Value | Meaning |
 |---|---|
-| `LOOKUP_STATE_UNSPECIFIED` | Default/zero value — should not appear in normal responses |
-| `LOOKUP_STATE_LOADING` | Request is in flight; used as the initial `StreamLookup` emission |
-| `LOOKUP_STATE_FOUND` | Callsign resolved successfully; `record` field is populated |
+| `LOOKUP_STATE_UNSPECIFIED` | Default or zero value. Normal responses do not contain this value. |
+| `LOOKUP_STATE_LOADING` | Request is in flight. Used as the initial `StreamLookup` emission |
+| `LOOKUP_STATE_FOUND` | The lookup found the callsign. The response contains `record`. |
 | `LOOKUP_STATE_NOT_FOUND` | Callsign does not exist in the provider |
 | `LOOKUP_STATE_ERROR` | Provider error (network failure, auth failure, rate limit) |
 | `LOOKUP_STATE_STALE` | Returning cached data while a background refresh is pending |
-| `LOOKUP_STATE_CANCELLED` | Lookup was superseded by a newer request |
+| `LOOKUP_STATE_CANCELLED` | A newer request replaced the lookup. |
 
 ## Error Handling Notes
 
-- `LookupService` returns gRPC `OK` for most responses; the semantic outcome is always in `LookupResult.state`.
-- Treat `LOOKUP_STATE_ERROR` as a soft error — log the `error_message`, show feedback to the user, but do not crash. The provider may recover on the next request.
-- `LOOKUP_STATE_STALE` means stale data is being returned while the cache refreshes. Display the stale data and update when the next result arrives.
-- Clients should handle `CANCELLED` responses gracefully — they are expected during type-ahead debounce scenarios where older requests are abandoned.
+- `LookupService` returns gRPC `OK` for most responses. The semantic outcome is always in `LookupResult.state`.
+- Treat `LOOKUP_STATE_ERROR` as a soft error. Record the `error_message` and show user feedback. The provider can recover on the next request.
+- `LOOKUP_STATE_STALE` means the engine returns old data during a cache refresh. Display the old data. Update it after the next result.
+- Clients must accept `CANCELLED` responses. These responses occur when a type-ahead request replaces an older request.

--- a/docs/api/setup-service.md
+++ b/docs/api/setup-service.md
@@ -20,8 +20,8 @@ Use it to:
 
 | RPC | Status | Notes |
 |---|---|---|
-| `GetSetupStatus` | ✅ Implemented | Returns persisted setup status, config path, suggested log file path, and validation warnings |
-| `SaveSetup` | ✅ Implemented | Validates and writes `config.toml`, then hot-applies the new persisted config to the running engine |
+| `GetSetupStatus` | Implemented | Returns persisted setup status, config path, suggested log file path, and validation warnings |
+| `SaveSetup` | Implemented | Validates and writes `config.toml`, then hot-applies the new persisted config to the running engine |
 
 Both RPCs use unique request/response envelopes and share a reusable `SetupStatus` payload. `GetSetupStatusResponse.status` and `SaveSetupResponse.status` each carry that payload instead of reusing an RPC response as a nested model.
 
@@ -53,7 +53,7 @@ rpc GetSetupStatus(GetSetupStatusRequest) returns (GetSetupStatusResponse)
 | `active_station_profile_id` | `string` (optional) | Persisted active station-profile id when profile lifecycle is configured |
 | `station_profile_count` | `uint32` | Count of persisted station profiles currently stored |
 | `qrz_xml_username` | `string` (optional) | Persisted QRZ XML username |
-| `has_qrz_xml_password` | `bool` | Whether a QRZ XML password is stored |
+| `has_qrz_xml_password` | `bool` | Whether storage contains a QRZ XML password |
 | `suggested_log_file_path` | `string` | Recommended log file path when the user has not picked one yet |
 | `warnings` | `repeated string` | Human-readable setup gaps or validation warnings |
 
@@ -78,9 +78,9 @@ Saved setup persists the QRZ XML password so engine restarts can continue servin
 
 **Validation rules**
 
-- `station_profile.station_callsign` is required
-- `log_file_path` is required for the current operator-facing setup flow
-- QRZ XML username/password must either both be set or both be omitted
+- Supply `station_profile.station_callsign`.
+- Supply `log_file_path` for the current operator setup flow.
+- Supply both QRZ XML credentials or neither credential.
 - `dxcc`, `cq_zone`, and `itu_zone` must be greater than zero when present
 - `latitude` / `longitude` must be finite and within valid bounds
 
@@ -90,7 +90,7 @@ Saved setup persists the QRZ XML password so engine restarts can continue servin
 |---|---|---|
 | `status` | `SetupStatus` | The persisted setup state after validation/save completes |
 
-Legacy compatibility note: the proto still carries `storage_backend`, `sqlite_path`, and `suggested_sqlite_path` for older clients, but new callers should use `log_file_path` and `suggested_log_file_path`.
+Legacy compatibility note: the proto still contains `storage_backend`, `sqlite_path`, and `suggested_sqlite_path` for older clients. New callers must use `log_file_path` and `suggested_log_file_path`.
 
 ## Persistence model
 
@@ -101,4 +101,4 @@ Legacy compatibility note: the proto still carries `storage_backend`, `sqlite_pa
   - environment: `QSORIPPER_CONFIG_PATH`
   - CLI: `--config path\to\config.toml`
 
-Saved setup is hot-applied to the running engine for **new** requests. Existing saved QSOs remain unchanged because they already carry their own `station_snapshot`.
+The engine hot-applies saved setup for **new** requests. Existing QSOs do not change because each QSO contains its own `station_snapshot`.

--- a/docs/api/station-profile-service.md
+++ b/docs/api/station-profile-service.md
@@ -20,14 +20,14 @@ Historical QSOs remain stable because saved records already carry their own `sta
 
 | RPC | Status | Notes |
 |---|---|---|
-| `ListStationProfiles` | ✅ Implemented | Returns every persisted profile plus the active id |
-| `GetStationProfile` | ✅ Implemented | Reads a single profile by id |
-| `SaveStationProfile` | ✅ Implemented | Creates or updates a profile and optionally makes it active |
-| `DeleteStationProfile` | ✅ Implemented | Deletes an inactive profile |
-| `SetActiveStationProfile` | ✅ Implemented | Switches the persisted active profile |
-| `GetActiveStationContext` | ✅ Implemented | Returns persisted active, effective active, and session override state |
-| `SetSessionStationProfileOverride` | ✅ Implemented | Applies a process-session override for new QSO saves |
-| `ClearSessionStationProfileOverride` | ✅ Implemented | Clears the process-session override |
+| `ListStationProfiles` | Implemented | Returns every persisted profile plus the active id |
+| `GetStationProfile` | Implemented | Reads a single profile by id |
+| `SaveStationProfile` | Implemented | Creates or updates a profile and optionally makes it active |
+| `DeleteStationProfile` | Implemented | Deletes an inactive profile |
+| `SetActiveStationProfile` | Implemented | Switches the persisted active profile |
+| `GetActiveStationContext` | Implemented | Returns persisted active, effective active, and session override state |
+| `SetSessionStationProfileOverride` | Implemented | Applies a process-session override for new QSO saves |
+| `ClearSessionStationProfileOverride` | Implemented | Clears the process-session override |
 
 ## Contract shape
 
@@ -35,7 +35,7 @@ This service follows the same protobuf 1-1-1 rule as the rest of the engine surf
 
 - every RPC has a unique request/response envelope
 - shared payloads such as `StationProfileRecord` and `ActiveStationContext` live in their own support files under `proto/services/`
-- response envelopes wrap those payloads instead of being reused as nested models elsewhere
+- Response envelopes contain those payloads. Do not reuse an envelope as a nested model.
 
 ### Reusable payloads
 
@@ -60,6 +60,6 @@ This service follows the same protobuf 1-1-1 rule as the rest of the engine surf
 ## Notes
 
 - `SaveStationProfile`, `DeleteStationProfile`, and `SetActiveStationProfile` require persisted setup to already exist. Run `SetupService.SaveSetup` first.
-- When `profile_id` is omitted on save, the server generates one from the profile metadata.
-- The active profile cannot be deleted; activate another profile first.
+- When a save request omits `profile_id`, the server generates it from profile metadata.
+- Do not delete the active profile. Activate another profile first.
 - Session overrides are process-local and in-memory only. Restarting the engine clears them.

--- a/docs/api/workflows.md
+++ b/docs/api/workflows.md
@@ -1,6 +1,6 @@
 # Workflow Examples
 
-This page provides example request/response shapes and state transitions for common QsoRipper engine workflows. These are intended to make integration concrete rather than requiring you to derive behavior from raw proto names.
+This page gives request, response, and state-transition examples for common QsoRipper workflows. The examples explain integration behavior that proto names do not show.
 
 All examples show field values in a language-neutral pseudo-JSON format. Actual wire encoding is binary protobuf.
 
@@ -82,7 +82,7 @@ The streaming variant is ideal for TUI/GUI clients that want to show a loading i
 
 **Stream (fresh lookup, no prior cache entry):**
 
-Message 1 — emitted immediately:
+Message 1 - emitted immediately:
 ```json
 {
   "result": {
@@ -92,7 +92,7 @@ Message 1 — emitted immediately:
 }
 ```
 
-Message 2 — emitted after provider responds:
+Message 2 - emitted after provider responds:
 ```json
 {
   "result": {
@@ -106,14 +106,14 @@ Message 2 — emitted after provider responds:
 ```
 *Stream closes after message 2.*
 
-**Stream (stale cache hit — returns cached data while refreshing):**
+**Stream (stale cache hit - returns cached data while refreshing):**
 
 Message 1:
 ```json
 { "result": { "state": "LOOKUP_STATE_LOADING", "queried_callsign": "K7ABC" } }
 ```
 
-Message 2 — stale entry returned immediately:
+Message 2 - stale entry returned immediately:
 ```json
 {
   "result": {
@@ -125,7 +125,7 @@ Message 2 — stale entry returned immediately:
 }
 ```
 
-Message 3 — fresh result replaces stale entry:
+Message 3 - fresh result replaces stale entry:
 ```json
 {
   "result": {
@@ -188,17 +188,17 @@ Use `GetCachedCallsign` when you want a zero-latency check without triggering a 
 **Recommended type-ahead pattern:**
 
 1. On each keystroke, call `GetCachedCallsign` for a zero-latency cache check.
-2. If the result is `FOUND` or `STALE`, display it immediately — no network call needed.
+2. If the result is `FOUND` or `STALE`, display it immediately - no network call needed.
 3. After a short debounce (typing has stabilized), call `StreamLookup` to fetch a fresh result.
 4. Update the display when the stream emits `FOUND`, `NOT_FOUND`, or `ERROR`.
 
-Calling `StreamLookup` on every keystroke without debounce would generate unnecessary network traffic. Wait for typing to stabilize before firing a provider lookup, and cancel in-flight streams when a newer request supersedes them.
+Do not call `StreamLookup` after each keystroke. This action causes unnecessary network traffic. Wait until typing stops. Cancel an active stream when a new request replaces it.
 
 ---
 
 ## LogbookService Workflows
 
-> **Note:** Local `LogbookService` CRUD, status, and ADIF import/export flows are implemented today. QRZ sync remains unimplemented; see the [LogbookService Reference](logbook-service.md) for the current status table.
+> **Note:** Local `LogbookService` implements CRUD, status, and ADIF transfer. QRZ sync has no implementation. See the [LogbookService Reference](logbook-service.md).
 
 ---
 
@@ -221,7 +221,7 @@ Calling `StreamLookup` on every keystroke without debounce would generate unnece
 }
 ```
 
-> When an effective active station context exists, `station_callsign` can be omitted from `LogQso` and will be derived from that active context. If no active context exists, the request must still provide `station_callsign` explicitly.
+> When an active station context exists, `LogQso` can omit `station_callsign`. The engine gets it from that context. Otherwise, the request must supply it.
 
 **Response:**
 ```json
@@ -351,9 +351,12 @@ Client closes the send side after all chunks are sent.
 
 Notes:
 - The server buffers all incoming chunks, parses only after the client closes the stream, then imports records.
-- Imported `STATION_CALLSIGN`, `OPERATOR`, and `MY_*` fields are preserved as historical `station_snapshot` data.
-- The active station profile is only used when the ADIF record has no local-station context at all, and that fallback is reported in `warnings`.
-- Records with unrecognized core ADIF values such as `BAND`, `MODE`, or invalid `QSO_DATE`/`TIME_ON` are skipped with warnings; the raw ADIF values remain in `extra_fields` for round-trip export fidelity.
+- The engine preserves imported `STATION_CALLSIGN`, `OPERATOR`, and `MY_*` fields in historical `station_snapshot` data.
+- The engine uses the active station profile only when the ADIF record has no local-station context. It reports this fallback in `warnings`.
+- The server skips records that have unrecognized core ADIF values.
+  Examples include `BAND`, `MODE`, or invalid `QSO_DATE` and `TIME_ON` values.
+  The server adds warnings for these records.
+  Raw values remain in `extra_fields` for round-trip export.
 
 ---
 
@@ -372,10 +375,10 @@ Export all QSOs between two dates:
 
 **Response stream:** One or more `ExportAdifResponse` messages containing raw ADIF bytes in `chunk.data`, then stream close.
 
-Clients should concatenate chunk data in order to reconstruct the complete ADIF file.
+Clients must concatenate chunk data to reconstruct the complete ADIF file.
 
 Notes:
-- Filters already present in `ExportAdifRequest` (`after`, `before`, `contest_id`) are applied before serialization.
+- Apply the `ExportAdifRequest` filters before serialization: `after`, `before`, and `contest_id`.
 - Export order is chronological (`oldest first`) for predictable migration output.
 - When `include_header` is `true`, the payload starts with an ADIF header containing the QsoRipper program metadata.
 
@@ -398,4 +401,4 @@ Use `GetSyncStatus` to verify engine connectivity and check logbook statistics:
 }
 ```
 
-> Current server reports live local counts from the configured backend. Until QRZ sync is implemented, QRZ-specific fields remain `0` or absent.
+> The current server reports live local counts from the configured backend. Until QRZ sync has an implementation, QRZ fields remain `0` or absent.

--- a/docs/architecture/data-model.md
+++ b/docs/architecture/data-model.md
@@ -2,7 +2,10 @@
 
 ## Overview
 
-QsoRipper uses **Protocol Buffers (proto3)** as the canonical schema definition for all shared domain types and engine/client service contracts. Proto files are the single source of truth — Rust structs and C# classes are generated from them, keeping engine hosts and clients aligned across language boundaries.
+QsoRipper uses **Protocol Buffers (proto3)** for all shared domain types and service contracts.
+Proto files are the single source of truth.
+The build generates Rust structures and C# classes from these files.
+Thus, engine hosts and clients use the same cross-language contracts.
 
 ## Why Protocol Buffers?
 
@@ -10,16 +13,16 @@ QsoRipper uses **Protocol Buffers (proto3)** as the canonical schema definition 
 |---|---|
 | Cross-language type safety | Code generation for Rust (`prost`) and C# (`Grpc.Tools`) from one schema |
 | Wire format | Binary protobuf over gRPC for inter-process communication |
-| Forward compatibility | Proto3 ignores unknown fields — matches QRZ API's own forward-compat model |
-| Schema evolution | Adding optional fields is non-breaking; `buf breaking` enforces rules |
-| Performance | Binary serialization is fast and compact — no JSON parsing overhead on the hot path |
+| Forward compatibility | Proto3 ignores unknown fields - matches QRZ API's own forward-compat model |
+| Schema evolution | Adding optional fields is non-breaking. `buf breaking` enforces rules |
+| Performance | Binary serialization is fast and compact - no JSON parsing overhead on the hot path |
 
 ## Architecture Alignment
 
 The proto-first approach directly supports these architecture principles:
 
-- **Principle #6 (Normalize Data Immediately)**: QRZ XML/ADIF responses are parsed and mapped into proto domain types at the provider edge. Internal communication always uses normalized types.
-- **Principle #8 (Consumer-Driven Interfaces)**: Proto messages are designed around what the UI needs (for example, `LookupResult` wraps state + data + latency), not QRZ's XML structure.
+- **Principle #6 (Normalize Data Immediately)**: Providers parse QRZ XML or ADIF responses and map them to proto domain types. Internal communication always uses normalized types.
+- **Principle #8 (Consumer-Driven Interfaces)**: UI requirements control proto message design. For example, `LookupResult` contains state, data, and latency.
 - **Stable core, volatile edges**: Proto domain types are the stable core. QRZ XML parsing, ADIF parsing, and HTTP concerns are edge adapters that produce proto types.
 
 ## Proto Layout Rules
@@ -29,8 +32,10 @@ QsoRipper treats the protobuf 1-1-1 guidance as an architectural rule, not a sty
 - **One top-level entity per file by default**: messages, enums, and services each get their own `.proto` file.
 - **Service declaration files contain only the service**: request, response, stream item, enum, and support payload messages live in separate files under `proto/services/`.
 - **Every RPC gets unique request/response envelopes**: unary and streaming methods both use method-specific `XxxRequest` / `XxxResponse` messages.
-- **Reusable business payloads stay separate from envelopes**: shared models such as `LookupResult`, `QsoRecord`, `SetupStatus`, and `ActiveStationContext` are nested inside envelopes rather than returned directly as RPC shapes.
-- **Exceptions are rare and explicit**: if QsoRipper ever deviates from 1-1-1, that decision must be documented and justified in the schema review. RPC envelopes are not the place for exceptions.
+- **Keep reusable business payloads separate from envelopes.**
+  Put shared models inside the method-specific envelopes.
+  Examples include `LookupResult`, `QsoRecord`, `SetupStatus`, and `ActiveStationContext`.
+- **Exceptions are rare and explicit**: The schema review must document and justify each change from 1-1-1. Do not use RPC envelopes for exceptions.
 
 ## Directory Structure
 
@@ -65,7 +70,7 @@ proto/
 | TUI client | Rust (ratatui) | Keyboard-first client proving Rust can consume the gRPC seam too |
 | CLI / GUI / DebugHost clients | C# / .NET | Rich client and debugging surfaces on the shared contracts |
 
-**Key rule:** the protobuf/gRPC contract is the stable core. Any process that implements it can be an engine host, and any process that consumes it can be a client. Rust is no longer "the engine" as an architectural requirement; it is one engine implementation in the current repository.
+**Key rule:** the protobuf/gRPC contract is the stable core. Any process that implements it can be an engine host, and any process that consumes it can be a client. Rust is no longer "the engine" as an architectural requirement. It is one engine implementation in the current repository.
 
 ## Core Domain Types
 
@@ -81,7 +86,7 @@ Normalized representation of a ham radio operator/station. Derived from QRZ XML 
 - **Contact**: email, web_url, qsl_manager
 - **QSL preferences**: eqsl, lotw, paper_qsl (tri-state enum)
 - **Zone**: cq_zone, itu_zone, iota
-- **Metadata**: qrz_serial, last_modified, bio_length, image_url, etc.
+- **Metadata**: qrz_serial, last_modified, bio_length, image_url, and other items
 
 ### QsoRecord (`qso_record.proto`)
 
@@ -105,16 +110,36 @@ Wraps the async state machine for callsign lookups:
 Loading → Found | NotFound | Error | Stale | Cancelled
 ```
 
-Includes: state enum, optional CallsignRecord, cache_hit flag, lookup_latency_ms, plus prior-QSO history (`prior_qsos` and `prior_qso_total_count`) populated from the local logbook on every non-`Loading` result.
+It contains a state enum, optional `CallsignRecord`, `cache_hit`, and `lookup_latency_ms`.
+Each non-`Loading` result also contains local prior-QSO history.
+The history uses `prior_qsos` and `prior_qso_total_count`.
 
 ### QsoHistoryEntry (`qso_history_entry.proto`)
 
-Compact summary of a prior QSO with the queried callsign, returned alongside `LookupResult` so UIs can show a "worked before" badge without a second round-trip. Fields are a strict subset of `QsoRecord`: `local_id`, `utc_timestamp`, `band`, `mode`, `submode`, `frequency_hz`, `frequency_rx_hz`, `contest_id`. The shape covers both normal-mode badges and future contest-mode dupe rules — `(band, mode, contest_id)` is sufficient for every common contest dupe rule, and `contest_id` lets a future contest engine differentiate current-contest contacts from past contacts. Contest mode is not implemented yet; this shape is forward-compatible so adding it later is purely additive.
+This message is a compact summary of a prior QSO with the queried callsign.
+It accompanies `LookupResult`.
+Thus, a UI can show a "worked before" badge without a second request.
+Its fields are a strict subset of `QsoRecord`:
+
+- `local_id`
+- `utc_timestamp`
+- `band`
+- `mode`
+- `submode`
+- `frequency_hz`
+- `frequency_rx_hz`
+- `contest_id`
+
+The message supports normal-mode badges and future contest duplicate rules.
+`(band, mode, contest_id)` supports the common duplicate rules.
+`contest_id` separates current-contest contacts from past contacts.
+Contest mode is not implemented.
+The message supports a later additive implementation.
 
 ### Supporting Enums
 
 - **Band**: 2190m through submm (33 values, full ADIF 3.1.7 enumeration with frequency ranges)
-- **Mode**: 45 modes matching the complete ADIF 3.1.7 Mode enumeration; submodes are stored as a string field
+- **Mode**: 45 modes matching the complete ADIF 3.1.7 Mode enumeration. A string field stores submodes.
 - **GeoSource**: user, geocode, grid, zip, state, dxcc, none (maps to QRZ geoloc values)
 - **SyncStatus**: local_only, synced, modified, conflict
 - **QslStatus**: no, yes, requested, queued, ignore (aligned with ADIF QSL Sent/Rcvd enums)
@@ -131,42 +156,59 @@ Client → LookupService → Engine-specific lookup coordinator/provider chain
 ```
 
 Key RPCs:
-- `Lookup` — single request/response
-- `StreamLookup` — server-streaming progressive updates (Loading → Stale → Found)
-- `GetCachedCallsign` — L1 cache-only check
-- `GetDxccEntity` — DXCC entity lookup
-- `BatchLookup` — contest prefetch
+- `Lookup` - single request/response
+- `StreamLookup` - server-streaming progressive updates (Loading → Stale → Found)
+- `GetCachedCallsign` - L1 cache-only check
+- `GetDxccEntity` - DXCC entity lookup
+- `BatchLookup` - contest prefetch
 
-Each RPC returns a unique service envelope such as `LookupResponse`, `StreamLookupResponse`, or `GetCachedCallsignResponse`. Shared payloads like `LookupResult` stay nested inside those envelopes so each RPC can evolve independently. Current built-in engine hosts implement the unary/stream/cache lookup slice and advertise those capabilities explicitly (`lookup-callsign`, `lookup-stream`, `lookup-cache`). `BatchLookup` and `GetDxccEntity` by numeric `dxcc_code` are also implemented in both the Rust and .NET hosts; `GetDxccEntity` by callsign `prefix` is the only remaining branch that still returns `UNIMPLEMENTED`. See [`docs/api/lookup-service.md`](../api/lookup-service.md) for the authoritative RPC support table.
+Each RPC returns a unique service envelope.
+Examples include `LookupResponse`, `StreamLookupResponse`, and `GetCachedCallsignResponse`.
+Shared payloads remain inside these envelopes.
+Thus, each RPC can change independently.
+Both built-in hosts implement unary, stream, and cache lookup.
+They advertise `lookup-callsign`, `lookup-stream`, and `lookup-cache`.
+
+Both hosts also implement `BatchLookup`.
+They implement `GetDxccEntity` for numeric `dxcc_code` queries.
+The callsign `prefix` query still returns `UNIMPLEMENTED`.
+See [`docs/api/lookup-service.md`](../api/lookup-service.md) for the RPC support table.
 
 ### LogbookService
 
 QSO lifecycle management:
 
-- `LogQso` / `UpdateQso` / `DeleteQso` — CRUD with optional immediate QRZ sync
-- `ListQsos` — filtered/paginated query with server-streaming response
-- `SyncWithQrz` — full or incremental sync, streams progress updates
-- `ImportAdif` / `ExportAdif` — client-streaming import, server-streaming export
+- `LogQso` / `UpdateQso` / `DeleteQso` - CRUD with optional immediate QRZ sync
+- `ListQsos` - filtered/paginated query with server-streaming response
+- `SyncWithQrz` - full or incremental sync, streams progress updates
+- `ImportAdif` / `ExportAdif` - client-streaming import, server-streaming export
 
-Logbook RPCs follow the same rule: `ListQsos` streams `ListQsosResponse` envelopes that carry `QsoRecord`, `ExportAdif` streams `ExportAdifResponse` envelopes that carry `AdifChunk`, and unary RPCs use method-specific envelopes even when the payload is a single shared domain type.
+Logbook RPCs use the same envelope rule.
+`ListQsos` streams `ListQsosResponse` envelopes that contain `QsoRecord`.
+`ExportAdif` streams `ExportAdifResponse` envelopes that contain `AdifChunk`.
+Unary RPCs use method-specific envelopes for single shared payloads.
 
 ## ADIF as External Format
 
-ADIF (Amateur Data Interchange Format) is used exclusively for:
+QsoRipper uses ADIF (Amateur Data Interchange Format) only for:
 
-1. **QRZ Logbook API** — INSERT/FETCH use ADIF-encoded QSO data
-2. **File import/export** — standard `.adi` files from other logging programs
-3. **Contest log submission** — Cabrillo/ADIF export
+1. **QRZ Logbook API** - INSERT/FETCH use ADIF-encoded QSO data
+2. **File import/export** - standard `.adi` files from other logging programs
+3. **Contest log submission** - Cabrillo/ADIF export
 
 ADIF is **never** used for internal IPC. Engine-specific ADIF adapters convert to/from proto `QsoRecord` at the edge.
 
 ### ADIF Round-Trip Strategy
 
-QsoRecord includes an `extra_fields` map (`map<string, string>`) to preserve ADIF fields that don't have dedicated proto fields (e.g., satellite info, propagation conditions, application-defined fields). Core local-station ADIF fields now flow through `station_snapshot` instead of `extra_fields`. During import:
+QsoRecord includes an `extra_fields` map (`map<string, string>`) for ADIF fields without dedicated proto fields.
+Examples are satellite information, propagation conditions, and application-defined fields.
+Core local-station ADIF fields now flow through `station_snapshot` instead of `extra_fields`.
+During import:
 
 1. Recognized fields → mapped to dedicated QsoRecord fields
 2. Unrecognized fields → stored in `extra_fields` (keyed by uppercase ADIF field name)
-3. During export → dedicated fields are emitted first, then `extra_fields` are appended
+3. During export, emit dedicated fields first.
+4. Then append `extra_fields`.
 
 This ensures no data loss when round-tripping ADIF files through QsoRipper.
 
@@ -176,9 +218,9 @@ See `docs/integrations/adif-specification.md` for the complete ADIF 3.1.7 refere
 
 ### Tooling
 
-- **buf** — schema linting (`buf lint`) and breaking change detection (`buf breaking`)
-- **prost + tonic-build** — Rust struct/gRPC generation during Cargo builds
-- **Grpc.Tools** — C# class/gRPC generation during MSBuild
+- **buf** - schema linting (`buf lint`) and breaking change detection (`buf breaking`)
+- **prost + tonic-build** - Rust struct/gRPC generation during Cargo builds
+- **Grpc.Tools** - C# class/gRPC generation during MSBuild
 
 ### Build integration
 
@@ -200,8 +242,8 @@ dotnet build src/dotnet/QsoRipper.slnx
 
 | Language | Output path | Notes |
 |---|---|---|
-| Rust | Cargo `OUT_DIR` under `src/rust/target/` | Generated at build time by `src/rust/qsoripper-core/build.rs`; not checked in |
-| C# | MSBuild intermediate output under `src/dotnet/**/obj/` | Generated at build time by `Grpc.Tools`; not checked in |
+| Rust | Cargo `OUT_DIR` under `src/rust/target/` | Generated at build time by `src/rust/qsoripper-core/build.rs`. Not checked in |
+| C# | MSBuild intermediate output under `src/dotnet/**/obj/` | Generated at build time by `Grpc.Tools`. Not checked in |
 
 ## Adding a New Field
 
@@ -209,19 +251,20 @@ dotnet build src/dotnet/QsoRipper.slnx
 2. Run `buf lint` to verify naming conventions
 3. Run `buf breaking` to verify backward compatibility
 4. Rebuild the Rust workspace and .NET consumers so generated bindings refresh
-5. Update the provider adapter (e.g., QRZ XML parser) to populate the new field
-6. Update the UI components that should display the field
+5. Update the provider adapter (for example, QRZ XML parser) to populate the new field
+6. Update the UI components that display the field.
 
-**Important:** Never reuse or reassign proto field numbers. Deleted fields should be marked with `reserved`.
+**Important:** Never reuse or reassign proto field numbers. Mark deleted fields with `reserved`.
 
 ## Conventions
 
-- **Field numbering**: Group related fields in ranges (identity: 1-9, name: 10-19, address: 20-29, etc.)
+- **Field numbering**: Group related fields in ranges (identity: 1-9, name: 10-19, address: 20-29, and other items)
 - **Field naming**: snake_case in proto files (auto-converted to PascalCase in C#, snake_case in Rust)
-- **Optional fields**: Use `optional` keyword for fields that may not be present from the provider
-- **Enums**: Prefer `_UNSPECIFIED = 0` when the schema has a neutral default; operational defaults may intentionally keep a domain-specific zero value
+- **Optional fields**: Use the `optional` keyword for fields that the provider can omit.
+- **Enums**: Prefer `_UNSPECIFIED = 0` when the schema has a neutral default. An operational default can keep a domain-specific zero value.
 - **Timestamps**: Use `google.protobuf.Timestamp` for all date/time fields
 - **C# namespace**: Set via `option csharp_namespace = "QsoRipper.Domain"` or `"QsoRipper.Services"`
 - **Packages**: Keep the current `proto/domain` and `proto/services` layout with `qsoripper.domain` / `qsoripper.services` packages until the project deliberately introduces versioned external contracts
 - **1-1-1 layout**: Default to one top-level message, enum, or service per `.proto` file
-- **RPC message shapes**: Every RPC gets unique `XxxRequest` and `XxxResponse` envelopes; shared payloads are nested inside those envelopes rather than used as the top-level RPC contract
+- **RPC message shapes**: Give each RPC unique `XxxRequest` and `XxxResponse` envelopes.
+  Put shared payloads inside these envelopes.

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -1,18 +1,21 @@
 # QsoRipper Engine Specification
 
-> **Version 1.0** — The authoritative contract for implementing a QsoRipper engine in any language.
+> **Version 1.0** - The authoritative contract for implementing a QsoRipper engine in any language.
 >
 > This is a living document. When proto files, services, or behavioral contracts change, update this specification in the same change.
 
-A QsoRipper engine is the core runtime that owns QSO logging, callsign lookup, rig control, space weather, contest calendar lookup, station profiles, and external sync. Engines expose a gRPC API over HTTP/2 that any client — TUI, GUI, CLI, or web — can consume. The architecture is explicitly multi-engine: any conformant implementation, regardless of language, can serve as the engine behind any QsoRipper client.
+A QsoRipper engine is the core runtime that owns QSO logging, callsign lookup, rig control, space weather, contest calendar lookup, station profiles, and external sync. Engines expose a gRPC API over HTTP/2 that any client - TUI, GUI, CLI, or web - can consume. The architecture is explicitly multi-engine: any conformant implementation, regardless of language, can serve as the engine behind any QsoRipper client.
 
-This document is self-contained. A developer should be able to implement a fully conformant engine using only this specification and the `.proto` files under `proto/`.
+This document is self-contained. A developer can implement a conformant engine with this specification and the `.proto` files under `proto/`.
 
 ---
 
 ## 1. Overview
 
-QsoRipper is a high-performance ham radio logging system. Its architecture separates the **engine** (the server process that owns all data, integration, and business logic) from **clients** (TUI, GUI, CLI, DebugHost) that consume the engine over gRPC.
+QsoRipper is a high-performance ham radio logging system.
+The **engine** owns all data, integrations, and business logic.
+The clients use the engine through gRPC.
+Clients include the TUI, GUI, CLI, and DebugHost.
 
 Key architectural properties:
 
@@ -60,7 +63,11 @@ The engine does **not** own any UI rendering, keyboard handling, or display logi
           └────────────────────────────┘
 ```
 
-Clients connect to the engine through a single configured gRPC endpoint. The built-in local profiles use `http://127.0.0.1:50051` for Rust and `http://127.0.0.1:50052` for .NET so both engines can run concurrently. Clients may also connect through a gRPC-Web proxy for browser-based surfaces.
+Clients connect to the engine through one configured gRPC endpoint.
+The Rust profile uses `http://127.0.0.1:50051`.
+The .NET profile uses `http://127.0.0.1:50052`.
+Thus, both engines can operate at the same time.
+Browser clients can use a gRPC-Web proxy.
 
 ### 2.3 Protocol Buffers as Contract Core
 
@@ -68,10 +75,10 @@ All shared types live under `proto/`:
 
 | Directory | Contents |
 |---|---|
-| `proto/domain/` | Domain model messages and enums (QsoRecord, CallsignRecord, Band, Mode, etc.) |
+| `proto/domain/` | Domain model messages and enums (QsoRecord, CallsignRecord, Band, Mode, and other items) |
 | `proto/services/` | Service definitions, RPC envelopes, and service-layer support types |
 
-Engines generate language-specific bindings from these files. In Rust, `prost` and `tonic` generate types at build time. In C#, `Grpc.Tools` generates at build time. Never hand-write types that should come from proto generation.
+Engines generate language-specific bindings from these files. In Rust, `prost` and `tonic` generate types during the build. In C#, `Grpc.Tools` generates them. Never write generated types manually.
 
 The 1-1-1 rule applies: one top-level message, enum, or service per `.proto` file. Every RPC uses unique `XxxRequest`/`XxxResponse` envelopes. See `docs/architecture/data-model.md` for the full proto conventions.
 
@@ -80,7 +87,7 @@ The 1-1-1 rule applies: one top-level message, enum, or service per `.proto` fil
 - Native gRPC clients (CLI, TUI, GUI) connect directly over HTTP/2.
 - Browser clients (DebugHost) connect through a gRPC-Web proxy that translates between gRPC-Web and native gRPC.
 - The engine listens on a configurable address controlled by `QSORIPPER_SERVER_ADDR` or the launcher. Standalone defaults are `127.0.0.1:50051` for Rust and `127.0.0.1:50052` for .NET.
-- TLS is not required for local development. Production deployments should use TLS or a reverse proxy.
+- TLS is not necessary for local development. Production deployments must use TLS or a reverse proxy.
 
 ---
 
@@ -110,14 +117,14 @@ Returns metadata about the running engine.
 - Must always succeed if the engine is running.
 - Returns the engine's identity (`engine_id`, `display_name`), version string, and a list of supported capability strings.
 - The response is an `EngineInfo` message (see `proto/services/engine_info.proto`) containing:
-  - `engine_id` — stable identifier (for example, `"rust-tonic"` or `"dotnet-aspnet"`)
-  - `display_name` — human-readable label
-  - `version` — implementation version. Rust reports SemVer. .NET may report the four-component assembly version form.
-  - `capabilities` — repeated list of capability names (see §8)
+  - `engine_id` - stable identifier (for example, `"rust-tonic"` or `"dotnet-aspnet"`)
+  - `display_name` - human-readable label
+  - `version` - implementation version. Rust reports SemVer. .NET can report the four-component assembly version form.
+  - `capabilities` - repeated list of capability names (see §8)
 
 **Error semantics:**
-- This RPC should never fail under normal operation.
-- `UNAVAILABLE` — engine is shutting down.
+- This RPC must not fail during normal operation.
+- `UNAVAILABLE` - engine is shutting down.
 
 ### 3.2 LogbookService
 
@@ -152,15 +159,27 @@ Creates a new QSO record in the local logbook.
 4. Stamp `station_callsign` from the active station profile.
 5. Capture a `StationSnapshot` from the active station context and attach it to the QSO.
 6. Set `created_at` and `updated_at` to the current UTC time.
-7. Set `sync_status` to `SYNC_STATUS_LOCAL_ONLY`, clear QRZ linkage, and clear soft-delete state. These fields are engine-owned and caller values are ignored.
+7. Set `sync_status` to `SYNC_STATUS_LOCAL_ONLY`, clear QRZ linkage, and clear soft-delete state. The engine ignores caller values for these fields.
 8. Persist the record via the storage backend.
-9. If `sync_to_qrz=true`, immediately push the new record to QRZ Logbook (per-operation sync; see §7.3 below). On success, adopt the QRZ-assigned `qrz_logid`, set `sync_status=SYNC_STATUS_SYNCED`, and write the row back to storage. Populate `LogQsoResponse.sync_success=true`. On failure (no API key, network error, QRZ rejection), leave `sync_status=SYNC_STATUS_LOCAL_ONLY`, set `sync_success=false`, and put a human-readable message in `sync_error`. The local persist MUST succeed regardless. If sync was not requested, `sync_success=false` and `sync_error` is absent.
-10. Return the generated `local_id` and any successful QRZ `qrz_logid`. The response envelope does not carry a `QsoRecord`; clients that need the stored row call `GetQso`.
+9. If `sync_to_qrz=true`, immediately push the new record to QRZ Logbook.
+   This operation uses the per-operation sync in Section 7.3.
+   - On success, use the QRZ-assigned `qrz_logid`.
+   - Set `sync_status=SYNC_STATUS_SYNCED`.
+   - Write the row to storage.
+   - Set `LogQsoResponse.sync_success=true`.
+   - On failure, keep `sync_status=SYNC_STATUS_LOCAL_ONLY`.
+   - Set `sync_success=false`.
+   - Put a clear message in `sync_error`.
+   - The local save MUST succeed for all sync results.
+   - If sync was not requested, set `sync_success=false` and omit `sync_error`.
+10. Return the generated `local_id` and a successful QRZ `qrz_logid`.
+    The response does not contain a `QsoRecord`.
+    Clients that need the stored row call `GetQso`.
 
 **Error semantics:**
-- `INVALID_ARGUMENT` — missing or invalid required fields.
-- `FAILED_PRECONDITION` — no active station profile set (station context unavailable).
-- `INTERNAL` — storage write failure.
+- `INVALID_ARGUMENT` - missing or invalid required fields.
+- `FAILED_PRECONDITION` - no active station profile set (station context unavailable).
+- `INTERNAL` - storage write failure.
 
 #### UpdateQso
 
@@ -170,21 +189,47 @@ Updates an existing QSO record by `local_id`.
 1. Look up the existing record by `local_id`.
 2. Treat `request.qso` as a full replacement of all caller-owned QSO fields. Proto3 default values clear scalar fields, absent optional fields clear those fields, and `extra_fields` replaces the existing map. This RPC is not a patch operation because the request has no `FieldMask`.
 3. Set `updated_at` to the current UTC time.
-4. If the QSO was previously synced, set `sync_status` to `SYNC_STATUS_MODIFIED`. The engine — not the client — is the source of truth for `sync_status` and `qrz_logid` on update: round-tripping the existing values from a client request MUST NOT change them, and a client MUST NOT be able to advance a `LOCAL_ONLY` row to `SYNCED` (or claim a `qrz_logid`) via `UpdateQso`. The only state transitions the engine performs here are `SYNCED → MODIFIED` on edit, and (in step 6) `MODIFIED → SYNCED` on a successful per-op sync.
+4. If the QSO was previously synced, set `sync_status` to `SYNC_STATUS_MODIFIED`.
+   The engine owns `sync_status` and `qrz_logid` during an update.
+   A client request MUST NOT change these values.
+   A client MUST NOT change a `LOCAL_ONLY` row to `SYNCED` through `UpdateQso`.
+   A client also MUST NOT claim a `qrz_logid`.
+   An edit changes `SYNCED` to `MODIFIED`.
+   A successful step 6 sync changes `MODIFIED` to `SYNCED`.
 5. Persist the updated record.
-6. If `sync_to_qrz=true`, immediately push the updated record to QRZ Logbook (per-operation sync; see §7.3 below). If the row already has a `qrz_logid`, use REPLACE so the same remote row is updated in place; otherwise INSERT. On success, write back the QRZ-assigned `qrz_logid` and `sync_status=SYNC_STATUS_SYNCED`, and set `UpdateQsoResponse.sync_success=true`. On failure, leave the local row in its current state (`SYNC_STATUS_MODIFIED` or `SYNC_STATUS_LOCAL_ONLY`), set `sync_success=false`, and put a human-readable message in `sync_error`. If sync was not requested, `sync_success=false` and `sync_error` is absent. The local persist MUST succeed regardless.
-7. Return `success=true`. The response envelope does not carry a `QsoRecord`; clients that need the stored row call `GetQso`.
+6. If `sync_to_qrz=true`, immediately push the updated record to QRZ Logbook.
+   This operation uses the per-operation sync in Section 7.3.
+   - If the row has a `qrz_logid`, use REPLACE.
+   - If the row does not have a `qrz_logid`, use INSERT.
+   - On success, save the QRZ-assigned `qrz_logid`.
+   - Set `sync_status=SYNC_STATUS_SYNCED`.
+   - Set `UpdateQsoResponse.sync_success=true`.
+   - On failure, keep the current local sync state.
+   - Set `sync_success=false`.
+   - Put a clear message in `sync_error`.
+   - If sync was not requested, set `sync_success=false` and omit `sync_error`.
+   - The local save MUST succeed for all sync results.
+7. Return `success=true`.
+   The response does not contain a `QsoRecord`.
+   Clients that need the stored row call `GetQso`.
 
-The engine preserves all engine-owned fields from the existing row: `local_id`, `station_snapshot`, `created_at`, `qrz_logid`, `qrz_bookid`, sync state, delete state, and QRZ linkage held in optional fields. Resolution is by `local_id` only. A missing ID is `INVALID_ARGUMENT`; an unknown ID is `NOT_FOUND`.
+The engine preserves all engine-owned fields from the existing row.
+These fields include `local_id`, `station_snapshot`, `created_at`, `qrz_logid`, and `qrz_bookid`.
+They also include sync state, delete state, and optional QRZ linkage.
+The engine resolves records only by `local_id`.
+A missing ID is `INVALID_ARGUMENT`.
+An unknown ID is `NOT_FOUND`.
 
-Clients that round-trip a complete `QsoRecord` while editing MUST preserve `RstReport.raw`.
-Signed digital reports such as `+11` and `-10` are not legacy RST digit fields and MUST
-round-trip exactly when an unrelated field, including QRZ enrichment, is changed.
+Clients that round-trip a complete `QsoRecord` during an edit MUST preserve `RstReport.raw`.
+Signed digital reports include values such as `+11` and `-10`.
+They are not legacy RST digit fields.
+They MUST remain exact when an unrelated field changes.
+This requirement includes a QRZ enrichment change.
 
 **Error semantics:**
-- `NOT_FOUND` — no QSO with the given `local_id`.
-- `INVALID_ARGUMENT` — invalid field values.
-- `INTERNAL` — storage write failure.
+- `NOT_FOUND` - no QSO with the given `local_id`.
+- `INVALID_ARGUMENT` - invalid field values.
+- `INTERNAL` - storage write failure.
 
 #### DeleteQso
 
@@ -196,8 +241,8 @@ Soft-deletes a QSO record by `local_id`. See §7.8 for the complete state-transi
 3. Return success without physically removing the row.
 
 **Error semantics:**
-- `NOT_FOUND` — no QSO with the given `local_id`.
-- `INTERNAL` — storage delete failure.
+- `NOT_FOUND` - no QSO with the given `local_id`.
+- `INTERNAL` - storage delete failure.
 
 #### GetQso
 
@@ -207,7 +252,7 @@ Retrieves a single QSO record by `local_id`.
 - Return the full `QsoRecord` if found.
 
 **Error semantics:**
-- `NOT_FOUND` — no QSO with the given `local_id`.
+- `NOT_FOUND` - no QSO with the given `local_id`.
 
 #### ListQsos
 
@@ -215,14 +260,14 @@ Streams QSO records matching optional filter criteria.
 
 **Behavior:**
 - Apply filters from the request: time range (`after`/`before`), `callsign_filter`, `band_filter`, `mode_filter`, `contest_id`, `limit`, `offset`.
-- `after` and `before` are **inclusive** boundaries (`utc_timestamp_ms >= after` and `utc_timestamp_ms <= before`). A QSO whose timestamp exactly matches a boundary MUST be included.
-- `callsign_filter` is a case-insensitive substring match against **either** `station_callsign` **or** `worked_callsign`. The match is normalized via uppercase comparison so `"w1aw"` and `"W1AW"` behave identically regardless of database collation.
+- `after` and `before` are **inclusive** boundaries (`utc_timestamp_ms >= after` and `utc_timestamp_ms <= before`). The result MUST include a QSO that matches a boundary.
+- `callsign_filter` matches a substring in **either** `station_callsign` **or** `worked_callsign`. The engine normalizes uppercase values. Thus, database collation does not change the result.
 - Sort by `QsoSortOrder` (default: newest first).
 - Stream one `ListQsosResponse` per matching QSO record.
 - An empty logbook produces zero stream messages (not an error).
 
 **Error semantics:**
-- `INVALID_ARGUMENT` — malformed filter values.
+- `INVALID_ARGUMENT` - malformed filter values.
 
 #### SyncWithQrz
 
@@ -238,22 +283,22 @@ The sync follows the ordered lifecycle in §7.3:
 4. Upload local-only and remaining modified rows, then push pending remote deletes.
 5. Persist sync metadata from the `STATUS` result.
 
-New records use a normal INSERT. Modified records use the documented `OPTION=REPLACE` value exactly; engines must not append a `LOGID` selector to that option. QRZ matches the duplicate from the ADIF identity fields and returns the affected `qrz_logid`. On success, update `sync_status` to `SYNC_STATUS_SYNCED` and record that returned value.
+New records use a normal INSERT. Modified records use the documented `OPTION=REPLACE` value exactly. Engines must not append a `LOGID` selector to that option. QRZ matches the duplicate from the ADIF identity fields and returns the affected `qrz_logid`. On success, update `sync_status` to `SYNC_STATUS_SYNCED` and record that returned value.
 
-   **Previous-callsign rewrite (issue #337).** QRZ logbooks are bound to a single callsign and reject ADIF whose `STATION_CALLSIGN` does not match the logbook owner. Operators who have changed callsigns (e.g. KB7QOP → AE7XI) keep historical QSOs locally with the old call. To avoid those rejections, engines MUST:
+   **Previous-callsign rewrite (issue #337).** QRZ logbooks are bound to a single callsign and reject ADIF whose `STATION_CALLSIGN` does not match the logbook owner. Operators who have changed callsigns (for example KB7QOP → AE7XI) keep historical QSOs locally with the old call. To avoid those rejections, engines MUST:
 
    - Fetch the QRZ logbook owner callsign once per sync via QRZ `STATUS` before the download phase. Reuse the same result for the metadata phase. Do not call `STATUS` twice.
    - If `STATUS` fails or returns an empty owner, fall back to the cached `sync_metadata.qrz_logbook_owner`.
    - Per upload, when the resolved owner is non-empty and differs (case-insensitive, trimmed) from the QSO's `station_callsign`, rewrite the upload payload only:
      - Set the payload's `station_callsign` (and `station_snapshot.station_callsign`) to the owner.
-     - If `station_snapshot.operator_callsign` is empty, set it to the original `station_callsign` so the historical operator-of-record is preserved as ADIF `OPERATOR`.
-   - The local stored row MUST NOT be modified by the rewrite. Skip the rewrite entirely when `station_callsign` contains a `/` (portable / mobile / secondary suffix); those callsigns generally belong to a different QRZ logbook.
+     - If `station_snapshot.operator_callsign` is empty, set it to the original `station_callsign`. This action preserves the historical operator as ADIF `OPERATOR`.
+   - The rewrite MUST NOT modify the local stored row. Skip the rewrite when `station_callsign` contains a `/`. These callsigns usually belong to a different QRZ logbook.
 
-   *Known caveat:* on the next download, the merge logic for `SYNC_STATUS_SYNCED` rows is remote-wins, so the local `station_callsign` may drift to the book owner. The historical operator survives in `station_snapshot.operator_callsign`. Round-tripping the original via an `APP_QSORIPPER_ORIG_STATION_CALLSIGN` ADIF field on download is planned future work.
+   *Known limitation:* during the next download, remote-wins merge logic can change local `station_callsign` to the book owner. The historical operator remains in `station_snapshot.operator_callsign`. A future change will transfer the original value in `APP_QSORIPPER_ORIG_STATION_CALLSIGN`.
 
-The metadata phase updates `sync_metadata` with the QRZ QSO count, last sync timestamp, and logbook owner callsign from the initial `STATUS` call. Because `STATUS` precedes upload, the persisted `qrz_qso_count` reflects the pre-upload count; the next cycle observes the post-upload count.
+The metadata phase updates `sync_metadata` with the QRZ QSO count, last sync timestamp, and logbook owner callsign from the initial `STATUS` call. Because `STATUS` precedes upload, the persisted `qrz_qso_count` reflects the pre-upload count. The next cycle observes the post-upload count.
 
-The server stream MUST contain a terminal response with `complete=true`. Engines SHOULD emit intermediate phase/progress responses as work is produced; intermediate granularity is implementation-defined.
+The server stream MUST contain a terminal response with `complete=true`. Engines SHOULD emit intermediate responses while they produce work. Each implementation defines the intermediate detail.
 
 **Response fields (`SyncWithQrzResponse`):**
 
@@ -265,16 +310,19 @@ The server stream MUST contain a terminal response with `complete=true`. Engines
 | `downloaded_records` | `uint32` | Records downloaded (inserted or merged) from QRZ. |
 | `conflict_records` | `uint32` | Records flagged for conflict resolution. |
 | `current_action` | `string` (optional) | Human-readable status string for progress display. |
-| `complete` | `bool` | `true` on the terminal message; `false` on intermediate progress. |
+| `complete` | `bool` | `true` on the terminal message. `false` on intermediate progress. |
 | `error` | `string` (optional) | Accumulated error summary if any phase encountered failures. |
 | `remote_deletes_pushed` | `uint32` | Number of pending remote deletes successfully pushed to QRZ (Phase 2.5). |
 | `deletes_skipped_remote` | `uint32` | Number of download records skipped because they matched a soft-deleted local row (Phase 1). |
 | `duplicate_replaces` | `uint32` | INSERT uploads retried successfully as REPLACE after QRZ reported a duplicate. |
 
 **Error semantics:**
-- `FAILED_PRECONDITION` — QRZ logbook credentials are not configured. This is returned before the first stream message.
+- `FAILED_PRECONDITION` - QRZ logbook credentials are not configured. The engine returns this value before the first stream message.
 - Failures discovered before the first stream message use the appropriate gRPC status (`UNAVAILABLE` or `INTERNAL`).
-- After any stream message has been emitted, later integration, storage, parsing, and partial per-QSO failures are reported in a terminal response with `complete=true` and `error` populated. They do not change the transport status.
+- After the first stream message, report later failures in the terminal response.
+  Set `complete=true`, and populate `error`.
+  This rule applies to integration, storage, parsing, and per-QSO failures.
+  These failures do not change the transport status.
 
 #### GetSyncStatus
 
@@ -287,7 +335,7 @@ Returns the current sync metadata state.
 - If no sync has ever occurred, return zero remote count and no last-sync timestamp.
 
 **Error semantics:**
-- `INTERNAL` — storage read failure.
+- `INTERNAL` - storage read failure.
 
 #### ImportAdif
 
@@ -300,13 +348,22 @@ Imports QSO records from a client-streamed ADIF payload.
 4. For each parsed QSO, generate a `local_id`, normalize fields, and insert into storage.
 5. Return `records_imported`, `records_skipped`, `records_updated`, and sanitized warning strings. The response has no separate total or error fields.
 
-**Duplicate handling:** The engine should detect duplicates by matching on station callsign + worked callsign + band + mode + compatible submode/frequency + compatible UTC timestamp and skip them rather than creating duplicate entries. Timestamp matching must handle minute-precision ADIF sources (for example N1MM contest exports) by matching an existing second-precision QSO in the same displayed minute when either side is minute-precision. Small frequency drift between ADIF sources and QRZ-enriched rows should not create a duplicate when the contact identity otherwise matches.
+**Duplicate handling:** The engine must compare the station callsign, worked callsign, band, and mode.
+It must also compare compatible submode, frequency, and UTC timestamp values.
+If these values match, skip the new record.
+Timestamp matching must support ADIF sources that have minute precision.
+N1MM contest exports are one example.
 
-WSJT-X ingestion, manual ADIF imports, and any future ADIF-based recovery inputs MUST use this same import path so duplicate behavior, active station-profile fallback, refresh semantics, and storage state remain consistent across sources.
+Match a second-precision QSO in the same displayed minute when either value has minute precision.
+Small frequency differences must not create a duplicate when the contact identity matches.
+
+WSJT-X ingestion and manual ADIF imports MUST use this import path.
+Future ADIF recovery inputs MUST also use it.
+Thus, all sources use the same duplicate, station-profile, refresh, and storage behavior.
 
 **Error semantics:**
-- `INVALID_ARGUMENT` — ADIF content is malformed or unparseable.
-- `INTERNAL` — storage write failure.
+- `INVALID_ARGUMENT` - ADIF content is malformed or unparseable.
+- `INTERNAL` - storage write failure.
 
 #### ExportAdif
 
@@ -316,11 +373,11 @@ Streams the logbook as an ADIF document.
 1. Query all QSO records (optionally filtered by the request parameters).
 2. Serialize each QSO to ADIF format.
 3. Stream `ExportAdifResponse` messages, each containing an `AdifChunk`.
-4. When `include_header=true`, the first chunk contains the ADIF header. When false, no header is emitted.
+4. When `include_header=true`, the first chunk contains the ADIF header. When false, the engine emits no header.
 5. Preserve `extra_fields` from imported QSOs for lossless round-trip.
 
 **Error semantics:**
-- `INTERNAL` — storage read or serialization failure.
+- `INTERNAL` - storage read or serialization failure.
 
 ### 3.3 LookupService
 
@@ -351,18 +408,25 @@ Performs a single callsign lookup.
 6. Return a `LookupResult` containing the `CallsignRecord`, lookup state, latency, and cache hit status.
 7. Populate `prior_qsos` and `prior_qso_total_count` from the local logbook for every non-`Loading` result (`Found`, `NotFound`, `Stale`, cache hit, batch entry). See [3.3.1 Prior QSO history](#331-prior-qso-history) below.
 
-Desktop clients may use this RPC for both fast-entry and advanced QSO-card workflows. Those clients should debounce user typing and cancel stale in-flight UI requests, but they must still route callsign enrichment through this shared lookup service rather than duplicating QRZ XML logic in the UI layer.
+Desktop clients can use this RPC for fast entry and advanced QSO-card workflows.
+These clients must debounce user input.
+They must also cancel stale UI requests.
+They must use this shared lookup service for callsign enrichment.
+They must not duplicate QRZ XML logic in the UI.
 
 Credentials supplied through setup remain process-session secrets and are never serialized. For restart availability, operators provide secrets through the documented environment variables or a secure configuration provider. See §6.3.
 
-**Slash-call fallback:** If the callsign contains a `/` modifier (e.g., `W1AW/7`), and the full lookup fails, strip the modifier and retry with the base callsign. Populate `base_callsign`, `modifier_text`, and `modifier_kind` on the result.
+**Slash-call fallback:** A callsign can contain a `/` modifier, such as `W1AW/7`.
+If the full lookup fails, remove the modifier.
+Then retry with the base callsign.
+Populate `base_callsign`, `modifier_text`, and `modifier_kind` on the result.
 
 **In-flight deduplication:** If a lookup for the same callsign is already in progress, coalesce the request rather than firing a duplicate QRZ query.
 
 **Error semantics:**
-- `NOT_FOUND` — callsign not found in QRZ (this is a valid result state, not a gRPC error; return `LookupState.LOOKUP_STATE_NOT_FOUND`).
-- `UNAVAILABLE` — QRZ API unreachable (return `LookupState.LOOKUP_STATE_ERROR` in the result).
-- Missing QRZ credentials are represented as `LookupState.LOOKUP_STATE_ERROR` with a sanitized authentication/configuration message, not a transport error.
+- `NOT_FOUND` - callsign not found in QRZ (this is a valid result state, not a gRPC error. Return `LookupState.LOOKUP_STATE_NOT_FOUND`).
+- `UNAVAILABLE` - QRZ API unreachable (return `LookupState.LOOKUP_STATE_ERROR` in the result).
+- The engine represents missing QRZ credentials with `LookupState.LOOKUP_STATE_ERROR`. It supplies a sanitized authentication or configuration message.
 
 #### StreamLookup
 
@@ -374,9 +438,12 @@ Performs a callsign lookup with streaming progress updates.
 - If a fresh cache entry exists, emits a `Found` (or `NotFound`) update and closes the stream.
 - If a stale cache entry exists, emits a `Stale` update with the cached record, then continues to the provider.
 - After the provider call completes, emits the final `Found`, `NotFound`, or `Error` update and closes the stream.
-- Updates must be pushed to the transport as they are produced; engines must not buffer the full transition sequence before sending.
+- Engines must push updates to the transport when they produce them. Engines must not buffer the complete transition sequence.
 
-**Error semantics:** Same as `Lookup`. Per-request errors surface as a final `LookupResult` with state `LOOKUP_STATE_ERROR`; transport-level failures (e.g., the client dropping the stream) cancel the in-flight work without a panic.
+**Error semantics:** Use the same semantics as `Lookup`.
+A request error returns a final `LookupResult` with state `LOOKUP_STATE_ERROR`.
+A transport failure cancels the active work without a panic.
+A client stream disconnect is one transport failure.
 
 #### GetCachedCallsign
 
@@ -388,7 +455,7 @@ Returns a cached lookup result without querying the external provider.
 - If not found or expired, return an empty result (not an error).
 
 **Error semantics:**
-- `INTERNAL` — storage read failure.
+- `INTERNAL` - storage read failure.
 
 #### GetDxccEntity
 
@@ -408,10 +475,10 @@ Returns DXCC entity information for a given DXCC code.
   when neither `dxcc_code` nor `prefix` is set.
 
 **Error semantics:**
-- `NOT_FOUND` — unknown DXCC code.
-- `UNIMPLEMENTED` — request used the `prefix` branch and the engine has not yet
+- `NOT_FOUND` - unknown DXCC code.
+- `UNIMPLEMENTED` - request used the `prefix` branch and the engine has not yet
   implemented prefix-based DXCC resolution.
-- `INVALID_ARGUMENT` — neither `dxcc_code` nor `prefix` was specified.
+- `INVALID_ARGUMENT` - the request contains neither `dxcc_code` nor `prefix`.
 
 #### BatchLookup
 
@@ -422,28 +489,40 @@ Performs lookups for multiple callsigns in a single request.
 - Perform lookups for each (cache-first, then external).
 - Return a list of `LookupResult` entries, one per input callsign.
 - Order of results matches order of input callsigns.
-- Engines should bound concurrency (the reference implementations cap parallel
-  lookups at 5) and reuse the same `LookupCoordinator` path that powers the unary
-  `Lookup` RPC so cache, debounce, and provider fallback semantics stay consistent.
+- Engines must limit concurrency.
+- Reference implementations limit parallel lookups to 5.
+- Engines must reuse the unary `LookupCoordinator` path. This keeps cache, debounce, and provider fallback behavior consistent.
 - Empty input is valid and returns an empty `results` list.
 
 **Error semantics:**
-- Per-callsign errors are reported in individual `LookupResult` entries, not as top-level gRPC errors.
-- `INTERNAL` — orchestration failure (e.g., a worker task panicked) before a per-callsign
-  result could be produced.
+- The engine reports each callsign error in its `LookupResult` entry, not as a top-level gRPC error.
+- `INTERNAL` - orchestration failure before the engine produces a result for each callsign.
 
 #### 3.3.1 Prior QSO history
 
 Every `LookupResult` returned by `Lookup`, `StreamLookup`, `GetCachedCallsign`, and `BatchLookup` (except the initial streaming `Loading` placeholder) must include the operator's prior contacts with the queried callsign:
 
-- `prior_qsos` — most-recent-first list of `QsoHistoryEntry` records, capped at the engine's history limit (the reference implementations use 25). Each entry carries `local_id`, `utc_timestamp`, `band`, `mode`, `submode`, `frequency_hz`, `frequency_rx_hz`, and `contest_id`.
-- `prior_qso_total_count` — total active prior QSOs with the worked callsign regardless of the cap, so clients can render "47 prior contacts (showing 25)".
+- `prior_qsos` - most-recent-first list of `QsoHistoryEntry` records, capped at the engine's history limit (the reference implementations use 25). Each entry carries `local_id`, `utc_timestamp`, `band`, `mode`, `submode`, `frequency_hz`, `frequency_rx_hz`, and `contest_id`.
+- `prior_qso_total_count` - total active prior QSOs with the worked callsign regardless of the cap, so clients can render "47 prior contacts (showing 25)".
 
-History is recomputed on every response (never cached in the lookup snapshot store) so manual logbook edits are reflected immediately. The query is an exact, case-insensitive match on `worked_callsign` against the active (not soft-deleted) logbook rows; a substring match on `worked_callsign` would silently produce wrong history (`K7A` matching `K7AB`). The `Loading` streaming placeholder must NOT carry history; populating it would defeat its low-latency purpose.
+The engine recalculates history for each response.
+It does not cache history in the lookup snapshot store.
+Thus, manual logbook edits appear immediately.
+The query makes an exact, case-insensitive `worked_callsign` match.
+It searches only active logbook rows.
+A substring match can produce incorrect history, such as `K7A` matching `K7AB`.
 
-Storage backends expose this via a dedicated `list_qso_history(worked_callsign, limit) -> { entries, total }` query rather than overloading the existing list-with-filter API. SQLite implementations should reuse the `idx_qsos_worked_callsign` index.
+The `Loading` streaming placeholder MUST NOT contain history.
+History increases its latency.
 
-The history shape is forward-compatible with future contest-mode dupe checking: `(band, mode, contest_id)` is sufficient for every common contest dupe rule, and `contest_id` lets a future contest engine partition current-contest contacts from past contacts. Contest mode is not part of this contract; when added later it will arrive as additive `LookupRequest` and `LookupResult` fields with no break to existing clients.
+Storage backends use a dedicated `list_qso_history(worked_callsign, limit) -> { entries, total }` query. SQLite implementations must reuse the `idx_qsos_worked_callsign` index.
+
+The history shape supports future contest duplicate checks.
+`(band, mode, contest_id)` supports the common duplicate rules.
+`contest_id` separates current-contest contacts from past contacts.
+Contest mode is not part of this contract.
+Add it later with new `LookupRequest` and `LookupResult` fields.
+This additive change must not break existing clients.
 
 ### 3.4 RigControlService
 
@@ -468,7 +547,7 @@ Returns the current rig connection status.
 - If rig control is disabled via configuration, return `Disabled`.
 
 **Error semantics:**
-- This RPC should always succeed. Connection problems are reported in the status value, not as gRPC errors.
+- This RPC must always succeed. The engine reports connection problems in the status value, not as gRPC errors.
 
 #### GetRigSnapshot
 
@@ -476,14 +555,14 @@ Returns the most recent normalized logging snapshot from the rig.
 
 **Behavior:**
 - Return a `RigSnapshot` containing required transmit-side `frequency_hz`, `band`, `mode`, optional `submode`, provider diagnostic `raw_mode`, optional split receive-side `frequency_rx_hz` and `band_rx`, optional `tx_power_watts`, `status`, and `sampled_at`.
-- In simplex operation, `frequency_hz` and `band` contain the current operating frequency and band. In split operation, they contain the transmit frequency and band when rigctld exposes it; `frequency_rx_hz` and `band_rx` contain the receive side.
-- `tx_power_watts` is normalized from Hamlib's relative `RFPOWER` level through `power2mW`. Relative power values never cross the engine boundary.
+- In simplex operation, `frequency_hz` and `band` contain the current operating frequency and band. In split operation, they contain the transmit frequency and band when rigctld exposes it. `frequency_rx_hz` and `band_rx` contain the receive side.
+- The engine normalizes `tx_power_watts` from Hamlib's relative `RFPOWER` level through `power2mW`. Relative power values never cross the engine boundary.
 - Split and power reads are capability tolerant. `RPRT` errors or unparseable values from optional commands leave the corresponding fields absent without failing the required frequency/mode snapshot.
 - If the rig is disconnected or disabled, return a snapshot with appropriate status and no frequency/mode data.
 - If the last snapshot is older than `QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS`, mark it as stale.
 
 **Error semantics:**
-- This RPC should always succeed. Rig errors are reported in the snapshot's `status` and `error_message` fields.
+- This RPC must always succeed. The engine reports rig errors in the snapshot `status` and `error_message` fields.
 
 #### TestRigConnection
 
@@ -497,121 +576,177 @@ Tests TCP connectivity to a rigctld instance, including unpersisted setup values
 5. Return success/failure with diagnostics.
 
 **Error semantics:**
-- Connection and protocol errors are reported in the response, not as gRPC errors.
+- The engine reports connection and protocol errors in the response, not as gRPC errors.
 
 #### Optional rig-control front door: standalone CatHub
 
-`RigControlService` consumes rig state from a rigctld-compatible endpoint. On a multi-app
-station the engine must **not** connect directly to the radio's serial port, because many
-applications share one radio and direct contention produces VFO A/B oscillation, frequency
-drift, and PTT conflicts.
+`RigControlService` gets rig state from a rigctld-compatible endpoint.
+On a multi-application station, the engine MUST NOT connect directly to the radio serial port.
+Many applications share one radio.
+Direct contention causes VFO changes, frequency drift, and PTT conflicts.
 
-The supported topology is a single independently installed CatHub daemon that owns
-the radio serial port and fans it out to every client over its native protocol. The engine
-points its `RigctldProvider` at one of the hub's read-only Hamlib NET endpoints
-(`QSORIPPER_RIGCTLD_HOST`:`QSORIPPER_RIGCTLD_PORT`); the hub also serves other applications
-(HDSDR/OmniRig, N1MM, ARCP-590, WSJT-X, Log4OM) on their own endpoints simultaneously. The
-hub enforces the no-VFO-retargeting invariant (baseline polling never emits VFO-select/retarget
-commands), serializes all writes, owns the radio's native push stream, and arbitrates PTT with
-a single-owner lease and a hard transmit-time ceiling. The engine's behavior contracts above
-are unchanged: it remains a read-mostly NET rigctl client and is agnostic to whether the
-endpoint is CatHub or a bare `rigctld`. CatHub is not part of either engine and is never
-required for ordinary QsoRipper logging.
+The supported topology uses one independently installed CatHub daemon.
+CatHub owns the radio serial port.
+It supplies a separate native-protocol endpoint to each client.
+The engine points `RigctldProvider` at a read-only Hamlib NET endpoint.
+`QSORIPPER_RIGCTLD_HOST` and `QSORIPPER_RIGCTLD_PORT` identify this endpoint.
+CatHub can also serve HDSDR, N1MM, ARCP-590, WSJT-X, and Log4OM.
+
+Baseline polling does not send VFO-select or VFO-retarget commands.
+
+CatHub puts all writes in sequence.
+It owns the native radio push stream.
+It controls PTT with one owner and a maximum transmit time.
+The engine remains a read-mostly NET rigctl client.
+It can use CatHub or a bare `rigctld`.
+CatHub is not part of an engine.
+
+Normal QsoRipper logging does not require it.
 
 The hub's read-only Hamlib NET endpoint implements the engine's optional logging probes:
 `i`/`\get_split_freq`, `x`/`\get_split_mode`, `l RFPOWER`, and `2`/`\power2mW`. CatHub serves
 these from its universal radio snapshot. The native TS-590 backend populates configured power
-from `PC;`; the rigctld bridge forwards the optional probes to its private downstream rigctld.
+from `PC;`. The rigctld bridge forwards the optional probes to its private downstream rigctld.
 When a backend cannot expose a value, CatHub returns `RPRT -11`, preserving the provider's
 capability-tolerant behavior.
 
 - CatHub implementation and design: <https://github.com/treitforge/cathub>.
 - QsoRipper integration setup: `docs/integrations/cathub-setup.md`.
 
-Native `ts590` endpoints support an opt-in, per-endpoint **single-VFO operating-VFO virtualization**
-policy (`single_vfo = true`). When enabled, the endpoint never exposes the physical VFO letter:
-it always presents the operating (receive) VFO as VFO A, mirroring `FA`/`FB` reads and writes
-onto whichever VFO the radio is on, intercepting `FR`/`FT` VFO-select verbs, forcing the `IF;`
-active-VFO digit (P10) and split to `0`, and re-presenting an A/B switch by pushing the new
-operating VFO's `FA` + `MD` + `IF`. This makes single-VFO loggers — N1MM Logger+ in SO1V mode,
-which otherwise warns "You should not use VFO B when configured for SO1V" and freezes — track
-the radio seamlessly across A/B switches. It is **off by default** and must stay off for genuine
-dual-VFO control panels such as ARCP-590. See design §8.4.2.
+Native `ts590` endpoints support an optional **single-VFO operating-VFO virtualization** policy.
+Set `single_vfo = true` to enable it for an endpoint.
+The endpoint does not expose the physical VFO letter.
+It presents the operating receive VFO as VFO A.
+It maps `FA` and `FB` reads and writes to the operating VFO.
+It intercepts `FR` and `FT` VFO-select commands.
 
-The **same `single_vfo` policy is available on `[[hamlib_net]]` (rigctld) endpoints** for
-rigctld clients that, like N1MM SO1V, expect to receive on VFO A: WSJT-X stops decoding when
-it sees VFO B as the active VFO, and Log4OM polls the fixed `\get_vfo_info VFOA` and would log
-the inactive VFO's stale frequency on VFO B. On a `single_vfo` Hamlib NET endpoint the endpoint
-uses a **strict** single-VFO contract: `get_vfo` reports `VFOA`; `get_vfo_info` resolves any
-requested VFO to the operating VFO and reports `Split: 0`; `get_split_vfo` reports `0`/`VFOA`;
-`set_split_vfo 1` is **rejected** (`RPRT -11`) because the presentation cannot model a real
-split (use WSJT-X "Fake It"); and `\set_vfo ?` advertises only `VFOA`. Reads and writes already
-target the operating VFO, so the frequency/mode are real on either physical VFO. The engine's
-read-only endpoint leaves `single_vfo = false` so it logs the true operating VFO. Plain
-`get_freq` / `get_mode` already read the operating VFO on every endpoint, which is why a logger that
-polls only `f` (WSJT-X) tracks A/B even without virtualization, whereas one that polls
-`get_vfo_info VFOA` (Log4OM) requires it.
+It forces the `IF;` active-VFO digit and split to `0`.
 
-Native TS-590 controllers that speak the radio's exact protocol — notably **ARCP-590**, Kenwood's
-own control panel — get a dedicated **transparent mirror** dialect (`dialect = "ts590-transparent"`)
-instead of the virtualizing `ts590` dialect. A transparent endpoint behaves as if it were wired
-directly to the rig: every request except PTT and auto-information is forwarded to the radio
-verbatim (`format_notification` returns nothing — the endpoint never consumes a synthesized frame),
-and the radio's entire CAT stream — both modeled frames and unmodeled ones — is relayed back
-byte-for-byte whenever the endpoint has auto-information enabled. Because the rig runs in AI2 and
-echoes every change any client makes through the hub, a transparent controller stays perfectly in
-sync with the radio's true VFO/frequency/mode/split state, eliminating the synthesis/snapshot
-drift (stale A/B, frozen frequency) that a virtualizing view can accumulate for a client that
-already knows the native protocol. The hub still owns the single physical port, so three things
-stay hub-mediated even on a mirror endpoint: PTT (`TX`/`RX`) routes through the shared single-owner
-lease; auto-information (`AI`) is virtualized per endpoint (the rig itself stays in hub-owned AI2);
-and identity/keepalive reads (`ID;`/`PS;`) are answered locally so the controller's steady-state
-heartbeat generates zero radio traffic. A lagged mirror endpoint is re-synced by re-presenting the
-full current state as raw frames (`FA`/`FB`/`FR`/`FT`/`MD`/`IF`). `ts590-transparent` is
-mutually exclusive with `single_vfo = true` (a mirror relays the radio's real dual-VFO stream and
-cannot virtualize the operating VFO); the daemon rejects that combination at config validation.
+After an A/B switch, it sends the new operating VFO `FA`, `MD`, and `IF`.
+This policy lets a single-VFO logger follow A/B switches.
+N1MM Logger+ in SO1V mode is one example.
+The policy is **off by default**.
+Keep it off for dual-VFO control panels such as ARCP-590.
+See design §8.4.2.
 
-To support transparent relay, the hub broadcasts a modeled native frame **twice** on its internal
-event bus: once as a coalesced modeled change (consumed by virtualizing endpoints) and once as a
-verbatim raw-native event (consumed only by transparent endpoints). Unmodeled frames continue to
-broadcast as a single verbatim raw event. This keeps existing virtualizing dialects byte-for-byte
-unchanged while giving a mirror endpoint the radio's exact stream.
+The same `single_vfo` policy is available on `[[hamlib_net]]` endpoints.
+Some rigctld clients expect to receive on VFO A.
+WSJT-X stops decoding when it sees VFO B as active.
+Log4OM polls the fixed `\get_vfo_info VFOA` command.
+Without virtualization, Log4OM can log the inactive VFO frequency.
+A `single_vfo` Hamlib NET endpoint uses this strict contract:
 
-The hub's Hamlib NET endpoints accept both the plain rigctld protocol (WSJT-X, N1MM, the engine)
-and Hamlib's **Extended Response Protocol** (ERP). An ERP request prefixes the command with a
-separator (`+` joins records with newlines; `;`, `|`, or `,` joins them on one line with that
-character), and the reply echoes the long command name, emits labeled data records, and ends
-with `RPRT x`. Log4OM-NG relies on ERP exclusively — it handshakes with `;V ?` (list supported
-VFOs) and polls with `+\get_vfo_info VFOA` — so a conformant hub must implement ERP framing for
-those shapes, not just the plain protocol, or Log4OM stays offline.
+- `get_vfo` reports `VFOA`.
+- `get_vfo_info` maps the requested VFO to the operating VFO.
+- `get_vfo_info` reports `Split: 0`.
+- `get_split_vfo` reports `0` and `VFOA`.
+- `set_split_vfo 1` returns `RPRT -11`.
+- `\set_vfo ?` advertises only `VFOA`.
+
+Use WSJT-X "Fake It" because this presentation cannot model a real split.
+Reads and writes target the operating VFO.
+Thus, frequency and mode are correct on each physical VFO.
+The engine read-only endpoint keeps `single_vfo = false`.
+Plain `get_freq` and `get_mode` already read the operating VFO.
+Thus, WSJT-X tracks A/B without virtualization.
+
+Log4OM polls `get_vfo_info VFOA` and requires virtualization.
+
+Native TS-590 controllers can use the **transparent mirror** dialect.
+ARCP-590 is one example.
+Set `dialect = "ts590-transparent"` instead of the virtualizing `ts590` dialect.
+A transparent endpoint behaves like a direct radio connection.
+It forwards each request except PTT and auto-information without a change.
+`format_notification` returns nothing.
+
+The endpoint does not use a generated frame.
+
+When auto-information is enabled, it relays the complete radio CAT stream.
+This stream includes modeled and unmodeled frames.
+The radio uses AI2 and reports each client change.
+Thus, a transparent controller remains synchronized with the actual radio state.
+This behavior prevents stale A/B state and a frozen frequency.
+CatHub still owns the physical port.
+
+PTT uses the shared single-owner lease.
+CatHub virtualizes auto-information for each endpoint.
+The radio remains in CatHub-owned AI2.
+CatHub answers `ID;` and `PS;` locally.
+
+Thus, the controller heartbeat does not cause radio traffic.
+CatHub restores a delayed mirror with current raw state frames.
+These frames include `FA`, `FB`, `FR`, `FT`, `MD`, and `IF`.
+Do not use `ts590-transparent` with `single_vfo = true`.
+The daemon rejects this combination during configuration validation.
+
+For transparent relay, CatHub broadcasts a modeled native frame two times.
+Virtualizing endpoints receive a combined modeled change.
+Transparent endpoints receive an exact raw-native event.
+CatHub broadcasts an unmodeled frame as one exact raw event.
+Existing virtualizing dialects remain unchanged.
+A mirror endpoint receives the exact radio stream.
+
+The Hamlib NET endpoints accept the plain rigctld protocol.
+WSJT-X, N1MM, and the engine use this protocol.
+The endpoints also accept Hamlib Extended Response Protocol (ERP).
+An ERP request puts a separator before the command.
+`+` puts each record on a new line.
+`;`, `|`, or `,` puts records on one line with that separator.
+
+The reply repeats the long command name.
+It sends labeled data records and ends with `RPRT x`.
+
+Log4OM-NG uses only ERP.
+It uses `;V ?` to get the supported VFOs.
+It polls with `+\get_vfo_info VFOA`.
+A conformant hub must implement ERP framing for these commands.
+Plain protocol support is not sufficient for Log4OM.
 
 ##### Managed and external configuration
 
 CatHub owns its standalone configuration and defaults to `%APPDATA%\cathub\cathub.toml` on
 Windows or `$XDG_CONFIG_HOME/cathub/cathub.toml` on Unix, overridable with
-`CATHUB_CONFIG_PATH`. QsoRipper may instead manage CatHub from its unified per-user
+`CATHUB_CONFIG_PATH`. QsoRipper can instead manage CatHub from its unified per-user
 `config.toml`. In that mode the daemon reads settings from `[cat_hub]` and the launcher passes
 the unified path explicitly. CatHub accepts both layouts.
 
-Because multiple components write the same file, every engine setup save is **merge-preserving**:
-the engine replaces only its own top-level tables (`logbook`, `storage`, `station_profile`,
-`station_profiles`, `qrz_xml`, `qrz_logbook`, `sync`, `rig_control`) and preserves all other
-tables (`[cat_hub]`, `[launcher]`, and any future component sections). The conditional
-`[wsjtx_ingest]` setup table is replaced only when `SaveSetup.wsjtx_ingest` is explicitly
-supplied; omitted WSJT-X ingest settings are preserved verbatim. A conformant engine in any
+Multiple components write the same file.
+Thus, each engine setup save MUST preserve unrelated data.
+The engine replaces only its owned top-level tables:
+
+- `logbook`
+- `storage`
+- `station_profile`
+- `station_profiles`
+- `qrz_xml`
+- `qrz_logbook`
+- `sync`
+- `rig_control`
+
+The engine preserves `[cat_hub]`, `[launcher]`, and future component sections.
+The conditional
+The engine replaces the `[wsjtx_ingest]` setup table only when the request contains
+`SaveSetup.wsjtx_ingest`. It preserves omitted WSJT-X ingest settings. A conformant engine in any
 language must implement this merge-preserving behavior rather than rewriting the whole file,
 so it never clobbers another component's configuration.
 
-`[cat_hub]` is a **managed-mode compatibility surface**: it is preserved verbatim on every save *unless*
-the `SaveSetup` request explicitly carries a `cat_hub` (`CatHubSettings`) message, in which case
-the engine performs a full-replacement rewrite of the section (see SetupService → SaveSetup). For
-status and wizard display, the engine parses `[cat_hub]` **leniently and separately** from its own
-configuration: a malformed or unknown-schema `[cat_hub]` yields an empty projection (and a logged
-warning) but never fails engine load. A conformant engine must keep this read path isolated so the
-daemon's section can never break engine startup, and must only rewrite `[cat_hub]` when an explicit
-replacement is supplied. When CatHub is externally managed, QsoRipper stores only its rigctld and
-CW broker client endpoints and does not write CatHub's standalone file. CatHub remains the
-authoritative parser and validator for both layouts.
+`[cat_hub]` is a **managed-mode compatibility surface**.
+Preserve it exactly during each save.
+Rewrite it only when `SaveSetup` contains a `cat_hub` message.
+In that condition, replace the complete section.
+See SetupService and `SaveSetup`.
+For status and wizard display, parse `[cat_hub]` separately from engine configuration.
+
+Use a lenient parser.
+
+A malformed or unknown schema produces an empty projection and a warning.
+It does not prevent engine load.
+Isolate this read path from engine startup.
+Rewrite `[cat_hub]` only after an explicit replacement.
+
+When CatHub is externally managed, store only the rigctld and CW client endpoints.
+Do not write the CatHub standalone file.
+CatHub is the authoritative parser and validator for both layouts.
 
 ### 3.5 SpaceWeatherService
 
@@ -637,7 +772,7 @@ Returns the most recently cached space weather snapshot.
 - If refresh fails after a previous successful fetch, return the cached values with `SPACE_WEATHER_STATUS_STALE`. Without usable cached data, return `SPACE_WEATHER_STATUS_ERROR`.
 
 **Error semantics:**
-- This RPC should always succeed. Data unavailability is reported in the snapshot status.
+- This RPC must always succeed. The engine reports unavailable data in the snapshot status.
 
 #### RefreshSpaceWeather
 
@@ -649,7 +784,7 @@ Forces an immediate refresh from the NOAA APIs.
 3. Return the new snapshot.
 
 **Error semantics:**
-- This RPC succeeds at the transport layer. Disabled configuration and NOAA failures are represented by an `ERROR` or `STALE` snapshot with a sanitized error message.
+- This RPC succeeds at the transport layer. The engine represents a disabled configuration or NOAA failure with an `ERROR` or `STALE` snapshot.
 
 ### 3.6 SetupService
 
@@ -670,12 +805,15 @@ First-run bootstrap and credential validation.
 
 #### GetSetupStatus
 
-Returns whether initial setup has been completed.
+Returns the initial setup status.
 
 **Behavior:**
 - Check if a valid configuration and station profile exist.
 - Return a `SetupStatus` indicating `complete` or `incomplete` with details about what is missing.
-- Include current `wsjtx_ingest` settings when configured and live `wsjtx_ingest_status` diagnostics. A conformant engine that runs the WSJT-X ingest supervisor (required when ingestion is enabled — see "WSJT-X ingest runtime behavior") MUST populate `wsjtx_ingest_status` with its current live state.
+- Include configured `wsjtx_ingest` settings and live `wsjtx_ingest_status` diagnostics.
+  An enabled ingestion configuration requires the WSJT-X ingest supervisor.
+  A conformant supervisor MUST put its current state in `wsjtx_ingest_status`.
+  See "WSJT-X ingest runtime behavior."
 
 #### SaveSetup
 
@@ -683,12 +821,12 @@ Persists setup configuration and station profile.
 
 **Behavior:**
 1. Validate all provided fields.
-2. Persist non-secret configuration and station/storage settings to the config path. QRZ passwords and API keys supplied by the request are installed only in process memory and are never serialized.
+2. Persist non-secret configuration and station/storage settings to the config path. Install QRZ passwords and API keys only in process memory. Never serialize them.
 3. Apply the configuration to the running engine (activate the station profile, enable integrations).
 4. Mark setup as complete.
 
 **CAT hub (`cat_hub`) management:**
-- Serial and WinKeyer endpoints may include `application_transport`, the paired virtual endpoint
+- Serial and WinKeyer endpoints can include `application_transport`, the paired virtual endpoint
   opened by the client application. The hub opens only `transport`. Engines preserve and return
   the application-side value for setup guidance and reject an endpoint whose two transports are the
   same.
@@ -697,20 +835,27 @@ Persists setup configuration and station profile.
   section. It never writes CatHub's external standalone file.
 - The field is **full-replacement**: when present it is the complete desired `[cat_hub]`
   section. A `radio` (with a `backend`) is required and at least one endpoint (a
-  `serial_endpoints` or `hamlib_net` entry) is required; the engine rewrites `[cat_hub]` from it.
+  `serial_endpoints` or `hamlib_net` entry) is required. The engine rewrites `[cat_hub]` from it.
 - When `cat_hub` is omitted, the engine leaves any existing `[cat_hub]` section **untouched**
   (verbatim, including comments and unknown keys). Only an explicit `cat_hub` triggers a
-  rewrite — so a routine save (e.g. updating QRZ credentials) never reserializes the daemon's
+  rewrite - so a routine save (for example updating QRZ credentials) never reserializes the daemon's
   configuration. This mirrors the conditional-ownership rule in the unified-configuration note.
-- QsoRipper performs bounded input validation for its compatibility projection. CatHub remains
-  authoritative and its `cathub config validate` command must be used for full semantic validation.
-  The compatibility validation covers `backend` ∈ {ts590, rigctld,
-  loopback}; radio `transport` ∈ {serial, tcp}; non-loopback serial radios require a `port`;
-  endpoint `dialect` ∈ {ts590, ts590-transparent, ts2000}; endpoint names unique across endpoints and hamlib_net; endpoint
-  transports distinct; hamlib_net binds distinct and in `host:port` form; an endpoint transport may
-  not reuse the radio port. CAT endpoint permission tokens include `read`, `frequency_write`,
-  `write`, `ptt`, and `config_write`; `frequency_write` grants tuning without other modeled
-  mutations, while `write` grants all modeled writes. Violations return `INVALID_ARGUMENT`.
+- QsoRipper performs limited input validation for its compatibility projection.
+  CatHub remains authoritative.
+  Use `cathub config validate` for complete semantic validation.
+  Compatibility validation checks these requirements:
+  - `backend` is `ts590`, `rigctld`, or `loopback`.
+  - Radio `transport` is `serial` or `tcp`.
+  - A non-loopback serial radio has a `port`.
+  - Endpoint `dialect` is `ts590`, `ts590-transparent`, or `ts2000`.
+  - Endpoint names are unique across serial and Hamlib NET endpoints.
+  - Endpoint transports are different.
+  - Hamlib NET binds are different and use `host:port`.
+  - An endpoint transport does not reuse the radio port.
+  CAT permission tokens include `read`, `frequency_write`, `write`, `ptt`, and `config_write`.
+  `frequency_write` permits tuning without other modeled changes.
+  `write` permits all modeled writes.
+  A violation returns `INVALID_ARGUMENT`.
 
 **WSJT-X ingest (`wsjtx_ingest`) management:**
 - The optional `wsjtx_ingest` field (`WsjtxIngestSettings`) lets setup clients manage the
@@ -718,56 +863,63 @@ Persists setup configuration and station profile.
 - Omit `wsjtx_ingest` to leave existing WSJT-X ingest settings unchanged. When present, the
   engine persists a replacement `[wsjtx_ingest]` table with `enabled`, `udp_enabled`,
   `udp_bind`, `adif_tail_enabled`, `adif_tail_path`, `poll_interval_ms`, and `sync_to_qrz`.
-- Defaults are conservative: ingestion disabled; UDP bind `127.0.0.1:2237`; UDP enabled when
-  ingestion is enabled and the field is omitted; ADIF tail disabled unless a path is supplied;
-  poll interval defaults to a modest nonzero value; immediate QRZ sync disabled.
+- Defaults limit automatic behavior:
+  - Ingestion is disabled.
+  - The UDP bind is `127.0.0.1:2237`.
+  - UDP is enabled when ingestion is enabled and its field is omitted.
+  - ADIF tailing is disabled unless a path is supplied.
+  - The poll interval has a nonzero default.
+  - Immediate QRZ sync is disabled.
 - Validation requires `udp_bind` to be `host:port` with port 1-65535 and `adif_tail_path` to
-  be present when ADIF tailing is enabled. `poll_interval_ms=0` means use the engine default;
-  positive values are accepted as supplied. Violations return `INVALID_ARGUMENT`.
+  be present when ADIF tailing is enabled. `poll_interval_ms=0` means use the engine default.
+  The engine accepts positive values as supplied. Violations return `INVALID_ARGUMENT`.
 - WSJT-X ingest is a first-class setup surface, not a TOML-only escape hatch. GUI setup wizard,
   GUI Settings, CLI `setup --status`, CLI `setup --from-env`, and the interactive CLI setup
   wizard must all project the same `WsjtxIngestSettings` fields. `setup --from-env` recognizes
   `QSORIPPER_WSJTX_INGEST_ENABLED`, `QSORIPPER_WSJTX_INGEST_UDP_ENABLED`,
   `QSORIPPER_WSJTX_INGEST_UDP_BIND`, `QSORIPPER_WSJTX_INGEST_ADIF_TAIL_ENABLED`,
   `QSORIPPER_WSJTX_INGEST_ADIF_TAIL_PATH`, `QSORIPPER_WSJTX_INGEST_POLL_INTERVAL_MS`, and
-  `QSORIPPER_WSJTX_INGEST_SYNC_TO_QRZ`. CLI setup may also accept shorter non-runtime aliases
-  for compatibility, but documentation and examples should prefer the canonical runtime names.
+  `QSORIPPER_WSJTX_INGEST_SYNC_TO_QRZ`. CLI setup can also accept shorter non-runtime aliases
+  for compatibility. Documentation and examples must use the canonical runtime names.
 
 **WSJT-X ingest runtime behavior:**
 - This runtime behavior is engine-neutral and REQUIRED: every conformant engine, regardless of
   implementation language, MUST provide WSJT-X ingestion when `wsjtx_ingest.enabled=true`. Both the
   Rust engine (`qsoripper-server`) and the .NET engine (`QsoRipper.Engine.DotNet`) implement this
-  contract; a third-party engine must too. An engine MAY surface a documented capability flag if it
+  contract. A third-party engine must too. An engine MAY surface a documented capability flag if it
   cannot host long-running background work, but the default expectation is full parity.
 - When enabled, a conformant engine starts a background supervisor with independent UDP and ADIF-tail
-  inputs. The supervisor MUST NOT block normal logging or engine startup after configuration has
-  been accepted. The supervisor MUST observe `wsjtx_ingest` settings changes applied through
-  `SaveSetup` at runtime (start, stop, rebind, or re-point the tail without a process restart).
-- UDP input listens for WSJT-X Logged ADIF datagrams and ignores non-logged WSJT-X messages. Raw
-  ADIF and lightweight JSON-wrapped ADIF may be accepted by test/simulation helpers, but runtime
+  inputs. The supervisor MUST NOT block normal logging or engine startup after the engine accepts
+  configuration. The supervisor MUST observe `wsjtx_ingest` settings changes that `SaveSetup`
+  applies at runtime (start, stop, rebind, or re-point the tail without a process restart).
+- UDP input listens for WSJT-X Logged ADIF datagrams and ignores non-logged WSJT-X messages.
+  Test and simulation helpers can accept raw ADIF and lightweight JSON-wrapped ADIF. Runtime
   framed WSJT-X packets must only import logged-QSO ADIF payloads.
-- ADIF-tail input polls `wsjtx_log.adi`, scans from byte 0 on first run for startup recovery, and
-  then imports only appended complete ADIF records while the engine is running. Complete-record
+- ADIF-tail input polls `wsjtx_log.adi`.
+- On the first run, it scans from byte 0 for startup recovery.
+- Then it imports only new complete ADIF records while the engine operates. Complete-record
   detection must honor ADIF field lengths as character counts so literal `<EOR>` text inside a
-  field value cannot move the cursor. It must not advance its cursor past an incomplete trailing
-  record or a failed import. Startup replay is recovery-only: it imports missing QSOs and skips
-  existing duplicates, including soft-deleted or locally edited rows that retain the original import
-  fingerprint, rather than refreshing older ADIF rows over newer local edits.
+    field value cannot move the cursor. It must not advance its cursor past an incomplete trailing
+    record or a failed import.
+
+   Startup replay is only for recovery.
+   It imports missing QSOs and skips existing duplicates.
+   Duplicates include deleted or edited rows that retain the original import fingerprint.
+  It does not replace newer local edits with older ADIF rows.
 - Both inputs feed `LogbookEngine::import_adif_qsos`. Duplicate UDP events, repeated ADIF scans,
   and later manual imports must not create duplicate QSOs.
-- `WsjtxIngestStatus` reports enabled/running state, UDP/tail health, last event time, last
-  imported callsign/local id, imported/updated/skipped/duplicate counters, parse errors, last
-  ingestion error, and last QRZ sync result.
-- When `sync_to_qrz=true`, imported or refreshed WSJT-X QSOs use the same per-operation QRZ upload
-  semantics as `LogQso(sync_to_qrz=true)`: success writes QRZ metadata back locally, while failure
-  leaves the local QSO persisted and retryable and records an actionable diagnostic. The async
-  writeback must patch only QRZ metadata and sync state onto the current local row so a stale upload
-  task cannot overwrite newer operator edits. QRZ upload work must not block the local UDP/tail
-  ingestion loops.
+- `WsjtxIngestStatus` reports the enabled state, running state, input health, and last event time.
+  It also reports result counters, parse errors, the last ingest error, and the last QRZ sync result.
+- When `sync_to_qrz=true`, imported or refreshed WSJT-X QSOs use the `LogQso` QRZ upload behavior.
+  Success stores QRZ metadata locally. Failure keeps the local QSO for a retry and records a clear diagnostic.
+  The asynchronous writeback changes only QRZ metadata and sync state.
+  It applies these changes to the current local row.
+  Thus, an old upload task cannot replace newer operator edits.
+  QRZ upload work must not block the local UDP or tail loops.
 
 **Error semantics:**
-- `INVALID_ARGUMENT` — invalid or missing required setup fields, an invalid `cat_hub` section, or invalid `wsjtx_ingest` settings.
-- `INTERNAL` — failed to persist configuration.
+- `INVALID_ARGUMENT` - invalid or missing required setup fields, an invalid `cat_hub` section, or invalid `wsjtx_ingest` settings.
+- `INTERNAL` - failed to persist configuration.
 
 #### GetSetupWizardState
 
@@ -776,7 +928,7 @@ Returns the current state of the setup wizard for multi-step UIs.
 **Behavior:**
 - Return the list of `SetupWizardStep` values with their completion status (`SetupWizardStepStatus`).
 - The ordered enum surface is `LOG_FILE`, `STATION_PROFILES`, `QRZ_INTEGRATION`, `CAT_HUB`, and `REVIEW`.
-- The CAT hub step (`SETUP_WIZARD_STEP_CAT_HUB`) is optional and always reported complete; it
+- The CAT hub step (`SETUP_WIZARD_STEP_CAT_HUB`) is optional and always reported complete. It
   exposes the current `[cat_hub]` projection for display and editing.
 
 #### ValidateSetupStep
@@ -790,7 +942,7 @@ Validates a single step of the setup wizard without persisting.
 - The station-profile wizard step requires profile name, station callsign, operator callsign, and grid because setup-completion guidance needs a complete operating identity. This is stricter than `SaveStationProfile`, which requires only profile name and station callsign.
 
 **Error semantics:**
-- `INVALID_ARGUMENT` — unknown step identifier.
+- `INVALID_ARGUMENT` - unknown step identifier.
 
 #### TestQrzCredentials
 
@@ -802,7 +954,7 @@ Tests QRZ XML API credentials by performing a real lookup request.
 3. Return failure with a descriptive message if authentication fails.
 
 **Error semantics:**
-- Authentication, rejection, and network failures are reported as `success=false` with a sanitized response message. Malformed requests use `INVALID_ARGUMENT`.
+- The engine reports authentication, rejection, and network failures as `success=false`. It supplies a sanitized response message. Malformed requests use `INVALID_ARGUMENT`.
 
 #### TestQrzLogbookCredentials
 
@@ -814,7 +966,7 @@ Tests QRZ logbook API credentials.
 3. Return failure with a descriptive message otherwise.
 
 **Error semantics:**
-- Authentication, rejection, and network failures are reported as `success=false` with a sanitized response message. Malformed requests use `INVALID_ARGUMENT`.
+- The engine reports authentication, rejection, and network failures as `success=false`. It supplies a sanitized response message. Malformed requests use `INVALID_ARGUMENT`.
 
 ### 3.7 StationProfileService
 
@@ -847,7 +999,7 @@ Returns all saved station profiles.
 Returns a single station profile by name.
 
 **Error semantics:**
-- `NOT_FOUND` — no profile with the given name.
+- `NOT_FOUND` - no profile with the given name.
 
 #### SaveStationProfile
 
@@ -859,15 +1011,15 @@ Creates or updates a station profile.
 3. If this is the first profile and no active profile is set, automatically activate it.
 
 **Error semantics:**
-- `INVALID_ARGUMENT` — missing or invalid fields.
+- `INVALID_ARGUMENT` - missing or invalid fields.
 
 #### DeleteStationProfile
 
 Deletes a station profile by name.
 
 **Error semantics:**
-- `NOT_FOUND` — no profile with the given name.
-- `FAILED_PRECONDITION` — cannot delete the active profile while it is active.
+- `NOT_FOUND` - no profile with the given name.
+- `FAILED_PRECONDITION` - cannot delete the active profile while it is active.
 
 #### SetActiveStationProfile
 
@@ -878,7 +1030,7 @@ Activates a saved profile as the current station context.
 - All subsequent `LogQso` calls will stamp QSOs with this profile's station data.
 
 **Error semantics:**
-- `NOT_FOUND` — no profile with the given name.
+- `NOT_FOUND` - no profile with the given name.
 
 #### GetActiveStationContext
 
@@ -894,7 +1046,7 @@ Temporarily overrides the active station profile for the current session.
 
 **Behavior:**
 - Accept a complete, valid `StationProfile` replacement. The current protobuf message is not a patch and has no field-presence model for individual scalar overrides.
-- Resolve the active context from the session profile as a full replacement of the saved active profile. Omitted optional sections and values are cleared for the session.
+- Resolve the active context from the session profile as a full replacement of the saved active profile. Clear omitted optional sections and values for the session.
 - The override persists until explicitly cleared or the engine restarts.
 
 #### ClearSessionStationProfileOverride
@@ -929,10 +1081,10 @@ Returns contests whose UTC window overlaps the requested time and lookahead wind
 The built-in WA7BNM provider uses the public RSS calendar feed and treats it as a metadata source. RSS-derived entries include name, UTC start/end, source link, and metadata-only status. The runtime engine must not scrape WA7BNM HTML detail pages for exchange, band, mode, or rules data. Richer details require an authorized data source, a user-configured source, a curated local catalog, or a reviewed catalog generated offline.
 
 **Local details catalog:**
-The engine loads a reviewed JSON catalog from `QSORIPPER_CONTEST_CALENDAR_DETAILS_PATH`, or from `data\contest-calendar\contest-details.json` when the variable is unset and that file exists. It uses the catalog to enrich RSS entries with known bands, modes, exchange text, rules URL, and `ContestDetailsStatus`. Catalog entries may match by `contestId`, `sourceUrl`, or normalized contest `name`. This catalog is offline input to the engine. Generated catalog candidates must be reviewed before they become authoritative engine input, and tools that produce them must respect rules-site terms.
+The engine loads a reviewed JSON catalog from `QSORIPPER_CONTEST_CALENDAR_DETAILS_PATH`. It uses the default catalog when that variable has no value. Catalog entries can match `contestId`, `sourceUrl`, or normalized contest `name`. This catalog is offline engine input. A person must review generated catalog candidates. Generator tools must obey rules-site terms.
 
 **Error semantics:**
-- This RPC should usually succeed. Data unavailability is reported through `ContestCalendarStatus` and `error_message`.
+- This RPC must usually succeed. The engine reports unavailable data through `ContestCalendarStatus` and `error_message`.
 - Proto3 accepts unknown numeric enum values. The service MUST explicitly reject unknown band or mode values with `INVALID_ARGUMENT`.
 
 #### RefreshContestCalendar
@@ -943,13 +1095,16 @@ Forces an immediate provider refresh and returns the resulting contest entries p
 1. Fetch fresh data from the configured contest calendar provider.
 2. Parse and normalize contest entries into `ContestCalendarEntry`.
 3. Update the cache on success.
-4. On provider failure, return stale cached data when available; otherwise return `CONTEST_CALENDAR_STATUS_ERROR` or `CONTEST_CALENDAR_STATUS_DISABLED`.
+4. On provider failure, return stale cached data when available. Otherwise return `CONTEST_CALENDAR_STATUS_ERROR` or `CONTEST_CALENDAR_STATUS_DISABLED`.
 
 ### 3.9 CwService
 
 **Proto file:** `proto/services/cw_service.proto`
 
-Engine-owned CW macro expansion and keyer dispatch for contest workflows. The service is intentionally independent from UI key bindings: clients may map F-keys, buttons, or CLI commands to named macros, but the engine owns expansion and backend dispatch.
+The engine expands CW macros and sends them to the keyer.
+The service does not depend on UI key bindings.
+Clients can map F-keys, buttons, or CLI commands to named macros.
+The engine owns macro expansion and backend dispatch.
 
 #### RPCs
 
@@ -975,7 +1130,14 @@ The first conformant implementation exposes built-in named macros. Persisted use
 
 #### Macro grammar
 
-CW macro templates are ASCII text with braced tokens. Token names are case-insensitive. Unknown tokens are rejected with `INVALID_ARGUMENT`; they are not passed through literally. Literal braces are escaped by doubling them: `{{` emits `{` and `}}` emits `}`. Unmatched braces are rejected with `INVALID_ARGUMENT`. Expansion preserves all other whitespace and punctuation.
+CW macro templates are ASCII text with braced tokens.
+Token names are case-insensitive.
+The engine rejects unknown tokens with `INVALID_ARGUMENT`.
+It does not send unknown tokens as literal text.
+
+Double braces identify literal braces: `{{` emits `{` and `}}` emits `}`.
+The engine rejects unmatched braces with `INVALID_ARGUMENT`.
+Expansion preserves all other whitespace and punctuation.
 
 Defined tokens:
 
@@ -983,9 +1145,9 @@ Defined tokens:
 |---|---|
 | `{MYCALL}` | Active station context station callsign. If no active station callsign exists, reject with `FAILED_PRECONDITION`. |
 | `{HISCALL}` | `CwSendContext.worked_callsign`, normalized to uppercase. |
-| `{RST}` | `CwSendContext.rst`; default `599` when omitted. |
+| `{RST}` | `CwSendContext.rst`. Default `599` when omitted. |
 | `{EXCH}` | `CwSendContext.exchange`. |
-| `{NR}` | `CwSendContext.serial`, formatted as decimal with no padding for the first slice. Future contest sessions may assign this engine-side. |
+| `{NR}` | `CwSendContext.serial`, in decimal form without initial padding. Future contest sessions can assign this value in the engine. |
 
 #### Backend semantics
 
@@ -993,13 +1155,32 @@ Defined tokens:
 |---|---|
 | `CW_KEYER_BACKEND_NULL` | Always accepts valid expanded text and performs no hardware I/O. This backend exists for CI, development, and CLI smoke tests. |
 | `CW_KEYER_BACKEND_WINKEYER` | Sends expanded text and control commands to a serial-connected WinKeyer-compatible hardware keyer. The engine reports serial connection errors explicitly and never silently falls back to null when WinKeyer is selected. |
-| `CW_KEYER_BACKEND_CWDAEMON` | Reserved for future UDP cwdaemon support. cwdaemon is a mostly Linux-oriented background daemon that accepts CW text over UDP and performs keying through hardware it controls. UDP is best-effort, so completion cannot be proven by the engine. |
+| `CW_KEYER_BACKEND_CWDAEMON` | Reserved for future UDP cwdaemon support. cwdaemon is a Linux-oriented daemon. It accepts CW text over UDP and controls keying hardware. UDP does not prove completion. |
 
-`SendCwMacro` and `SendCwText` return the expanded text and a `CwSendState`. `ACCEPTED` means the configured backend accepted the command for dispatch. `COMPLETED` may only be returned by a backend that can prove completion. `AbortCw` sends the backend's abort or clear-buffer command when supported and returns `ABORT_REQUESTED`.
+`SendCwMacro` and `SendCwText` return the expanded text and a `CwSendState`. `ACCEPTED` means the configured backend accepted the command. Only a backend that proves completion can return `COMPLETED`. `AbortCw` sends the available abort or clear-buffer command and returns `ABORT_REQUESTED`.
 
-The WinKeyer backend is an engine-lifetime, serialized hardware session. The engine opens the serial port and sends Host Open (`00 02`) on the first status or control operation, retains the returned firmware revision, and reuses that connection for later RPCs. All keyer commands run through one backend worker or lock so concurrent RPCs cannot interleave serial bytes. On shutdown, initialization failure after Host Open, or an I/O failure, the engine makes a best-effort Host Close (`00 03`) before releasing the port. It never opens and abandons a new host session for each RPC.
+The WinKeyer backend is one serialized session for the engine lifetime.
+During the first operation, the engine opens the serial port.
+Then it sends Host Open (`00 02`).
+The engine keeps the returned firmware revision.
+It reuses the connection for later RPCs.
+One backend worker or lock controls all keyer commands.
 
-Hardware transmission is opt-in. `SendCwMacro` and `SendCwText` reject with `FAILED_PRECONDITION` unless `QSORIPPER_CW_TRANSMIT_ENABLED=true`; status and speed operations remain available for setup diagnostics. Each accepted hardware send arms the configured safety ceiling. At expiry the engine requests WinKeyer status (`15`) and clears the input buffer (`0A`) only when the BUSY bit remains set. `AbortCw` cancels the active watchdog and clears the buffer immediately. A subsequent send replaces the previous watchdog deadline.
+Thus, concurrent RPCs cannot mix serial bytes.
+
+Before it releases the port, the engine attempts Host Close (`00 03`).
+It does this during shutdown, initialization failure, or I/O failure.
+It does not create and abandon a host session for each RPC.
+
+Hardware transmission is opt-in.
+`SendCwMacro` and `SendCwText` reject with `FAILED_PRECONDITION` unless `QSORIPPER_CW_TRANSMIT_ENABLED=true`.
+Status and speed operations remain available for setup diagnostics.
+Each accepted hardware send starts the configured safety timer.
+
+At expiry, the engine requests WinKeyer status (`15`).
+It clears the input buffer (`0A`) only when the BUSY bit remains set.
+`AbortCw` cancels the active watchdog and clears the buffer immediately.
+A subsequent send replaces the previous watchdog deadline.
 
 CW configuration is read from the shared `[cw_keying]` table in `config.toml`. Each corresponding `QSORIPPER_CW_*` environment variable overrides only that TOML key. Both engines apply the same precedence and validation at startup. Setup saves preserve the entire `[cw_keying]` table verbatim because the CW service does not yet expose a configuration mutation RPC.
 
@@ -1007,11 +1188,11 @@ CW configuration is read from the shared `[cw_keying]` table in `config.toml`. E
 
 #### Error semantics
 
-- `NOT_FOUND` — unknown macro name.
-- `INVALID_ARGUMENT` — invalid speed, malformed macro text, unknown token, or missing token context.
-- `FAILED_PRECONDITION` — no active station context for `{MYCALL}`, the configured backend is unavailable, or hardware text transmission was requested while the explicit transmit gate is disabled.
-- `UNAVAILABLE` — keyer I/O failure where retrying may help.
-- `INTERNAL` — unexpected backend failure.
+- `NOT_FOUND` - unknown macro name.
+- `INVALID_ARGUMENT` - invalid speed, malformed macro text, unknown token, or missing token context.
+- `FAILED_PRECONDITION` - no active station context for `{MYCALL}`, the configured backend is unavailable, or hardware text transmission was requested while the explicit transmit gate is disabled.
+- `UNAVAILABLE` - keyer I/O failure. A retry can correct the failure.
+- `INTERNAL` - unexpected backend failure.
 
 ### 3.10 GreatCircleService
 
@@ -1032,29 +1213,29 @@ beam-heading indicators, and contact-distance displays.
 Computes the great-circle path from `origin` to `target`.
 
 **Request fields:**
-- `GeoReference origin` — required; must contain `coordinates` or `maidenhead`.
-- `GeoReference target` — required; same constraint.
-- `uint32 sample_count` — `0` selects the engine default (64); valid range is `2..=512`; values of `1` or `> 512` are rejected.
+- `GeoReference origin` - required. Must contain `coordinates` or `maidenhead`.
+- `GeoReference target` - required. Same constraint.
+- `uint32 sample_count` - `0` selects the engine default (64). Valid range is `2..=512`. Values of `1` or `> 512` are rejected.
 
 **`GeoReference` resolution:**
 - If `coordinates` is present, it is used directly.
 - Otherwise the engine resolves `maidenhead` (4, 6, or 8-character locator, case-insensitive) to the locator's center coordinates.
-- If neither is set, `INVALID_ARGUMENT` is returned.
+- If neither has a value, the engine returns `INVALID_ARGUMENT`.
 
 **Response fields:**
 - `GreatCirclePath path`:
-  - `GeoPoint origin`, `target` — resolved coordinates (after Maidenhead → lat/lon expansion).
-  - `double distance_km` — great-circle distance using a spherical Earth model with `R = 6371.0088 km`.
-  - `optional double initial_bearing_deg`, `final_bearing_deg` — true-north bearings in `[0, 360)`. Both are absent when origin and target are the same point or antipodal (the great circle is non-unique in those cases).
-  - `repeated GeoPoint samples` — `sample_count` evenly-spaced points along the geodesic, including both endpoints.
+  - `GeoPoint origin`, `target` - resolved coordinates (after Maidenhead → lat/lon expansion).
+  - `double distance_km` - great-circle distance using a spherical Earth model with `R = 6371.0088 km`.
+  - `optional double initial_bearing_deg`, `final_bearing_deg` - true-north bearings in `[0, 360)`. Both are absent when origin and target are the same point or antipodal (the great circle is non-unique in those cases).
+  - `repeated GeoPoint samples` - `sample_count` evenly-spaced points along the geodesic, including both endpoints.
 
 **Error semantics:**
-- `INVALID_ARGUMENT` — missing reference, unresolvable Maidenhead locator, latitude/longitude out of range, NaN/Inf, or `sample_count` out of range.
+- `INVALID_ARGUMENT` - missing reference, unresolvable Maidenhead locator, latitude/longitude out of range, NaN/Inf, or `sample_count` out of range.
 
 **Behavior:**
 - Computation is purely deterministic: identical inputs return bit-identical outputs across engine restarts and across the Rust and .NET implementations within `~1e-3` km / `~1e-3°`.
-- No external I/O; the RPC must complete entirely from in-process math.
-- This service is required, not optional. Engines that lack the math should still expose the RPC and return `UNIMPLEMENTED`, but the reference Rust and .NET engines both implement it.
+- No external I/O. The RPC must complete entirely from in-process math.
+- This service is necessary. Engines without the calculation must expose the RPC and return `UNIMPLEMENTED`. Both reference engines implement it.
 
 ### 3.11 DeveloperControlService
 
@@ -1079,8 +1260,8 @@ Returns the full runtime configuration snapshot.
 - Each `RuntimeConfigDefinition` supplies type, description, allowed values, secret metadata, and `default_value` when a canonical default exists.
 - Each `RuntimeConfigValue` reports a redacted display value and its `RuntimeConfigValueSource`: `DEFAULT`, `BASE_CONFIG`, `SESSION_OVERRIDE`, or `RUNTIME_OVERRIDE`.
 - Secret values are never returned. A configured secret sets `has_value=true`, `redacted=true`, and a redacted `display_value`.
-- Engines supporting QRZ lookup, QRZ Logbook, and rig control MUST advertise the common hot-apply keys `QSORIPPER_QRZ_XML_USERNAME`, `QSORIPPER_QRZ_XML_PASSWORD`, `QSORIPPER_QRZ_LOGBOOK_API_KEY`, and `QSORIPPER_RIGCTLD_ENABLED`. Other definitions may be implementation-specific.
-- Startup-only settings such as the active storage backend are reported elsewhere and MUST NOT be advertised here unless the engine can safely hot-apply them.
+- Engines supporting QRZ lookup, QRZ Logbook, and rig control MUST advertise the common hot-apply keys `QSORIPPER_QRZ_XML_USERNAME`, `QSORIPPER_QRZ_XML_PASSWORD`, `QSORIPPER_QRZ_LOGBOOK_API_KEY`, and `QSORIPPER_RIGCTLD_ENABLED`. Other definitions can be implementation-specific.
+- The engine reports startup-only settings elsewhere. It MUST NOT advertise them here unless it can safely hot-apply them.
 
 #### ApplyRuntimeConfig
 
@@ -1089,11 +1270,13 @@ Applies one or more runtime configuration mutations.
 **Behavior:**
 1. Accept a list of `RuntimeConfigMutation` entries (field name + new value + mutation kind).
 2. Validate each mutation against the field's allowed values and type.
-3. Apply the mutations to the running engine state. A successful response guarantees the active integration observes the new value without restart.
+3. Apply the changes to the active engine state.
 4. Return the updated configuration snapshot.
 
+A successful response guarantees that the active integration observes the new value without a restart.
+
 **Error semantics:**
-- `INVALID_ARGUMENT` — unknown field name, invalid value, or type mismatch.
+- `INVALID_ARGUMENT` - unknown field name, invalid value, or type mismatch.
 
 #### ResetRuntimeConfig
 
@@ -1108,7 +1291,7 @@ Resets all runtime configuration overrides to the startup/base configuration.
 
 **Proto file:** `proto/services/stress_control_service.proto`
 
-Load testing control plane. Implementation is optional; engines that do not support stress testing should return `UNIMPLEMENTED` for all RPCs.
+Load-test control plane. Implementation is optional. Engines without stress-test support must return `UNIMPLEMENTED` for all RPCs.
 
 #### RPCs
 
@@ -1157,14 +1340,14 @@ Selection is controlled by the `QSORIPPER_STORAGE_BACKEND` environment variable.
 
 ### 4.2 In-Memory Backend
 
-- All data is stored in-process data structures (maps, vectors).
+- The memory backend stores all data in process data structures (maps and vectors).
 - Data is lost on engine restart.
 - Suitable for testing, development, and conformance runs.
 - Must implement the full `EngineStorage` trait (logbook + lookup snapshots).
 
 ### 4.3 SQLite Backend
 
-- Data is persisted to a SQLite file at the path specified by `QSORIPPER_SQLITE_PATH` (or `QSORIPPER_STORAGE_PATH`).
+- The SQLite backend stores data in the file that `QSORIPPER_SQLITE_PATH` or `QSORIPPER_STORAGE_PATH` specifies.
 - Must use WAL journal mode for concurrent read/write performance.
 - Must set `busy_timeout = 5000` (5 seconds) to handle transient lock contention.
 - Must enable `foreign_keys = ON`.
@@ -1176,7 +1359,7 @@ The SQLite backend uses the following schema (defined in `src/rust/qsoripper-sto
 
 #### `qsos` table
 
-QSO records are stored as protobuf binary blobs in a `record` column, with indexed extraction columns for efficient querying.
+The SQLite backend stores QSO records as protobuf binary blobs in a `record` column. Indexed extraction columns support efficient queries.
 
 | Column | Type | Constraints | Description |
 |---|---|---|---|
@@ -1207,7 +1390,7 @@ Singleton row tracking QRZ logbook sync state.
 | `last_sync_ms` | `INTEGER` | | Last sync timestamp in ms |
 | `qrz_logbook_owner` | `TEXT` | | QRZ logbook owner callsign |
 
-A seed row `(1, 0)` is inserted on creation.
+The backend inserts a seed row `(1, 0)` during creation.
 
 #### `lookup_snapshots` table
 
@@ -1222,9 +1405,9 @@ Cached callsign lookup results.
 
 ### 4.5 Migration Strategy
 
-- Migrations are embedded in the engine binary and applied at startup.
-- Each migration is a numbered SQL file (e.g., `0001_initial.sql`).
-- The engine must track which migrations have been applied and only run new ones.
+- The engine embeds migrations in its binary and applies them during startup.
+- Each migration is a numbered SQL file (for example, `0001_initial.sql`).
+- The engine must track completed migrations and run only new migrations.
 - Migrations must be idempotent where possible.
 - Schema changes must be backward-compatible: add columns with defaults, never remove columns in active use.
 
@@ -1232,9 +1415,9 @@ Cached callsign lookup results.
 
 All backends must implement the `EngineStorage` trait, which decomposes into:
 
-- **`LogbookStore`** — `insert_qso`, `update_qso`, `delete_qso`, `get_qso`, `list_qsos`, `qso_counts`, `get_sync_metadata`, `upsert_sync_metadata`
-- **`LookupSnapshotStore`** — `get_lookup_snapshot`, `upsert_lookup_snapshot`, `delete_lookup_snapshot`
-- **`backend_name()`** — returns the backend identifier string (e.g., `"memory"`, `"sqlite"`)
+- **`LogbookStore`** - `insert_qso`, `update_qso`, `delete_qso`, `get_qso`, `list_qsos`, `qso_counts`, `get_sync_metadata`, `upsert_sync_metadata`
+- **`LookupSnapshotStore`** - `get_lookup_snapshot`, `upsert_lookup_snapshot`, `delete_lookup_snapshot`
+- **`backend_name()`** - returns the backend identifier string (for example, `"memory"`, `"sqlite"`)
 
 ---
 
@@ -1256,8 +1439,8 @@ All backends must implement the `EngineStorage` trait, which decomposes into:
 - Lookup: `?s=<callsign>&callsign=<callsign>&agent=<user_agent>`
 
 **Response format:** XML with namespace `http://xmldata.qrz.com`. The engine must use namespace-aware XML parsing. Key elements:
-- `<Callsign>` — contains all station data fields
-- `<Session>` — contains session key, error messages, subscription status
+- `<Callsign>` - contains all station data fields
+- `<Session>` - contains session key, error messages, subscription status
 
 **Normalization:** Map QRZ XML fields to `CallsignRecord` proto fields immediately at the provider edge. Never expose raw XML structures beyond the QRZ adapter.
 
@@ -1288,7 +1471,11 @@ All backends must implement the `EngineStorage` trait, which decomposes into:
 
 **Response format:** Ampersand-delimited key-value pairs. Check `RESULT` field for success/failure.
 
-**ADIF interchange:** The logbook API uses ADIF format for QSO data. The engine must serialize/deserialize ADIF at this boundary. When exporting numeric ADIF fields for QRZ uploads, engines must normalize them to QRZ-compatible values; for example, `TX_PWR` must be sent as a numeric watt value and omitted if the local value cannot be normalized safely.
+**ADIF interchange:** The logbook API uses ADIF for QSO data.
+The engine must serialize and deserialize ADIF at this boundary.
+Normalize numeric fields before a QRZ upload.
+For example, send `TX_PWR` as a numeric watt value.
+Omit it when the engine cannot safely normalize the local value.
 
 **Credential env vars:**
 - `QSORIPPER_QRZ_LOGBOOK_API_KEY`
@@ -1304,8 +1491,8 @@ All backends must implement the `EngineStorage` trait, which decomposes into:
 
 | Command | Response | Description |
 |---|---|---|
-| `f\n` | Frequency in Hz (e.g., `14074000`) | Get current frequency |
-| `m\n` | Mode and passband (e.g., `USB\n2400`) | Get current mode |
+| `f\n` | Frequency in Hz (for example, `14074000`) | Get current frequency |
+| `m\n` | Mode and passband (for example, `USB\n2400`) | Get current mode |
 | `s\n` | Split enabled and TX VFO | Detect split operation |
 | `i\n` | Split TX frequency in Hz | Get transmit frequency when split |
 | `x\n` | Split TX mode and passband | Get transmit mode when split |
@@ -1320,7 +1507,7 @@ All backends must implement the `EngineStorage` trait, which decomposes into:
   retry. If that retry fails, the rig status transitions to `Disconnected` or `Error`.
 - Each successful poll constructs a `RigSnapshot` and caches it.
 - Optional command failures do not change the connection status and do not discard required fields.
-- If the snapshot is older than `QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS`, it is marked stale.
+- If the snapshot is older than `QSORIPPER_RIGCTLD_STALE_THRESHOLD_MS`, the engine marks it stale.
 
 **Read timeout:** `QSORIPPER_RIGCTLD_READ_TIMEOUT_MS` controls the per-command TCP read timeout.
 
@@ -1355,7 +1542,7 @@ All backends must implement the `EngineStorage` trait, which decomposes into:
 
 **Parsed fields:** contest name, UTC start time, UTC end time, source URL, source name, and deterministic `contest_id`.
 
-**Optional enrichment:** `QSORIPPER_CONTEST_CALENDAR_DETAILS_PATH` may point to a reviewed JSON file. If unset, the engine uses `data\contest-calendar\contest-details.json` when the file exists:
+**Optional enrichment:** `QSORIPPER_CONTEST_CALENDAR_DETAILS_PATH` can point to a reviewed JSON file. If unset, the engine uses `data\contest-calendar\contest-details.json` when the file exists:
 
 ```json
 {
@@ -1373,14 +1560,28 @@ All backends must implement the `EngineStorage` trait, which decomposes into:
 }
 ```
 
-The standalone generator creates a review file from the WA7BNM 12-month calendar by default. It follows calendar detail links as an offline build step, extracts factual fields such as mode, bands, exchange, and the official rules URL, then optionally fetches official rules pages to fill gaps. It can also consume RSS metadata or an optional seed catalog of known official rules URLs:
+By default, the standalone generator creates a WA7BNM 12-month review file.
+As an offline build step, it follows calendar detail links.
+It extracts mode, bands, exchange, and the official rules URL.
+It can get official rules pages to fill information gaps.
+It can also use RSS metadata or a seed catalog of official rules URLs:
 
 ```powershell
 dotnet run --project src\dotnet\QsoRipper.Tools.ContestCatalog -- --output artifacts\contest-calendar\contest-details.generated.json
 dotnet run --project src\dotnet\QsoRipper.Tools.ContestCatalog -- --promote-candidates --output data\contest-calendar\contest-details.json
 ```
 
-The default output is `artifacts\contest-calendar\contest-details.generated.json`. It is not loaded by the engine. By default, extracted facts are written as `candidateBands`, `candidateModes`, and `candidateExchange` so a maintainer can verify facts and copy only factual fields into `data\contest-calendar\contest-details.json`. `--promote-candidates` writes those factual candidates into canonical catalog fields for a reviewed local database and omits the review-only candidate fields. The generator may read WA7BNM detail pages only as offline calendar metadata, but it refuses to treat WA7BNM or ContestCalendar URLs as official rules pages and should not copy rules prose into the catalog.
+The default output is `artifacts\contest-calendar\contest-details.generated.json`.
+The engine does not load this file.
+By default, the generator writes facts as `candidateBands`, `candidateModes`, and `candidateExchange`.
+A maintainer can verify these facts.
+Then the maintainer can copy factual fields into `data\contest-calendar\contest-details.json`.
+`--promote-candidates` writes verified candidates into the catalog fields.
+
+It omits the review-only candidate fields.
+The generator can read WA7BNM detail pages only as offline calendar metadata.
+It does not use WA7BNM or ContestCalendar URLs as official rules pages.
+It must not copy rules text into the catalog.
 
 ---
 
@@ -1388,7 +1589,7 @@ The default output is `artifacts\contest-calendar\contest-details.generated.json
 
 ### 6.1 Environment Variables
 
-All configuration is driven by environment variables prefixed with `QSORIPPER_`. The engine should also support loading from a `.env` file at the config path.
+Environment variables with the `QSORIPPER_` prefix control all configuration. The engine must also load a `.env` file from the configuration path.
 
 #### Global
 
@@ -1434,7 +1635,7 @@ All configuration is driven by environment variables prefixed with `QSORIPPER_`.
 
 #### CW Keying
 
-The same keys may be persisted under `[cw_keying]` in the shared `config.toml`: `backend`, `winkeyer_port`, `winkeyer_baud`, `cathub_endpoint`, `cathub_client_name`, `speed_wpm`, `transmit_enabled`, and `max_tx_ms`. Environment variables in the table below override their corresponding persisted values.
+The engine can store the same keys under `[cw_keying]` in the shared `config.toml`: `backend`, `winkeyer_port`, `winkeyer_baud`, `cathub_endpoint`, `cathub_client_name`, `speed_wpm`, `transmit_enabled`, and `max_tx_ms`. Environment variables in the table below override the stored values.
 
 | Variable | Type | Default | Description |
 |---|---|---|---|
@@ -1499,7 +1700,7 @@ The engine must start and function even when external integrations are unavailab
 
 ### 6.3 Configuration Persistence
 
-- Configuration is persisted as a shared TOML file in `QSORIPPER_CONFIG_PATH`.
+- The engine stores configuration in a shared TOML file at `QSORIPPER_CONFIG_PATH`.
 - The `SaveSetup` RPC writes only non-secret configuration to this path.
 - On startup, the engine loads persisted configuration and overlays environment variable overrides (env vars take precedence).
 - Runtime config mutations (via `DeveloperControlService`) are ephemeral and do not persist across restarts unless explicitly saved.
@@ -1507,10 +1708,13 @@ The engine must start and function even when external integrations are unavailab
 
 #### Secret handling
 
-- QRZ XML passwords, QRZ Logbook API keys, provider session keys, and future integration credentials MUST NOT be serialized to the shared TOML file.
+- The engine MUST NOT serialize QRZ passwords, API keys, session keys, or other credentials to the shared TOML file.
 - Secrets supplied by `SaveSetup` or `DeveloperControlService` are process-session values. Restart-persistent secrets come from environment variables or a platform secure configuration provider.
 - Status and runtime configuration responses expose only configured/unconfigured state and redacted display text. Logs and error details never contain secret values or sensitive request payloads.
-- On loading a legacy config that contains plaintext QRZ secrets, an engine MAY use those values for the current process so logging remains available, but it MUST immediately rewrite the owned config tables without the plaintext fields. That migration is idempotent.
+- A legacy configuration can contain plaintext QRZ secrets.
+  An engine MAY use these values for the current process.
+  It MUST immediately rewrite its owned tables without the plaintext fields.
+  This migration is idempotent.
 
 ---
 
@@ -1520,13 +1724,14 @@ The engine must start and function even when external integrations are unavailab
 
 Every logged QSO must carry station identity data. The station context system works as follows:
 
-1. **Station profiles** are named, persisted sets of station defaults: callsign, operator callsign, grid square, county, state, country, DXCC, CQ/ITU zones, latitude/longitude, and ARRL section.
+1. **Station profiles** are named and saved sets of station defaults.
+   They contain callsigns, location data, DXCC, zones, coordinates, and ARRL section.
 
-2. **Active profile** — exactly one saved profile is active at any time. A session profile set through `SetSessionStationProfileOverride` fully replaces that saved profile for runtime station context until cleared. It is not a field overlay because the current protobuf request carries a complete `StationProfile` without patch presence semantics.
+2. **Active profile** - exactly one saved profile is active at any time. A session profile set through `SetSessionStationProfileOverride` fully replaces that saved profile for runtime station context until cleared. It is not a field overlay because the current protobuf request carries a complete `StationProfile` without patch presence semantics.
 
-3. **Station snapshot** — when a QSO is logged, the engine captures the current station context as an immutable `StationSnapshot` and attaches it to the `QsoRecord`. This snapshot is never retroactively updated if the profile changes.
+3. **Station snapshot** - when the engine logs a QSO, it captures the current station context in an immutable `StationSnapshot`. It never updates this snapshot after a profile change.
 
-4. **Materialization** — the engine must implement a `station_snapshot_from_profile` function that converts the effective `StationProfile` into a `StationSnapshot` suitable for embedding in a QSO.
+4. **Materialization** - the engine must implement a `station_snapshot_from_profile` function that converts the effective `StationProfile` into a `StationSnapshot` suitable for embedding in a QSO.
 
 ### 7.2 QSO Lifecycle
 
@@ -1551,10 +1756,13 @@ Every logged QSO must carry station identity data. The station context system wo
 #### Deleting a QSO
 
 1. Client calls `DeleteQso` with `local_id` (and optional `delete_from_qrz` flag).
-2. Engine performs a **soft delete** — the row stays in storage with `deleted_at` set to now (UTC). See §7.8 for full semantics.
-3. If `delete_from_qrz = true` and the row has a non-empty `qrz_logid`, the engine sets `pending_remote_delete = true` so a future sync can issue the QRZ DELETE; this RPC does **not** call QRZ inline.
-4. Response includes `success`, `remote_delete_queued`. The legacy `qrz_delete_success`/`qrz_delete_error` fields stay false/empty (deprecated; do not consume).
-5. Re-deleting an already soft-deleted row succeeds idempotently and may upgrade `pending_remote_delete` from false to true.
+2. Engine performs a **soft delete** - the row stays in storage with `deleted_at` set to now (UTC). See §7.8 for full semantics.
+3. If `delete_from_qrz = true`, check `qrz_logid`.
+   For a non-empty value, set `pending_remote_delete = true`.
+   A future sync will send the QRZ DELETE.
+   This RPC does **not** call QRZ.
+4. Response includes `success`, `remote_delete_queued`. The legacy `qrz_delete_success`/`qrz_delete_error` fields stay false/empty (deprecated. Do not consume).
+5. A repeated delete of a soft-deleted row succeeds and can change `pending_remote_delete` from false to true.
 
 ### 7.3 Sync Lifecycle
 
@@ -1566,34 +1774,66 @@ Call QRZ `STATUS` once before download. Use its owner callsign for upload rewrit
 
 #### Phase 0.5: Push local corrections before download
 
-Before fetching remote QSOs, engines MUST resolve the QRZ logbook owner callsign (via `STATUS`, falling back to cached metadata on transient failure) and push local rows with `sync_status = MODIFIED` and a non-empty `qrz_logid` when the effective conflict policy is `CONFLICT_POLICY_FLAG_FOR_REVIEW` or `CONFLICT_POLICY_UNSPECIFIED`. This uses the documented replace form `ACTION=INSERT&OPTION=REPLACE`. QRZ identifies the existing record from the ADIF identity fields.
+Before a fetch, engines MUST resolve the QRZ logbook owner callsign.
+Use `STATUS`, or use cached metadata after a temporary failure.
+For applicable conflict policies, upload changed local rows that have a `qrz_logid`.
+The applicable policies are `CONFLICT_POLICY_FLAG_FOR_REVIEW` and `CONFLICT_POLICY_UNSPECIFIED`.
+Use `ACTION=INSERT&OPTION=REPLACE`.
+QRZ identifies the existing record from the ADIF identity fields.
 
-This pre-download upload prevents a stale QRZ copy from being downloaded first and converting a normal local correction into `CONFLICT` before the upload phase can update QRZ. Engines MUST remember the `qrz_logid` values successfully uploaded during this phase and ignore matching remote rows returned by the same sync's subsequent `FETCH`, because QRZ may briefly return the stale pre-replace copy.
+This upload prevents an old QRZ copy from arriving before the local correction.
+Thus, it prevents an incorrect `CONFLICT` state.
+Engines MUST remember each successfully uploaded `qrz_logid`.
+They MUST ignore matching rows from the next `FETCH` in the same sync.
+QRZ can temporarily return the old copy.
 
 #### Phase 1: Download
 
 1. Call QRZ logbook API `FETCH` with `OPTION=ALL` (full sync) or `OPTION=ALL,MODSINCE:YYYY-MM-DD` (incremental).
 2. Parse the ADIF response into QSO records. Engines MUST recognise QRZ-specific ADIF application fields and map them onto dedicated domain fields (see §7.5 Import).
 3. For each remote QSO:
-    a. Prefer a direct match on `qrz_logid` if one was returned for that record.
+    a. Prefer a direct match on `qrz_logid` if QRZ returned one for that record.
     b. Otherwise, fuzzy-match against local records: callsign (case-insensitive) + UTC timestamp (within a tolerance window, typically ±60s) + band + mode.
-    c. If the remote `qrz_logid` was successfully uploaded during Phase 0.5 of this same sync, skip it rather than overwriting the corrected local row with a stale remote response.
+    c. Check whether Phase 0.5 uploaded the remote `qrz_logid`.
+       If it did, skip the remote row.
+       Do not replace the corrected local row with an old remote response.
     d. If matched, apply the configured `ConflictPolicy`:
-       - `CONFLICT_POLICY_LAST_WRITE_WINS` — treat the remote record as authoritative and overwrite local fields; mark the merged row as `SYNCED`.
-       - `CONFLICT_POLICY_FLAG_FOR_REVIEW` — when the local row was locally edited (`sync_status = MODIFIED`), preserve the local fields, set `sync_status = CONFLICT`, and increment the sync result's conflict counter so operators can reconcile manually. When the local row is already `SYNCED`, remote wins (no conflict).
-       - `CONFLICT_POLICY_UNSPECIFIED` — engines MUST treat the zero value as `FLAG_FOR_REVIEW` (the safe, non-destructive default) per §6.3.
-       - When the matched local row is `SYNC_STATUS_LOCAL_ONLY`, engines MUST link the QRZ identity and mark it `SYNCED` without overwriting locally logged contest/contact fields. Engines MUST fill missing worked-station enrichment fields from the remote QRZ ADIF record (for example `GRIDSQUARE`, `COUNTRY`, `DXCC`, `STATE`, `CNTY`, `CQZ`, `ITUZ`, `CONT`, worked-station lat/lon/altitude, and other remote-only ADIF extras) so QSOs uploaded by external loggers can adopt QRZ Logbook enrichment on the next sync.
+       - `CONFLICT_POLICY_LAST_WRITE_WINS`: Use the remote record as the authority.
+         Replace local fields with remote fields.
+         Mark the merged row as `SYNCED`.
+       - `CONFLICT_POLICY_FLAG_FOR_REVIEW`: Check whether the local row is `MODIFIED`.
+         If it is, preserve local fields and set `sync_status = CONFLICT`.
+         Increase the conflict counter.
+         If the local row is `SYNCED`, the remote record has priority.
+       - `CONFLICT_POLICY_UNSPECIFIED`: Treat the zero value as `FLAG_FOR_REVIEW`.
+         Section 6.3 defines this safe default.
+       - For `SYNC_STATUS_LOCAL_ONLY`, link the QRZ identity and mark the row `SYNCED`.
+         Do not replace locally logged contest or contact fields.
+         Fill missing worked-station enrichment from the remote QRZ ADIF record.
+         This enrichment includes gridsquare, country, DXCC, state, county, zones, continent, and coordinates.
+         It also includes remote-only ADIF extras.
     e. If unmatched, insert as a new local record with `sync_status = SYNCED` and populate `qrz_logid` from the remote record.
-4. Filter ghost records: remote QSOs missing required fields (callsign, timestamp) are skipped without incrementing any counter.
-5. **Soft-delete suppression:** before matching, engines MUST load the full local record set including soft-deleted rows (see §7.8) and build the set of `qrz_logid` values associated with locally soft-deleted QSOs. Any remote QSO whose `qrz_logid` is in that set MUST be skipped (no insert, no merge), and the engine MUST increment the `deletes_skipped_remote` counter on the sync result. This prevents resurrection of QSOs the operator has trashed locally before the queued remote-delete (Phase 2.5) has propagated.
+4. Filter ghost records. Skip remote QSOs that do not contain the necessary callsign or timestamp. Do not increment a counter.
+5. **Soft-delete suppression:** Load all local records before matching.
+   Include soft-deleted rows.
+   See §7.8.
+   Build a set of `qrz_logid` values for locally deleted QSOs.
+   Skip each remote QSO whose `qrz_logid` is in this set.
+   Do not insert or merge it.
+   Increment `deletes_skipped_remote`.
+
+   This action prevents restoration before the Phase 2.5 remote delete.
 
 #### Phase 2: Upload
 
-1. Query local QSOs with `sync_status` in (`LOCAL_ONLY`, `MODIFIED`). Soft-deleted rows MUST NOT be uploaded as inserts/updates regardless of `sync_status`; they are handled by Phase 2.5.
+1. Query local QSOs with `sync_status` in (`LOCAL_ONLY`, `MODIFIED`). Phase 2.5 MUST handle soft-deleted rows. Do not upload these rows as inserts or updates.
 2. For each QSO, serialize to ADIF and call the QRZ logbook API:
    - If `sync_status = LOCAL_ONLY` (new record, no `qrz_logid`), use `ACTION=INSERT`.
    - If `sync_status = MODIFIED` and the record has a `qrz_logid`, use the documented replace form `ACTION=INSERT&OPTION=REPLACE`. QRZ identifies the existing record from the ADIF identity fields. Engines MUST NOT append a `LOGID` selector to `OPTION` or use the undocumented `ACTION=REPLACE` form.
-   - If `sync_status = MODIFIED` but no `qrz_logid` is available (e.g., first sync after upgrading from an engine that didn't persist the logid), fall back to `ACTION=INSERT`. Engines SHOULD additionally run the repair pass described in §7.7 before the first sync so modified-without-logid rows are rare.
+   - If `sync_status = MODIFIED` but no `qrz_logid` is available, use `ACTION=INSERT`.
+     This condition can occur after an upgrade from an engine that did not save the log ID.
+     Engines SHOULD also run the repair pass in Section 7.7 before the first sync.
+     This pass decreases the number of modified rows without a log ID.
 3. Accept both `RESULT=OK` (insert) and `RESULT=REPLACE` (update) as success indicators when parsing the QRZ response.
 4. On success, set `sync_status = SYNCED` and store the returned `LOGID` (or the supplied one for a REPLACE that echoes nothing) in `qrz_logid`.
 5. On per-QSO failure, log the error and continue with remaining QSOs.
@@ -1602,32 +1842,45 @@ This pre-download upload prevents a stale QRZ copy from being downloaded first a
 
 1. Query local QSOs where `deleted_at IS NOT NULL AND pending_remote_delete = true AND qrz_logid` is non-empty.
 2. For each such row, call the QRZ logbook API `ACTION=DELETE&KEY=<api_key>&LOGID=<qrz_logid>`.
-3. Treat the following responses as success (the remote row is gone or never existed — the operator's intent is satisfied):
+3. Treat the following responses as success. The remote row does not exist, which satisfies the operator intent:
    - `RESULT=OK`
    - `RESULT=FAIL&REASON=<text>` where `<text>` matches a not-found indicator (case-insensitive substring match on `not found`, `no such`, `does not exist`, or `no record`)
    - HTTP 404 from the QRZ endpoint
-4. On success, the engine MUST clear `pending_remote_delete` and clear `qrz_logid` (so a future re-sync cannot re-target a now-detached logid) while leaving `deleted_at` set so the row remains in the trash view. Increment the `remote_deletes_pushed` counter.
+4. On success, clear `pending_remote_delete` and `qrz_logid`.
+   Thus, a later sync cannot target the detached logid.
+   Keep `deleted_at` set so the row remains in the trash view.
+   Increment `remote_deletes_pushed`.
 5. On other failures (network, authentication, unrecognized REASON), the engine MUST leave `pending_remote_delete = true` and `qrz_logid` intact so the next sync retries. Append a description of the failure to the sync error summary.
-6. Authentication errors MUST propagate from the QRZ adapter as auth-failure exceptions (not collapsed into "not found"); engines surface them in the same way as other Phase 2 auth errors.
+6. The QRZ adapter MUST return authentication errors as authentication-failure exceptions.
+   It MUST NOT change them to "not found."
+   Engines handle them like other Phase 2 authentication errors.
 
 #### Phase 3: Metadata
 
 1. Reuse the Phase 0 QRZ `STATUS` result. Do not make a second status call.
-2. Update `sync_metadata` with the count, timestamp, and owner. If Phase 0 `STATUS` failed, engines SHOULD fall back to cached owner metadata and locally computed counts rather than inventing a remote count.
+2. Update `sync_metadata` with the count, timestamp, and owner.
 
-**Resilience:** A failure in any phase should not prevent other phases from executing. The engine should report partial success/failure in the stream. A fatal failure in Phase 1 (e.g., metadata load failure, fetch failure) MUST short-circuit the rest of `execute_sync` so that `last_sync` is NOT advanced — the next attempt re-fetches the same window.
+**Resilience:** A phase failure must not prevent other applicable phases.
+The engine must report partial results in the stream.
+A fatal Phase 1 failure MUST stop the remainder of `execute_sync`.
+Metadata load and fetch failures are fatal.
+Do not advance `last_sync`.
+The next attempt must fetch the same window.
 
 #### Per-Operation Sync (`sync_to_qrz=true` on LogQso/UpdateQso)
 
-When `LogQso.sync_to_qrz=true` or `UpdateQso.sync_to_qrz=true`, engines MUST attempt to push the affected row to QRZ immediately after the local persist. This is independent of the bulk sync flow (`SyncWithQrz`) and lets clients log a QSO and get an authoritative QRZ logid back in a single round-trip.
+When per-operation sync is true, attempt the QRZ upload after the local save.
+This applies to `LogQso` and `UpdateQso`.
+This operation is independent of `SyncWithQrz`.
+It returns the authoritative QRZ logid in the same request.
 
 **Selection rule (mirrors Phase 2):**
-- If the local row has a non-empty `qrz_logid`, replace it using `ACTION=INSERT&OPTION=REPLACE`; QRZ identifies the existing record from the ADIF identity fields.
+- If the local row has a non-empty `qrz_logid`, replace it using `ACTION=INSERT&OPTION=REPLACE`. QRZ identifies the existing record from the ADIF identity fields.
 - Otherwise INSERT (`ACTION=INSERT`).
 
 **Success path:** adopt the QRZ-assigned `LOGID`, set `sync_status=SYNC_STATUS_SYNCED`, write the row back to local storage, and populate the response's `sync_success=true` (and `qrz_logid` for `LogQsoResponse`).
 
-**Failure path:** the local persist MUST happen before the remote call and remains successful regardless of remote outcome. The QRZ failure is reported, not raised: leave the row's `sync_status` untouched (`LOCAL_ONLY` or `MODIFIED`), set `sync_success=false`, and put a human-readable message in `sync_error`. The next bulk `SyncWithQrz` will retry the row via Phase 2.
+**Failure path:** the local storage operation MUST occur before the remote call. A remote failure does not change the local result. Report the QRZ failure and keep `sync_status` unchanged. Set `sync_success=false` and put a clear message in `sync_error`. The next `SyncWithQrz` retries the row in Phase 2.
 
 **Configuration not present:** if no QRZ logbook API key is configured, return `sync_success=false` with `sync_error="QRZ Logbook API key is not configured."`. The local row still persists.
 
@@ -1656,16 +1909,16 @@ Client calls Lookup("W1AW")
 
 #### Slash-Call Fallback
 
-For callsigns with modifiers (e.g., `W1AW/7`, `VE3/W1AW`):
+For callsigns with modifiers (for example, `W1AW/7`, `VE3/W1AW`):
 
 1. Attempt lookup with the full callsign.
 2. If not found, extract the base callsign (strip the modifier).
 3. Retry lookup with the base callsign.
 4. On the result, populate:
-   - `base_callsign` — the callsign used for the successful lookup
-   - `modifier_text` — the modifier portion (e.g., `/7`)
-   - `modifier_kind` — the type of modifier (`ModifierKind` enum)
-   - `callsign_ambiguity` — flags if the callsign interpretation is ambiguous
+   - `base_callsign` - the callsign used for the successful lookup
+   - `modifier_text` - the modifier portion (for example, `/7`)
+   - `modifier_kind` - the type of modifier (`ModifierKind` enum)
+   - `callsign_ambiguity` - flags if the callsign interpretation is ambiguous
 
 #### Zone Cascade
 
@@ -1681,10 +1934,12 @@ When DXCC data is available, cascade zone information onto the lookup result if 
 
 1. Parse the ADI-format input (header + records delimited by `<eor>`).
 2. Map ADIF field names to `QsoRecord` proto fields.
-3. Map QRZ-specific application fields to dedicated domain fields — not generic `extra_fields` — so sync can round-trip them:
+3. Map QRZ-specific application fields to dedicated domain fields - not generic `extra_fields` - so sync can round-trip them:
    - `APP_QRZLOG_LOGID` (canonical) and the legacy alias `APP_QRZ_LOGID` → `qrz_logid`
    - `APP_QRZLOG_QSO_ID` (canonical) and the legacy alias `APP_QRZ_BOOKID` → `qrz_bookid`
-   Engines MUST NOT leave these app keys in `extra_fields` once a dedicated domain field carries the value, otherwise downstream sync will treat the record as unlinked and re-upload it as a duplicate.
+   Remove these application keys from `extra_fields` after mapping them.
+   Otherwise, sync can treat the record as unlinked.
+   It can then upload the record as a duplicate.
 4. Map normalized ADIF fields to their dedicated proto slots rather than `extra_fields`:
    - `BAND_RX` → `band_rx` (Band enum)
    - `FREQ_RX` → `frequency_rx_hz` (MHz → Hz via string math for sub-kHz precision)
@@ -1695,14 +1950,15 @@ When DXCC data is available, cascade zone information onto the lookup result if 
    - `QSO_COMPLETE` → `qso_complete` (`Y`/`N`/`NIL`/`?` → `QsoCompletion` enum)
    - `MY_ALTITUDE` → `station_snapshot.altitude_meters`
    - `MY_GRIDSQUARE_EXT` → `station_snapshot.gridsquare_ext`
-   - `APP_QSORIPPER_RX_WPM` → `cw_decode_rx_wpm` (parsed as unsigned integer; non-numeric values fall back to `extra_fields`)
-   - `APP_QSORIPPER_CW_TRANSCRIPT` → `cw_decode_transcript` (decoded CW transcript snapshot for the QSO; empty values are dropped)
+   - `APP_QSORIPPER_RX_WPM` → `cw_decode_rx_wpm` (parsed as unsigned integer. Non-numeric values fall back to `extra_fields`)
+   - `APP_QSORIPPER_CW_TRANSCRIPT` → `cw_decode_transcript` (decoded CW transcript snapshot for the QSO. The decoder drops empty values)
    - `ARRL_SECT` and `SKCC` → worked-station `arrl_section` and `skcc_number`
    - `QSL_SENT`, `QSL_RCVD`, `QSLSDATE`, and `QSLRDATE` → typed QSL status/date fields
    - `LOTW_QSL_SENT`, `LOTW_QSL_RCVD`, `LOTW_QSLSDATE`, and `LOTW_QSLRDATE` → typed LoTW status/date fields
    - `EQSL_QSL_SENT`, `EQSL_QSL_RCVD`, `EQSL_QSLSDATE`, and `EQSL_QSLRDATE` → typed eQSL status/date fields
    - `MY_LAT`, `MY_LON`, `MY_ARRL_SECT`, `MY_CQ_ZONE`, and `MY_ITU_ZONE` → dedicated `station_snapshot` fields
-   Unrecognized values (e.g., malformed LAT, unknown `QSO_COMPLETE` literal) fall back to `extra_fields` under the original key.
+
+   Unrecognized values (for example, malformed LAT, unknown `QSO_COMPLETE` literal) fall back to `extra_fields` under the original key.
 5. Preserve any other unrecognized ADIF fields in the `extra_fields` map for lossless round-trip.
 6. Generate a `local_id` for each imported record.
 7. Normalize callsigns and validate required fields.
@@ -1718,7 +1974,15 @@ See `docs/integrations/adif-specification.md` for the authoritative field-name t
    - `qrz_logid` → `APP_QRZLOG_LOGID`
    - `qrz_bookid` → `APP_QRZLOG_QSO_ID`
    When iterating `extra_fields`, skip keys already covered by these dedicated emissions (`APP_QRZLOG_LOGID`, `APP_QRZ_LOGID`, `APP_QRZLOG_QSO_ID`, `APP_QRZ_BOOKID`) to avoid duplicate ADIF fields.
-4. Emit normalized ADIF fields from their dedicated proto slots whenever populated, including the worked/station, QSL, LoTW, eQSL, SKCC, ARRL section, zone, and coordinate mappings listed above. When iterating `extra_fields`, skip every key handled by a dedicated field so the dedicated proto value always wins and the ADIF output never contains the same field twice. Engines MUST sanitize `cw_decode_transcript` to printable ASCII (plus CR/LF/tab) before emitting `APP_QSORIPPER_CW_TRANSCRIPT` so the .NET char-count length and Rust byte-count length agree across runtimes.
+4. Emit each populated normalized ADIF field from its dedicated proto slot.
+   This rule includes station, QSL, LoTW, eQSL, SKCC, section, zone, and coordinate mappings.
+   When iterating `extra_fields`, skip each key that has a dedicated field.
+   Thus, the dedicated proto value wins.
+   The ADIF output must not contain a field two times.
+   Sanitize `cw_decode_transcript` before emitting `APP_QSORIPPER_CW_TRANSCRIPT`.
+
+   Permit printable ASCII, CR, LF, and tab.
+   This makes .NET character lengths and Rust byte lengths equal.
 5. Include other `extra_fields` to preserve data from previous imports.
 6. Output records delimited by `<eor>`.
 
@@ -1739,20 +2003,33 @@ See `docs/integrations/adif-specification.md` for the authoritative field-name t
 | `OK` | Success |
 | `INVALID_ARGUMENT` | Malformed request, missing required fields, invalid values |
 | `NOT_FOUND` | Requested entity does not exist |
-| `FAILED_PRECONDITION` | Operation cannot proceed due to system state (e.g., no credentials, no active profile) |
+| `FAILED_PRECONDITION` | Operation cannot proceed due to system state (for example, no credentials, no active profile) |
 | `UNAVAILABLE` | External service unreachable |
-| `UNIMPLEMENTED` | RPC is defined but not yet implemented |
+| `UNIMPLEMENTED` | The RPC exists but has no implementation. |
 | `INTERNAL` | Unexpected server error (storage failure, serialization bug) |
 
 ### 7.7 Startup Data-Repair Pass
 
 Engines that persist `extra_fields` as an opaque blob MUST run a best-effort data-repair pass on startup against the active logbook store. The pass:
 
-1. **Backfills dedicated domain fields from legacy `extra_fields`.** Scans every QSO and, for each record where `qrz_logid`/`qrz_bookid` are empty but a legacy key exists in `extra_fields` (e.g. `APP_QRZ_LOGID`, `APP_QRZLOG_LOGID`, `APP_QRZ_BOOKID`, `APP_QRZLOG_QSO_ID`), moves the value into the dedicated field and removes the legacy key from `extra_fields`.
+1. **Backfill dedicated domain fields from legacy `extra_fields`.**
+   Scan each QSO.
+   Find records with an empty `qrz_logid` or `qrz_bookid`.
+   For these records, find the related legacy application key in `extra_fields`.
+   Move the value to the dedicated field.
+   Remove the legacy key from `extra_fields`.
 2. **Collapses duplicate rows that share a `qrz_logid`.** After the backfill, any group of QSOs with the same non-empty `qrz_logid` represents a historical duplicate-import bug. The engine keeps the oldest row as the winner, merges non-empty string fields from the losing rows into the winner, and deletes the losers. The winner keeps `sync_status = SYNCED`.
-3. **Logs a summary** of how many rows were backfilled, how many duplicates were collapsed, and any per-row errors, but does not fail engine startup on per-row errors.
+3. **Log a summary.**
+   Include the backfilled row count and collapsed duplicate count.
+   Include errors for each applicable row.
+   A row error does not stop engine startup.
 
-This pass exists because an earlier engine revision failed to map QRZ app fields onto dedicated domain columns (see §7.5 Import), causing subsequent syncs to re-upload every QSO as a new record and multiplying the logbook. The repair pass is idempotent; engines that have already cleaned their data will do no work on subsequent startups.
+An earlier engine revision did not map QRZ application fields to dedicated columns.
+See §7.5 Import.
+Later syncs uploaded each QSO as a new record.
+This error created duplicate logbook records.
+The repair pass is idempotent.
+An engine does no work after the data is clean.
 
 ### 7.8 Soft-Delete and Restore
 
@@ -1763,9 +2040,12 @@ QSOs are soft-deleted: `DeleteQso` marks the row with a tombstone instead of rem
 Every `QsoRecord` carries two soft-delete fields:
 
 - `deleted_at` (optional `Timestamp`): when set, the row is considered deleted. Null on active rows.
-- `pending_remote_delete` (bool): set to true when the local delete should be propagated to QRZ on the next sync. Cleared once the remote delete completes (or if the row is restored).
+- `pending_remote_delete` (bool): true when the engine must send the local delete to QRZ during the next sync. The engine clears it after remote deletion or restoration.
 
-Storage backends MUST persist both fields and MUST default `deleted_at` to null and `pending_remote_delete` to false for records written before this contract existed (idempotent migration on startup).
+Storage backends MUST save both fields.
+For older records, set `deleted_at` to null.
+Set `pending_remote_delete` to false.
+This startup migration is idempotent.
 
 #### DeleteQso semantics
 
@@ -1774,18 +2054,22 @@ Storage backends MUST persist both fields and MUST default `deleted_at` to null 
 3. If `delete_from_qrz = true` AND the row has a non-empty `qrz_logid`, set `pending_remote_delete = true`. Otherwise leave it false.
 4. Persist via `SoftDeleteQso` storage path (no row removal).
 5. Return `success = true`, `remote_delete_queued = pending_remote_delete`.
-6. If `delete_from_qrz = true` but `qrz_logid` is empty, the response surfaces an explanatory `qrz_delete_error` — the row is still soft-deleted locally, just not queued for remote delete.
+6. If `delete_from_qrz = true` but `qrz_logid` is empty, the response surfaces an explanatory `qrz_delete_error` - the row is still soft-deleted locally, just not queued for remote delete.
 7. Re-deleting an already soft-deleted row is an idempotent success. If the second call sets `delete_from_qrz = true` and the row has a logid, it MAY upgrade `pending_remote_delete` from false to true.
-8. The engine MUST NOT call the QRZ `ACTION=DELETE` API inline from this RPC. Remote delete is performed by the sync engine (§7.3 Phase 2).
+8. The engine MUST NOT call the QRZ `ACTION=DELETE` API from this RPC. The sync engine performs the remote delete (§7.3 Phase 2).
 
 #### RestoreQso semantics
 
 1. Resolve the row by `local_id`. If not found, return `NOT_FOUND`.
 2. Clear both `deleted_at` and `pending_remote_delete` via the `RestoreQso` storage path.
-3. If the restored row has no `qrz_logid` and its `sync_status` was `SYNCED` (i.e., the QRZ-side state never actually existed for this local row), demote `sync_status` to `LOCAL_ONLY` so the next sync re-uploads it. Update `updated_at = now`.
-4. Return `success = true` and the restored `QsoRecord`.
-5. Restoring a row that is not soft-deleted is an idempotent success (no-op).
-6. Engines MAY refuse `RestoreQso` with `FAILED_PRECONDITION` while a sync is in flight.
+3. Check whether the restored row has a `qrz_logid`.
+4. If it does not and `sync_status` was `SYNCED`, set the status to `LOCAL_ONLY`.
+5. Set `updated_at = now`.
+6. Return `success = true` and the restored `QsoRecord`.
+7. Restoring a row that is not soft-deleted is an idempotent success (no-op).
+8. Engines MAY refuse `RestoreQso` with `FAILED_PRECONDITION` while a sync is in flight.
+
+The next sync uploads a restored row without `qrz_logid`.
 
 #### UpdateQso on a soft-deleted row
 
@@ -1795,19 +2079,25 @@ Storage backends MUST persist both fields and MUST default `deleted_at` to null 
 
 - `ListQsos` defaults to `DeletedRecordsFilter::ACTIVE_ONLY` when the filter is `UNSPECIFIED`. Engines MUST exclude soft-deleted rows from the default list.
 - `DELETED_ONLY` returns only soft-deleted rows (the trash view).
-- `ALL` returns both. Trash UIs should request `DELETED_ONLY`; standard logbook views should rely on the default.
+- `ALL` returns both. Trash UIs must request `DELETED_ONLY`. Standard logbook views must use the default.
 - `GetQso` MUST return a soft-deleted row by id (so a trash UI can fetch a single deleted row by its `local_id`).
 
 #### Import / Export interaction
 
-- `ImportAdif` duplicate matching uses the default (active-only) listing so that soft-deleted rows do not block re-import of a corrected QSO. (A deleted dup is treated as absent.)
+- `ImportAdif` duplicate matching uses the default active-only list.
+  Thus, a soft-deleted row does not block import of a corrected QSO.
 - `ExportAdif` uses the default (active-only) listing so soft-deleted rows are not exported.
 
 #### Sync interaction
 
 - Sync Phase 1 (download) MUST skip a remote row whose `qrz_logid` matches a soft-deleted local row. The local user's delete intent wins. The sync summary SHOULD report skipped count.
-- Sync Phase 2 (upload) MUST, after the normal upload pass, iterate rows where `pending_remote_delete = true`, call QRZ `ACTION=DELETE&KEY=…&LOGID=…`, and on success or HTTP 404 ("logid not found") clear both `qrz_logid` and `pending_remote_delete` while leaving `deleted_at` set. On other failures, leave the flags and surface the error in the sync summary.
-- Permanent purge of soft-deleted rows is handled by `PurgeDeletedQsos` (§7.9), which reuses the Phase 2 remote delete flow when `include_pending_remote_deletes = true`.
+- After normal Phase 2 upload, process rows where `pending_remote_delete = true`.
+  Call QRZ `ACTION=DELETE&KEY=…&LOGID=…`.
+  Treat success and HTTP 404 as completion.
+  Then clear `qrz_logid` and `pending_remote_delete`.
+  Keep `deleted_at` set.
+  For other failures, keep the flags and report the error.
+- `PurgeDeletedQsos` (§7.9) permanently purges soft-deleted rows. It reuses the Phase 2 flow when `include_pending_remote_deletes = true`.
 
 ---
 
@@ -1823,7 +2113,7 @@ Storage backends MUST persist both fields and MUST default `deleted_at` to null 
 #### Preconditions
 
 1. `confirm` MUST be `true`. If `false`, the engine MUST return `INVALID_ARGUMENT`.
-2. The engine MUST return `FAILED_PRECONDITION` if a sync is currently in progress. Purging a row mid-sync is racy and could lead to inconsistent state.
+2. The engine MUST return `FAILED_PRECONDITION` during an active sync. A purge during a sync can cause an inconsistent state.
 
 #### Eligibility
 
@@ -1832,7 +2122,7 @@ Only rows with `deleted_at IS NOT NULL` are eligible for purge. Rows that are no
 - If `local_ids` is non-empty, only those IDs are eligible (still must be soft-deleted).
 - If `older_than` is set, only rows with `deleted_at <= older_than` are eligible.
 - If both filters are set, both must match (AND semantics).
-- If both are empty/unset, all soft-deleted rows are purged.
+- If both have no value, the engine purges all soft-deleted rows.
 
 #### Remote delete behavior
 
@@ -1841,12 +2131,12 @@ When `include_pending_remote_deletes = true`:
 1. Before the local hard-delete, the engine MUST iterate eligible rows that have `pending_remote_delete = true` and a non-empty `qrz_logid`.
 2. For each such row, the engine SHOULD issue a QRZ `ACTION=DELETE` call using the same flow as sync Phase 2 (§7.3).
 3. On success or HTTP 404 ("logid not found"): count toward `remote_deletes_pushed`. The row is then eligible for local purge.
-4. On other failures: count toward `remote_deletes_failed`. The row MUST NOT be purged locally; the operator can retry.
-5. If QRZ is not configured: rows needing remote deletes are counted as failed and are not purged locally.
+4. On other failures, increment `remote_deletes_failed`. The engine MUST NOT purge the local row. The operator can retry.
+5. If QRZ is not configured, count the applicable rows as failed. Do not purge them locally.
 
 When `include_pending_remote_deletes = false`:
 
-- The engine skips the remote delete entirely. Rows with `pending_remote_delete = true` are purged locally regardless. The remote QSO on QRZ survives — this is the operator's explicit choice.
+- The engine skips the remote delete. It purges local rows with `pending_remote_delete = true`. The remote QRZ QSO remains by operator choice.
 
 #### Storage operation
 
@@ -1880,7 +2170,7 @@ Every engine must implement `GetEngineInfo` to report its identity and capabilit
 |---|---|---|
 | `engine_id` | `rust-tonic` | `dotnet-aspnet` |
 | `display_name` | `QsoRipper Rust Engine` | `QsoRipper .NET Engine` |
-| `version` | SemVer package version, for example `0.1.0` | Assembly informational/version string, which may contain four numeric components |
+| `version` | SemVer package version, for example `0.1.0` | Assembly information or version string, which can contain four numeric components |
 | `capabilities` | List of supported capability strings | List of supported capability strings |
 
 > **Note:** Earlier drafts of this spec referenced `engine_language` and `storage_backend` fields. These were never added to the `EngineInfo` proto message. Use `engine_id` to infer the implementation language if needed.
@@ -1905,9 +2195,9 @@ Both engines currently report the following capabilities:
 | `cw-keying` | CW macro expansion and keyer dispatch |
 | `purge` | Permanent removal of soft-deleted QSOs (§7.9) |
 
-> **Note:** Earlier drafts listed aspirational names (`sync`, `rig_control`, `stress`, `adif_import`, `adif_export`) that were never adopted. The canonical names above use kebab-case and match what both engines actually report. New capabilities should follow this convention.
+> **Note:** Earlier drafts listed planned names (`sync`, `rig_control`, `stress`, `adif_import`, `adif_export`) that were not adopted. The canonical names use kebab-case and match both engines. New capabilities must use this convention.
 
-Engines currently report a static set of capabilities. Configuration-gated capability reporting (e.g., hiding `lookup-callsign` when no QRZ credentials are configured) is a planned enhancement.
+Engines currently report a static set of capabilities. Configuration-gated capability reporting (for example, hiding `lookup-callsign` when no QRZ credentials are configured) is a planned enhancement.
 
 ---
 
@@ -1922,7 +2212,14 @@ The black-box conformance harness lives at `tests/Run-EngineConformance.ps1`. It
 3. Compares normalized results across engine implementations and storage backends for field-level parity.
 4. Writes a structured JSON summary to `artifacts/conformance/<run-id>/`.
 
-The protobuf files and this specification define conformance. The black-box harness is a required executable acceptance layer, but it is not the only test layer. Network-dependent QRZ behavior, precise gRPC status codes, streaming cancellation/timing, scheduler state, startup repair, runtime configuration, rig, weather, contest, station-profile, and Great Circle contracts are also covered by the reference engines' service-level integration and unit suites. A new engine must provide equivalent automated coverage for required services it cannot exercise through the CLI.
+The protobuf files and this specification define conformance.
+The black-box harness is a required executable acceptance layer.
+It is not the only test layer.
+Reference-engine integration and unit tests cover other contracts.
+These contracts include QRZ, gRPC status, streaming, schedulers, startup repair, and runtime configuration.
+They also include rig, weather, contest, station-profile, and Great Circle behavior.
+
+A new engine must give equivalent automated coverage for services outside the CLI.
 
 ### 9.2 Required Test Scenarios
 
@@ -1940,7 +2237,7 @@ A conformant engine must pass all of the following scenarios:
 5. `GetQso` returns the logged QSO with all fields intact.
 6. `ListQsos` returns exactly the expected QSOs with correct ordering.
 7. `UpdateQso` modifies the specified fields and updates `updated_at`.
-8. `DeleteQso` soft-deletes the QSO; default `ListQsos` hides it, and `GetQso` returns it with `deleted_at` set.
+8. `DeleteQso` soft-deletes the QSO. Default `ListQsos` hides it, and `GetQso` returns it with `deleted_at` set.
 9. `RestoreQso` clears the tombstone and returns the row to the default list.
 10. `PurgeDeletedQsos(confirm=true)` physically removes a re-deleted row, after which `GetQso` returns `NOT_FOUND`.
 11. Inclusive time boundaries and case-insensitive station/worked callsign filters produce identical results on memory and SQLite.
@@ -2044,13 +2341,13 @@ A conformant engine must pass all of the following scenarios:
 
 - **1-1-1 rule:** One top-level message, enum, or service per `.proto` file.
 - **Per-RPC envelopes:** Every RPC gets unique `XxxRequest` and `XxxResponse` messages.
-- **Service declarations** contain only the `service` block; all message types live in separate files.
-- **Domain types** live in `proto/domain/`; transport/service support types live in `proto/services/`.
-- **Reusable payloads** are extracted into dedicated messages and wrapped from each response — never reuse one RPC's response as another's.
+- **Service declarations** contain only the `service` block. All message types live in separate files.
+- **Domain types** live in `proto/domain/`. Transport/service support types live in `proto/services/`.
+- Extract **reusable payloads** into dedicated messages. Wrap them in each response. Never reuse one RPC response in another RPC.
 - Run `buf lint` to validate proto files. Run `buf breaking` to guard against incompatible schema changes.
 
 See `docs/architecture/data-model.md` for the complete proto conventions and field-addition guide.
 
 ## Appendix C: Contract Evolution
 
-Known reference-engine divergences must be tracked as issues and must not be presented here as accepted exceptions to normative behavior. Any future behavior change updates protobuf, this specification, both reference implementations, and conformance coverage in the same change.
+Track known reference-engine differences as issues. Do not present them as accepted exceptions. Each behavior change must update contracts, implementations, and conformance coverage.

--- a/docs/development/ui-inspection.md
+++ b/docs/development/ui-inspection.md
@@ -124,7 +124,7 @@ Notes:
 - The script is currently Windows-only.
 - The script bootstraps a repo-local Node 22 + Terminalizer runtime on first use.
 - No global Terminalizer install is required.
-- The current terminal lane targets scripted CLI workflows honestly; it can point at a future TUI binary later without changing the artifact contract.
+- The current terminal lane targets scripted CLI workflows honestly. It can point at a future TUI binary later without changing the artifact contract.
 - Output includes a GIF, transcript, YAML recording, and JSON summary.
 
 ### Terminal / TUI live automation
@@ -148,7 +148,7 @@ Notes:
 - Action scripts are JSON and conceptually mirror `drive-avalonia.ps1`: scenario in, artifacts plus `report.json` out.
 - The harness can drive either a structured command or the built-in deterministic `sample-tui` fixture.
 - Snapshot actions write rendered `*.screen.png` files plus `*.screen.txt`, `*.screen.json`, and `*.ansi.txt` artifacts under `artifacts\ux\current\<scenario>\`.
-- Keep `scripts\capture-tui.ps1` for rendered GIF review; the two paths are complementary.
+- Keep `scripts\capture-tui.ps1` for rendered GIF review. The two paths are complementary.
 
 ## Recommended quick verification
 

--- a/docs/documentation-style.md
+++ b/docs/documentation-style.md
@@ -1,0 +1,123 @@
+# Documentation standard
+
+QsoRipper uses ASD-STE100 Simplified Technical English, Issue 9, for
+documentation and reports.
+
+The user can request a different style. Use that style only for the requested
+content.
+
+## Scope
+
+Use this standard for these types of text:
+
+- README files
+- Architecture, design, API, integration, and operation documents
+- Test, experiment, incident, and investigation reports
+- Release notes
+- Issue and pull request text
+- Review findings, plans, and generated summaries
+
+This standard governs all documentation. Apply it to new text and to text that
+you change in an existing file.
+
+## Vocabulary
+
+- Use approved words only with their approved meanings and parts of speech.
+- Use established QsoRipper terms as technical nouns or technical verbs.
+- Define an uncommon project term at its first use.
+- Use one term for one item or action.
+- Do not use a different term only to add variety.
+- Use American English spelling.
+- Do not use Latin abbreviations.
+- Keep a multi-word noun to three words or fewer.
+
+## Controlled technical terms
+
+Use these QsoRipper terms as technical nouns:
+
+- ADIF
+- API
+- backend
+- callsign
+- client
+- decoder
+- engine
+- endpoint
+- gRPC
+- logbook
+- protobuf
+- QSO
+- QRZ
+- RPC
+- TUI
+
+Use these QsoRipper terms as technical verbs:
+
+- decode
+- deserialize
+- export
+- import
+- parse
+- serialize
+- stream
+- sync
+
+Add a term to this list when it has a special project meaning. Use that term
+with the same meaning in all documents.
+
+Identifiers and product names can contain other technical terms. Keep these
+items exact.
+
+## Verbs and voice
+
+- Use the infinitive, imperative, simple present, simple past, or simple future.
+- Use a past participle only as an adjective when the context is clear.
+- Use an `-ing` word only as a technical noun or technical modifier.
+- Do not use an auxiliary verb to make a complex verb construction.
+- Use active voice when you know the agent.
+- You can use passive voice in descriptive text when you do not know the agent.
+- Do not use contractions.
+
+## Sentences
+
+- Put only one instruction in each sentence.
+- You can put more than one instruction in a sentence when the actions occur
+  at the same time.
+- Use no more than 20 words in a procedural sentence.
+- Use no more than 25 words in a descriptive sentence.
+- Use no more than six sentences in one paragraph.
+- Use a vertical list for complex text.
+
+## Punctuation
+
+- Do not use a semicolon.
+- Use a hyphen when Issue 9 requires one.
+- Do not use punctuation to join long sentences.
+- Keep punctuation in exact technical content unchanged.
+
+## Exact technical content
+
+Keep these items exact:
+
+- Code and identifiers
+- Commands and file paths
+- Protocol fields and wire values
+- Configuration keys
+- Log text and test output
+- Direct quotations
+- Legal notices
+
+Explain an exact item with STE text when an explanation is necessary.
+
+## Review
+
+Review new and changed prose against the Issue 9 rules and dictionary.
+Record project-specific terms as technical nouns or technical verbs.
+
+Check each technical term before you add it to the controlled list.
+Automated checks do not replace the dictionary and context review.
+
+Do not state that text conforms to STE unless you complete the full review.
+
+Reference:
+[ASD-STE100 Issue 9](https://www.asd-ste100.org/assets/files/ASD-STE100_ISSUE9.pdf).

--- a/docs/experiments/cw-decoder-bakeoff-2026-05.md
+++ b/docs/experiments/cw-decoder-bakeoff-2026-05.md
@@ -1,13 +1,12 @@
-# CW Decoder Bake-Off — May 2026
+# CW Decoder Bake-Off - May 2026
 
 This document captures a multi-round parallel experiment to fix two specific
 failure modes in the CW decoder observed on real over-the-air captures:
 
-1. **Ghost character cascades** — when SNR drops within an otherwise-decodable
-   region, the decoder emits a stream of phantom `E`/`T`/`I`/`M` characters
-   instead of dropping output.
-2. **Word-segmentation errors** — leading characters of repeated callsigns
-   (e.g. `WA` of `WA6MOW`) silently disappear before reaching the decoder's
+1. **Ghost character cascades** - SNR decreases in a region that the decoder can usually decode.
+   The decoder then emits many false `E`, `T`, `I`, and `M` characters.
+2. **Word-segmentation errors** - leading characters of repeated callsigns
+   (for example `WA` of `WA6MOW`) silently disappear before reaching the decoder's
    gap-classification stage.
 
 Eight algorithmic approaches were implemented in parallel git worktrees and
@@ -28,36 +27,36 @@ the final `transcript`/`end` event. Each transcript was normalized via
 
 Metrics:
 
-- **CER** — character error rate (Levenshtein distance / max-length)
-- **WER** — word error rate
+- **CER** - character error rate (Levenshtein distance / max-length)
+- **WER** - word error rate
 - Token recall / precision
 
 Six samples from `data/cw-samples/training-set-a/`:
 
 | Sample | Truth (excerpt) | Notes |
 |---|---|---|
-| `cq-pota-aa6pw` | `NQ POTA AA6PW AA6PW CQPOTA AA6PW...` | Headline ghost target — heavy E/T/I cascades |
+| `cq-pota-aa6pw` | `NQ POTA AA6PW AA6PW CQPOTA AA6PW...` | Headline ghost target - heavy E/T/I cascades |
 | `cq-sota-wa7ben` | CQ SOTA call from WA7BEN | Standard pileup CQ |
-| `wa6mow` | WA6MOW callsign repeats | Word-segmentation target — `WA` drops |
+| `wa6mow` | WA6MOW callsign repeats | Word-segmentation target - `WA` drops |
 | 3 additional CQ/exchange samples | mixed | Baseline coverage |
 
 Mean CER is the unweighted average across the six samples.
 
 ---
 
-## Round 1 — initial algorithmic diversity
+## Round 1 - initial algorithmic diversity
 
 Four orthogonal approaches launched in parallel.
 
-### viterbi — `u/randy/cw-exp-viterbi` @ `f16c651` 🥇 WINNER
+### viterbi - `u/randy/cw-exp-viterbi` @ `f16c651` - winner
 
 **Hypothesis:** Hard length thresholding (dit < X ms, dah ≥ X ms) is too
 brittle when SNR varies inside a region.
 
 **Implementation** (`vendor/ditdah/src/decoder.rs`):
 
-1. `merge_short_blips` — coalesce sub-threshold blips before classification.
-2. `soft_decode_intervals` — Gaussian per-class log-probability over (dit, dah)
+1. `merge_short_blips` - coalesce sub-threshold blips before classification.
+2. `soft_decode_intervals` - Gaussian per-class log-probability over (dit, dah)
    lengths given current WPM estimate.
 3. Argmax over the soft scores instead of hard threshold.
 
@@ -73,28 +72,28 @@ brittle when SNR varies inside a region.
 an element is borderline length, instead of flipping a coin at the threshold.
 
 **Why `wa6mow` did not move:** the `WA` problem is upstream of length
-classification — elements are not detected at all, so no classifier can fix
+classification - elements are not detected at all, so no classifier can fix
 it. See gap-gmm / next-round notes.
 
-### charlm — `u/randy/cw-exp-charlm` @ `b15ed0c` — mixed, partially salvageable
+### charlm - `u/randy/cw-exp-charlm` @ `b15ed0c` - mixed, partially salvageable
 
 **Hypothesis:** A character-level n-gram language model can rescore ambiguous
 decodes using English / callsign-prefix frequency.
 
 **Implementation:** 4-gram + callsign-prefix LM scored against decoder output.
 A mid-edit syntax error (orphan `];` debris from an incomplete edit) caused 13
-cascading "unknown prefix" diagnostics; cleaned up by the orchestrator.
+cascading "unknown prefix" diagnostics. Cleaned up by the orchestrator.
 
-**Results:** Mean CER worse on most samples — the English LM over-confidently
+**Results:** Mean CER worse on most samples - the English LM over-confidently
 "corrects" rare callsigns toward English text.
 
 **Salvageable win:** **`wa6mow` recall 0.67 → 1.00**. The callsign-prefix
 component genuinely helps when the substring contains a known prefix pattern.
 
-**Action:** cherry-pick the callsign-join logic only; discard English LM
+**Action:** cherry-pick the callsign-join logic only. Discard English LM
 rescoring.
 
-### snr-gate — `u/randy/cw-exp-snr-gate` @ `9b07ad5` — honest negative
+### snr-gate - `u/randy/cw-exp-snr-gate` @ `9b07ad5` - honest negative
 
 **Hypothesis:** Suppress decoding entirely in low-SNR regions.
 
@@ -105,7 +104,7 @@ Default-off plumbing landed correctly.
 signals). Plumbing kept because it is reusable for elem-gate and future
 experiments.
 
-### ctc-neural — `u/randy/cw-exp-ctc-neural` @ `04d7456` — research artifact
+### ctc-neural - `u/randy/cw-exp-ctc-neural` @ `04d7456` - research artifact
 
 **Hypothesis:** End-to-end CNN + CTC trained on synthetic CW.
 
@@ -124,24 +123,25 @@ decode. ~50 hours of synthetic training data.
 1. **Blank-collapse trap** required four fixes (head bias init
    `head.bias[BLANK] = -3.0`, pitch-invariant pooling, high-SNR curriculum
    warmup, `GroupNorm` not `BatchNorm`) just to train.
-2. Synthetic training data did not generalize to real OTA — synthetic too
+2. Synthetic training data did not generalize to real OTA - synthetic too
    clean.
 3. Tiny model + short clips + no LM thrashes on calls it has never seen.
 
-**Verdict:** Not shippable as a decoder. It did, however, beat the baseline on
-`cq-pota-aa6pw` (0.202) without any morse-domain heuristic, proving "noise
-regions are decodable if you stop forcing them through hard classifiers." That
-result motivated the ARRL corpus track.
+**Verdict:** Do not ship this decoder.
+It did beat the baseline on `cq-pota-aa6pw` with a score of 0.202.
+It did this without a Morse-domain heuristic.
+The result shows that a decoder can process noise regions without hard classifiers.
+This result motivated the ARRL corpus track.
 
 ---
 
-## Round 2 — targeted mechanism stacking
+## Round 2 - targeted mechanism stacking
 
-### elem-gate — `u/randy/cw-exp-elem-gate` @ `2b36af5` 🥈 ties Viterbi, orthogonal mechanism
+### elem-gate - `u/randy/cw-exp-elem-gate` @ `2b36af5` 🥈 ties Viterbi, orthogonal mechanism
 
 **Hypothesis:** Per-element SNR gate (different from region-level snr-gate).
 
-**Implementation:** Compute SNR for each detected element; drop elements below
+**Implementation:** Compute SNR for each detected element. Drop elements below
 a configurable dB floor. Env var `DITDAH_ELEM_GATE_DB` (default 12 dB).
 
 **Results:**
@@ -153,22 +153,22 @@ a configurable dB floor. Env var `DITDAH_ELEM_GATE_DB` (default 12 dB).
 | `wa6mow` WER | 0.600 | 0.600 |
 
 **Key insight:** reaches the same `cq-pota-aa6pw` CER as Viterbi via a
-completely different mechanism (gate vs. soft classification). They should
-**stack** — Viterbi handles borderline lengths, elem-gate kills phantom
+completely different mechanism (gate compared with soft classification). They must
+**stack** - Viterbi handles borderline lengths, elem-gate kills phantom
 elements before they reach the classifier.
 
-### bigram-viterbi — `u/randy/cw-exp-bigram-viterbi` @ `1eea2ed` — no-op pending corpus
+### bigram-viterbi - `u/randy/cw-exp-bigram-viterbi` @ `1eea2ed` - no-op pending corpus
 
 **Hypothesis:** Replace argmax with full Viterbi over character bigrams.
 
-**Result:** No-op at safe weights — bigrams trained on a small synthetic
+**Result:** No-op at safe weights - bigrams trained on a small synthetic
 corpus contained no real signal. **Now unblocked** by the 154k-character ARRL
 corpus from `arrl-corpus-fast`.
 
-### gap-gmm — `u/randy/cw-exp-gap-gmm` @ `2bd6e19` — falsified hypothesis
+### gap-gmm - `u/randy/cw-exp-gap-gmm` @ `2bd6e19` - falsified hypothesis
 
 **Hypothesis:** Inter-element gaps follow a 3-component GMM (intra-char,
-inter-char, inter-word); EM fit gives better word boundaries than fixed
+inter-char, inter-word). EM fit gives better word boundaries than fixed
 thresholds.
 
 **Result:** No improvement on `wa6mow`. Diagnostic insight: the `WA` of
@@ -179,7 +179,7 @@ smoothed-power.
 **Value:** killed a wrong hypothesis cheaply. Future word-segmentation work
 must target onset detection, not gap classification.
 
-### ensemble — `u/randy/cw-exp-ensemble` @ `050991d` — infrastructure win, voting inconclusive
+### ensemble - `u/randy/cw-exp-ensemble` @ `050991d` - infrastructure win, voting inconclusive
 
 **Hypothesis:** Vote across multiple decoder variants per region.
 
@@ -204,9 +204,9 @@ retrained ctc-neural decoder as a fourth voter.
 
 ---
 
-## Round 3 — ARRL auto-labeled corpus
+## Round 3 - ARRL auto-labeled corpus
 
-### arrl-corpus-fast — `u/randy/cw-exp-arrl-corpus-fast` @ `4dd5183` — pipeline shipped
+### arrl-corpus-fast - `u/randy/cw-exp-arrl-corpus-fast` @ `4dd5183` - pipeline shipped
 
 **Goal:** Build an auto-labeled training corpus from ARRL Code Practice MP3s,
 which ship with ground-truth text files at predictable URLs.
@@ -247,9 +247,9 @@ manifest        1.0s
 report          1.2s
 ```
 
-**Known gap:** 15 WPM yields zero chunks — `cw-decoder` does not lock at slow
+**Known gap:** 15 WPM yields zero chunks - `cw-decoder` does not lock at slow
 speeds in its current configuration. MP3 + truth files are intact and cached
-on disk; once decoder lock-range is widened,
+on disk. Once decoder lock-range is widened,
 `run.py --skip-stages 0,1,2 --speeds 15` will harvest in seconds.
 
 **Other speeds (5 / 7.5 / 10 / 13 / 35 / 40 WPM)** are supported by the index
@@ -264,15 +264,15 @@ A serial pilot (`u/randy/cw-exp-arrl-corpus`) was also completed (449 chunks /
 
 | # | Approach | Mean CER | aa6pw CER | wa6mow WER | Status | Recommendation |
 |---|---|---:|---:|---:|---|---|
-| — | baseline | 0.234 | 0.321 | 0.600 | reference | — |
-| 🥇 | **viterbi** | **0.202** | **0.167** | 0.600 | ready | **merge to main** |
+| - | baseline | 0.234 | 0.321 | 0.600 | reference | - |
+| 1 | **viterbi** | **0.202** | **0.167** | 0.600 | ready | **merge to main** |
 | 🥈 | **elem-gate** | 0.208 | **0.167** | 0.600 | ready | **stack on viterbi** |
 | 3 | ensemble (anchor) | 0.219 | 0.167 | **0.400** | infra | hold for ctc retrain |
-| 4 | charlm | mixed | — | recall 1.00 | partial | cherry-pick callsign-join only |
+| 4 | charlm | mixed | - | recall 1.00 | partial | cherry-pick callsign-join only |
 | 5 | snr-gate | 0.234 | 0.321 | 0.600 | plumbing | keep, default-off |
-| 6 | bigram-viterbi | no-op | — | — | unblocked | retrain on ARRL corpus |
-| 7 | gap-gmm | no-op | — | — | falsified | discard, fix upstream first |
-| 8 | ctc-neural | 0.917 | **0.202** | — | research | retrain on ARRL → 4th voter |
+| 6 | bigram-viterbi | no-op | - | - | unblocked | retrain on ARRL corpus |
+| 7 | gap-gmm | no-op | - | - | falsified | discard, fix upstream first |
+| 8 | ctc-neural | 0.917 | **0.202** | - | research | retrain on ARRL → 4th voter |
 
 ---
 
@@ -281,13 +281,13 @@ A serial pilot (`u/randy/cw-exp-arrl-corpus`) was also completed (449 chunks /
 1. **Soft beats hard.** The single biggest CER win came from replacing one
    hard threshold with a soft Gaussian (Viterbi).
 2. **Two orthogonal mechanisms reach the same ceiling.** Viterbi and elem-gate
-   both hit `cq-pota-aa6pw` CER 0.167 from completely different angles —
+   both hit `cq-pota-aa6pw` CER 0.167 from completely different angles -
    strong evidence they will stack.
 3. **Word segmentation is upstream.** `gap-gmm` falsified the
-   gap-classification hypothesis. Don't waste effort on classifier-stage
-   word-gap work; fix element detection first.
+   gap-classification hypothesis. Do not use effort on classifier-stage
+   word-gap work. Fix element detection first.
 4. **Synthetic neural did not generalize** but proved the hypothesis. Real
-   path requires real corpus — which now exists (ARRL pipeline).
+   path requires real corpus - which now exists (ARRL pipeline).
 5. **Corpus throughput matters.** ~40× speedup just from index-driven
    discovery + parallelism. Same lesson likely applies to future training
    pipelines.
@@ -305,7 +305,7 @@ A serial pilot (`u/randy/cw-exp-arrl-corpus`) was also completed (449 chunks /
   `git worktree add -b u/randy/cw-exp-<name> C:\Users\randy\Git\qsoripper-experiments\<name> <base-sha>`.
   Each worktree has its own `target/` dir so parallel cargo builds do not
   collide.
-- ARRL corpus pipeline is idempotent — re-running with cached state skips
+- ARRL corpus pipeline is idempotent - re-running with cached state skips
   ~200 cached sessions in <2 s.
 
 ## Operational notes
@@ -314,7 +314,7 @@ A serial pilot (`u/randy/cw-exp-arrl-corpus`) was also completed (449 chunks /
   package name is `cw-decoder-poc`).
 - `bench.py` invokes the default `stream-region` subcommand. For ensemble
   variants use `stream-region-ensemble --variant <v>`.
-- Always rebuild before benchmarking — bench.py uses the pre-built
+- Always rebuild before benchmarking - bench.py uses the pre-built
   `target/release/cw-decoder.exe` and a stale binary will mask source-level
   failures.
 - `RegionStreamConfig::default()` does not match CLI defaults
@@ -327,15 +327,15 @@ A serial pilot (`u/randy/cw-exp-arrl-corpus`) was also completed (449 chunks /
 
 Concrete experiments unlocked by this work:
 
-- **bigram-viterbi (re-run)** — train transition matrix on the 154k-char ARRL
+- **bigram-viterbi (re-run)** - train transition matrix on the 154k-char ARRL
   corpus instead of synthetic data. Probably the cheapest next win.
-- **ctc-neural (retrain)** — retrain on the 17.84 h ARRL corpus with a
+- **ctc-neural (retrain)** - retrain on the 17.84 h ARRL corpus with a
   beam-search decoder + n-gram language model trained on the same corpus.
   Issue #409 has the full Phase 1-7 plan.
-- **viterbi + elem-gate stack** — combine the two mechanisms; both hit
-  `cq-pota-aa6pw` 0.167 independently, so a stacked decoder may break that
+- **viterbi + elem-gate stack** - combine the two mechanisms. Both hit
+  `cq-pota-aa6pw` 0.167 independently, so a stacked decoder can break that
   ceiling.
-- **Upstream element detection** — re-investigate onset detection / Goertzel /
+- **Upstream element detection** - re-investigate onset detection / Goertzel /
   smoothed-power so `WA` of `WA6MOW` survives. Required for any further
   word-segmentation work.
 

--- a/docs/experiments/kaggle-morse-v2-baseline-2026-05.md
+++ b/docs/experiments/kaggle-morse-v2-baseline-2026-05.md
@@ -1,4 +1,4 @@
-# Kaggle Morse Learning Machine Challenge v2 — Baseline (2026-05-09)
+# Kaggle Morse Learning Machine Challenge v2 - Baseline (2026-05-09)
 
 First QsoRipper CW decoder submission to the public Kaggle leaderboard for the
 [Morse Learning Machine Challenge v2](https://www.kaggle.com/competitions/morse-learning-machine-challenge-v2).
@@ -16,12 +16,12 @@ First QsoRipper CW decoder submission to the public Kaggle leaderboard for the
 | Submission ID | 52489975 |
 
 Lower mean Levenshtein distance is better. There is no published golden
-baseline for the v2 dataset yet; this number anchors all future improvements.
+baseline for the v2 dataset yet. This number anchors all future improvements.
 
 ## What was decoded
 
 The competition ships 200 unlabeled WAVs (`cw001.wav` … `cw200.wav`) and asks
-for one transcript per file. There is **no training set** with truth — scoring
+for one transcript per file. There is **no training set** with truth - scoring
 is leaderboard-only against the hidden ground truth.
 
 Decoder used: `experiments/cw-decoder/target/release/cw-decoder.exe stream-region --file <wav> --json --no-realtime`.
@@ -37,18 +37,18 @@ synthetic adversarial suite + bake-off identified:
   band, or sub-region durations were rejected by `min_region_s`. Examples:
   cw187, cw189, cw190.
 - **Ghost/noise expansions**: short bursts decoded as long noisy `E/T/I/M`
-  cascades (e.g. cw197 `'O1T 0MD9 94WWWO B6 Z'`).
+  cascades (for example cw197 `'O1T 0MD9 94WWWO B6 Z'`).
 - **Leading-character drops** (the WA6MOW class from training-set-a): clean
-  callsigns recovered with one or two leading letters chopped, e.g. cw185
+  callsigns recovered with one or two leading letters chopped, for example cw185
   `'EUXILIARN'` (probably "AUXILIARY").
-- **Strong long-form CW recovered well**: cw194, cw195, cw196, cw198 each
-  produce 50+ char readable English, suggesting the steady-state portion of
-  the engine is healthy and the loss is concentrated at edges and weak files.
+- **Strong long-form CW recovered well**: cw194, cw195, cw196, and cw198 each
+  produce more than 50 readable characters. The steady-state engine is healthy.
+  Most loss occurs at signal edges and in weak files.
 
 The 20.5% "no transcript at all" rate is the single biggest concrete win
-available — every empty row is currently scoring `len(truth)` in Levenshtein.
-A naive "always emit something" lower-bound on those 41 files would meaningfully
-move the public score even without changing the engine.
+available - every empty row is currently scoring `len(truth)` in Levenshtein.
+A naive "always emit something" lower limit on those 41 files can improve the
+public score without an engine change.
 
 ## How to reproduce
 
@@ -69,21 +69,21 @@ $env:KAGGLE_API_TOKEN = (Get-Content .env | Select-String '^KAGGLE_API_TOKEN=').
 In priority order (matching the bake-off direction in
 `docs/experiments/cw-decoder-bakeoff-2026-05.md`):
 
-1. **Reduce empty-transcript rate.** Lower
-   `RegionStreamConfig::min_tonal_prominence_ratio` and `min_region_s` for the
-   Kaggle bench specifically, OR add a "best guess from raw envelope" fallback
-   when the region pipeline produces nothing. Goal: <5% empty.
+1. **Reduce the empty-transcript rate.**
+   Lower `RegionStreamConfig::min_tonal_prominence_ratio` and `min_region_s` for the Kaggle test.
+   Alternatively, add a raw-envelope estimate when the region pipeline produces no output.
+   The target empty rate is less than 5 percent.
 2. **Hard-stack Viterbi + elem-gate** (the recommended next ensemble move from
-   PR #410's discussion). Should attack the ghost-cascade class directly.
+   PR #410's discussion). This change must correct the ghost-cascade class directly.
 3. **Backward re-decode for warmup losses.** WA6MOW-class leading-character
    drops dominate the partial-callsign failures here too.
 4. **Lower SNR / off-pitch sweep**. Several empty files appear to have
    off-band pitch or weak signal. Widening the pitch search range or using a
-   coarser threshold on a second pass should rescue them.
+   coarser threshold on a second pass can correct them.
 
 ## Files in this baseline run
 
-- `experiments/cw-decoder/scripts/kaggle_morse_v2/submission.csv` — the actual
+- `experiments/cw-decoder/scripts/kaggle_morse_v2/submission.csv` - the actual
   uploaded submission (200 rows, regenerable).
-- `experiments/cw-decoder/scripts/kaggle_morse_v2/manifest.jsonl` — file index.
+- `experiments/cw-decoder/scripts/kaggle_morse_v2/manifest.jsonl` - file index.
 - Submission ID 52489975 on Kaggle ledger.

--- a/docs/integrations/adif-specification.md
+++ b/docs/integrations/adif-specification.md
@@ -1,14 +1,14 @@
 # ADIF Specification Reference (v3.1.7)
 
-> Reference for QsoRipper development based on the [ADIF 3.1.7 specification](https://www.adif.org/317/ADIF_317.htm).
-> Machine-readable exports (CSV, JSON, XML) are available at https://adif.org.uk/317/resources
+> This QsoRipper reference uses the [ADIF 3.1.7 specification](https://www.adif.org/317/ADIF_317.htm).
+> CSV, JSON, and XML exports are available at https://adif.org.uk/317/resources.
 
 ## Overview
 
-ADIF (Amateur Data Interchange Format) is the standard for exchanging ham radio QSO data between applications. It defines precise text-based representations for amateur radio information. ADIF is **not** a database schema or UI specification — it only governs import/export interchange.
+ADIF (Amateur Data Interchange Format) is the standard for exchanging ham radio QSO data between applications. It defines precise text-based representations for amateur radio information. ADIF is **not** a database schema or UI specification - it only governs import/export interchange.
 
 Key points:
-- Applications choose which fields to support; not all fields are required
+- Applications choose which fields to support. The standard does not require all fields.
 - Minimum suggested QSO: `QSO_DATE`, `TIME_ON`, `FREQ` and/or `BAND`, `CALL`, `MODE`
 - Field names are case-insensitive
 - Two file formats: **ADI** (tag-length-value, the primary format) and **ADX** (XML-based)
@@ -21,24 +21,24 @@ Key points:
 | Type | Indicator | Description |
 |---|---|---|
 | Boolean | B | Single char: `Y`/`y` (true) or `N`/`n` (false) |
-| Character | — | ASCII 32-126 |
+| Character | - | ASCII 32-126 |
 | Date | D | 8 digits `YYYYMMDD` in UTC (1930 ≤ YYYY) |
-| Digit | — | ASCII 48-57 |
+| Digit | - | ASCII 48-57 |
 | Enumeration | E | Case-insensitive value from a defined set |
-| GridSquare | — | 2/4/6/8-char Maidenhead locator (case-insensitive) |
-| GridSquareExt | — | Characters 9-10 (or 9-12) of extended Maidenhead locator |
-| Integer | — | Decimal integer, optional leading minus |
+| GridSquare | - | 2/4/6/8-char Maidenhead locator (case-insensitive) |
+| GridSquareExt | - | Characters 9-10 (or 9-12) of extended Maidenhead locator |
+| Integer | - | Decimal integer, optional leading minus |
 | IntlString | I | Unicode/UTF-8 string (**ADX files only**) |
-| IOTARefNo | — | Format `CC-XXX` (continent + 3-digit island group) |
+| IOTARefNo | - | Format `CC-XXX` (continent + 3-digit island group) |
 | Location | L | 11 chars: `XDDD MM.MMM` (X=N/S/E/W, DDD=degrees, MM.MMM=minutes) |
 | MultilineString | M | Characters + CR/LF line breaks |
 | Number | N | Decimal number, optional minus, optional decimal point |
-| PositiveInteger | — | Unsigned decimal integer > 0 |
-| POTARef | — | Parks on the Air reference: `xxxx-nnnnn[@yyyyyy]` |
-| SOTARef | — | SOTA reference: `prefix/REF-NNN` |
+| PositiveInteger | - | Unsigned decimal integer > 0 |
+| POTARef | - | Parks on the Air reference: `xxxx-nnnnn[@yyyyyy]` |
+| SOTARef | - | SOTA reference: `prefix/REF-NNN` |
 | String | S | Sequence of Characters (ASCII 32-126) |
 | Time | T | 4 digits `HHMM` or 6 digits `HHMMSS` in UTC |
-| WWFFRef | — | WWFF reference: `xxFF-nnnn` (8-11 chars) |
+| WWFFRef | - | WWFF reference: `xxFF-nnnn` (8-11 chars) |
 
 ---
 
@@ -86,53 +86,53 @@ Key points:
 
 | Mode | Submodes (selected) |
 |---|---|
-| AM | — |
-| ARDOP | — |
-| ATV | — |
+| AM | - |
+| ARDOP | - |
+| ATV | - |
 | C4FM | *(import-only, use DIGITALVOICE + submode C4FM)* |
 | CHIP | CHIP64, CHIP128 |
-| CLO | — |
-| CONTESTI | — |
+| CLO | - |
+| CONTESTI | - |
 | CW | PCW |
 | DIGITALVOICE | C4FM, DMR, DSTAR, FREEDV, M17 |
 | DOMINO | DOM-M, DOM4, DOM5, DOM8, DOM11, DOM16, DOM22, DOM44, DOM88, DOMINOEX, DOMINOF |
 | DSTAR | *(import-only, use DIGITALVOICE + submode DSTAR)* |
 | DYNAMIC | VARA HF, VARA SATELLITE, VARA FM 1200, VARA FM 9600, FREEDATA |
-| FAX | — |
-| FM | — |
+| FAX | - |
+| FM | - |
 | FSK | SCAMP_FAST, SCAMP_SLOW, SCAMP_VSLOW |
-| FT8 | — |
+| FT8 | - |
 | HELL | FMHELL, FSKHELL, FSKH105, FSKH245, HELL80, HELLX5, HELLX9, HFSK, PSKHELL, SLOWHELL |
 | ISCAT | ISCAT-A, ISCAT-B |
 | JT4 | JT4A through JT4G |
 | JT9 | JT9-1, JT9-2, JT9-5, JT9-10, JT9-30, JT9A-H (+ FAST variants) |
-| JT44 | — |
+| JT44 | - |
 | JT65 | JT65A, JT65B, JT65B2, JT65C, JT65C2 |
 | MFSK | FST4, FST4W, FT2, FT4, JS8, JTMS, MFSK4-128(L), MSK144, Q65, FSQCALL |
 | MTONE | SCAMP_OO, SCAMP_OO_SLW |
-| MSK144 | — |
+| MSK144 | - |
 | OFDM | RIBBIT_PIX, RIBBIT_SMS |
 | OLIVIA | OLIVIA 4/125, 4/250, 8/250, 8/500, 16/500, 16/1000, 32/1000 |
 | OPERA | OPERA-BEACON, OPERA-QSO |
 | PAC | PAC2, PAC3, PAC4 |
 | PAX | PAX2 |
-| PKT | — |
+| PKT | - |
 | PSK | PSK10-1000 variants, QPSK31-500, FSK31, 8PSK variants, SIM31, PSKAM/PSKFEC variants |
-| Q15 | — |
+| Q15 | - |
 | QRA64 | QRA64A through QRA64E |
 | ROS | ROS-EME, ROS-HF, ROS-MF |
 | RTTY | ASCI |
-| RTTYM | — |
+| RTTYM | - |
 | SSB | USB, LSB |
-| SSTV | — |
-| T10 | — |
+| SSTV | - |
+| T10 | - |
 | THOR | THOR-M, THOR4-100, THOR25X4, THOR50X1, THOR50X2 |
 | THRB | THRBX, THRBX1-4, THROB1-4 |
 | TOR | AMTORFEC, GTOR, NAVTEX, SITORB |
-| V4 | — |
-| VOI | — |
-| WINMOR | — |
-| WSPR | — |
+| V4 | - |
+| VOI | - |
+| WINMOR | - |
+| WSPR | - |
 
 ### Continent Enumeration
 
@@ -256,7 +256,7 @@ Key points:
 
 ---
 
-## QSO Fields — Complete Reference
+## QSO Fields - Complete Reference
 
 > All fields are optional. Applications decide which to support. Field names are case-insensitive.
 
@@ -264,34 +264,34 @@ Key points:
 
 | Field | Type | Enum | Description |
 |---|---|---|---|
-| CALL | String | — | Contacted station's callsign |
-| CONTACTED_OP | String | — | Callsign of the individual operating the contacted station |
-| NAME | String | — | Contacted operator's name |
-| AGE | Number | — | Contacted operator's age (0-120) |
-| ADDRESS | MultilineString | — | Contacted station's full mailing address |
-| QTH | String | — | Contacted station's city |
-| EMAIL | String | — | Contacted station's email |
-| WEB | String | — | Contacted station's URL |
-| SILENT_KEY | Boolean | — | Contacted operator is now a Silent Key |
-| EQ_CALL | String | — | Contacted station's owner's callsign |
-| PFX | String | — | Contacted station's WPX prefix |
+| CALL | String | - | Contacted station's callsign |
+| CONTACTED_OP | String | - | Callsign of the individual operating the contacted station |
+| NAME | String | - | Contacted operator's name |
+| AGE | Number | - | Contacted operator's age (0-120) |
+| ADDRESS | MultilineString | - | Contacted station's full mailing address |
+| QTH | String | - | Contacted station's city |
+| EMAIL | String | - | Contacted station's email |
+| WEB | String | - | Contacted station's URL |
+| SILENT_KEY | Boolean | - | Contacted operator is now a Silent Key |
+| EQ_CALL | String | - | Contacted station's owner's callsign |
+| PFX | String | - | Contacted station's WPX prefix |
 
 ### Core QSO Fields
 
 | Field | Type | Enum | Description |
 |---|---|---|---|
-| QSO_DATE | Date | — | Date QSO started (YYYYMMDD, UTC) |
-| QSO_DATE_OFF | Date | — | Date QSO ended |
-| TIME_ON | Time | — | QSO start time (HHMM or HHMMSS, UTC) |
-| TIME_OFF | Time | — | QSO end time |
+| QSO_DATE | Date | - | Date QSO started (YYYYMMDD, UTC) |
+| QSO_DATE_OFF | Date | - | Date QSO ended |
+| TIME_ON | Time | - | QSO start time (HHMM or HHMMSS, UTC) |
+| TIME_OFF | Time | - | QSO end time |
 | BAND | Enum | Band | QSO band |
 | BAND_RX | Enum | Band | Logging station's receiving band (split QSO) |
 | MODE | Enum | Mode | QSO mode |
 | SUBMODE | String | Submode | QSO submode |
-| FREQ | Number | — | QSO frequency in MHz |
-| FREQ_RX | Number | — | Logging station's receiving frequency in MHz (split QSO) |
+| FREQ | Number | - | QSO frequency in MHz |
+| FREQ_RX | Number | - | Logging station's receiving frequency in MHz (split QSO) |
 | QSO_COMPLETE | Enum | QSO Complete | Whether QSO was complete (Y/N/NIL/?) |
-| QSO_RANDOM | Boolean | — | Whether QSO was random or scheduled |
+| QSO_RANDOM | Boolean | - | Whether QSO was random or scheduled |
 
 ### Signal Reports
 
@@ -306,21 +306,21 @@ Key points:
 
 | Field | Type | Enum | Description |
 |---|---|---|---|
-| GRIDSQUARE | GridSquare | — | Contacted station's Maidenhead grid (2/4/6/8 chars) |
-| GRIDSQUARE_EXT | GridSquareExt | — | Characters 9-12 of contacted station's extended grid |
-| LAT | Location | — | Contacted station's latitude |
-| LON | Location | — | Contacted station's longitude |
+| GRIDSQUARE | GridSquare | - | Contacted station's Maidenhead grid (2/4/6/8 chars) |
+| GRIDSQUARE_EXT | GridSquareExt | - | Characters 9-12 of contacted station's extended grid |
+| LAT | Location | - | Contacted station's latitude |
+| LON | Location | - | Contacted station's longitude |
 | DXCC | Enum | DXCC Entity Code | Contacted station's DXCC entity code |
-| COUNTRY | String | — | Contacted station's DXCC entity name |
-| STATE | Enum | Primary Admin Subdiv | Contacted station's primary admin subdivision (US state, etc.) |
-| CNTY | Enum | Secondary Admin Subdiv | Contacted station's secondary admin subdivision (US county, etc.) |
-| CNTY_ALT | SecondaryAdminSubdivListAlt | — | Alternate secondary admin subdivision codes |
+| COUNTRY | String | - | Contacted station's DXCC entity name |
+| STATE | Enum | Primary Admin Subdiv | Contacted station's primary admin subdivision (US state, and other items) |
+| CNTY | Enum | Secondary Admin Subdiv | Contacted station's secondary admin subdivision (US county, and other items) |
+| CNTY_ALT | SecondaryAdminSubdivListAlt | - | Alternate secondary admin subdivision codes |
 | CONT | Enum | Continent | Contacted station's continent |
-| CQZ | PositiveInteger | — | Contacted station's CQ zone (1-40) |
-| ITUZ | PositiveInteger | — | Contacted station's ITU zone (1-90) |
-| IOTA | IOTARefNo | — | Contacted station's IOTA designator (CC-XXX) |
-| IOTA_ISLAND_ID | PositiveInteger | — | Contacted station's IOTA island identifier |
-| DISTANCE | Number | — | Distance in km between stations (≥0) |
+| CQZ | PositiveInteger | - | Contacted station's CQ zone (1-40) |
+| ITUZ | PositiveInteger | - | Contacted station's ITU zone (1-90) |
+| IOTA | IOTARefNo | - | Contacted station's IOTA designator (CC-XXX) |
+| IOTA_ISLAND_ID | PositiveInteger | - | Contacted station's IOTA island identifier |
+| DISTANCE | Number | - | Distance in km between stations (≥0) |
 | REGION | Enum | Region | Contacted station's WAE/CQ entity within DXCC |
 
 ### Logging Station Fields (MY_ prefix)
@@ -371,24 +371,24 @@ Key points:
 | QSL_SENT_VIA | Enum | QSL Via | Means by which QSL was sent |
 | QSL_RCVD | Enum | QSL Rcvd | Paper QSL received status (default: N) |
 | QSL_RCVD_VIA | Enum | QSL Via | Means by which QSL was received |
-| QSLSDATE | Date | — | QSL sent date |
-| QSLRDATE | Date | — | QSL received date |
-| QSL_VIA | String | — | Contacted station's QSL route |
-| QSLMSG | MultilineString | — | Message for paper/electronic QSL |
-| QSLMSG_RCVD | MultilineString | — | Message received on QSL |
+| QSLSDATE | Date | - | QSL sent date |
+| QSLRDATE | Date | - | QSL received date |
+| QSL_VIA | String | - | Contacted station's QSL route |
+| QSLMSG | MultilineString | - | Message for paper/electronic QSL |
+| QSLMSG_RCVD | MultilineString | - | Message received on QSL |
 | LOTW_QSL_SENT | Enum | QSL Sent | LoTW QSL sent status (default: N) |
 | LOTW_QSL_RCVD | Enum | QSL Rcvd | LoTW QSL received status (default: N) |
-| LOTW_QSLSDATE | Date | — | Date QSL sent to LoTW |
-| LOTW_QSLRDATE | Date | — | Date QSL received from LoTW |
+| LOTW_QSLSDATE | Date | - | Date QSL sent to LoTW |
+| LOTW_QSLRDATE | Date | - | Date QSL received from LoTW |
 | EQSL_QSL_SENT | Enum | QSL Sent | eQSL sent status (default: N) |
 | EQSL_QSL_RCVD | Enum | QSL Rcvd | eQSL received status (default: N) |
-| EQSL_QSLSDATE | Date | — | Date QSL sent to eQSL |
-| EQSL_QSLRDATE | Date | — | Date QSL received from eQSL |
+| EQSL_QSLSDATE | Date | - | Date QSL sent to eQSL |
+| EQSL_QSLRDATE | Date | - | Date QSL received from eQSL |
 | EQSL_AG | Enum | EQSL_AG | eQSL Authenticity Guaranteed status (default: U) |
 | DCL_QSL_SENT | Enum | QSL Sent | DARC Community Logbook sent status (default: N) |
 | DCL_QSL_RCVD | Enum | QSL Rcvd | DARC Community Logbook received status (default: N) |
-| DCL_QSLSDATE | Date | — | Date QSL sent to DCL |
-| DCL_QSLRDATE | Date | — | Date QSL received from DCL |
+| DCL_QSLSDATE | Date | - | Date QSL sent to DCL |
+| DCL_QSLRDATE | Date | - | Date QSL received from DCL |
 | CREDIT_SUBMITTED | CreditList | Credit | Credits sought for this QSO |
 | CREDIT_GRANTED | CreditList | Credit | Credits granted for this QSO |
 
@@ -418,8 +418,8 @@ Key points:
 | SRX_STRING | String | Contest info received (Cabrillo format) |
 | STX | Integer | Contest serial number transmitted (≥0) |
 | STX_STRING | String | Contest info transmitted (Cabrillo format) |
-| CHECK | String | Contest check (e.g. ARRL Sweepstakes) |
-| CLASS | String | Contest class (e.g. ARRL Field Day) |
+| CHECK | String | Contest check (for example ARRL Sweepstakes) |
+| CLASS | String | Contest class (for example ARRL Field Day) |
 | PRECEDENCE | String | Contest precedence |
 | ARRL_SECT | Enum (ARRL Section) | Contacted station's ARRL section |
 
@@ -488,7 +488,7 @@ The primary interchange format. Tag-length-value syntax.
 
 - `FIELDNAME`: case-insensitive field name
 - `LENGTH`: unsigned decimal integer = number of characters in DATA
-- `TYPE`: optional data type indicator (e.g., `S` for String, `D` for Date, `N` for Number)
+- `TYPE`: optional data type indicator (for example, `S` for String, `D` for Date, `N` for Number)
 - `DATA`: field value (exactly LENGTH characters)
 
 ### File Structure
@@ -503,13 +503,13 @@ Record2 <EOR>
 
 - If the file starts with `<`, there is no header (first `<` begins first record)
 - Header can contain arbitrary text + header data specifiers
-- Characters between data specifiers and outside tags are ignored (allows formatting)
+- Parsers ignore characters between data specifiers and outside tags. This permits formatting.
 
 ### Header Fields
 
 | Field | Description |
 |---|---|
-| ADIF_VER | ADIF version number (e.g., `3.1.7`) |
+| ADIF_VER | ADIF version number (for example, `3.1.7`) |
 | CREATED_TIMESTAMP | File creation timestamp |
 | PROGRAMID | Name of the generating application |
 | PROGRAMVERSION | Version of the generating application |
@@ -554,12 +554,12 @@ Generated by QsoRipper v0.1.0
 ### Parsing Rules
 
 1. **Case-insensitive**: field names, mode/band values, EOH/EOR tags
-2. **Ignore unknown fields**: forward compatibility — skip fields your app doesn't recognize
+2. **Ignore unknown fields**: forward compatibility - skip fields that the application does not recognize
 3. **Ignore text outside specifiers**: allows comments, whitespace, formatting between records
 4. **Length-delimited**: the LENGTH value determines exactly how many characters to read for DATA
-5. **No maximum field length**: importing apps may truncate, exporting apps may write any length
+5. **No maximum field length**: Importing applications can truncate. Exporting applications can write any length.
 6. **Field order arbitrary**: fields within a record can appear in any order
-7. **No duplicate fields per record**: each field name may appear at most once per record
+7. **No duplicate fields per record**: Each field name can occur only once in each record.
 
 ### Application-Defined Fields
 
@@ -605,7 +605,7 @@ XML-based format with UTF-8 encoding. Uses `.adx` extension. Supports internatio
 </ADX>
 ```
 
-ADX support is optional — all ADIF-compliant apps must support ADI, but ADX is not required.
+ADX support is optional - all ADIF-compliant apps must support ADI, but ADX is not required.
 
 ---
 
@@ -616,34 +616,34 @@ The ADIF parser (Rust-side edge adapter) converts ADIF fields to/from proto `Qso
 | ADIF Field | Proto QsoRecord Field | Notes |
 |---|---|---|
 | STATION_CALLSIGN | station_callsign | Falls back to OPERATOR if absent |
-| CALL | worked_callsign | — |
+| CALL | worked_callsign | - |
 | QSO_DATE + TIME_ON | utc_timestamp | Combined into Timestamp |
 | QSO_DATE_OFF + TIME_OFF | utc_end_timestamp | End date falls back to QSO_DATE when ADIF omits QSO_DATE_OFF |
 | BAND | band | Map string to Band enum |
-| MODE + SUBMODE | mode | Map to Mode enum; store submode separately if needed |
+| MODE + SUBMODE | mode | Map to Mode enum. Store submode separately if needed |
 | FREQ | frequency_hz | Convert MHz → Hz via string/decimal math for sub-kHz precision |
 | RST_SENT | rst_sent | Parse into RstReport |
 | RST_RCVD | rst_received | Parse into RstReport |
-| TX_PWR | tx_power | — |
-| CONTACTED_OP | worked_operator_callsign | — |
-| GRIDSQUARE | worked_grid | — |
-| COUNTRY | worked_country | — |
-| DXCC | worked_dxcc | — |
-| STATE | worked_state | — |
-| CONT | worked_continent | — |
-| CQZ | worked_cq_zone | — |
-| ITUZ | worked_itu_zone | — |
-| CNTY | worked_county | — |
-| IOTA | worked_iota | — |
-| ARRL_SECT | worked_arrl_section | — |
-| NAME | worked_operator_name | — |
-| CONTEST_ID | contest_id | — |
-| STX | serial_sent | — |
-| SRX | serial_received | — |
-| STX_STRING | exchange_sent | — |
-| SRX_STRING | exchange_received | — |
-| COMMENT | comment | — |
-| NOTES | notes | — |
+| TX_PWR | tx_power | - |
+| CONTACTED_OP | worked_operator_callsign | - |
+| GRIDSQUARE | worked_grid | - |
+| COUNTRY | worked_country | - |
+| DXCC | worked_dxcc | - |
+| STATE | worked_state | - |
+| CONT | worked_continent | - |
+| CQZ | worked_cq_zone | - |
+| ITUZ | worked_itu_zone | - |
+| CNTY | worked_county | - |
+| IOTA | worked_iota | - |
+| ARRL_SECT | worked_arrl_section | - |
+| NAME | worked_operator_name | - |
+| CONTEST_ID | contest_id | - |
+| STX | serial_sent | - |
+| SRX | serial_received | - |
+| STX_STRING | exchange_sent | - |
+| SRX_STRING | exchange_received | - |
+| COMMENT | comment | - |
+| NOTES | notes | - |
 | QSL_SENT | qsl_sent_status | Map Y/N/R/Q/I to QslStatus enum |
 | QSL_RCVD | qsl_received_status | Map Y/N/R/I to QslStatus enum |
 | QSLSDATE | qsl_sent_date | Stored as a Timestamp at 00:00:00 UTC |
@@ -665,7 +665,9 @@ The ADIF parser (Rust-side edge adapter) converts ADIF fields to/from proto `Qso
 | MY_ALTITUDE | station_snapshot.altitude_meters | Logging-station altitude in meters (MSL) |
 | MY_GRIDSQUARE_EXT | station_snapshot.gridsquare_ext | Extended grid chars 9-12 |
 
-**Fields not in QsoRecord or its nested station snapshot** (such as unsupported `MY_` fields, propagation data, satellite info, etc.) are preserved in an overflow map for round-trip fidelity during ADIF import/export.
+**Fields outside `QsoRecord` and its station snapshot** remain in an overflow map.
+Examples include unsupported `MY_` fields, propagation data, and satellite information.
+This map preserves the fields during ADIF import and export.
 
 ---
 
@@ -684,16 +686,16 @@ Alternatives: [`adif-rs`](https://github.com/macopacabana/adif-rs) (simpler), [`
 ### Recommended .NET Package
 
 The .NET GUI does not parse ADIF directly (gRPC provides normalized proto types), but for any direct ADIF file handling:
-- [`AdifNet`](https://www.nuget.org/packages/AdifNet/) — full ADI+ADX, .NET 8, SQL adapter
-- [`AdifLib`](https://www.nuget.org/packages/AdifLib/) — lightweight, .NET Standard 2.0
+- [`AdifNet`](https://www.nuget.org/packages/AdifNet/) - full ADI+ADX, .NET 8, SQL adapter
+- [`AdifLib`](https://www.nuget.org/packages/AdifLib/) - lightweight, .NET Standard 2.0
 
 ### Design Considerations
 
-1. **Round-trip fidelity**: preserve all ADIF fields during import, even those not in QsoRecord, so exports don't lose data
+1. **Round-trip fidelity**: preserve all ADIF fields during import, even those not in QsoRecord, so exports do not lose data
 2. **Forward compatibility**: ignore unknown fields (matching ADIF's upward compatibility policy)
-3. **Band/Mode normalization**: convert string values to proto enums; handle submodes
+3. **Band/Mode normalization**: convert string values to proto enums. Handle submodes
 4. **Date/time combining**: merge QSO_DATE + TIME_ON into a single UTC timestamp
-5. **Frequency vs Band**: FREQ is optional when BAND is present; derive one from the other when possible
+5. **Frequency vs Band**: FREQ is optional when BAND is present. Derive one from the other when possible
 6. **Import-only fields**: accept deprecated fields on import but never emit them on export
 
 ---

--- a/docs/integrations/cathub-setup.md
+++ b/docs/integrations/cathub-setup.md
@@ -42,18 +42,20 @@ QsoRipper resolves the executable in this order:
 1. The path in `CATHUB_EXECUTABLE`.
 2. A binary bundled at `artifacts\publish\cathub\Release\cathub.exe` on Windows, or the
    equivalent platform path.
-3. `cathub` on `PATH`.
+3. A source build in a sibling CatHub checkout at `..\cathub\target\release\cathub.exe`,
+   or the equivalent platform path.
+4. `cathub` on `PATH`.
 
-QsoRipper never downloads, installs, or updates CatHub during startup.
-The current supported executable range is `>=0.1.0 <0.2.0`; the launcher checks
+QsoRipper does not download, install, or update CatHub during startup.
+The current supported executable range is `>=0.1.0 <0.2.0`. The launcher checks
 `cathub --version` and reports an incompatible version separately from a spawn failure.
 
 ## Configuration modes
 
 ### QsoRipper-managed unified configuration
 
-Existing `[cat_hub]` settings in QsoRipper's per-user `config.toml` remain supported. The
-QsoRipper settings UI may edit this section, and the launcher passes the unified file to
+Existing `[cat_hub]` settings in QsoRipper's per-user `config.toml` remain supported.
+The QsoRipper settings UI can edit this section. The launcher passes the unified file to
 CatHub explicitly with `--section cat_hub`. CatHub ignores unrelated QsoRipper tables.
 
 This mode keeps one station configuration file. QsoRipper setup saves preserve `[cat_hub]`
@@ -92,14 +94,14 @@ cathub config migrate `
   --output "$env:APPDATA\cathub\cathub.toml"
 ```
 
-Migration refuses to overwrite an existing destination unless `--force` is supplied.
+Migration refuses to overwrite an existing destination unless the command includes `--force`.
 Source removal is opt-in and creates a `.bak` file first.
 
 ## Start with the QsoRipper launcher
 
 Select **CatHub standalone service** in `launcher.ps1`. The launcher:
 
-1. Chooses the unified QsoRipper file when it contains `[cat_hub]`; otherwise it uses the
+1. Chooses the unified QsoRipper file when it contains `[cat_hub]`. Otherwise it uses the
    external CatHub path.
 2. Resolves the configured, bundled, or installed CatHub executable.
 3. Starts CatHub before either engine.
@@ -155,7 +157,7 @@ does not require the published `cathub-protocol` Rust crate or `CatHub.Protocol`
 package. Those packages are for independent applications that develop against CatHub's typed
 API.
 
-The dependency pin is recorded in `config\cathub-dependency.json`. When both repositories are
+QsoRipper records the dependency pin in `config\cathub-dependency.json`. When both repositories are
 checked out as siblings, verify the temporary QsoRipper protocol snapshot with:
 
 ```powershell

--- a/docs/integrations/cw-keying.md
+++ b/docs/integrations/cw-keying.md
@@ -1,6 +1,6 @@
 # CW keying setup
 
-QsoRipper exposes the same engine-backed CW macro and keyer behavior through the Rust and .NET engines. The default `null` backend expands and accepts macros without touching radio hardware. Use it to verify station context and contest exchanges before enabling a WinKeyer. Use the `cathub` backend when QsoRipper and N1MM need the same physical keyer; retain the direct `winkeyer` backend for single-client stations.
+QsoRipper exposes the same engine-backed CW macro and keyer behavior through the Rust and .NET engines. The default `null` backend expands and accepts macros without touching radio hardware. Use it to verify station context and contest exchanges before enabling a WinKeyer. Use the `cathub` backend when QsoRipper and N1MM need the same physical keyer. Use the direct `winkeyer` backend for single-client stations.
 
 ## Safety model
 
@@ -36,9 +36,9 @@ qsoripper cw speed 28
 
 ### Shared keyer through CatHub (recommended for N1MM)
 
-Create a dedicated com0com pair such as `COM40 <-> COM41`. CatHub opens `COM40`; N1MM opens `COM41`. Neither N1MM nor a QsoRipper engine opens physical `COM3`.
+Create a dedicated com0com pair such as `COM40 <-> COM41`. CatHub opens `COM40`. N1MM opens `COM41`. Neither N1MM nor a QsoRipper engine opens physical `COM3`.
 
-Create a second pair such as `COM42 <-> COM43` for device maintenance. CatHub opens `COM42`; WKTools opens `COM43`. Do not make WKTools and N1MM share COM41.
+Create a second pair such as `COM42 <-> COM43` for device maintenance. CatHub opens `COM42`. WKTools opens `COM43`. Do not make WKTools and N1MM share COM41.
 
 Add this to the unified configuration:
 
@@ -76,11 +76,24 @@ max_tx_ms = 30000
 
 Start CatHub before either engine. Configure N1MM's WinKeyer port as `COM41`, 1200 baud. Configure WKTools for `COM43`, 1200 baud. QsoRipper talks to the typed API and can remain connected while N1MM uses the virtual serial endpoint.
 
-CatHub schedules complete jobs without interleaving. N1MM Escape clears only N1MM's active stream; QsoRipper cancellation affects only its named client. The station-wide emergency stop remains global. A fixed-speed QsoRipper job temporarily overrides the keyer and restores the primary endpoint's fixed or pot-controlled speed afterward.
+CatHub schedules complete jobs without interleaving. N1MM Escape clears only N1MM's active stream. QsoRipper cancellation affects only its named client. The station-wide emergency stop remains global. A fixed-speed QsoRipper job temporarily overrides the keyer and restores the primary endpoint's fixed or pot-controlled speed afterward.
 
-The speed-pot notification contains an offset from the active `MIN_WPM` setting. CatHub tracks each client's Speed Pot Setup command, reports the canonical actual WPM through the typed API, and forwards the original protocol byte unchanged to N1MM.
+The speed-pot notification contains an offset from the active `MIN_WPM` setting.
+CatHub tracks the Speed Pot Setup command for each client.
+It reports the actual WPM through the typed API.
+It forwards the original protocol byte to N1MM without a change.
 
-Routine operation never writes EEPROM. Reset, EEPROM, firmware, calibration, and baud-changing commands require an endpoint with `config_write`, an empty transmit queue, and an exclusive maintenance lease. During maintenance, CatHub safely closes the physical host session, keeps replies private to the maintenance session, rejects other transmission, then reopens the host session and restores foreground transient state. Close WKTools when maintenance is complete so it releases COM43. Do not grant `config_write` to the everyday N1MM endpoint.
+Routine operation does not write EEPROM.
+Maintenance commands require an endpoint with `config_write`.
+They also require an empty transmit queue and an exclusive maintenance lease.
+These commands include reset, EEPROM, firmware, calibration, and baud changes.
+During maintenance, CatHub safely closes the physical host session.
+It sends replies only to the maintenance session and rejects other transmissions.
+
+Then it opens the host session and restores the foreground transient state.
+
+Close WKTools after maintenance to release COM43.
+Do not grant `config_write` to the normal N1MM endpoint.
 
 ### Direct single-client connection
 
@@ -144,10 +157,10 @@ Persisted TOML is also read at engine startup. A `QSORIPPER_CW_*` environment va
 | Access denied or port busy | Close other logging/keyer software using the port and verify OS permissions. Only one process can own the WinKeyer session. |
 | CatHub API unavailable | Start CatHub, verify `api_bind`, and confirm the engine endpoint includes the `http://` scheme. |
 | N1MM cannot open its keyer | N1MM must open the application side of the virtual pair (for example COM41), never physical COM3 or CatHub's COM40 side. |
-| Pot speed is offset | The raw protocol byte is relative to the active Speed Pot Setup minimum; use `cw status` for canonical WPM. |
+| Pot speed is offset | The raw protocol byte is relative to the active Speed Pot Setup minimum. Use `cw status` for canonical WPM. |
 | Host Open times out | Verify the port, cable, device power, and baud rate. Most WinKeyer devices use 1200 baud. |
 | Send is rejected as disabled | Set `QSORIPPER_CW_TRANSMIT_ENABLED=true` only after completing the safe probe workflow, then restart. |
-| Safety ceiling error | The keyer was still busy at `QSORIPPER_CW_MAX_TX_MS`; inspect the queued macro and keyer/radio state before retrying. |
+| Safety ceiling error | The keyer was still busy at `QSORIPPER_CW_MAX_TX_MS`. Inspect the queued macro and keyer/radio state before retrying. |
 | Wrong callsign or exchange | Verify the active station profile and pass the required `--his-call`, `--exchange`, or `--nr` context. |
 | Invalid speed | Use an integer from 5 through 99 WPM. |
 

--- a/docs/integrations/qrz-logbook-api.md
+++ b/docs/integrations/qrz-logbook-api.md
@@ -19,7 +19,7 @@ The QRZ Logbook API provides an HTTP REST interface for external programs to int
 - Every QSO record has a unique integer **`logid`**.
 - Every logbook has a unique integer **`bookid`** and belongs to a specific QRZ member.
 - A logbook serves exactly **one callsign**. Every character in a callsign is significant, including portable/mobile identifiers. For example, `XX1XX` and `XX1XX/M` are separate callsigns requiring separate logbooks.
-- When a user changes callsigns, a new logbook is opened. The user then has multiple logbooks (one per callsign).
+- When a user changes callsigns, QRZ opens a new logbook. The user then has one logbook for each callsign.
 
 ### Required QSO fields for insertion
 
@@ -33,14 +33,17 @@ A QSO record requires these key attributes to be inserted:
 
 ### Logbook date range
 
-Each logbook has a configurable date range corresponding to when the callsign was/will be active (typically license effective through expiration date). **QSOs with dates outside this range will be rejected.**
+Each logbook has a configurable date range.
+This range identifies when the callsign is active.
+Usually, it starts on the license effective date and ends on the expiration date.
+**QRZ rejects a QSO that has a date outside this range.**
 
 ### Access key model
 
-- A QRZ member may have access to multiple logbooks.
+- A QRZ member can have access to multiple logbooks.
 - `bookid` values are never transmitted directly in the API.
 - Instead, an opaque **API Access Key** provided by QRZ conveys both user identification and logbook routing.
-- The access key for a given logbook is obtained through the QRZ website.
+- Get the access key for a logbook from the QRZ website.
 
 ---
 
@@ -62,11 +65,11 @@ All applications **must** provide an identifiable `User-Agent` HTTP header.
 
 **Format guidance from QRZ:**
 
-- Personal scripts: include your callsign and a unique script name, e.g. `QsoRipper/0.1.0 (AA7BQ)`
-- Applications: `ApplicationName/version`, e.g. `QsoRipper/1.0.0`
+- Personal scripts: include your callsign and a unique script name, for example `QsoRipper/0.1.0 (AA7BQ)`
+- Applications: `ApplicationName/version`, for example `QsoRipper/1.0.0`
 - Maximum length: **128 characters**
 
-Applications with missing or generic user agents (e.g. `node-fetch`, `python-requests`) may be subject to rate limiting or restrictions.
+QRZ can limit applications that have missing or generic user agents, such as `node-fetch` and `python-requests`.
 
 ---
 
@@ -93,7 +96,7 @@ Every API request must include `KEY` and `ACTION`. The server rejects requests c
 | `LOGIDS` | Comma-separated list of `logid` values affected by the action |
 | `LOGID` | Single `logid` of inserted/replaced record (INSERT only, since it is a single-record operation) |
 | `COUNT` | Number of QSO records affected by the action |
-| `DATA` | Action-specific data payload (e.g. status reports) |
+| `DATA` | Action-specific data payload (for example status reports) |
 
 ---
 
@@ -108,7 +111,7 @@ Inserts one QSO record into the logbook selected by the API access key.
 | Parameter | Value |
 |---|---|
 | `ACTION` | `INSERT` |
-| `ADIF` | The ADIF data to be inserted |
+| `ADIF` | The ADIF data for insertion |
 | `OPTION` | _(optional)_ `REPLACE` to automatically overwrite any existing duplicate QSOs |
 
 **Response:**
@@ -135,9 +138,9 @@ RESULT=OK&LOGID=130877825&COUNT=1
 **Implementation warnings:**
 
 - The `REPLACE` option **will overwrite confirmed QSOs** with the supplied unconfirmed QSO data until QRZ re-verifies the match. Treat this as a high-risk operation requiring explicit user intent.
-- Send the option as exactly `REPLACE`. Do not append a `LOGID` selector to the
-  `OPTION` value. QRZ matches the duplicate from the supplied ADIF record and
-  returns the affected `LOGID`.
+- Send the option as exactly `REPLACE`.
+- Do not append a `LOGID` selector to the `OPTION` value.
+- QRZ matches the duplicate from the supplied ADIF record and returns the affected `LOGID`.
 
 ---
 
@@ -160,7 +163,7 @@ Deletes one or more QSO records from the logbook selected by the API access key.
 | `LOGIDS` | Comma-separated list of `logid` values that were **not found** (only when `RESULT=PARTIAL`) |
 | `COUNT` | Number of QSO records actually deleted |
 
-**Critical warning:** This command **permanently deletes** records. There is **no undo**. Deleted records cannot be recovered. QsoRipper should require explicit user confirmation before executing DELETE operations.
+**Critical warning:** This command **permanently deletes** records. There is **no undo**. You cannot recover deleted records. QsoRipper must get user confirmation before a DELETE operation.
 
 ---
 
@@ -181,7 +184,17 @@ Returns a status report for the logbook selected by the API access key.
 | `RESULT` | `OK` (success), `FAIL` (invalid access key) |
 | `DATA` | `&`-separated list of `name=value` pairs containing logbook status |
 
-**DATA payload may include:** total QSOs in book, total confirmed, DXCC total, USA states total, start date, end date, book owner, bookid, book name, authorized users.
+**The DATA payload can include:**
+
+- Total QSOs in the logbook
+- Total confirmed QSOs
+- DXCC total
+- USA states total
+- Start and end dates
+- Logbook owner
+- `bookid`
+- Logbook name
+- Authorized users
 
 ---
 
@@ -198,11 +211,11 @@ Fetches one or more QSO records from the logbook matching specified criteria.
 
 **FETCH option parameters:**
 
-Options are sent as a comma-separated list of colon-separated `name:value` pairs with **no spaces**. Example: `BAND:80m,MODE:SSB,MAX:400`
+Send options as a comma-separated list of colon-separated `name:value` pairs with **no spaces**. Example: `BAND:80m,MODE:SSB,MAX:400`
 
 | Option | Description |
 |---|---|
-| `ALL` | Fetch the entire logbook (default). When used, only `TYPE` and `STATUS` may also be specified. |
+| `ALL` | Fetch the complete logbook (default). With this option, specify only `TYPE` and `STATUS`. |
 | `DXCC:nnn` | Fetch records with DXCC=nnn |
 | `BETWEEN:2014-01-01+2014-01-31` | Fetch records between start and end dates (inclusive) |
 | `MODSINCE:2023-01-01` | Only return records modified since this date |
@@ -211,7 +224,7 @@ Options are sent as a comma-separated list of colon-separated `name:value` pairs
 | `MODE:xxx` | Fetch QSOs with the given mode |
 | `CALL:XX1XX` | Fetch QSOs with the indicated callsign |
 | `LOGIDS:nnn+nnn+nnn` | Fetch specific records by logid list (plus-separated) |
-| `MAX:nnnn` | Maximum number of records to return (0 = count only; unspecified = unlimited) |
+| `MAX:nnnn` | Maximum number of records to return (0 = count only. Unspecified = unlimited) |
 | `TYPE:ADIF\|LOGIDS` | Response format: ADIF data (default) or logid list |
 | `STATUS:CONFIRMED\|ALL` | Filter: confirmed records only, or all records (default: ALL) |
 
@@ -222,22 +235,23 @@ Options are sent as a comma-separated list of colon-separated `name:value` pairs
 | `RESULT` | `OK` (matches found), `FAIL` (parameter or other problem) |
 | `COUNT` | Total number of records matching selection criteria |
 | `LOGIDS` | Comma-separated list of matching `logid` values (limited by `MAX`) |
-| `ADIF` | ADIF data for matching QSOs (limited by `MAX`; returned when `TYPE` is `ADIF` or default) |
+| `ADIF` | ADIF data for matching QSOs (limited by `MAX`. Returned when `TYPE` is `ADIF` or default) |
 
 **Usage notes:**
 
-- Multiple options may be combined, separated by `&` or `;` characters.
+- You can combine multiple options. Separate them with `&` or `;`.
 - `COUNT` always reflects the total match count for the given criteria regardless of `MAX`.
 - To fetch **only the count**, set `MAX:0`.
-- When `ALL` is specified, only `TYPE` and `STATUS` may accompany it.
+- When you specify `ALL`, specify only `TYPE` and `STATUS` with it.
 
 ### Recommended paging strategy
 
 Large logbooks can cause timeouts if fetched in one request. Use bounded fetches:
 
 1. Start with `MAX:250,AFTERLOGID:0`
-2. If 250 records are returned, make another request with `AFTERLOGID` set to the highest `app_qrzlog_logid` value returned + 1
-3. Repeat until fewer than 250 (or your `MAX`) records are returned
+2. If QRZ returns 250 records, make another request.
+3. Set `AFTERLOGID` to one more than the highest returned `app_qrzlog_logid`.
+4. Repeat until QRZ returns fewer than 250 records or the specified `MAX`.
 
 ---
 
@@ -245,9 +259,9 @@ Large logbooks can cause timeouts if fetched in one request. Use bounded fetches
 
 | Scenario | Detection | QsoRipper behavior |
 |---|---|---|
-| Auth / privilege failure | `RESULT=AUTH` | Treat as credential/config issue; do not retry; surface to user |
-| Validation failure | `RESULT=FAIL` with `REASON` | Surface clear reason to user; keep local state unchanged |
-| Partial delete | `RESULT=PARTIAL` | Log which logids were not found; surface to user for review |
+| Auth / privilege failure | `RESULT=AUTH` | Treat as credential/config issue. Do not retry. Surface to user |
+| Validation failure | `RESULT=FAIL` with `REASON` | Surface clear reason to user. Keep local state unchanged |
+| Partial delete | `RESULT=PARTIAL` | Log which logids were not found. Surface to user for review |
 | Date range rejection | `RESULT=FAIL`, reason mentions date range | Surface as data validation error with the logbook's configured range |
 | Network / transient failure | No response or HTTP error | Bounded retries with timeout and jitter |
 | Rate limiting | HTTP 429 or similar | Back off with exponential delay |
@@ -258,7 +272,7 @@ Large logbooks can cause timeouts if fetched in one request. Use bounded fetches
 
 ## ADIF format notes
 
-QSO data is exchanged using ADIF (Amateur Data Interchange Format). Each field uses the format `<fieldname:length>value` and records end with `<eor>`.
+QRZ exchanges QSO data in ADIF (Amateur Data Interchange Format). Each field uses `<fieldname:length>value`. Each record ends with `<eor>`.
 
 **Example ADIF record:**
 
@@ -266,20 +280,20 @@ QSO data is exchanged using ADIF (Amateur Data Interchange Format). Each field u
 <band:3>80m<mode:3>SSB<call:4>XX1X<qso_date:8>20140121<station_callsign:5>AA7BQ<time_on:4>0346<eor>
 ```
 
-The QsoRipper adapter should include a robust ADIF parser/serializer that handles:
+The QsoRipper adapter must include an ADIF parser and serializer that handles:
 
 - Variable field lengths and ordering
 - Optional fields present or absent per record
 - Multi-record payloads from FETCH responses
-- QRZ-compatible normalization for numeric fields on upload; for example,
-  `TX_PWR` must be numeric watts, so values like `100W` should be normalized to
-  `100` and unparseable values should be omitted rather than sent verbatim
+- QRZ-compatible normalization for numeric fields on upload. For example,
+  `TX_PWR` must be numeric watts. Normalize values such as `100W` to
+  `100`. Omit values that you cannot parse.
 
 ---
 
 ## Mapping into QsoRipper domain
 
-The adapter should parse ADIF and map into internal QSO structures, then expose normalized domain records to the app layer.
+The adapter must parse ADIF and map it to internal QSO structures. It then sends normalized domain records to the application layer.
 
 ### Minimum field mapping
 
@@ -296,7 +310,7 @@ The adapter should parse ADIF and map into internal QSO structures, then expose 
 | `comment` / `notes` | Operator notes (optional) |
 | `gridsquare` | Locator (optional) |
 
-Additional ADIF fields should be preserved as extension data to support round-tripping with QRZ.
+The adapter must preserve additional ADIF fields as extension data for a complete QRZ transfer cycle.
 
 ---
 
@@ -308,6 +322,6 @@ Use these environment variables (see `.env.example`):
 |---|---|
 | `QSORIPPER_QRZ_LOGBOOK_BASE_URL` | Logbook API endpoint (default: `https://logbook.qrz.com/api`) |
 | `QSORIPPER_QRZ_LOGBOOK_API_KEY` | QRZ-issued logbook access key |
-| `QSORIPPER_QRZ_USER_AGENT` | User-Agent header value (e.g. `QsoRipper/0.1.0 (YOURCALL)`) |
+| `QSORIPPER_QRZ_USER_AGENT` | User-Agent header value (for example `QsoRipper/0.1.0 (YOURCALL)`) |
 | `QSORIPPER_QRZ_HTTP_TIMEOUT_SECONDS` | HTTP request timeout |
 | `QSORIPPER_QRZ_MAX_RETRIES` | Maximum retry count for transient failures |

--- a/docs/integrations/qrz-xml-lookup-api.md
+++ b/docs/integrations/qrz-xml-lookup-api.md
@@ -10,7 +10,7 @@ This document is a comprehensive development reference for QsoRipper's consumpti
 
 The QRZ XML service provides real-time access to callsign and DXCC data from the QRZ.COM database over standard HTTP. Responses are XML formatted.
 
-**Subscription model:** Any QRZ user can authenticate, but an active QRZ Logbook Data subscription is required to receive full field data. Non-subscriber access returns a limited field set and is intended for testing only.
+**Subscription model:** Any QRZ user can authenticate. Full field data requires an active QRZ Logbook Data subscription. Non-subscriber access returns limited test data.
 
 ---
 
@@ -31,7 +31,7 @@ https://xmldata.qrz.com/xml/<version_identifier>/?<query_parameters>
 | Identifier | Behavior |
 |---|---|
 | _(none)_ | Legacy mode (v1.24) |
-| `1.xx` | Use specific version (e.g. `1.34`; dot may be omitted: `134`) |
+| `1.xx` | Use a specific version, such as `1.34`. You can omit the dot: `134`. |
 | `current` | Use the latest available version |
 
 An invalid version identifier returns an error.
@@ -50,8 +50,8 @@ https://xmldata.qrz.com/xml/current/?username=xx1xxx;password=abcdef  (latest)
 
 ## HTTP protocol notes
 
-- Requests may use either HTTP `GET` or `POST`.
-- Query parameter separators: either `&` or `;` are accepted.
+- Requests can use HTTP `GET` or `POST`.
+- QRZ accepts `&` or `;` as query parameter separators.
 - The interface does not use HTTP cookies, JavaScript, or HTML (except for the biography fetch, which returns HTML).
 
 ---
@@ -72,7 +72,7 @@ https://xmldata.qrz.com/xml/current/?username=xx1xxx;password=abcdef;agent=QsoRi
 |---|---|---|
 | `username` | Yes | A valid QRZ.COM username |
 | `password` | Yes | The correct password for the username |
-| `agent` | Strongly recommended | Product name and version (e.g. `QsoRipper/0.1.0`). Assists QRZ support and troubleshooting. If omitted, QRZ falls back to the HTTP `User-Agent` header. |
+| `agent` | Strongly recommended | Product name and version (for example `QsoRipper/0.1.0`). Assists QRZ support and troubleshooting. If omitted, QRZ falls back to the HTTP `User-Agent` header. |
 
 ### Successful login response
 
@@ -94,10 +94,10 @@ The `<QRZDatabase>` node includes `version` and `xmlns` attributes.
 
 - All post-login requests must include the session key via the `s=` parameter.
 - Session keys have **no guaranteed lifetime**. They are dynamically managed by the server.
-- A key is valid for a single user and may be **immediately invalidated** if the user's IP address or other identifying information changes.
-- Clients should perform **one login per session** and cache/reuse the key for all subsequent requests.
-- When a response **omits the `<Key>` element**, no valid session exists and re-login is required.
-- Monitor every response for session status and be prepared to re-authenticate at any time.
+- A key is valid for one user. QRZ can **immediately invalidate** it when the user's identifying information changes.
+- Clients must perform **one login per session**. They must keep and use the key for all later requests.
+- When a response **omits the `<Key>` element**, no valid session exists. Log in again.
+- Monitor each response for session status. Be ready to authenticate again.
 
 ### Session node fields
 
@@ -107,10 +107,10 @@ The `<QRZDatabase>` node includes `version` and `xmlns` attributes.
 | `Count` | Number of lookups performed by this user in the current 24-hour period |
 | `SubExp` | Subscription expiration date/time, or the string `"non-subscriber"` |
 | `GMTime` | Server timestamp for this response |
-| `Message` | Informational message for the user (e.g. subscription notices) |
-| `Error` | Error message (e.g. "password incorrect", "session timeout", "callsign not found") |
+| `Message` | Informational message for the user (for example subscription notices) |
+| `Error` | Error message (for example "password incorrect", "session timeout", "callsign not found") |
 
-Both `Error` and `Message` should be surfaced to the user when present. `Count`, `SubExp`, and `GMTime` are informational.
+Show `Error` and `Message` to the user when these fields contain values. `Count`, `SubExp`, and `GMTime` contain information.
 
 ---
 
@@ -118,7 +118,7 @@ Both `Error` and `Message` should be surfaced to the user when present. `Count`,
 
 ### Top-level node
 
-All responses are wrapped in `<QRZDatabase>`. Three child node types are defined:
+`<QRZDatabase>` contains all responses. It defines three child node types:
 
 - `<Session>` - always present
 - `<Callsign>` - present on successful callsign lookup
@@ -126,7 +126,7 @@ All responses are wrapped in `<QRZDatabase>`. Three child node types are defined
 
 ### Forward compatibility requirement
 
-QRZ may add new XML nodes or attributes at any time. The parser **must**:
+QRZ can add new XML nodes or attributes at any time. The parser **must**:
 
 - Parse in an "object=attribute" manner
 - Ignore unknown nodes and attributes without error
@@ -204,7 +204,7 @@ https://xmldata.qrz.com/xml/current/?s=<session_key>;callsign=<target>
 
 ### Complete callsign node fields
 
-Not all fields are returned with every request. Field ordering is arbitrary and subject to change.
+QRZ does not return all fields with each request. Field order can change.
 
 | Field | Description |
 |---|---|
@@ -255,7 +255,7 @@ Not all fields are returned with every request. Field ordering is arbitrary and 
 | `lotw` | Will accept LOTW (0/1 or blank if unknown) |
 | `iota` | IOTA designator (blank if unknown) |
 | `geoloc` | Source of lat/long data (see geolocation section) |
-| `attn` | Attention address line; prepend to address (v1.34+) |
+| `attn` | Attention address line. Prepend to address (v1.34+) |
 | `nickname` | A different or shortened name used on the air (v1.34+) |
 | `name_fmt` | Combined full name and nickname in QRZ display format (v1.34+, format subject to change) |
 
@@ -292,7 +292,7 @@ Nearly every callsign will include geographic coordinates, but accuracy varies s
 | `zip` | Derived from the callsign's USA zip code |
 | `state` | Derived from the callsign's USA state |
 | `dxcc` | Derived from the callsign's DXCC entity (country center) |
-| `none` | No value could be determined |
+| `none` | The lookup did not find a value. |
 
 **QsoRipper implementation note:** Surface the `geoloc` value as metadata so the UI or consumer can convey coordinate confidence. Do not treat all coordinates as equally precise.
 
@@ -319,7 +319,7 @@ The `dxcc=` parameter provides three lookup modes:
 | Input | Behavior |
 |---|---|
 | `dxcc=291` (numeric) | Return the DXCC entity record for entity 291 |
-| `dxcc=XX1XX` (callsign) | Reduce to 4, then 3, then 2-letter prefix; return first matching DXCC entity |
+| `dxcc=XX1XX` (callsign) | Reduce to 4, then 3, then 2-letter prefix. Return first matching DXCC entity |
 | `dxcc=all` (keyword) | Return the entire list of 380+ DXCC entities. **Use sparingly.** |
 
 ### Example request
@@ -375,7 +375,7 @@ https://xmldata.qrz.com/xml/current/?s=<session_key>;dxcc=291
 - Entities with IDs greater than 900 are unique to QRZ and not part of the standard DXCC list.
 - Lat/lon values represent the approximate geographic center of the entity.
 - Non-match failures return: `No DXCC information for: xxxx`
-- Cache the `dxcc=all` result locally and refresh infrequently; do not call it on every session.
+- Cache the `dxcc=all` result locally and refresh infrequently. Do not call it on every session.
 
 ---
 
@@ -400,7 +400,7 @@ Typically "item not found" responses. The session remains valid and `<Key>` is s
 
 ### 2) Session errors
 
-The session has expired or been invalidated. The `<Key>` field is **not returned**.
+The session expired, or QRZ invalidated it. The response does **not** contain the `<Key>` field.
 
 ```xml
 <?xml version="1.0" ?>
@@ -414,16 +414,16 @@ The session has expired or been invalidated. The `<Key>` field is **not returned
 
 ### Special error: "Connection refused"
 
-This error indicates service is refused for the user. **Successful login will not be possible for at least 24 hours.** No further details are provided.
+This error means QRZ refuses service for the user. **Login will fail for at least 24 hours.** QRZ supplies no more details.
 
 ### Error handling strategy for QsoRipper
 
 | Error class | Detection | QsoRipper behavior |
 |---|---|---|
-| Session timeout / invalid key | `<Error>` present AND `<Key>` absent | Re-authenticate immediately; retry the original request once |
-| Callsign not found | `<Error>` contains "Not found" AND `<Key>` present | Negative-cache with short TTL; do not retry |
-| Connection refused | `<Error>` is "Connection refused" | Back off for 24 hours; surface to user as config/account issue |
-| Password incorrect | `<Error>` contains auth failure text | Stop retries; surface as credential error |
+| Session timeout / invalid key | `<Error>` present AND `<Key>` absent | Re-authenticate immediately. Retry the original request once |
+| Callsign not found | `<Error>` contains "Not found" AND `<Key>` present | Negative-cache with short TTL. Do not retry |
+| Connection refused | `<Error>` is "Connection refused" | Back off for 24 hours. Surface to user as config/account issue |
+| Password incorrect | `<Error>` contains auth failure text | Stop retries. Surface as credential error |
 | Network / HTTP failure | No XML response at all | Bounded retries with timeout and jitter |
 
 In all cases, **never block the local QSO logging path** on lookup availability.
@@ -474,7 +474,7 @@ Use these environment variables (see `.env.example`):
 | `QSORIPPER_QRZ_XML_BASE_URL` | XML service base URL (default: `https://xmldata.qrz.com/xml/current/`) |
 | `QSORIPPER_QRZ_XML_USERNAME` | QRZ username for XML API login |
 | `QSORIPPER_QRZ_XML_PASSWORD` | QRZ password for XML API login |
-| `QSORIPPER_QRZ_USER_AGENT` | Agent string sent with requests (e.g. `QsoRipper/0.1.0`) |
+| `QSORIPPER_QRZ_USER_AGENT` | Agent string sent with requests (for example `QsoRipper/0.1.0`) |
 | `QSORIPPER_QRZ_HTTP_TIMEOUT_SECONDS` | HTTP request timeout |
 | `QSORIPPER_QRZ_MAX_RETRIES` | Maximum retry count for transient failures |
 

--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -1,6 +1,6 @@
 # QsoRipper Keyboard Shortcuts Reference
 
-All three QsoRipper surfaces — GUI (Avalonia), TUI (ratatui), and Win32 — share a
+All three QsoRipper surfaces - GUI (Avalonia), TUI (ratatui), and Win32 - share a
 keyboard-first design philosophy. This document is the authoritative reference for
 shortcuts across surfaces.
 
@@ -19,39 +19,39 @@ shortcuts across surfaces.
 
 | Action | GUI | TUI | Win32 | Notes |
 |---|---|---|---|---|
-| Log QSO | Ctrl+Enter or F10 | F10 or Alt+Enter | F10 or Shift+Enter or Alt+Enter | F10 is shared across all; GUI adds Ctrl+Enter |
+| Log QSO | Ctrl+Enter or F10 | F10 or Alt+Enter | F10 or Shift+Enter or Alt+Enter | F10 is shared across all. GUI adds Ctrl+Enter |
 | Reset QSO timer | F7 | F7 | F7 | Consistent across all surfaces |
 | Cycle band | ←/→ on band button | ←/→ in band field | ←/→ in band field | Same gesture, different control types |
 | Cycle mode | ←/→ on mode button | ←/→ in mode field | ←/→ in mode field | Same gesture, different control types |
 | Jump to callsign | Alt+C | Alt+C | Alt+C | Consistent across all surfaces |
 | Jump to band | Alt+B | Alt+B | Alt+B | Consistent across all surfaces |
 | Jump to mode | Alt+M | Alt+M | Alt+M | Consistent across all surfaces |
-| Open QSO Card | Alt+A or Ctrl+L | — | — | GUI only (overlay form); TUI/Win32 show fields inline |
+| Open QSO Card | Alt+A or Ctrl+L | - | - | GUI only (overlay form). TUI/Win32 show fields inline |
 
 ## Grid / QSO List
 
 | Action | GUI | TUI | Win32 | Notes |
 |---|---|---|---|---|
-| Edit selected cell | F2 | — | — | GUI only (DataGrid inline edit) |
-| Save pending edits | Ctrl+S | — | — | GUI only (commit grid edits) |
+| Edit selected cell | F2 | - | - | GUI only (DataGrid inline edit) |
+| Save pending edits | Ctrl+S | - | - | GUI only (commit grid edits) |
 | Delete selected QSO | Ctrl+D or Delete | D or Delete | D or Delete | GUI requires Ctrl+D or Delete key |
-| Refresh | F5 | — | — | GUI only |
-| Callsign lookup card | F8 | — | — | GUI only (side panel with QRZ data) |
-| Toggle inspector | Alt+Enter | — | — | GUI only (detail panel) |
-| Zoom in | Ctrl++ | — | — | GUI only |
-| Zoom out | Ctrl+- | — | — | GUI only |
-| Reset zoom | Ctrl+0 | — | — | GUI only |
+| Refresh | F5 | - | - | GUI only |
+| Callsign lookup card | F8 | - | - | GUI only (side panel with QRZ data) |
+| Toggle inspector | Alt+Enter | - | - | GUI only (detail panel) |
+| Zoom in | Ctrl++ | - | - | GUI only |
+| Zoom out | Ctrl+- | - | - | GUI only |
+| Reset zoom | Ctrl+0 | - | - | GUI only |
 
 ## System
 
 | Action | GUI | TUI | Win32 | Notes |
 |---|---|---|---|---|
-| Sync with QRZ | F6 | — | — | GUI only |
+| Sync with QRZ | F6 | - | - | GUI only |
 | Toggle rig control | Ctrl+R | F8 | F8 | Different key: GUI uses Ctrl+R, TUI/Win32 use F8 |
-| Toggle space weather | Ctrl+W | — | — | GUI only |
-| Settings | Ctrl+, | — | — | GUI only (dialog) |
-| Sort chooser | Ctrl+Shift+S | — | — | GUI only |
-| Column chooser | Ctrl+H | — | — | GUI only |
+| Toggle space weather | Ctrl+W | - | - | GUI only |
+| Settings | Ctrl+, | - | - | GUI only (dialog) |
+| Sort chooser | Ctrl+Shift+S | - | - | GUI only |
+| Column chooser | Ctrl+H | - | - | GUI only |
 
 ## QSO Card (GUI only)
 
@@ -75,22 +75,22 @@ shortcuts across surfaces.
 
 ## Surface-Specific Differences
 
-### F2 — Edit Cell (GUI) vs Toggle Advanced (TUI/Win32)
+### F2 - Edit Cell (GUI) vs Toggle Advanced (TUI/Win32)
 In TUI and Win32, F2 toggles between the basic and advanced log form views.
 The GUI uses F2 for DataGrid cell editing because the advanced form is a
 separate overlay (Alt+A). This is an intentional divergence.
 
-### F5/F6 — Refresh/Sync (GUI) vs Advanced Tabs (TUI/Win32)
+### F5/F6 - Refresh/Sync (GUI) vs Advanced Tabs (TUI/Win32)
 In TUI and Win32, F5/F6 cycle between advanced form tabs. The GUI uses F5
 for grid refresh and F6 for QRZ sync. The QSO card uses Ctrl+Tab and Alt+1..6
 for tab switching instead.
 
-### F8 — Callsign Card (GUI) vs Rig Toggle (TUI/Win32)
+### F8 - Callsign Card (GUI) vs Rig Toggle (TUI/Win32)
 In TUI and Win32, F8 toggles rig control. The GUI uses F8 for the callsign
 lookup card and Ctrl+R for rig control. This gives the GUI a dedicated key
 for the frequently-used callsign lookup without losing rig control access.
 
-### Alt+Enter — Inspector (GUI) vs Log QSO (TUI/Win32)
+### Alt+Enter - Inspector (GUI) vs Log QSO (TUI/Win32)
 In TUI and Win32, Alt+Enter logs or updates a QSO. The GUI uses Alt+Enter
 for the QSO inspector panel and Ctrl+Enter/F10 for logging. This avoids
 conflict with the menu access key system where Alt activates the menu bar.
@@ -108,11 +108,11 @@ based on the current focus area:
 | Search | Esc clear · Enter search · F3 grid · Ctrl+N logger |
 
 ### Inline Shortcut Hints (GUI)
-Toolbar buttons show their keyboard shortcuts directly on the button face
-(e.g. "Sort Ctrl+⇧+S", "Cols Ctrl+H", "⟳ Sync F6") so they are discoverable
-without hovering for tooltips.
+Toolbar buttons show their keyboard shortcuts on the button face.
+Examples include "Sort Ctrl+Shift+S", "Cols Ctrl+H", and "Sync F6".
+Users do not have to point at a button to find its shortcut.
 
 ### Post-Log Focus Return (GUI)
-After logging a QSO with F10 or Ctrl+Enter, the GUI automatically clears the
-form and returns focus to the callsign field for immediate next-contact entry.
+After you log a QSO with F10 or Ctrl+Enter, the GUI clears the form.
+It returns focus to the callsign field for the next contact.
 This matches the TUI behavior for rapid contest logging.

--- a/experiments/cathub-frequency-probe-native/README.md
+++ b/experiments/cathub-frequency-probe-native/README.md
@@ -2,7 +2,11 @@
 
 Native C++/Win32 diagnostic app for fast-launch CAT latency testing.
 
-This is a no-.NET sibling of `experiments\cathub-frequency-probe`. It talks directly to cathub's rigctld-compatible endpoint at `127.0.0.1:4532` over Winsock, polls `f`, `m`, and `v` every 100 ms, and displays a large amber TS-590-style frequency readout.
+This application is the native version of `experiments\cathub-frequency-probe`.
+It uses Winsock to connect directly to CatHub at `127.0.0.1:4532`.
+This endpoint is compatible with `rigctld`.
+The application polls `f`, `m`, and `v` every 100 ms.
+It shows the frequency in a large amber TS-590-style display.
 
 It also loads `qsoripper_ffi.dll` beside the executable and uses the existing Rust FFI shim to call the engine gRPC `GetRigSnapshot` path at `http://127.0.0.1:50051`. That keeps the native probe aligned with the C# WinUI probe's direct cathub vs engine skew comparison without adding a C++ gRPC stack.
 
@@ -12,7 +16,11 @@ Build from the repository root:
 .\build.ps1 cathub-probe-native
 ```
 
-The probe is opt-in and is not part of the default `.\build.ps1` flow. Running the standalone command expects `src\rust\target\release\qsoripper_ffi.dll` to already exist for engine skew; if it is missing, the direct cathub display still works but `ENGINE SKEW` reports `ERR`.
+The probe is optional.
+The default `.\build.ps1` flow does not build it.
+The standalone command uses `src\rust\target\release\qsoripper_ffi.dll` for engine skew.
+If the DLL is absent, the direct CatHub display continues to work.
+In this condition, `ENGINE SKEW` reports `ERR`.
 
 Run:
 
@@ -26,4 +34,4 @@ Diagnostic log:
 %LOCALAPPDATA%\qsoripper\cathub-frequency-probe-native.log
 ```
 
-The `ENGINE SKEW` tile is `engine_frequency_hz - direct_cathub_frequency_hz`. `0 Hz` means the engine and cathub agree; a persistent non-zero value means the engine/UI path is behind or ahead of live cathub state.
+The `ENGINE SKEW` tile is `engine_frequency_hz - direct_cathub_frequency_hz`. `0 Hz` means the engine and cathub agree. A persistent non-zero value means the engine/UI path is behind or ahead of live cathub state.

--- a/experiments/cathub-frequency-probe/README.md
+++ b/experiments/cathub-frequency-probe/README.md
@@ -2,7 +2,11 @@
 
 Single-purpose WinUI 3 diagnostic app for CAT latency testing.
 
-The app bypasses the normal QsoRipper UI update paths. It opens one persistent TCP connection to cathub's rigctld-compatible endpoint at `127.0.0.1:4532`, polls `f`, `m`, and `v` every 100 ms, and also polls the engine's gRPC `GetRigSnapshot` endpoint at `http://127.0.0.1:50051`.
+The application does not use the normal QsoRipper UI update paths.
+It opens one persistent TCP connection to the CatHub endpoint at `127.0.0.1:4532`.
+This endpoint is compatible with `rigctld`.
+The application polls `f`, `m`, and `v` every 100 ms.
+It also polls the engine `GetRigSnapshot` endpoint at `http://127.0.0.1:50051`.
 
 It displays the live direct cathub frequency, VFO, mode, query time, detected frequency-change gap, and engine skew. Engine skew is `engine_frequency_hz - direct_cathub_frequency_hz`.
 

--- a/experiments/cw-decoder/EXPERIMENT_REPORT.md
+++ b/experiments/cw-decoder/EXPERIMENT_REPORT.md
@@ -1,4 +1,4 @@
-# CW Decoder — Adversarial Synthetic Test Suites
+# CW Decoder - Adversarial Synthetic Test Suites
 
 **Branch:** `u/randy/cw-adversarial-suite`
 **Base SHA:** `bc4580e`
@@ -6,13 +6,13 @@
 
 This experiment replaces the 6-sample smoke bench with **8 synthetic
 adversarial suites × 20 examples = 160 deterministic examples**, each
-targeting a specific decoder failure mode. We evaluate the current
-baseline `cw-decoder.exe` (built from `bc4580e`, no source change) on
-every suite and additionally cross-check against the `viterbi` branch
-binary that happened to already be built locally.
+targeting a specific decoder failure mode.
+We evaluate the current baseline `cw-decoder.exe` on every suite.
+The binary was built from `bc4580e` without a source change.
+We also compare it with the locally available `viterbi` branch binary.
 
 All audio is regeneratable bit-exactly from a fixed seed
-(`SEED_BASE = 0xC0DEC0DE`). WAVs are not committed; only the
+(`SEED_BASE = 0xC0DEC0DE`). WAVs are not committed. Only the
 manifest + scripts.
 
 ## Files
@@ -24,18 +24,18 @@ manifest + scripts.
 | `experiments/cw-decoder/scripts/bench_adversarial.py` | Bench harness (CER/WER + element-level + suite-specific metrics) |
 | `experiments/cw-decoder/adversarial_report.json` | Baseline run (this branch) |
 | `experiments/cw-decoder/adversarial_report_viterbi.json` | Cross-comparison vs viterbi worktree binary |
-| `data/cw-samples/synthetic-adversarial/<suite>/*.wav` | Regenerated locally; gitignored |
+| `data/cw-samples/synthetic-adversarial/<suite>/*.wav` | Regenerated locally. Gitignored |
 
 ## Suite spec
 
 | Suite | n | Stresses | Generator notes |
 |---|---|---|---|
-| `weak-prefix` | 20 | First key-down events at -10 dB SNR, ramped back to clean over 600 ms | Linear amplitude ramp on the leading 600 ms of CW activity; rest is clean + 0.05 white noise floor |
-| `mid-region-collapse` | 20 | Middle of long region drops 12 dB for 2 s, then recovers | 50-ms raised-cosine edges on the gain notch; 0.04 white noise floor |
+| `weak-prefix` | 20 | First key-down events at -10 dB SNR, ramped back to clean over 600 ms | Linear amplitude ramp on the leading 600 ms of CW activity. Rest is clean + 0.05 white noise floor |
+| `mid-region-collapse` | 20 | Middle of long region drops 12 dB for 2 s, then recovers | 50-ms raised-cosine edges on the gain notch. 0.04 white noise floor |
 | `qrm-same-pitch` | 20 | Two stations at same pitch, secondary starts at 50% of primary, lower amplitude | Sum of two synth tracks at the same `pitch_hz`, primary 0.5 / secondary 0.35 |
 | `off-pitch-start` | 20 | ±100 Hz drift over first 1 s, stable after | True linear chirp via cumsum on instantaneous frequency |
-| `farnsworth-extremes` | 20 | Element WPM 30, character WPM 10 (slow Farnsworth) | Element-level dot duration uses 30 WPM; letter/word gaps stretched to 10 WPM |
-| `noise-only` | 20 | White or pink noise, no CW. Truth is empty. | 8–14 s of Voss-McCartney pink or Gaussian white at 0.08–0.15 amplitude |
+| `farnsworth-extremes` | 20 | Element WPM 30, character WPM 10 (slow Farnsworth) | Element-level dot duration uses 30 WPM. Letter/word gaps stretched to 10 WPM |
+| `noise-only` | 20 | White or pink noise, no CW. Truth is empty. | 8-14 s of Voss-McCartney pink or Gaussian white at 0.08-0.15 amplitude |
 | `slow-arrl-style` | 20 | Clean signals at 5 / 10 / 13 / 15 WPM (round-robin by index) | Standard timing, 0.025 white noise floor |
 | `fast-contest` | 20 | 35 / 40 / 45 WPM short contest exchanges | Standard timing, 0.025 white noise floor |
 
@@ -49,16 +49,16 @@ is sampled per-example from a small set near 600 Hz. Example content draws from
 |---|---:|---:|---:|---:|---|
 | `weak-prefix`         | 0.051 | 0.205 | 0.983 | 0.998 | first-1 survive 70%, first-2 30%, first-3 25%, **first-5 5%** |
 | `mid-region-collapse` | 0.040 | 0.077 | 0.963 | 1.000 | 0.0 ghost chars / s of -12 dB silence |
-| `qrm-same-pitch`      | 0.927 | 1.088 | 0.918 | 0.729 | — |
-| `off-pitch-start`     | 0.051 | 0.164 | 0.944 | 0.998 | — |
-| `farnsworth-extremes` | 0.790 | 1.352 | 0.362 | 0.650 | — |
+| `qrm-same-pitch`      | 0.927 | 1.088 | 0.918 | 0.729 | - |
+| `off-pitch-start`     | 0.051 | 0.164 | 0.944 | 0.998 | - |
+| `farnsworth-extremes` | 0.790 | 1.352 | 0.362 | 0.650 | - |
 | `noise-only`          | 0.000 | 0.000 | 1.000 | 1.000 | **fully empty 100%**, 0 ghost chars / s |
-| `slow-arrl-style`     | 0.213 | 0.438 | 0.888 | 0.951 | — |
-| `fast-contest`        | 0.000 | 0.000 | 1.000 | 1.000 | — |
+| `slow-arrl-style`     | 0.213 | 0.438 | 0.888 | 0.951 | - |
+| `fast-contest`        | 0.000 | 0.000 | 1.000 | 1.000 | - |
 | **Overall**           | **0.259** | **0.416** | **0.882** | **0.916** | |
 
-Element-level alignment uses Needleman–Wunsch on the dit/dah string of each
-text (gaps stripped). Element recall = matches / |truth elements|; element
+Element-level alignment uses Needleman-Wunsch on the dit/dah string of each
+text (gaps stripped). Element recall = matches / |truth elements|. Element
 precision = matches / |hypothesis elements|.
 
 ## Cross-comparison: viterbi worktree binary
@@ -71,61 +71,65 @@ Mostly identical to baseline, with **one notable regression**:
 | `mid-region-collapse` | 0.040 | **0.228** | +0.19 |
 | `mid-region-collapse` extra-chars-per-silence-s (mean / max) | 0.0 / 0.0 | **2.88 / 14.5** | viterbi cascades phantom chars during the drop |
 | `qrm-same-pitch` | 0.927 | 0.970 | +0.04 |
-| All other suites | — | — | within ±0.001 |
+| All other suites | - | - | within ±0.001 |
 
 This is the synthetic analog of the **aa6pw cascade** failure mode (phantom
 characters fanning out from a low-SNR region). The current branch's baseline
-does **not** exhibit it on synthetic input; viterbi does.
+does **not** exhibit it on synthetic input. Viterbi does.
 
 ## Specific findings the brief asked for
 
-1. **`weak-prefix` (WA6MOW analog)** — at -10 dB SNR ramped over 600 ms, the
-   first character of a callsign survives **70%** of the time, the first
-   two **30%**, the first three **25%**, and only **5%** of first-5 prefixes
-   survive intact. The decoder correctly emits the rest of the message
-   (overall CER is only 5.1%) but the prefix is consistently chewed off —
-   exactly the WA6MOW pattern.
+1. **`weak-prefix` (WA6MOW analog)**: The SNR increases from -10 dB during 600 ms.
+   The first character survives in **70%** of the samples.
+   The first two characters survive in **30%** of the samples.
+   The first three survive in **25%** of the samples.
+   Only **5%** of the first five characters survive without a change.
+   The decoder correctly emits the remainder of the message.
 
-2. **`mid-region-collapse` (aa6pw cascade analog)** — the current baseline
+   The total CER is only 5.1 percent.
+   However, the decoder consistently removes the prefix.
+   This behavior matches the WA6MOW pattern.
+
+2. **`mid-region-collapse` (aa6pw cascade analog)**: The current baseline
    produces **0.0 phantom characters per second** of -12 dB silence. The
-   region-isolated decoder is well-behaved here; cascades do not appear in
-   synthetic input at -12 dB. The viterbi binary on the other hand averages
-   **2.88 phantom chars/s** with peaks of **14.5**, so this suite cleanly
-   surfaces the cascade regression as soon as a candidate decoder is sloppy
-   about silence detection.
+   region-isolated decoder is well-behaved here. Cascades do not appear in
+   synthetic input at -12 dB.
+   The viterbi binary averages **2.88 phantom characters each second**.
+   Its peak is **14.5**.
+   Thus, this suite identifies the cascade regression when silence detection is not strict.
 
-3. **`noise-only` (hallucination check)** — the decoder is clean: **100% of
+3. **`noise-only` (hallucination check)** - the decoder is clean: **100% of
    noise-only inputs produce empty output** (0 ghost chars / s, mean and
    max). Any future decoder that loses this property will be caught on the
    first run.
 
-4. **`farnsworth-extremes`** — the worst suite by raw character recall:
+4. **`farnsworth-extremes`** - the worst suite by raw character recall:
    element recall drops to **0.362** (precision 0.650). The long word /
    letter gaps cause the region streamer to cut messages into fragments
    that the decoder either misreads or drops entirely. CER 0.79, WER 1.35.
 
-5. **`qrm-same-pitch`** — CER 0.93. Element recall is high (0.92) because
-   the truth's elements are physically present in the audio; element
+5. **`qrm-same-pitch`** - CER 0.93. Element recall is high (0.92) because
+   the truth's elements are physically present in the audio. Element
    precision drops (0.73) because the interferer adds extra elements that
    confuse character segmentation.
 
-6. **`fast-contest`** — perfect (CER 0).
+6. **`fast-contest`** - perfect (CER 0).
 
 ## Regression-gate guidance
 
 Suites suitable as **hard regression gates** (current baseline already
-passes; any regression here is a real bug):
+passes. Any regression here is a real bug):
 
 | Suite | Suggested gate |
 |---|---|
 | `noise-only` | `mean_ghost_chars_per_s == 0.0` AND `fully_empty_rate == 1.0` |
 | `fast-contest` | `mean_cer == 0.0` |
-| `mid-region-collapse` | `max_extra_chars_per_silence_s ≤ 0.5` (would have caught the viterbi regression) |
+| `mid-region-collapse` | `max_extra_chars_per_silence_s ≤ 0.5` (detects the viterbi regression) |
 | `weak-prefix` overall | `mean_cer ≤ 0.10` |
 | `off-pitch-start` | `mean_cer ≤ 0.10` |
 
 Suites suitable as **soft regression gates** (track over time, expect
-improvement, large absolute swings should block merge):
+improvement, large absolute changes must block a merge):
 
 | Suite | Current baseline | Notes |
 |---|---:|---|
@@ -155,5 +159,5 @@ python experiments\cw-decoder\scripts\bench_adversarial.py `
     --out experiments\cw-decoder\adversarial_report_other.json
 ```
 
-The 6-sample bench at the worktree root remains as a smoke test; this
+The 6-sample bench at the worktree root remains as a smoke test. This
 adversarial suite becomes the success criterion for Round 4+ work.

--- a/experiments/cw-decoder/README.md
+++ b/experiments/cw-decoder/README.md
@@ -1,76 +1,71 @@
 # CW Decoder Experiment
 
-This folder is the current sandbox for improving QsoRipper CW decoding on real off-air audio.
+This folder contains experiments that improve QsoRipper CW decoding for real off-air audio.
 
-The project has converged on two parallel goals:
+The project has two goals:
 
-1. keep a **simple append-only event-stream foundation** that behaves like what the operator actually hears and sees, and
-2. layer more ambitious signal-processing experiments on top without allowing them to regress that foundation.
+1. Keep a **simple append-only event-stream foundation** that agrees with the audio and visual output.
+2. Add signal-processing experiments without a regression in that foundation.
 
-The current breakthrough is that the best live behavior did **not** come from rolling transcript windows, overlap stitching, or commit heuristics. It came from consuming the same stable dit/dah/gap event stream that paints the Visualizer bars and appending each matured event once in audio order. That path is now the "line in the sand": Decode, Labeling, Tuning, Bench, and Visualizer should all key off it first, while experimental decoders are compared against it rather than silently replacing it.
+Rolling transcript windows, overlap stitching, and commit heuristics did **not** give the best live behavior.
+
+The best path consumes the stable dit/dah/gap event stream that paints the Visualizer bars. It appends each mature event once in audio order.
+
+This path is the reference baseline. Decode, Labeling, Tuning, Bench, and Visualizer use it first. Tests compare experimental decoders with it.
 
 > **Foundational baseline (May 2026): region-isolated streaming transcript.**
 >
-> A full QEX-style technical write-up of this baseline (architecture,
-> design rationale, results, and future directions) lives at
+> A full QEX-style technical article about this baseline is available at
 > [`docs/cw-decoder-architecture.html`](docs/cw-decoder-architecture.html).
-> Open it in any browser for the rendered article; it is the canonical
-> reference for the architecture summarized here.
+> The article describes the architecture, design reasons, results, and future work.
+> Open it in a browser. It is the primary reference for this architecture.
 >
-> The append-only event-stream foundation is excellent for *driving the
-> visualizer* (waveform, lock state, pitch, WPM, classified events). But
-> for the **transcript** itself, real-world QSO audio with multiple
-> bursts at very different WPMs separated by background static (operator
-> pauses, TX/RX cycles, ragchew vs contest mixes) needs a different
-> decoder shape: detect each burst as a region, decode each region
-> independently with its own pitch/WPM/k-means lock, and append the
-> region's text once it has been stable for a trailing-static window.
+> The append-only event stream drives the visualizer. It supplies the waveform, lock state, pitch, WPM, and classified events.
 >
-> The reference implementation lives in
-> `src\region_streamer.rs` (`RegionStreamer`) and
-> `src\region_stream.rs` (`decode_region_stream`). It is exposed three
-> ways:
+> Real QSO audio can contain several bursts at different speeds. Background static can separate operator pauses, TX/RX cycles, and different QSO types.
 >
-> - **Batch mode** — `cw-decoder stream-region --file <path>` — runs
->   region detection over the entire file and emits one transcript per
->   region. This is the canonical reference output.
-> - **Live streaming** — `cw-decoder stream-live-v3 --region-transcript`
->   — runs `RegionStreamer` *alongside* the V3 envelope streamer. The
->   envelope path keeps driving viz events; only the cumulative
->   `transcript` field on emitted `text` / `appended` / `end` events is
->   sourced from region-isolated decode. `RegionStreamer::trim_committed`
->   bounds memory growth in long live sessions and `RegionStreamer::reset`
->   honors stdin-control `ResetLock` requests cleanly without restarting
->   the process.
-> - **Both UI surfaces wire `--region-transcript`** by default:
->   - Production logger GUI (F7 live mic) —
+> The transcript path detects each burst as a region. It decodes each region with an independent pitch, WPM, and k-means lock.
+>
+> It appends the region text after the text is stable for a trailing-static window.
+>
+> The reference implementation is in `src\region_streamer.rs` (`RegionStreamer`) and `src\region_stream.rs` (`decode_region_stream`).
+> Three interfaces expose it:
+>
+> - **Batch mode:** `cw-decoder stream-region --file <path>` detects regions in the complete file.
+>   It emits one transcript for each region. This output is the reference output.
+> - **Live streaming:** `cw-decoder stream-live-v3 --region-transcript` runs `RegionStreamer` with the V3 envelope streamer.
+>   The envelope path continues to supply visualizer events.
+>   Region decode supplies only the cumulative `transcript` field on `text`, `appended`, and `end` events.
+>   `RegionStreamer::trim_committed` limits memory use in long sessions.
+>   `RegionStreamer::reset` processes stdin-control `ResetLock` requests without a process restart.
+> - **User interfaces:** Both interfaces use `--region-transcript` by default:
+>   - Production logger GUI (F7 live microphone):
 >     `src\dotnet\QsoRipper.Gui\Services\CwDecoderProcessSampleSource.cs`
->   - Experimental CW visualizer GUI (live mic + file replay) —
+>   - Experimental CW visualizer GUI (live microphone and file replay):
 >     `experiments\cw-decoder\gui\Services\CwDecoderProcess.cs`
 >
-> **Reference success metric.** This baseline produces a 100% exact-match
-> transcript for the multi-burst real-world sample
-> `cw-samples\training-set-b\radio-20260502-105714.mp3` (truth file
-> `radio-20260502-105714.truth.txt`):
+> **Reference success metric.** This baseline gives a 100% exact-match transcript for this real multi-burst sample:
+> `cw-samples\training-set-b\radio-20260502-105714.mp3`.
+>
+> The truth file is `radio-20260502-105714.truth.txt`.
 >
 > ```text
 > IHU NVCHU 7QP W7N 7QP W7N
 > ```
 >
-> Both `stream-region` (batch) and `stream-live-v3 --region-transcript`
-> (live streaming) produce that exact string with the default
-> `RegionStreamerConfig::default()` config (merge_gap=0.5s,
-> min_region=0.3s, threshold_factor=0.30, pad=0.15s,
-> min_tonal_prominence_ratio=8.0, stable_latency=0.6s) and
-> `--decode-every-ms 250`.
+> Both `stream-region` and `stream-live-v3 --region-transcript` give that exact text with `RegionStreamerConfig::default()`.
+> The configuration is `merge_gap=0.5s`, `min_region=0.3s`, `threshold_factor=0.30`, `pad=0.15s`, `min_tonal_prominence_ratio=8.0`, and `stable_latency=0.6s`.
+> The command also uses `--decode-every-ms 250`.
 >
-> The baseline now also includes deterministic synthetic impairment
-> coverage in `region_streamer.rs`: clean four-burst copy, quiet static
-> gaps, noise-only no-ghost-text, and a moderate white-noise + QSB +
-> offset-QRM exchange (`CQ TEST KC7AVA 73`). `synthetic_qso.rs` also
-> carries regression coverage for the live-CQ failure mode where an
-> isolated final over marker `K` (`-.-`) was auto-calibrated as `S`
-> (`...`) when it was decoded as its own short region.
+> `region_streamer.rs` includes deterministic synthetic impairment tests:
+>
+> - a clean four-burst copy
+> - quiet static gaps
+> - noise without ghost text
+> - moderate white noise, QSB, and offset QRM for `CQ TEST KC7AVA 73`
+>
+> `synthetic_qso.rs` includes a regression test for an isolated final over marker.
+> Previously, the decoder calibrated `K` (`-.-`) as `S` (`...`) in a short independent region.
 >
 > For broader QSO-debug traffic, use the synthetic suite generator:
 >
@@ -79,28 +74,27 @@ The current breakthrough is that the best live behavior did **not** come from ro
 >   gen-qso-suite --output .artifacts\cw-qso-suite --ragchew 6 --contest 6
 > ```
 >
-> The generator emits deterministic ragchew and contest WAVs, `.truth.txt`
-> sidecars, and `manifest.ndjson`, then validates each sample through the
-> region decoder. Use `--require-exact` when you want CI-style non-zero
-> exit on any transcript mismatch; leave it off for exploratory debugging
-> runs where failures are the point.
+> The generator creates deterministic ragchew and contest WAV files.
+> It also creates `.truth.txt` sidecars and `manifest.ndjson`.
+> It then validates each sample with the region decoder.
 >
-> **Multi-pitch burst discovery (June 2026).** The pitch-routing front
-> end of `decode_region_stream` was upgraded from a whole-buffer mean-
-> Goertzel sweep to a hybrid windowed/mean approach in
-> `region_stream::discover_burst_pitches`. The whole-buffer mean smears
-> long-form ragchew turns at distinct pitches into one artifact peak;
-> the windowed source (10 s window, 5 s hop, with a noise-floor
-> confidence gate) surfaces each turn's pitch independently. The mean
-> source still runs alongside to preserve dense-cluster contest cases.
-> The combined synthetic suite now scores 12/12 exact copy (was 6/12);
-> validated through both `decode_region_stream` (batch) and
-> `RegionStreamer` (live streaming) paths at 12/16/48 kHz sample rates.
+> Use `--require-exact` to get a nonzero exit code for a transcript mismatch.
+> Do not use it for exploratory tests that intentionally find failures.
 >
-> **Future experiments must not regress this baseline.** Before merging
-> any change that touches `region_streamer.rs`, `region_stream.rs`,
-> `stream-live-v3`, the GUI launchers, or the underlying decoder
-> primitives, re-run the cross-validation:
+> **Multi-pitch burst discovery (June 2026).** `region_stream::discover_burst_pitches` now uses both windowed and mean Goertzel sweeps.
+>
+> A whole-buffer mean can merge long ragchew turns at different pitches into one false peak.
+> The windowed source finds each turn independently. It uses a 10-second window, a 5-second hop, and a noise-floor confidence gate.
+>
+> The mean source continues to support contest audio with dense pitch groups.
+> The combined synthetic suite now gives 12/12 exact copies. The earlier result was 6/12.
+>
+> Tests covered `decode_region_stream` and `RegionStreamer` at 12 kHz, 16 kHz, and 48 kHz.
+>
+> **Future experiments must not regress this baseline.**
+> Run this cross-validation before you merge a related change.
+>
+> This requirement applies to `region_streamer.rs`, `region_stream.rs`, `stream-live-v3`, GUI launchers, and decoder primitives.
 >
 > ```powershell
 > cd C:\Users\randy\Git\qsoripper
@@ -115,75 +109,80 @@ The current breakthrough is that the best live behavior did **not** come from ro
 > cargo test --manifest-path experiments\cw-decoder\Cargo.toml region_streamer::tests::synthetic
 > ```
 >
-> If you need to roll back to this baseline at any point, the reference
-> commits are PR #375 (region-based streaming decoder, batch path) and
-> PR #376 (live streaming + GUI wiring) on branch
-> `u/randy/region-based-streaming-cw`.
+> For rollback, use the commits from PR #375 and PR #376.
+> PR #375 added the region-based batch decoder. PR #376 added live streaming and GUI integration.
 >
-> The append-only event-stream foundation in `append_decode.rs` is
-> still the source of truth for the visualizer's bar painting and for
-> the `cw_decode_rx_wpm` aggregator that feeds the production logger;
-> region-isolated decode supplements it for transcript text only.
+> The reference branch is `u/randy/region-based-streaming-cw`.
+>
+> The append-only event stream in `append_decode.rs` remains the source for visualizer bars.
+> It also supplies the `cw_decode_rx_wpm` aggregator for the production logger.
+> Region-isolated decode supplies only transcript text.
 
-> **Integration status (round 1, issue #321)**: the production GUI now hosts the
-> `cw-decoder` binary as a subprocess and auto-fills `QsoRecord.cw_decode_rx_wpm`
-> on logged CW QSOs (time-weighted mean over the QSO start/end window, ADIF
-> field `APP_QSORIPPER_RX_WPM`). See
-> `src\dotnet\QsoRipper.Gui\Services\CwDecoderProcessSampleSource.cs`,
-> `src\dotnet\QsoRipper.Gui\Services\CwQsoWpmAggregator.cs`, and the
-> **Settings → Display → Monitor radio** section in the main window.
-> Round 2 will move the decoder behind an engine-side `CwDecodeService`
-> so all clients can consume the same stream.
+> **Integration status (round 1, issue #321).** The production GUI runs `cw-decoder` as a subprocess.
+> It automatically sets `QsoRecord.cw_decode_rx_wpm` on logged CW QSOs.
+> The value is a time-weighted mean for the QSO start and end window.
+> The ADIF field is `APP_QSORIPPER_RX_WPM`.
 >
-> **Fresh-user prerequisites for the radio monitor to do anything:**
+> See `src\dotnet\QsoRipper.Gui\Services\CwDecoderProcessSampleSource.cs` and `src\dotnet\QsoRipper.Gui\Services\CwQsoWpmAggregator.cs`.
+> Also see **Settings > Display > Monitor radio** in the main window.
 >
-> 1. Build the decoder once: from `experiments\cw-decoder\` run
->    `cargo build --release` (this folder is a stand-alone Cargo workspace and
->    is **not** built by the main `cargo build` in `src\rust\`). Built outputs
->    land in `experiments\cw-decoder\target\release\cw-decoder.exe`.
-> 2. Either leave the binary at that default location (the GUI walks up from
->    its base directory looking for it) or set the `CW_DECODER_EXE` env var to
->    an absolute path.
-> 3. Allow the application access to a capture device. The decoder uses the
->    OS default capture device unless you pick a specific one in the dropdown.
-> 4. Open **Settings → Display** in the GUI and tick *Enable radio monitor
->    (auto-fills CW WPM on logged QSOs)*. Pick a capture device from the
->    dropdown — physical inputs (microphones, USB Audio CODEC dongles) appear
->    as plain device names; system output devices that can be tapped via
->    WASAPI loopback appear with a `(system output / loopback)` suffix so you
->    can validate without a radio by playing audio through your speakers.
->    Save. Optionally tick *Show CW WPM in the status bar* (toggle live with
->    `Ctrl+Shift+W`) to see the live WPM readout, which dims when the monitor
->    is off as a reminder. If the decoder gets "stuck" on a wrong baseline
->    (e.g. a slow station hands off to a fast one and the dot/dash estimator
->    doesn't follow), press `Ctrl+Alt+W` to restart the decoder process and
->    let the confidence state machine re-acquire from scratch.
+> Round 2 will put the decoder behind an engine-side `CwDecodeService`.
+> All clients will then use the same stream.
 >
-> If the binary cannot be found, the monitor toggle silently flips back off
-> and the status row reports `CW WPM: decoder not built`. If the binary is
-> found but launching fails (e.g. cpal cannot open the capture device), the
-> status row reports the underlying error and the toggle flips off.
+> **Radio monitor prerequisites:**
 >
-> **Validating the GUI without a radio (loopback / file playback):**
+> 1. Go to `experiments\cw-decoder\`.
+> 2. Run `cargo build --release`.
+> 3. Keep the binary at `experiments\cw-decoder\target\release\cw-decoder.exe`.
+>    Alternatively, set `CW_DECODER_EXE` to an absolute path.
+> 4. Permit the application to use a capture device.
+> 5. Open **Settings > Display**.
+> 6. Select *Enable radio monitor (auto-fills CW WPM on logged QSOs)*.
+> 7. Select a capture device.
+> 8. Save the settings.
 >
-> 1. Build the decoder (`cargo build --release` in `experiments\cw-decoder`).
-> 2. Open **Settings → Display → Monitor radio**, enable the monitor, and
->    pick a `(system output / loopback)` entry from the *Capture device*
->    dropdown — for example *Speakers (Realtek)  (system output / loopback)*.
->    The dropdown auto-detects the loopback case so you don't need to know
->    the underlying WASAPI plumbing.
-> 3. Play a CW practice clip through your speakers. The status row (when
->    enabled with `Ctrl+Shift+W`) reports a live WPM.
-> 4. Cross-platform alternative: install VB-Audio Cable or similar, route
->    system output to the cable, and pick the cable's *input* entry from the
->    dropdown (the plain non-loopback variant).
-> 5. List candidate device names from the command line with
->    `experiments\cw-decoder\target\release\cw-decoder.exe devices` (add
->    `--json` for machine-readable output that mirrors the GUI dropdown) —
->    this prints both input devices and the output devices that are usable
->    as loopback targets.
-> 6. Log a CW QSO during playback and confirm `cw_decode_rx_wpm` is
->    populated on the new row in the recent-QSO grid.
+> This folder is an independent Cargo workspace. The main `cargo build` in `src\rust\` does not build it.
+>
+> The GUI searches parent directories for the default binary.
+> The decoder uses the default operating-system capture device unless you select another device.
+>
+> Physical inputs have normal device names.
+> WASAPI loopback outputs have the suffix `(system output / loopback)`.
+> Use a loopback output to test with audio from the speakers.
+>
+> Select *Show CW WPM in the status bar* to see the live WPM value.
+> Use `Ctrl+Shift+W` to change this option.
+> The value becomes dim when the monitor is off.
+>
+> Use `Ctrl+Alt+W` if the decoder does not follow a large speed change.
+> This command restarts the decoder and resets its confidence state.
+>
+> If the GUI cannot find the binary, it clears the monitor option.
+> The status row shows `CW WPM: decoder not built`.
+>
+> If launch fails, the status row shows the error and clears the option.
+> For example, cpal can fail to open the capture device.
+>
+> **Validate the GUI without a radio:**
+>
+> 1. Build the decoder in `experiments\cw-decoder` with `cargo build --release`.
+> 2. Open **Settings > Display > Monitor radio**.
+> 3. Enable the monitor.
+> 4. Select a `(system output / loopback)` capture device.
+>    For example, select *Speakers (Realtek) (system output / loopback)*.
+> 5. Play a CW practice clip through the speakers.
+> 6. Use `Ctrl+Shift+W` to show the live WPM value.
+> 7. Log a CW QSO during playback.
+> 8. Confirm that the recent-QSO row contains `cw_decode_rx_wpm`.
+>
+> The GUI detects WASAPI loopback devices automatically.
+>
+> For a cross-platform option, install VB-Audio Cable or equivalent software.
+> Route system output to the cable. Select the cable input in the capture-device list.
+>
+> Run `experiments\cw-decoder\target\release\cw-decoder.exe devices` to list candidate devices.
+> Add `--json` for machine-readable output.
+> The output includes input devices and output devices that support loopback.
 
 ## Current architecture
 
@@ -194,28 +193,73 @@ The current breakthrough is that the best live behavior did **not** come from ro
 Main experiment executable. It currently exposes several surfaces:
 
 - **Offline decode**
-  - `file` — single-pass or sliding-window whole-file decode through `ditdah`
+  - `file` - single-pass or sliding-window whole-file decode through `ditdah`
 - **Live capture**
-  - `devices` — list available CPAL input devices (add `--json` for machine-readable output that includes both inputs and loopback-capable outputs)
-  - `live` — TUI-driven capture + rolling-window `ditdah` decode (legacy interactive surface)
+  - `devices` - list available CPAL input devices (add `--json` for machine-readable output that includes both inputs and loopback-capable outputs)
+  - `live` - TUI-driven capture + rolling-window `ditdah` decode (legacy interactive surface)
 - **Custom streaming decoder**
-  - `stream-file` — file-driven streaming decode with optional NDJSON event output and live `--stdin-control` config updates
-  - `stream-live` — live capture through the streaming Goertzel decoder, with optional `--record` WAV mirror and `--stdin-control`
-  - `stream-live-v2` — whole-growing-buffer `ditdah` replay. This was a valuable intermediate reference because it proved that re-decoding the whole accumulated buffer and replacing the displayed transcript was far better than sliding-window `ditdah` stitching. It is no longer the GUI default, but remains useful for A/B comparison.
-  - `stream-live-v3` — **current GUI foundation.** In-house envelope decoder that drives Decode, Labeling, Tuning, Bench, and the **VISUALIZER** tab. Goertzel envelope → percentile-based noise/signal floors → hysteresis state machine → k-means dot/dah classifier. Emits NDJSON `viz` frames (envelope curve, noise/signal floors, hysteresis bands, classified events, on-duration histogram, k-means centroids, current/locked WPM, SNR) so the operator can *see* exactly what the decoder is reacting to. Its transcript is produced by the append-only event-stream decoder in `src\append_decode.rs`: each matured `on_dit`, `on_dah`, `off_char`, and `off_word` bar is consumed once in sample-time order, appended to a raw Morse stream (`.` / `-` / `/` / `//`), and decoded into a single growing text line with real spaces for word gaps. Optional `--pin-wpm` (hard-pins the streamer's `locked_wpm` so the first decode honors the operator), `--pin-hz` (bypasses the auto pitch detector when it locks onto a noise/harmonic peak), and `--min-snr-db` (default 6.0; below this floor the decoder still emits viz frames but suppresses text — kills the "noise-locked dit-spam" failure mode where the auto-pitch detector locks onto a high-tone harmonic). The streamer also enforces a default dynamic-range bimodality gate (`(signal_floor - noise_floor) / envelope_max >= 0.55`) which catches high-variance noise that sneaks past the SNR ratio gate. When either gate fires the visualizer overlays a red `LOW SNR` badge so the suppression is visible. Live captures auto-save to `experiments\cw-decoder\captures\viz-yyyyMMdd-HHmmss.wav` for later labeling. For file replay, `stream-live-v3 --file --play` clocks decoder feeding from the output playback cursor so the bars/transcript stay aligned with the audio instead of drifting in a separate process.
+  - `stream-file` - file-driven streaming decode with optional NDJSON event output and live `--stdin-control` config updates
+  - `stream-live` - live capture through the streaming Goertzel decoder, with optional `--record` WAV mirror and `--stdin-control`
+  - `stream-live-v2` - whole-growing-buffer `ditdah` replay.
+    This reference showed that complete-buffer decode was better than sliding-window transcript stitching.
+    It is not the GUI default, but it remains useful for A/B tests.
+  - `stream-live-v3` - **current GUI foundation.**
+    This in-house envelope decoder drives Decode, Labeling, Tuning, Bench, and the **VISUALIZER** tab.
+    Its stages are Goertzel envelope, percentile floors, hysteresis, and k-means dot/dah classification.
+    It emits NDJSON `viz` frames for these values:
+    - envelope curve
+    - noise and signal floors
+    - hysteresis bands
+    - classified events
+    - on-duration histogram
+    - k-means centroids
+    - current and locked WPM
+    - SNR
+    The operator can use these values to examine decoder operation.
+    The append-only decoder in `src\append_decode.rs` supplies the transcript.
+    It consumes each mature `on_dit`, `on_dah`, `off_char`, and `off_word` bar once.
+    It appends the bars to a raw Morse stream in sample-time order.
+    The raw stream uses `.`, `-`, `/`, and `//`.
+
+    Decode produces one growing text line with spaces for word gaps.
+    `--pin-wpm` fixes the initial `locked_wpm` to the operator value.
+    `--pin-hz` bypasses automatic pitch detection.
+    Use it when the detector selects noise or a harmonic.
+    `--min-snr-db` has a default value of 6.0.
+
+    Below this value, the decoder emits visualizer frames but suppresses text.
+    This control stops noise-locked dit spam from a high-tone harmonic.
+    A dynamic-range bimodality gate also rejects high-variance noise.
+    Its default expression is `(signal_floor - noise_floor) / envelope_max >= 0.55`.
+    When either gate rejects text, the visualizer shows a red `LOW SNR` badge.
+
+    Live captures go to `experiments\cw-decoder\captures\viz-yyyyMMdd-HHmmss.wav`.
+    Use these captures for later labeling.
+    During file replay, `stream-live-v3 --file --play` uses the output playback cursor.
+    Thus, the bars and transcript stay synchronized with the audio.
 - **Causal ditdah baseline**
-  - `stream-file-ditdah` — file-driven causal whole-window `ditdah` replay
-  - `stream-live-ditdah` — live capture through the rolling-window causal baseline, with optional `--record` WAV mirror. **Deprecated** — kept only for A/B comparison; the GUI now uses the `stream-live-v3` append foundation.
+  - `stream-file-ditdah` - file-driven causal whole-window `ditdah` replay
+  - `stream-live-ditdah` - live capture through the rolling-window causal baseline, with an optional `--record` WAV mirror.
+    **Deprecated.** Use it only for A/B tests. The GUI now uses the `stream-live-v3` append foundation.
 - **Labeling helpers**
-  - `harvest-file` — find candidate "golden copy" windows by intersecting offline `ditdah` and the streaming decoder, optional `--needle` anchors
-  - `preview-window` — render a slowed WAV preview of a window for human verification
-  - `profile-window` — emit a tone-energy profile for the labeling UI's signal-profile editor
+  - `harvest-file` - find candidate "golden copy" windows by intersecting offline `ditdah` and the streaming decoder, optional `--needle` anchors
+  - `preview-window` - render a slowed WAV preview of a window for human verification
+  - `profile-window` - emit a tone-energy profile for the labeling UI's signal-profile editor
 - **Playback helper**
-  - `play-file` — play an audio file through the default output device and emit JSON progress for the GUI's inline transport
+  - `play-file` - play an audio file through the default output device and emit JSON progress for the GUI's inline transport
 - **Tone diagnostics**
-  - `probe-fisher` — sweep candidate pitches across an audio file and rank them by trial-decode Fisher score
+  - `probe-fisher` - sweep candidate pitches across an audio file and rank them by trial-decode Fisher score
 - **Cold-start + lock-stability benchmark**
-  - `bench-latency` — feed a deterministic synthetic scenario matrix (silence/noise/voice lead-ins + long-clean-CW lock-stability stress) or a real recording (`--from-file --truth --cw-onset-ms`) through the streaming decoder and report two classes of metrics: cold-start *acquisition latency* (time from CW onset to first stable-N-correct decoded run) and *lock stability* once locked (post-first-lock uptime ratio, `PitchLost` count, relock cycles, longest non-Locked gap). Headline metric is `lat_ms = t_stable_N - cw_onset_ms`. Add `--foundation` to score the append-only event-stream transcript path used by the GUI; in that mode latency-specific lock metrics are intentionally empty and the output is a transcript-quality/regression record.
+  - `bench-latency` - runs a deterministic synthetic matrix or a real recording through the streaming decoder.
+    The synthetic matrix has silence, noise, voice lead-ins, and long clean CW.
+    For a real recording, use `--from-file --truth --cw-onset-ms`.
+    The command reports cold-start acquisition latency and lock stability.
+    Acquisition latency ends at the first stable, correct run of N characters.
+    Lock metrics include uptime ratio, `PitchLost` count, relock cycles, and the longest unlocked gap.
+    The main metric is `lat_ms = t_stable_N - cw_onset_ms`.
+
+    Add `--foundation` to score the GUI append-only transcript path.
+    This mode reports transcript quality for regression tests. Its latency-specific lock metrics are empty.
 
 All `--json` and `--record` flags are what the Avalonia GUI uses to drive the engine over stdout/stderr NDJSON.
 
@@ -233,13 +277,15 @@ Current uses:
 
 ### `validate-corpus` (region path, end-to-end)
 
-Walks a directory of `*.truth.txt` sidecars, pairs each with its matching
-audio file (`.wav` preferred, then `.mp3`/`.m4a`/`.flac`), runs every
-entry through the production region-isolated decoder (`region_stream`),
-and prints a per-entry pass / character error rate / ghost-char table
-plus a summary line. Designed to close the loop between the operator-
-curated truth workflow (PR #381 Visualizer "Save Truth") and the same
-batch decode core that backs the `RegionStreamer` live commits.
+This command finds `*.truth.txt` sidecars in a directory.
+It pairs each sidecar with its audio file.
+It prefers `.wav`, then `.mp3`, `.m4a`, or `.flac`.
+It sends each entry through the production region decoder (`region_stream`).
+It prints pass status, character error rate, and ghost-character count for each entry.
+It also prints a summary.
+
+The command connects the PR #381 Visualizer "Save Truth" workflow to the batch decode core.
+`RegionStreamer` also uses this decode core for live commits.
 
 ```powershell
 # Validate every operator-saved truth pair under your local corpus root.
@@ -263,14 +309,19 @@ cargo run --release --manifest-path experiments\cw-decoder\Cargo.toml `
     --dir "C:\path\to\cw-samples" --json
 ```
 
-Subdirectory entries are namespaced by their relative path (e.g.
-`training-set-a/cw_30wpm_abbrev`) so duplicate basenames across folders
-keep distinct ids in the output table and JSON stream. Pass
+The relative path is the namespace for a subdirectory entry.
+For example, an entry can use `training-set-a/cw_30wpm_abbrev`.
+Thus, duplicate basenames in different folders keep distinct IDs in the output table and JSON stream.
+Pass
 `--no-recursive` to limit the walk to the top-level directory.
 
 ### Stress-test harness (`scripts\stress-gen.ps1` + `scripts\stress-eval.ps1`)
 
-Generates a deterministic matrix of "stressed" copies of a clean baseline WAV via `ffmpeg`, then runs the cw-decoder over every variant and emits a degradation summary + CSV. Useful for catching regressions when changing acquisition or decoding logic, and for honestly measuring how far down the SNR ladder the current implementation can still find and decode a known signal.
+The scripts use `ffmpeg` to generate a deterministic matrix of stressed copies from a clean WAV file.
+They run cw-decoder on each variant. They write a degradation summary and a CSV file.
+
+Use the harness to find regressions in acquisition or decode logic.
+It also measures the lowest SNR at which the decoder can find and decode the known signal.
 
 The matrix currently covers (per baseline):
 
@@ -279,7 +330,7 @@ The matrix currently covers (per baseline):
 - **white noise** SNR ladder: 20, 10, 6, 3, 0 dB
 - **pink noise** SNR ladder: 20, 10, 6, 3, 0 dB (closer to band hiss)
 - **brown / red noise**: 10, 6, 3 dB (atmospheric / QRN-like)
-- **narrow IF**: 250–1100 Hz bandpass (simulates a narrow CW filter)
+- **narrow IF**: 250-1100 Hz bandpass (simulates a narrow CW filter)
 - **QRM**: steady carrier at 850 Hz mixed at -16 dB
 - **combined weak-signal presets**: `weak_pink_snr6` (-18 dB signal + pink @6 dB SNR), `weak_pink_snr3` (-24 dB + pink @3 dB SNR)
 
@@ -300,8 +351,12 @@ Generate and score:
 
 Current observed behavior on the 30 WPM youtube baseline (sender at ~30 WPM):
 
-- decoder reports **29.5 WPM** on `clean` and remains at 28–30 WPM down through the entire attenuation ladder (including -30 dB), through brown/pink/white noise SNR ≥ 6 dB, through the narrow IF, and through QRM at +250 Hz from the CW pitch
-- pitch lock starts to wander to a side-bin (~574 Hz) at pink_snr6, white_snr6, weak_pink_snr3 — these are the cases where the next experimental work (top-K candidate tracking, oracle-tone eval) should pay off
+- The decoder reports **29.5 WPM** for `clean`.
+- It stays between 28 WPM and 30 WPM through the complete attenuation ladder, including -30 dB.
+- It stays in that range with brown, pink, or white noise at SNR values of 6 dB or more.
+- It also stays in that range with the narrow IF and QRM 250 Hz from the CW pitch.
+- Pitch lock moves to a side bin near 574 Hz for `pink_snr6`, `white_snr6`, and `weak_pink_snr3`.
+- Top-K candidate tracking and oracle-tone evaluation can help these cases.
 
 Stress audio is large and reproducible from the script, so `data/cw-stress/` is gitignored. Commit only the script changes and any operator-curated `TRUTH.txt` files.
 
@@ -329,12 +384,18 @@ Recent custom-streaming changes on this branch added:
 - **adjacent-bin tone purity gate** to suppress broadband impulses (finger snaps, key clicks, splatter) at the source
 - **wide-bin sniff** (`--wide-bin-count`) to integrate energy across ±N Goertzel bins for acoustically re-captured CW
 - **force-pitch override** (`--force-pitch-hz`) that bypasses acquisition when the operator already knows the target
-- **min-pulse / min-gap dot-fraction filters** that reject sub-dot blips and fill sub-dot gaps in the keying envelope (mic-mode default off, file-mode default off, mic preset turns them on)
-- **WASAPI loopback capture** (`stream-live --loopback`) for same-machine digital playback (YouTube, browsers, local files) — separates "speaker→mic acoustic recapture" (research) from "render→loopback digital pipe" (operational)
+- **min-pulse / min-gap dot-fraction filters** reject sub-dot pulses and fill sub-dot gaps.
+  File and microphone modes disable them by default. The microphone preset enables them.
+- **WASAPI loopback capture** (`stream-live --loopback`) for same-machine digital playback (YouTube, browsers, local files) - separates "speaker→mic acoustic recapture" (research) from "render→loopback digital pipe" (operational)
 - **centroid pitch picking** as a tiebreaker so locks centre on the energy ridge instead of edge-locking on a side bin
 - **mic-mode preset** that bundles wider bins, lower purity, and the min-pulse/min-gap filters in one toggle
-- **lockstep decode-and-play** (`stream-file --decode-and-play` / GUI **DECODE+PLAY**) so the audio you hear is exactly the audio being decoded, with a single cursor controlling pause / seek / region trim
-- **confidence state machine + held-event buffer** (`hunting` / `probation` / `locked`) so decoded characters never reach the operator until the lock has cleared its first quality watchdog. Bogus locks made on voice formants or impulse noise are silently discarded; genuine CW that started streaming during the verification window is buffered and flushed in order at the moment the lock is confirmed. The GUI surfaces this as a prominent **● LOCKED / ◐ VERIFYING SIGNAL / ○ ACQUIRING TARGET** badge in the status bar.
+- **lockstep decode-and-play** (`stream-file --decode-and-play` / GUI **DECODE+PLAY**) uses one audio cursor.
+  The cursor controls decode, playback, pause, seek, and region trim.
+- **confidence state machine + held-event buffer** uses `hunting`, `probation`, and `locked` states.
+  Characters do not reach the operator until the first quality check succeeds.
+  The decoder discards false locks from voice formants or impulse noise.
+  It buffers genuine CW during verification. It flushes the events in order when it confirms the lock.
+  The GUI shows this state in the status bar.
 
 This path is the more ambitious live decoder, but it still needs better corpus-driven measurement.
 
@@ -352,9 +413,18 @@ This is intentionally simple:
 - `off_char` flushes that character
 - `off_word` flushes that character and appends a real space
 
-The raw debug representation is the same thing without Morse lookup: `.` for a dit, `-` for a dah, `/` for a character gap, and `//` for a word gap. This proved crucial because it made the decoder's output comparable to the colored Visualizer bars without being coupled to Avalonia redraws. Redraw-level logging repeated rolling windows and produced false text; event-stream logging exposed the actual heard sequence.
+The raw debug representation does not apply Morse lookup.
+It uses `.` for a dit and `-` for a dah.
+It uses `/` for a character gap and `//` for a word gap.
 
-This is now the current reference path for live decoding and regression prevention. More complex pipelines may improve the event classifier, pitch selection, preprocessing, or spacing policy, but they should preserve this append-only contract or prove a measurable improvement against it.
+This representation permits comparison with the colored Visualizer bars.
+It does not depend on Avalonia redraws.
+Redraw logging repeated rolling windows and produced false text.
+Event-stream logging showed the audio sequence.
+
+This is the reference path for live decoding and regression prevention.
+Complex pipelines can improve event classification, pitch selection, preprocessing, or spacing.
+They must preserve this append-only contract or show a measurable improvement.
 
 ### 3. Causal ditdah baseline
 
@@ -377,7 +447,7 @@ It remains a useful historical reference and comparison strategy for label-drive
 
 ## Signal processing architecture
 
-The custom streaming decoder (`src\streaming.rs`) is a chain of stages, each addressing a specific failure mode the project has hit on real off-air audio. Read top-to-bottom — each stage assumes the previous one has done its job.
+The custom streaming decoder (`src\streaming.rs`) is a chain of stages, each addressing a specific failure mode the project has hit on real off-air audio. Read top-to-bottom - each stage assumes the previous one has done its job.
 
 ```
                     raw input audio (file or capture device)
@@ -388,7 +458,7 @@ The custom streaming decoder (`src\streaming.rs`) is a chain of stages, each add
                      └───────────────┬───────────────┘
                                      ▼
                      ┌───────────────────────────────┐
-                     │   HP / LP biquad chain        │  300–1500 Hz CW band
+                     │   HP / LP biquad chain        │  300-1500 Hz CW band
                      └───────────────┬───────────────┘
                                      ▼
                 ┌────────────────────┴────────────────────┐
@@ -448,33 +518,29 @@ The custom streaming decoder (`src\streaming.rs`) is a chain of stages, each add
 
 ### Key design properties
 
-- **Two-stage detection.** Acquisition uses `trial_decode_score` (a real
-  ditdah pass on a candidate window) so we only lock on tones that
-  actually look like CW — not just strong tones. Tracking is a much
-  cheaper per-sample Goertzel + gates path so the steady-state CPU
-  cost is small.
+- **Two-stage detection.** Acquisition uses `trial_decode_score`, which performs a ditdah pass on a candidate window.
+  Thus, acquisition locks only on tones that look like CW.
+  Tracking uses a less expensive Goertzel and gate path for each sample.
+  This design keeps the steady-state CPU cost low.
 - **Acquisition-first hypothesis.** The custom decoder was originally
-  the bottleneck; it now isn't. The remaining hard cases on the
+  the bottleneck. It is not the bottleneck now. The remaining hard cases on the
   9-label corpus are dominated by **wrong-tone lock**, **late lock**,
   and **lock on noise**, not by symbol classification errors. The
   oracle-tone eval mode and the planned top-K tracker (Phase 3) target
   these directly.
-- **Confidence machine = first-class operator UX.** The decoder's
-  internal lifecycle (`Hunting` / `Probation` / `Locked`) is exposed
-  to the GUI as a coloured status badge, and char-class events are
-  gated by it. Bogus locks made on voice formants or transient impulses
-  never reach the transcript, even when the watchdog needs several
-  seconds of accumulated audio to confirm them as bogus.
+- **Confidence machine = first-class operator UX.** The GUI shows the decoder state in a colored status badge.
+  The states are `Hunting`, `Probation`, and `Locked`.
+  The state controls character events. Thus, voice and transient false locks do not reach the transcript.
+  The watchdog can take several seconds to confirm a false lock.
 - **Held-event buffer keeps probation honest.** While in `Probation`,
   decoded characters are held (not dropped). If the lock survives,
   the held buffer is flushed in order so genuine CW that started
   during the verification window is preserved. If the lock is rejected,
   the held buffer is discarded.
-- **Two acquisition surfaces, one engine.** Voice-acoustic capture
-  (mic) and digital same-machine playback (loopback) flow through the
-  same streaming decoder; the mic path layers on the wide-bin /
-  min-pulse / min-gap / lower-purity preset, while loopback uses the
-  default file-mode tuning because the audio is bit-identical to the
+- **Two acquisition surfaces, one engine.** Microphone and loopback
+  audio use the same streaming decoder. The microphone path uses the
+  wide-bin, min-pulse, min-gap, and lower-purity preset. Loopback uses
+  the default file-mode settings because its audio is identical to the
   source.
 
 ### Confidence state machine
@@ -510,15 +576,29 @@ Char-class events (`Char`, `Garbled`, `Word`, `WpmUpdate`):
 |------------|----------------------------|
 | Hunting    | Dropped at the gate (lock not even attempted yet, or just lost) |
 | Probation  | Buffered in `held_events`, awaiting verdict |
-| Locked     | Passed through unchanged; held buffer is flushed on the transition |
+| Locked     | Passed through unchanged. Held buffer is flushed on the transition |
 
 Confidence transitions emit `StreamEvent::Confidence { state }`, which serializes as `{"type":"confidence","state":"hunting|probation|locked"}` over NDJSON. The Avalonia GUI reads this on the Decode tab and updates the status badge plus colour scheme.
 
-This was added specifically in response to the YouTube reference clip (`cw_30wpm_youtube_12k.wav`) where the pre-CW voice section was producing decoded garbage like `MI U I EIE N` and the decoder was missing the actual `CQ DE K UR` because the bad voice lock had to age out via the slow steady-state watchdog. With the confidence machine: the bad lock now goes through Probation silently, the watchdog rejects it, the held buffer is discarded, and the operator sees nothing until the real lock at ~604 Hz survives its check and flushes the genuine `73 TNX RST R TU = OM FB ...` transcript.
+The YouTube reference clip `cw_30wpm_youtube_12k.wav` caused this change.
+Its pre-CW voice produced false text such as `MI U I EIE N`.
+The decoder also missed `CQ DE K UR` because the false voice lock expired slowly.
+
+The confidence machine puts the false lock into Probation without output.
+The watchdog rejects the lock and discards its held events.
+The operator sees no text until the real lock near 604 Hz passes its check.
+The decoder then flushes the genuine `73 TNX RST R TU = OM FB ...` transcript.
 
 ## GUI architecture
 
-The Avalonia app under `gui\` (titled **CW SCOPE**) is the main operator surface. It launches the Rust `cw-decoder` and `eval` binaries from `experiments\cw-decoder\target\{release,debug}\`, walking up from `AppContext.BaseDirectory` to find them — either build flavor works, with release preferred when both are present. The key constraint is that the GUI does **not** rebuild the Rust engine on its own; if no binary is found it throws with a hint to run `cargo build` (typically `--release`) in `experiments\cw-decoder` first.
+The Avalonia application in `gui\` is named **CW SCOPE**. It is the main operator interface.
+It starts the Rust `cw-decoder` and `eval` binaries.
+It searches upward from `AppContext.BaseDirectory` for `experiments\cw-decoder\target\{release,debug}\`.
+Debug and release binaries work. The GUI selects the release binary when both exist.
+
+The GUI does **not** build the Rust engine.
+If it finds no binary, it tells the operator to run `cargo build`.
+Usually, run `cargo build --release` in `experiments\cw-decoder`.
 
 The GUI is organized into three tabs: **Decode**, **Labeling**, and **Tuning**.
 
@@ -544,18 +624,47 @@ Current decode-tab workflow also includes:
 - inline audio playback with a shared transport / progress surface
 - a real-time playback signal view driven by the same broad-band profile pipeline used in labeling
 - an explicit **CURRENT TONE** readout during live decode and playback
-- a prominent confidence badge — **● LOCKED** (green), **◐ VERIFYING SIGNAL** (amber), or **○ ACQUIRING TARGET** (red) — that surfaces the streaming decoder's confidence machine to the operator. Decoded characters do not appear in the transcript until the badge is green; while the badge is amber the engine is buffering candidate output and waiting for a quality watchdog confirmation.
+- a prominent confidence badge that shows **LOCKED**, **VERIFYING SIGNAL**, or **ACQUIRING TARGET**
+  - decoded characters appear only when the badge is green
+  - while the badge is amber, the engine buffers candidate output and waits for the quality check
 - a **Mic mode** preset toggle that bundles wide-bin sniff, lower tone-purity threshold, and the min-pulse/min-gap dot filters into one click for acoustically re-captured CW
-- **WASAPI loopback** capture (`stream-live --loopback`) — for same-machine playback decode (YouTube, browsers, local files) the audio is taken from the system render endpoint instead of a microphone, bypassing the speaker→room→mic chain entirely
+- **WASAPI loopback** capture (`stream-live --loopback`) for playback on the same computer
+  - supports YouTube, browsers, and local files
+  - reads audio from the system render endpoint and bypasses acoustic microphone capture
 - an experimental **RANGE LOCK** mode for custom streaming, so live/file decode can prefer the strongest tone inside a chosen Hz window
-- an experimental **TONE PURITY** gate that compares each instantaneous target-bin power against the off-band noise bins (q25 of bins at ±150/300/500/700 Hz) at the *same* sample. A real CW tone scores 5–20+ instantaneous purity; a 5 ms broadband impulse (finger snap, key click, lightning, switching ground) lights up *all* bins together so the ratio collapses to ~1 and is rejected at the source. Default `min_tone_purity = 3.0`; set to 0 to disable. Reuses the existing noise bins (no new Goertzels), and runs *before* smoothing so the gate fires faster than the 200 ms noise smoother can equalize.
-- an optional **SHOW CHAR HZ** overlay so each decoded character can display the tone the streaming decoder had locked when it emitted that symbol; a companion **SHOW PURITY** toggle adds the per-character peak tone-purity ratio under the Hz line, so spurious characters from broadband impulses (typically `purity ~1`) are visually distinguishable from real CW (`purity 5-20+`)
-- a **FORCE PITCH (Hz)** acquisition override that locks the streaming decoder to an exact pitch instead of running auto-acquisition (0 = auto). The Fisher quality watchdog AND the confidence machine are both bypassed when forced — the decoder goes straight to Locked and stays there. Useful when the operator already knows the target tone, or as a diagnostic ("does the decoder fail because of acquisition or downstream?")
-- a **WIDE BINS** wide-bin sniff (0–8) that adds companion Goertzels at `pitch ± k * bin_width` and sums their power into the main signal estimate. `0` = single 40 Hz bin (default). `N=2` ≈ 200 Hz of integration bandwidth. Built specifically for **acoustically re-captured CW** (speaker → mic round-trip) where speaker frequency response, room reverb, and slight pitch drift smear the tone across many Goertzel bins; without this gate a single 40 Hz slice catches only ~30% of the signal energy and the keying envelope flickers within elements. CLI: `--wide-bin-count <N>` on `stream-file` and `stream-live`. NDJSON: `"wide_bin_count": <N>`. Combine with `--force-pitch-hz` for live mic capture: e.g. `--force-pitch-hz 620 --wide-bin-count 2`.
+- an experimental **TONE PURITY** gate
+  - compares target-bin power with off-band noise bins for the same sample
+  - uses q25 of bins at offsets of 150, 300, 500, and 700 Hz
+  - gives a real CW tone an instantaneous purity value from 5 to more than 20
+  - gives a broadband impulse a value near 1 and rejects it
+  - uses `min_tone_purity = 3.0` by default
+  - uses a value of 0 to disable the gate
+  - reuses existing noise bins and runs before smoothing
+- an optional **SHOW CHAR HZ** overlay that shows the locked tone for each character
+  - **SHOW PURITY** adds the peak tone-purity ratio below the frequency
+  - broadband impulses usually have `purity ~1`
+  - real CW usually has `purity 5-20+`
+- a **FORCE PITCH (Hz)** acquisition override that locks the streaming decoder to an exact pitch instead of running auto-acquisition (0 = auto). The Fisher quality watchdog AND the confidence machine are both bypassed when forced - the decoder goes straight to Locked and stays there. Useful when the operator already knows the target tone, or as a diagnostic ("does the decoder fail because of acquisition or downstream?")
+- a **WIDE BINS** control from 0 to 8
+  - adds Goertzel bins at `pitch ± k * bin_width`
+  - sums their power into the main signal estimate
+  - uses one 40 Hz bin when the value is 0
+  - gives approximately 200 Hz of integration bandwidth when `N=2`
+  - supports CW audio that passes from a speaker through a room to a microphone
+  - compensates for speaker response, room reverberation, and small pitch changes
+  - prevents envelope flicker when one 40 Hz bin captures only about 30% of the signal energy
+  - uses CLI option `--wide-bin-count <N>` on `stream-file` and `stream-live`
+  - uses NDJSON field `"wide_bin_count": <N>`
+  - can be combined with `--force-pitch-hz` for live microphone capture
+  - example: `--force-pitch-hz 620 --wide-bin-count 2`
 
-The tone-purity gate replaces an earlier "recent-audio re-detection" guard that ran at character emission time. That earlier guard could not catch transient impulses because by the time it re-ran pitch detection the impulse was already history; the new gate runs per Goertzel power sample and ANDs with the existing amplitude / smoothed-SNR gates so a sample only counts as key-down when the locked bin is meaningfully louder than its closely-spaced neighbors.
+The tone-purity gate replaces a recent-audio detection guard that ran when a character was emitted.
+The earlier guard did not detect a completed transient impulse.
+The new gate runs for each Goertzel power sample.
+It operates with the amplitude and smoothed-SNR gates.
+A sample is key-down only when the locked bin is sufficiently louder than adjacent bins.
 
-That replay path is useful for answering: _“what did the live path think happened, and what does an offline rerun on the same captured audio think happened?”_
+Use replay to compare the live result with an offline result for the same captured audio.
 
 ### Labeling tab
 
@@ -581,9 +690,13 @@ Signal-profile rendering now also works without a usable pitch lock by falling b
 Harvest caching is now both:
 
 - in-memory while you stay in the current GUI session, and
-- persisted under the local app-data cache so previously harvested files reopen with their cached candidate list after restarting the app, unless you explicitly click **HARVEST** again.
+- stored in the local application-data cache
 
-The strong-signal W1AW path also now uses warmup-aware harvest windows for the streaming side, so short-window harvest is no longer forced into whole-file fallback just because the streaming decoder starts cold on every 4-second slice.
+After a restart, a harvested file opens with its cached candidate list.
+Select **HARVEST** again to replace the list.
+
+The strong-signal W1AW path now uses warmup-aware harvest windows for streaming.
+Thus, a cold decoder on each four-second slice does not force a complete-file fallback.
 
 ### Tuning tab
 
@@ -606,7 +719,7 @@ That gives the branch an honest loop:
 
 ## Labeling model and whether it still makes sense
 
-Yes — **the labeling approach still makes sense and is still worth pursuing**.
+Yes - **the labeling approach still makes sense and is still worth pursuing**.
 
 The current exact-window + clipped-edge scheme has already paid off because it separated two very different classes of problems:
 
@@ -623,7 +736,7 @@ With the labels, we can already see that:
 
 That said, the current label schema is **necessary but not sufficient** for the hardest recordings.
 
-The next label additions should be optional, not a schema reset:
+Make the next label additions optional. Do not reset the schema:
 
 - target tone estimate / confidence
 - multiple-signal flag
@@ -710,15 +823,13 @@ to drive two operator-facing surfaces:
 
 - **CW WPM auto-fill**: when a CW QSO is logged, the time-weighted mean WPM
   over the QSO start→end window is written to `QsoRecord.cw_decode_rx_wpm`.
-- **F9 CW Stats pane**: live overlay showing the current confidence/lock
-  state, signal pitch (Hz), instantaneous WPM, last decoded characters and
-  the most recent garbled symbol. Driven entirely by the same NDJSON stream
-  the CW Scope tooling uses.
+- **F9 CW Stats pane**: This live overlay shows confidence, lock state, signal pitch, WPM, recent characters, and the last garbled symbol.
+  The CW Scope tools and this pane use the same NDJSON stream.
 
-The episode boundary for both surfaces is **operator activity, not decoder
-lock**: the QSO clock starts the moment the operator first types a callsign
-and ends on save or clear. The decoder process itself runs continuously
-whenever Radio Monitor is enabled.
+**Operator activity, not decoder lock, defines the episode boundary.**
+The QSO clock starts when the operator first types a callsign.
+It ends when the operator saves or clears the QSO.
+The decoder runs continuously while Radio Monitor is enabled.
 
 ### Advanced diagnostics mode
 
@@ -744,9 +855,8 @@ captured WAV over the same time window. Sample form:
 cw-decoder decode-and-play --json --start 12.4 --end 47.9 "session.wav"
 ```
 
-Use this to compare what the operator saw in the status bar against what the
-decoder would emit in a deterministic offline replay — the canonical way to
-debug round 1 WPM regressions without trying to reproduce live propagation.
+Use this command to compare the status-bar value with a deterministic offline replay.
+This method finds round 1 WPM regressions without a reproduction of live propagation.
 
 WAV size is roughly 330 MB/hour (48 kHz mono, 16-bit) and is not rotated in
 round 1. Disable diagnostics or prune `%LOCALAPPDATA%\QsoRipper\diagnostics`
@@ -754,12 +864,11 @@ manually between debug sessions.
 
 ### WPM emission smoothing (#326)
 
-The first live capture made with the diagnostics bundle revealed a failure
-mode in `current_wpm()`: a sustained signal degradation produced a
-monotonically drifting raw WPM (11.3 → 6.75 over ~6 s on a real on-air QSO)
-while the pitch lock was still nominally healthy. The pitch-quality
-watchdog only fired ~6 s after the WPM had already collapsed, so the
-operator-facing speed dropped from a correct ~13 WPM to ~6 WPM mid-QSO.
+The first diagnostics capture found a failure in `current_wpm()`.
+During a sustained signal degradation, raw WPM decreased from 11.3 to 6.75 in approximately six seconds.
+The pitch lock continued to report a good condition.
+The pitch-quality watchdog operated approximately six seconds after the WPM decrease.
+Thus, the displayed speed decreased from approximately 13 WPM to 6 WPM during the QSO.
 
 `StreamingDecoder` now emits a smoothed value instead of the raw
 `current_wpm()` in `StreamEvent::WpmUpdate`:
@@ -768,21 +877,28 @@ operator-facing speed dropped from a correct ~13 WPM to ~6 WPM mid-QSO.
    single degenerate calibration windows where one mis-classified
    character produces a wild dot-length estimate.
 2. **Rate cap of `WPM_MAX_REL_DELTA_PER_EMIT` (=3%) per emit.** Real
-   operators cannot physically alter keying speed faster than this between
-   adjacent character emits; anything larger is the dit-cluster
-   calibration tracking the noise instead of the operator. Genuine WPM
-   changes still converge in ~3 s; a crashing calibration gets stretched
-   far enough that the watchdog drops the lock first.
+   operators cannot change keying speed by more than this between adjacent
+   characters. A larger change shows that dit-cluster calibration follows
+   noise instead of the operator. Genuine WPM changes converge in
+   approximately three seconds. A calibration failure becomes slow enough
+   for the watchdog to drop the lock first.
 
-The internal `current_wpm()` is unchanged and is still what end-of-run
-summaries and the harvest output use. Replaying the original captured
-session through the fixed decoder shows the displayed WPM staying above
-9.5 WPM across the same crash window where the pre-fix value bottomed at
-6.75 WPM.
+The internal `current_wpm()` is unchanged.
+End-of-run summaries and harvest output continue to use it.
+In a replay of the captured session, displayed WPM stays above 9.5.
+Before the fix, it decreased to 6.75 in the same interval.
 
 ## Current labeled corpus
 
-Label files live at the **repo root** under `data\cw-samples\`, not under `experiments\cw-decoder\`. `--all-labels` resolves `data\cw-samples\` relative to the current working directory, so it works fine when `eval` is invoked from the repo root and silently finds nothing when invoked from elsewhere. The examples below use `--labels-dir data\cw-samples` to make the path explicit, but `--all-labels` is equivalent when the cwd is the repo root.
+Label files are under `data\cw-samples\` at the repository root.
+They are not under `experiments\cw-decoder\`.
+
+`--all-labels` resolves `data\cw-samples\` from the current working directory.
+It finds the labels when you run `eval` from the repository root.
+It can find no labels when you run the command from a different directory.
+
+The examples use `--labels-dir data\cw-samples` to make the path clear.
+From the repository root, `--all-labels` gives the same result.
 
 Current corpus files and label counts:
 
@@ -806,7 +922,9 @@ The corpus currently has **9 labels**. The safest command form is explicit about
 cargo run --release --manifest-path experiments\cw-decoder\Cargo.toml --bin eval -- --labels-dir data\cw-samples
 ```
 
-`--all-labels` is equivalent when run from the repo root, but it resolves `data\cw-samples\` relative to the current working directory and is easier to misuse from `experiments\cw-decoder`.
+From the repository root, `--all-labels` gives the same result.
+It resolves `data\cw-samples\` from the current working directory.
+Do not run it from `experiments\cw-decoder`.
 
 Current exact-window score:
 
@@ -823,7 +941,9 @@ Interpretation:
 
 - exact-window scoring still tells us what the classifier can do when the target audio is bounded correctly
 - full-stream scoring tells us that acquisition, segmentation, gap maturity, and finalization are the hard live problems
-- the append-only event-stream foundation is the current best live-facing compromise because it removes rolling-window string replacement/stitching from the critical path while staying directly measurable against labels and replay transcripts
+- the append-only event-stream foundation is the best current live path
+- it removes rolling-window replacement and stitching from the critical path
+- labels and replay transcripts can measure its results directly
 
 ### Append-foundation smoke evidence
 
@@ -844,13 +964,17 @@ On synthetic PARIS bench scenarios the foundation clean/noise transcripts are re
 ## What we know with reasonable confidence
 
 1. **The simple append-event stream is working much better than the rolling-window transcript machinery.**
-   The important shift was moving from "decode a rolling window, then stitch text" to "classify bars, then append matured events once." That removes a whole class of ghost characters, repeated prefixes, disappearing/replacing text, and overlapping-window artifacts.
+   The new method classifies bars and appends each mature event once.
+   The old method decoded a rolling window and then joined its text.
+   The new method removes ghost characters, repeated prefixes, text replacement, and overlapping-window artifacts.
 2. **Visualizer truth is event truth, not redraw truth.**
    The colored bars are a rolling display. Logging every redraw records repeated partial windows (`..`, then `..-`, then `..- ...`) and creates fake Morse. The useful debug layer is the audio-time event stream beneath the redraw.
 3. **Spacing is now visible and testable.**
-   The raw stream (`.` / `-` / `/` / `//`) made it obvious when a word gap was being emitted where a character gap was expected, for example `...//.-` (`S A`) instead of `.../.-` (`SA`). Future spacing work can now target that exact failure instead of guessing from final text.
+   The raw stream (`.` / `-` / `/` / `//`) shows incorrect word gaps.
+   For example, it shows `...//.-` (`S A`) instead of `.../.-` (`SA`).
+   Future spacing work can target this failure directly.
 4. **Audio/playback synchronization matters.**
-   The old Visualizer file path decoded in one process and played audio in another, so visual bars could lead or lag what the operator heard. `stream-live-v3 --file --play` fixes this by using one process and feeding the decoder from the output playback cursor.
+The old Visualizer file path used separate decode and audio processes. Thus, the visual bars did not always agree with the audio. `stream-live-v3 --file --play` uses one process. It sends the output playback cursor to the decoder.
 5. **Hard contest audio is still the frontier.**
    The foundation does not magically solve target isolation, voice lead-ins, same-band QRM, or weak/noisy spacing. It gives us a stable place to measure those failures without rolling-window artifacts obscuring them.
 
@@ -864,15 +988,16 @@ The append-only path is now the default contract:
 audio -> envelope/viz events -> append event decoder -> transcript
 ```
 
-Regressions should be caught at several levels:
+Use several test levels to detect regressions:
 
-1. **Unit level:** `AppendEventDecoder` tests should cover repeated `viz` frames, character gaps, word gaps, and final pending-character flush.
+1. **Unit level:** `AppendEventDecoder` tests must cover repeated `viz` frames, character gaps, word gaps, and the final pending-character flush.
 2. **CLI level:** `stream-live-v3 --json` transcript events must keep `transcript` / `text` as the append-foundation text, with `cursor_transcript` only as diagnostics.
-3. **GUI level:** Decode, Labeling, Bench, Tuning, and Visualizer should default to or explicitly include `foundation`; any future mode should be labeled as experimental.
-4. **Corpus level:** every future algorithm should report against `--labels-dir data\cw-samples` and include `foundation` in strategy sweeps.
-5. **Bench level:** `bench-latency --foundation --json` should remain a quick smoke that emits recognizable transcript rows before deeper latency metrics are trusted.
+3. **GUI level:** Decode, Labeling, Bench, Tuning, and Visualizer must use or include `foundation`. Identify each future mode as experimental.
+4. **Corpus level:** Each future algorithm must report against `--labels-dir data\cw-samples`. Each strategy sweep must include `foundation`.
+5. **Bench level:** Keep `bench-latency --foundation --json` as a quick test. It must produce recognizable transcript rows before detailed latency tests.
 
-The rule of thumb: improvements may change how events are detected, filtered, or classified, but they should not reintroduce rolling text stitching as the primary live transcript path.
+Improvements can change event detection, filtering, or classification.
+They must not restore rolling text stitching as the primary live transcript path.
 
 ### Keep pursuing labeling, but evolve it carefully
 
@@ -887,7 +1012,7 @@ Instead:
 
 ### Use foundation-first evaluation
 
-For corpus work, the current order should stay:
+For corpus work, keep the current order:
 
 1. append-foundation score / replay transcript
 2. exact-window label score as the upper-bound classifier check
@@ -916,17 +1041,25 @@ But every improvement must be measured back against:
 ## Recommended next steps
 
 1. **Promote foundation regression checks.**
-   Add/keep tests around `src\append_decode.rs`, require `foundation` in strategy sweeps, and preserve `raw_morse`/`cursor_transcript` diagnostics so future changes can explain differences instead of only showing final text.
+   Keep tests for `src\append_decode.rs`.
+   Require `foundation` in strategy sweeps.
+   Preserve `raw_morse` and `cursor_transcript` diagnostics.
+   These diagnostics must explain changes, not only show final text.
 2. **Quantify spacing failures.**
-   The current foundation exposed word-gap mistakes cleanly. The next useful scorer should classify failures as character substitution vs char-gap vs word-gap errors.
+   The current foundation clearly showed word-gap errors.
+   The next scorer must classify character substitution, character-gap, and word-gap errors.
 3. **Close the acquisition gap after voice/noise lead-ins.**
-   Synthetic bench results show the append foundation is honest: clean/noise PARIS is recognizable, but voice lead-ins still create pre-target garbage. That points to better target detection and lock admission, not transcript stitching.
+   Synthetic test results show that the append foundation gives an accurate result.
+   It recognizes clean and noisy PARIS, but voice lead-ins still cause incorrect initial text.
+   Improve target detection and lock admission. Do not change transcript stitching.
 4. **Layer preprocessing carefully.**
    Real-radio bandpass+compander preprocessing can help dramatically, but it previously broke clean synthetic CW in some paths. Treat preprocessing as an optional layer above the foundation with explicit A/B coverage.
 5. **Add richer label metadata for hard cases.**
-   Target tone, multi-signal flag, negative/no-copy regions, and gap annotations will make future experiments much easier to judge.
+   Add target tone, a multi-signal flag, negative regions, no-copy regions, and gap annotations.
+   These values will help the review of future experiments.
 6. **Top-K candidate tracker.**
-   Replace single-pitch lock with a CFAR-scored ridge tracker over 350-1500 Hz so multi-signal contest audio can present per-track candidates instead of one winner-takes-all lock.
+   Replace single-pitch lock with a CFAR-scored ridge tracker over 350-1500 Hz.
+   Show separate track candidates for contest audio that contains multiple signals.
 
 Current evidence suggests:
 
@@ -954,7 +1087,7 @@ If the goal is custom-streaming research:
 
 ## Build and run
 
-The Avalonia GUI launches whichever Rust binaries it finds under `experiments\cw-decoder\target\{release,debug}\` (release preferred) but does **not** rebuild them. A debug build is enough to make the GUI run; release is recommended for realistic decode latency. Build the engine first, then the GUI:
+The Avalonia GUI launches whichever Rust binaries it finds under `experiments\cw-decoder\target\{release,debug}\` (release preferred) but does **not** rebuild them. A debug build is enough to make the GUI run. Release is recommended for realistic decode latency. Build the engine first, then the GUI:
 
 ```powershell
 cargo build --release --manifest-path experiments\cw-decoder\Cargo.toml
@@ -1019,7 +1152,10 @@ Probe likely target tones by Fisher score:
 cargo run --release --manifest-path experiments\cw-decoder\Cargo.toml -- probe-fisher data\cw-samples\k5zd-zs4tx-80m-qso.mp3 --min-hz 350 --max-hz 1500 --step-hz 10 --top 8
 ```
 
-Run the cold-start + lock-stability benchmark on the synthetic scenario matrix (silence/noise/voice/long-clean-CW lead-ins; latency `lat_ms = t_stable_N - cw_onset_ms`, plus post-lock uptime / drops / relock cycles / longest non-Locked gap):
+Run the cold-start and lock-stability benchmark on the synthetic scenario matrix.
+The matrix includes silence, noise, voice, and long-clean-CW lead-ins.
+It reports `lat_ms = t_stable_N - cw_onset_ms`.
+It also reports post-lock uptime, drops, relock cycles, and the longest non-Locked gap.
 
 ```powershell
 .\experiments\cw-decoder\target\release\cw-decoder.exe bench-latency
@@ -1042,7 +1178,7 @@ Compare two configurations by tagging each run with `--label`. Combine with `--j
 .\experiments\cw-decoder\target\release\cw-decoder.exe bench-latency --label no-purity   --purity 0 --json > bench-no-purity.ndjson
 ```
 
-Run the append-foundation bench smoke. This records transcript quality for the GUI foundation; latency and lock fields are intentionally empty in this mode:
+Run the append-foundation bench smoke. This records transcript quality for the GUI foundation. Latency and lock fields are intentionally empty in this mode:
 
 ```powershell
 .\experiments\cw-decoder\target\release\cw-decoder.exe bench-latency --foundation --json > bench-foundation.ndjson
@@ -1069,22 +1205,42 @@ The variant matrix is intentionally tiered:
 
 | Tier | Variants | What stresses the decoder |
 |---|---|---|
-| baseline | `clean`, `weak`, `qrn`, `qsb`, `weak_qsb` | mild SNR / fade — decoder should pass cleanly |
-| extreme | `extreme_qrn`, `crushed`, `deep_qsb`, `buried` | heavy brown noise (mostly killed by the 300 Hz HP) + deep slow QSB; `buried` combines all three and is where the decoder first cracks |
-| harsh   | `harsh_white`, `inband_qrm`, `chaos` | white / CW-band-bandpassed noise the front end *cannot* filter away; locks acquire instantly on the right pitch but symbol classification fails — this is where the decoder's downstream gating becomes the bottleneck rather than acquisition |
+| baseline | `clean`, `weak`, `qrn`, `qsb`, `weak_qsb` | mild SNR or fade. The decoder must pass. |
+| extreme | `extreme_qrn`, `crushed`, `deep_qsb`, `buried` | heavy brown noise (mostly killed by the 300 Hz HP) + deep slow QSB. `buried` combines all three and is where the decoder first cracks |
+| harsh   | `harsh_white`, `inband_qrm`, `chaos` | white / CW-band-bandpassed noise the front end *cannot* filter away. Locks acquire instantly on the right pitch but symbol classification fails - this is where the decoder's downstream gating becomes the bottleneck rather than acquisition |
 
-The `harsh_white` / `inband_qrm` / `chaos` variants currently expose a real weakness: even with a healthy lock and a passed Fisher confidence check, the keying envelope chatters in dense in-band noise and the ditdah classifier emits long runs of garbage characters. Improving the `false_chars_before_stable` metric on these three is the next concrete bench target. Tracked in [#320](https://github.com/rtreit/qsoripper/issues/320).
+The `harsh_white`, `inband_qrm`, and `chaos` variants show a decoder weakness.
+The keying envelope chatters in dense in-band noise, although lock and Fisher confidence are good.
+The ditdah classifier then emits long groups of incorrect characters.
+
+The next bench target is a better `false_chars_before_stable` value for these variants.
+Issue [#320](https://github.com/rtreit/qsoripper/issues/320) tracks this work.
 
 ### Downstream classifier hardening for #320 (chatter-merge + duration sanity + rescue suppression)
 
-The first hysteresis-only patch killed the long ghost-character stream on `harsh_white` but did not change the underlying truth: the dense-noise variants chatter the keying envelope, and the dot/dah classifier was happy to interpret the chatter as a stream of `E`s and `T`s. A second pass landed four cooperating fixes (all opt-in, all exposed via CLI / JSON config / bench script):
+The first hysteresis-only patch stopped the long ghost-character stream on `harsh_white`.
+It did not stop envelope chatter in dense noise.
+The dot/dah classifier interpreted this chatter as groups of `E` and `T`.
+
+A second change added four related fixes.
+All fixes are optional and available through the CLI, JSON configuration, and bench script.
 
 1. **Hard ON-duration sanity gate** (always on). After the dot length is known, ON intervals shorter than `0.4 · dot` or longer than `4.8 · dot` are dropped *and* the in-progress letter is cleared. This stops both threshold chatter from being classified as a dit and giant QRM blobs from being classified as a dah. Tracked by the `invalid_on_duration_dropped` counter.
-2. **Single-element rescue suppression**. The previous code rescued any `valid_morse` letter when the rhythm gate was closed, which let single-element `E` (`.`) and `T` (`-`) ghosts leak through every short blip. The rescue is now restricted to multi-element patterns, gated by `RhythmGate::was_recently_mature`. Tracked by `single_element_rescue_suppressed`.
-3. **Real merge for `min_gap_dot_fraction`**. Previously a short OFF was just dropped, leaving the surrounding ON runs to be classified separately (so a real dah broken by a tiny noise dip could become `. .` instead of `-`). The new sanitizer (`sanitize_interval` in `streaming.rs`) actually fuses the surrounding ON intervals into one element before classification. Tracked by `short_gaps_bridged` and `on_runs_merged`.
+2. **Single-element rescue suppression**. Previously, the code rescued all `valid_morse` letters when the rhythm gate was closed.
+   Thus, short pulses produced false `E` (`.`) and `T` (`-`) characters.
+   Rescue now applies only to multi-element patterns and uses `RhythmGate::was_recently_mature`.
+   The `single_element_rescue_suppressed` counter tracks this action.
+3. **Real merge for `min_gap_dot_fraction`**. Previously, the code dropped a short OFF interval.
+   It then classified the adjacent ON intervals separately.
+   Thus, a noise gap in a dah produced `. .` instead of `-`.
+   The `sanitize_interval` function in `streaming.rs` now combines adjacent ON intervals before classification.
+   The `short_gaps_bridged` and `on_runs_merged` counters track this action.
 4. **Hysteresis wired through every streaming path**. `--hysteresis-fraction` is now accepted by `cw-decoder stream-file`, `stream-live`, `decode-and-play`, `bench-latency`, and `eval` (previously only `bench-latency` and JSON-stdin took it). The `bench-30wpm.ps1` script gained `-Hysteresis`, `-MinGap`, and `-MinPulse` parameters so the full sweep is one command.
 
-Bench JSON now also carries a `decoder_counters` block (`raw_edges_total`, `short_pulses_dropped`, `short_gaps_bridged`, `on_runs_merged`, `invalid_on_duration_dropped`, `single_element_rescue_suppressed`, `chars_emitted`, etc.) so a future tuning pass can prove a config improves CER instead of just suppressing output.
+Bench JSON now includes a `decoder_counters` block.
+It includes `raw_edges_total`, `short_pulses_dropped`, `short_gaps_bridged`, and `on_runs_merged`.
+It also includes `invalid_on_duration_dropped`, `single_element_rescue_suppressed`, and `chars_emitted`.
+These values show whether a configuration improves CER or only suppresses output.
 
 Best-known bench config on the 12-variant matrix is `-Hysteresis 0.3 -MinGap 0.2 -MinPulse 0.3`:
 
@@ -1100,26 +1256,51 @@ Best-known bench config on the 12-variant matrix is `-Hysteresis 0.3 -MinGap 0.2
 | inband_qrm    | 0              | 0                 | (never stable)  | (never stable)     |
 | chaos         | 0              | 0                 | (never stable)  | (never stable)     |
 
-So the four-patch combination reduces ghost output across the whole baseline tier (zero on most, one on the two QSB-heavy variants) without regressing latency, and it completely silences the harsh-tier ghost flood. The remaining gap — getting `harsh_white` / `inband_qrm` / `chaos` to a *stable* lock at all — is no longer a downstream-classifier problem; it is acquisition under continuous in-band carriers, which is what the next iteration (CFAR-style local-contrast detection or envelope-against-slow-carrier-floor) needs to address. The acceptance criteria in #320 are still not fully met, but the ghost-character class of failure that the issue opened with is resolved.
+The four fixes reduce ghost output across the complete baseline tier without a latency regression.
+Most variants have zero ghost characters. The two QSB-heavy variants have one.
+The fixes also stop the harsh-tier ghost flood.
+
+The remaining problem is stable acquisition for `harsh_white`, `inband_qrm`, and `chaos`.
+Continuous in-band carriers cause this problem, not the downstream classifier.
+The next test must examine CFAR local-contrast detection or an envelope against a slow carrier floor.
+
+The changes do not meet all acceptance criteria in #320.
+They do resolve the initial ghost-character failure.
 
 ### Opt-in CFAR keying (#322)
 
-A first cut of the CFAR keying idea ships behind an opt-in flag. With `--cfar-keying` (or `-CfarKeying` in `bench-30wpm.ps1`) the on/off threshold state machine is fed the dimensionless ratio `smoothed / noise` instead of raw `smoothed` Goertzel power, and the global `snr_ok` gate is bypassed (the rolling-quantile threshold over the ratio supplies its own discrimination). This is the only per-frame variant from the #322 experiment matrix that produced any stable transcript on `harsh_white` (stable @72.9 s with 38 ghost characters before lock). It costs the `clean` and `qsb` scenarios in exchange, so the flag stays off by default; the production decoder behavior across all 12 baseline scenarios is unchanged.
+The first CFAR keying implementation is available through an optional flag.
+Use `--cfar-keying`, or use `-CfarKeying` in `bench-30wpm.ps1`.
+
+This mode sends the dimensionless ratio `smoothed / noise` to the on/off threshold state machine.
+It does not use raw `smoothed` Goertzel power.
+It bypasses the global `snr_ok` gate.
+The rolling-quantile threshold for the ratio supplies its own discrimination.
+
+This was the only per-frame variant in the #322 matrix that produced a stable `harsh_white` transcript.
+It became stable at 72.9 seconds after 38 ghost characters.
+However, it causes regressions in the `clean` and `qsb` scenarios.
+Therefore, the flag is off by default.
+Production behavior is unchanged for all 12 baseline scenarios.
 
 | Mode | PASS | WARN | FAIL | Total ghost | `harsh_white` |
 | --- | --- | --- | --- | --- | --- |
 | default (no flag) | 6 | 3 | 3 | 2 | no stable |
 | `-CfarKeying` | 5 | 3 | 4 | 42 | **stable @72.9 s** |
 
-The empirical conclusion (recorded on issue #322): per-frame normalization alone cannot crack the harsh tier without regressing the clean tier. The `--cfar-keying` substrate is the foundation for the next iteration — soft element-window matched scoring that integrates the ratio metric over candidate ~1-dot, ~3-dot, and ~7-dot windows once the dot estimate is primed.
+Issue #322 records the result.
+Per-frame normalization alone cannot decode the harsh tier without a regression in the clean tier.
+
+The next iteration will use `--cfar-keying` as its base.
+It will apply soft matched scoring to candidate one-dot, three-dot, and seven-dot windows after the initial dot estimate.
 
 ## Repo-local artifacts
 
-- `gui-screenshot*.png` — historical GUI screenshots tracking visual iteration on the Decode tab
-- `screenshots\sensitivity-panel.png` — close-up of the sensitivity / threshold panel
-- `target\` — local Cargo build output (debug + release) for `cw-decoder` and `eval`
-- `gui\bin\`, `gui\obj\` — local .NET build output for the Avalonia GUI
-- `bench-runs\` — per-label JSON results from `bench-30wpm.ps1`
-- `artifacts\run\cw-debug-bars-*.txt` — Visualizer append-debug raw Morse streams (`.` / `-` / `/` / `//`) flushed when a clip stops
+- `gui-screenshot*.png` - historical GUI screenshots tracking visual iteration on the Decode tab
+- `screenshots\sensitivity-panel.png` - close-up of the sensitivity / threshold panel
+- `target\` - local Cargo build output (debug + release) for `cw-decoder` and `eval`
+- `gui\bin\`, `gui\obj\` - local .NET build output for the Avalonia GUI
+- `bench-runs\` - per-label JSON results from `bench-30wpm.ps1`
+- `artifacts\run\cw-debug-bars-*.txt` - Visualizer append-debug raw Morse streams (`.` / `-` / `/` / `//`) flushed when a clip stops
 
-These are not committed-meaningful build artifacts; they exist to make the GUI runnable without an extra build step on the developer machine.
+These are not committed-meaningful build artifacts. They exist to make the GUI runnable without an extra build step on the developer machine.

--- a/experiments/cw-decoder/docs/cw-decoder-architecture.html
+++ b/experiments/cw-decoder/docs/cw-decoder-architecture.html
@@ -1,774 +1,529 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
 <head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Region-Isolated Streaming for Real-World CW Copy &mdash; QsoRipper Technical Report</title>
-<style>
-  :root {
-    --navy: #102a54;
-    --rule: #102a54;
-    --accent: #b21f1f;
-    --muted: #555;
-    --bg: #faf8f3;
-    --code-bg: #f1ede4;
-  }
-  html, body {
-    margin: 0;
-    padding: 0;
-    background: var(--bg);
-    color: #111;
-    font-family: "Georgia", "Times New Roman", serif;
-    font-size: 15px;
-    line-height: 1.5;
-  }
-  .page {
-    max-width: 980px;
-    margin: 24px auto 64px;
-    padding: 0 28px;
-  }
-  .masthead {
-    border-top: 6px double var(--navy);
-    border-bottom: 1px solid var(--navy);
-    padding: 14px 0 10px;
-    margin-bottom: 18px;
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-    font-variant: small-caps;
-    letter-spacing: 0.05em;
-    color: var(--navy);
-  }
-  .masthead .pub { font-weight: bold; font-size: 1.1em; }
-  .masthead .meta { font-size: 0.85em; color: var(--muted); letter-spacing: 0.04em; }
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Region-Isolated Streaming for Real-World CW Copy</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #172033;
+      --muted: #596273;
+      --paper: #ffffff;
+      --page: #edf1f7;
+      --line: #c9d1df;
+      --blue: #163d72;
+      --red: #9f2929;
+      --green: #1f6b42;
+      --soft-blue: #eef5ff;
+      --soft-green: #edf8f1;
+    }
 
-  h1.title {
-    font-size: 1.85em;
-    color: var(--navy);
-    margin: 0 0 4px;
-    line-height: 1.2;
-    font-weight: bold;
-  }
-  .subtitle {
-    font-style: italic;
-    color: var(--muted);
-    margin: 0 0 8px;
-    font-size: 1.05em;
-  }
-  .byline {
-    font-size: 0.95em;
-    margin: 0 0 4px;
-  }
-  .affiliation {
-    font-size: 0.85em;
-    color: var(--muted);
-    font-style: italic;
-    margin: 0 0 18px;
-  }
+    * { box-sizing: border-box; }
 
-  .abstract {
-    border-left: 4px solid var(--navy);
-    background: #fff;
-    padding: 12px 16px;
-    margin: 0 0 24px;
-    font-size: 0.97em;
-  }
-  .abstract .label {
-    font-variant: small-caps;
-    letter-spacing: 0.06em;
-    color: var(--navy);
-    font-weight: bold;
-    margin-right: 6px;
-  }
+    body {
+      margin: 0;
+      color: var(--ink);
+      background: var(--page);
+      font-family: "Segoe UI", Arial, sans-serif;
+      line-height: 1.55;
+    }
 
-  .columns {
-    column-count: 2;
-    column-gap: 28px;
-    column-rule: 1px solid #ddd;
-    text-align: justify;
-    hyphens: auto;
-  }
-  /* Some elements look poor when split across columns. */
-  figure, pre, table, .callout, h2, h3 {
-    break-inside: avoid;
-  }
+    main {
+      max-width: 1040px;
+      margin: 32px auto;
+      padding: 56px 64px;
+      background: var(--paper);
+      box-shadow: 0 12px 34px rgba(23, 32, 51, 0.12);
+    }
 
-  h2 {
-    font-size: 1.15em;
-    color: var(--navy);
-    border-bottom: 1px solid var(--navy);
-    padding-bottom: 2px;
-    margin: 22px 0 8px;
-    font-variant: small-caps;
-    letter-spacing: 0.04em;
-  }
-  h3 {
-    font-size: 1.0em;
-    color: #222;
-    margin: 16px 0 6px;
-    font-style: italic;
-  }
-  p { margin: 0 0 10px; }
+    header {
+      padding-bottom: 28px;
+      border-bottom: 3px solid var(--blue);
+    }
 
-  pre, code {
-    font-family: "Consolas", "Menlo", monospace;
-    font-size: 0.85em;
-  }
-  pre {
-    background: var(--code-bg);
-    padding: 10px 12px;
-    border-left: 3px solid var(--navy);
-    overflow-x: auto;
-    line-height: 1.4;
-    margin: 8px 0 14px;
-  }
-  code {
-    background: var(--code-bg);
-    padding: 0 3px;
-    border-radius: 2px;
-  }
-  pre code {
-    background: transparent;
-    padding: 0;
-  }
+    .kicker {
+      margin: 0 0 10px;
+      color: var(--blue);
+      font-size: 0.82rem;
+      font-weight: 700;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
 
-  figure {
-    margin: 12px 0;
-    background: #fff;
-    border: 1px solid #ccc;
-    padding: 10px;
-    text-align: center;
-  }
-  figure svg { max-width: 100%; height: auto; }
-  figcaption {
-    font-size: 0.83em;
-    color: var(--muted);
-    margin-top: 6px;
-    text-align: left;
-    font-style: italic;
-  }
-  figcaption strong { font-style: normal; color: var(--navy); }
+    h1 {
+      max-width: 850px;
+      margin: 0;
+      font-family: Georgia, serif;
+      font-size: clamp(2.2rem, 5vw, 4rem);
+      line-height: 1.05;
+    }
 
-  table {
-    border-collapse: collapse;
-    width: 100%;
-    margin: 8px 0 14px;
-    font-size: 0.9em;
-  }
-  th, td {
-    border-bottom: 1px solid #bbb;
-    padding: 5px 8px;
-    text-align: left;
-    vertical-align: top;
-  }
-  th {
-    border-bottom: 2px solid var(--navy);
-    color: var(--navy);
-    font-variant: small-caps;
-    letter-spacing: 0.04em;
-  }
-  tr.match td:first-child { color: #1b6b1b; font-weight: bold; }
+    .subtitle {
+      max-width: 780px;
+      margin: 20px 0 0;
+      color: var(--muted);
+      font-size: 1.18rem;
+    }
 
-  .callout {
-    background: #fff;
-    border: 1px solid var(--navy);
-    border-left: 6px solid var(--navy);
-    padding: 10px 14px;
-    margin: 12px 0;
-    font-size: 0.93em;
-  }
-  .callout .label {
-    font-variant: small-caps;
-    color: var(--navy);
-    font-weight: bold;
-    letter-spacing: 0.06em;
-    margin-right: 6px;
-  }
+    .byline {
+      margin: 18px 0 0;
+      font-weight: 600;
+    }
 
-  .refs ol { padding-left: 22px; }
-  .refs li { margin-bottom: 5px; font-size: 0.9em; }
+    nav {
+      margin: 30px 0;
+      padding: 18px 22px;
+      background: var(--soft-blue);
+      border-left: 4px solid var(--blue);
+    }
 
-  .footer {
-    border-top: 6px double var(--navy);
-    margin-top: 28px;
-    padding-top: 10px;
-    font-size: 0.82em;
-    color: var(--muted);
-    text-align: center;
-  }
+    nav strong { display: block; margin-bottom: 8px; }
+    nav a { margin-right: 16px; color: var(--blue); }
 
-  .key { color: var(--accent); font-weight: bold; }
-  .small-caps { font-variant: small-caps; letter-spacing: 0.04em; }
+    h2 {
+      margin: 42px 0 16px;
+      padding-bottom: 7px;
+      border-bottom: 1px solid var(--line);
+      color: var(--blue);
+      font-family: Georgia, serif;
+      font-size: 1.8rem;
+    }
 
-  ul, ol { padding-left: 22px; }
-  li { margin-bottom: 4px; }
+    h3 {
+      margin: 28px 0 10px;
+      color: var(--ink);
+      font-size: 1.2rem;
+    }
 
-  @media (max-width: 720px) {
-    .columns { column-count: 1; }
-  }
-</style>
+    p, li { max-width: 82ch; }
+    li + li { margin-top: 8px; }
+
+    code {
+      padding: 0.08em 0.3em;
+      border-radius: 3px;
+      background: #f1f3f7;
+      font-family: Consolas, monospace;
+      font-size: 0.92em;
+    }
+
+    pre {
+      overflow-x: auto;
+      padding: 18px;
+      color: #e7edf8;
+      background: #101827;
+      border-radius: 6px;
+    }
+
+    pre code {
+      padding: 0;
+      color: inherit;
+      background: transparent;
+    }
+
+    .abstract, .callout {
+      margin: 28px 0;
+      padding: 20px 24px;
+      border: 1px solid var(--line);
+      background: #fafbfd;
+    }
+
+    .callout.success {
+      border-left: 5px solid var(--green);
+      background: var(--soft-green);
+    }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 12px;
+      margin: 24px 0;
+    }
+
+    .flow div {
+      min-height: 110px;
+      padding: 16px;
+      border: 1px solid var(--line);
+      border-top: 4px solid var(--blue);
+      background: #fff;
+    }
+
+    .flow strong { display: block; margin-bottom: 7px; }
+
+    table {
+      width: 100%;
+      margin: 22px 0;
+      border-collapse: collapse;
+    }
+
+    th, td {
+      padding: 10px 12px;
+      border: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    th {
+      color: #fff;
+      background: var(--blue);
+    }
+
+    .pass { color: var(--green); font-weight: 700; }
+    .exact { white-space: nowrap; }
+
+    footer {
+      margin-top: 48px;
+      padding-top: 18px;
+      border-top: 1px solid var(--line);
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    @media (max-width: 760px) {
+      main { margin: 0; padding: 32px 22px; }
+      .flow { grid-template-columns: 1fr; }
+      table { display: block; overflow-x: auto; }
+    }
+
+    @media print {
+      body { background: #fff; }
+      main { margin: 0; padding: 0; box-shadow: none; }
+      a { color: inherit; text-decoration: none; }
+    }
+  </style>
 </head>
 <body>
-<div class="page">
-
-  <div class="masthead">
-    <span class="pub">QsoRipper Technical Report</span>
-    <span class="meta">A Forum for Communications Experimenters &middot; May 2026</span>
-  </div>
-
-  <h1 class="title">Region-Isolated Streaming for Real-World CW Copy</h1>
-  <p class="subtitle">A practical decoder architecture that holds 100% copy on multi-burst, mixed-speed off-air audio with operator pauses</p>
-  <p class="byline">Randy Treit, KC7AVA &mdash; with collaboration from the QsoRipper agent toolchain</p>
-  <p class="affiliation">QsoRipper Project &middot; <code>experiments/cw-decoder</code></p>
+<main>
+  <header>
+    <p class="kicker">QsoRipper technical report | May 2026</p>
+    <h1>Region-Isolated Streaming for Real-World CW Copy</h1>
+    <p class="subtitle">
+      This decoder architecture isolates each CW burst before it adds text to the transcript.
+    </p>
+    <p class="byline">Randy Treit, KC7AVA, with the QsoRipper agent toolchain</p>
+  </header>
 
   <div class="abstract">
-    <p><span class="label">Abstract.</span>
-      Off-air CW audio rarely behaves like a textbook practice file. An operator
-      sends a short burst at 13 WPM, pauses through 1&ndash;3 seconds of band hiss,
-      then sends another burst at 30 WPM, then pauses again. Most streaming
-      decoders &mdash; including our own earlier &ldquo;V3 envelope&rdquo; foundation &mdash;
-      handle the first burst well, but smear the second through residual lock
-      state, mis-classify dits and dahs at the new speed, or hallucinate
-      &ldquo;ghost&rdquo; characters from the static between bursts. This report describes
-      a region-isolated streaming architecture that detects each active CW burst
-      as a discrete region, decodes each region independently with its own
-      pitch and speed lock, and only commits the region&rsquo;s text to the
-      transcript once a trailing-static window confirms the burst has ended.
-      The architecture preserves the rich visualizer event stream of the
-      previous foundation, runs in true real-time on a stock laptop, and
-      delivers a 100% character-exact transcript on the target multi-burst
-      reference recording.
+    <p>
+      <strong>Abstract.</strong>
+      Off-air CW contains speed changes, receiver noise, and long operator pauses.
+      The earlier V3 envelope decoder kept state between CW bursts.
+      That state caused incorrect characters after some speed changes and noise intervals.
+      The new architecture detects each CW burst as a separate region.
+      It decodes each region with an independent pitch and speed estimate.
+      It adds text only after a stable noise interval confirms the end of the region.
+      The target recording produces an exact transcript with this method.
     </p>
   </div>
 
-  <div class="columns">
+  <nav aria-label="Report contents">
+    <strong>Contents</strong>
+    <a href="#problem">Problem</a>
+    <a href="#design">Design</a>
+    <a href="#integration">Integration</a>
+    <a href="#results">Results</a>
+    <a href="#limits">Limits</a>
+    <a href="#reproduce">Reproduction</a>
+  </nav>
 
-  <h2>1. The Problem</h2>
+  <section id="problem">
+    <h2>1. Problem</h2>
 
-  <p>
-    QsoRipper is a keyboard-first ham-radio logging system whose CW
-    subsystem must do two things at once: paint a visualization of what
-    the radio is hearing right now (waveform, lock state, classified
-    elements, current and historical WPM) and append a clean text
-    transcript of every Morse character that actually came through. The
-    visualizer is forgiving &mdash; it is fine to show a flicker when the
-    band changes &mdash; but the transcript is not. Operators rely on it for
-    contest exchanges, callsign capture, and post-QSO reconstruction.
-    A single ghost word at the start of a transmission is worse than no
-    decode at all.
-  </p>
+    <p>
+      QsoRipper shows live CW data and records a clean transcript.
+      Operators use the transcript for callsigns, contest exchanges, and QSO review.
+      A false word can be worse than an empty result.
+    </p>
 
-  <p>
-    The reference test case for this work is
-    <code>radio-20260502-105714.mp3</code>, an off-air capture from the
-    author&rsquo;s Kenwood TS-590SG. The file contains four CW bursts at
-    visibly different speeds, separated by background hiss:
-  </p>
+    <p>
+      The reference recording is <code>radio-20260502-105714.mp3</code>.
+      It contains four off-air CW bursts from a Kenwood TS-590SG.
+      Noise intervals separate the bursts.
+      The approximate speeds are 13, 8, 30, and 30 WPM.
+    </p>
 
-  <ol>
-    <li><code>IHU</code> &mdash; ~13 WPM</li>
-    <li><code>NVCHU</code> &mdash; ~8 WPM</li>
-    <li><code>7QP W7N</code> &mdash; ~30 WPM</li>
-    <li><code>7QP W7N</code> &mdash; ~30 WPM (repeat)</li>
-  </ol>
+    <table>
+      <thead>
+        <tr><th>Region</th><th>Expected text</th><th>Approximate speed</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>1</td><td><code>IHU</code></td><td>13 WPM</td></tr>
+        <tr><td>2</td><td><code>NVCHU</code></td><td>8 WPM</td></tr>
+        <tr><td>3</td><td><code>7QP W7N</code></td><td>30 WPM</td></tr>
+        <tr><td>4</td><td><code>7QP W7N</code></td><td>30 WPM</td></tr>
+      </tbody>
+    </table>
 
-  <p>
-    The ground-truth file
-    <code>radio-20260502-105714.truth.txt</code> is the operator&rsquo;s
-    canonical copy: <code>IHU NVCHU 7QP W7N 7QP W7N</code>. The success
-    criterion was simple: produce that string, character for character,
-    when the same audio is streamed through the production logger&rsquo;s
-    F7 live-mic capture path. Anything less &mdash; a missing letter, a
-    ghost letter, a merged word &mdash; was treated as failure.
-  </p>
+    <p>
+      The truth file contains <code>IHU NVCHU 7QP W7N 7QP W7N</code>.
+      The success criterion requires an exact character match through the production live-audio path.
+    </p>
 
-  <h2>2. Why the Previous Foundation Came Up Short</h2>
+    <h3>1.1 Earlier V3 envelope decoder</h3>
 
-  <p>
-    The pre-existing &ldquo;V3 envelope&rdquo; decoder
-    (<code>stream-live-v3</code>) is built around a single
-    <code>LiveEnvelopeStreamer</code> that ingests audio continuously,
-    estimates a Goertzel envelope at the locked pitch, runs a
-    percentile-based hysteresis state machine to classify on/off
-    intervals, and feeds a k-means dot/dah classifier with a
-    sample-indexed commit cursor. It is excellent at painting the
-    visualizer and at producing a stable transcript on long, single-speed
-    transmissions. It powers the <code>cw_decode_rx_wpm</code> field that
-    the production logger writes to ADIF as
-    <code>APP_QSORIPPER_RX_WPM</code>.
-  </p>
+    <p>
+      <code>LiveEnvelopeStreamer</code> processes one continuous audio stream.
+      It estimates a Goertzel envelope at the selected pitch.
+      A hysteresis state machine classifies signal intervals.
+      A k-means classifier identifies dits and dahs.
+    </p>
 
-  <p>
-    On <code>radio-20260502-105714.mp3</code>, however, V3 produced a
-    transcript that drifted progressively further from truth as it moved
-    from burst to burst. The root causes were structural:
-  </p>
+    <p>
+      This path gives useful visual data and stable results for long transmissions at one speed.
+      It also supplies <code>cw_decode_rx_wpm</code> for <code>APP_QSORIPPER_RX_WPM</code>.
+    </p>
 
-  <ul>
-    <li>
-      <span class="key">Sticky speed lock.</span> The locked WPM from
-      burst&nbsp;1 (13 WPM) is still the working hypothesis when burst&nbsp;2
-      starts at 8 WPM. The k-means classifier mis-labels dahs from the
-      slower burst as dits, dits as inter-element gaps.
-    </li>
-    <li>
-      <span class="key">Stale noise floor.</span> The percentile-based
-      noise/signal floors are estimated over a sliding window. When
-      static between bursts dominates the window, the threshold drifts
-      and trailing dits of the previous burst can re-fire as ghost
-      elements.
-    </li>
-    <li>
-      <span class="key">Append-cursor smearing.</span> The
-      sample-indexed commit cursor advances monotonically. If a region
-      decodes wrong on the first pass, that wrong decode is locked into
-      the transcript &mdash; later cycles cannot undo it without producing
-      a worse artifact (the &ldquo;TSA USA EE TSA USA EE&rdquo;
-      ghost-repeat pattern).
-    </li>
-  </ul>
+    <p>The reference recording exposed three structural problems:</p>
 
-  <p>
-    A natural fix was to add more tuning knobs to V3: tighter relock
-    thresholds, more aggressive noise-floor decay, content-stability
-    gates on the commit cursor. Each of those helped a little and broke
-    something else. After several rounds of this, we stepped back and
-    considered a different decomposition.
-  </p>
+    <ul>
+      <li><strong>Speed lock:</strong> A speed estimate from one burst affected the next burst.</li>
+      <li><strong>Noise floor:</strong> Noise between bursts changed the signal threshold.</li>
+      <li><strong>Commit cursor:</strong> The append-only cursor kept incorrect text from an early decode cycle.</li>
+    </ul>
+  </section>
 
-  <h2>3. Region-Isolated Decoding</h2>
+  <section id="design">
+    <h2>2. Region-isolated design</h2>
 
-  <p>
-    The insight is that real-world QSO audio is naturally segmented by
-    the operator. A burst is a discrete unit of intent: the operator
-    keys, sends some elements, releases. Between bursts, the receiver
-    sits in band noise. If we could detect those bursts as
-    <em>regions</em> and decode each region independently &mdash; with its
-    own fresh pitch lock, its own k-means classifier, its own WPM
-    estimate &mdash; the cross-burst contamination disappears by
-    construction. There is nothing to leak.
-  </p>
+    <p>
+      An operator burst is a discrete unit.
+      The operator keys the transmitter, sends CW, and releases the key.
+      Receiver noise occurs between bursts.
+      The decoder uses these noise intervals as region boundaries.
+    </p>
 
-  <figure>
-    <svg viewBox="0 0 760 200" xmlns="http://www.w3.org/2000/svg">
-      <!-- Time axis -->
-      <line x1="20" y1="120" x2="740" y2="120" stroke="#222" stroke-width="1"/>
-      <text x="20" y="138" font-size="11" fill="#555">t = 0</text>
-      <text x="710" y="138" font-size="11" fill="#555">end</text>
+    <div class="flow" aria-label="Region decode flow">
+      <div>
+        <strong>1. Detect</strong>
+        Find active CW regions in the audio envelope.
+      </div>
+      <div>
+        <strong>2. Isolate</strong>
+        Give each region an independent audio window.
+      </div>
+      <div>
+        <strong>3. Decode</strong>
+        Estimate pitch, speed, dits, and dahs for that region.
+      </div>
+      <div>
+        <strong>4. Commit</strong>
+        Add stable region text to the transcript.
+      </div>
+    </div>
 
-      <!-- Noise floor band -->
-      <rect x="20" y="115" width="720" height="10" fill="#ddd" opacity="0.6"/>
+    <h3>2.1 Region detection</h3>
 
-      <!-- Bursts -->
-      <rect x="60"  y="60" width="80"  height="60" fill="#102a54" opacity="0.85"/>
-      <text x="100" y="55" font-size="11" text-anchor="middle" fill="#102a54">IHU</text>
-      <text x="100" y="142" font-size="9" text-anchor="middle" fill="#555">~13 WPM</text>
+    <p>
+      <code>decode_region_stream</code> implements region detection in <code>region_stream.rs</code>.
+      It performs a coarse Goertzel pitch scan.
+      Then it calculates a frame energy envelope at the strongest pitch.
+    </p>
 
-      <rect x="200" y="40" width="120" height="80" fill="#102a54" opacity="0.85"/>
-      <text x="260" y="35" font-size="11" text-anchor="middle" fill="#102a54">NVCHU</text>
-      <text x="260" y="142" font-size="9" text-anchor="middle" fill="#555">~8 WPM</text>
-
-      <rect x="380" y="70" width="140" height="50" fill="#102a54" opacity="0.85"/>
-      <text x="450" y="65" font-size="11" text-anchor="middle" fill="#102a54">7QP W7N</text>
-      <text x="450" y="142" font-size="9" text-anchor="middle" fill="#555">~30 WPM</text>
-
-      <rect x="570" y="70" width="140" height="50" fill="#102a54" opacity="0.85"/>
-      <text x="640" y="65" font-size="11" text-anchor="middle" fill="#102a54">7QP W7N</text>
-      <text x="640" y="142" font-size="9" text-anchor="middle" fill="#555">~30 WPM</text>
-
-      <!-- Region brackets -->
-      <g stroke="#b21f1f" stroke-width="1.5" fill="none">
-        <path d="M55 165 L55 175 L145 175 L145 165"/>
-        <path d="M195 165 L195 175 L325 175 L325 165"/>
-        <path d="M375 165 L375 175 L525 175 L525 165"/>
-        <path d="M565 165 L565 175 L715 175 L715 165"/>
-      </g>
-      <text x="100" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;1</text>
-      <text x="260" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;2</text>
-      <text x="450" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;3</text>
-      <text x="640" y="190" font-size="10" text-anchor="middle" fill="#b21f1f">Region&nbsp;4</text>
-    </svg>
-    <figcaption>
-      <strong>Figure 1.</strong> Schematic envelope of
-      <code>radio-20260502-105714.mp3</code>. Four CW bursts (dark
-      bars) at three distinct speeds are separated by background hiss
-      (gray band). Each burst becomes one decode region (red brackets);
-      the inter-burst static is never decoded.
-    </figcaption>
-  </figure>
-
-  <h3>3.1 Detection</h3>
-
-  <p>
-    Region detection is implemented in
-    <code>region_stream.rs</code>::<code>decode_region_stream</code>. The
-    function performs a coarse Goertzel pitch sweep over the entire
-    buffer, picks the dominant tone, and computes a frame-level energy
-    envelope at that pitch. From the envelope it derives two robust
-    floors via percentiles:
-  </p>
-
-  <pre><code>noise_floor  = quantile(env, 0.30)
+    <pre><code>noise_floor  = quantile(env, 0.30)
 signal_floor = quantile(env, 0.95)
 threshold    = noise_floor
-             + threshold_factor &times; (signal_floor - noise_floor)</code></pre>
+             + threshold_factor * (signal_floor - noise_floor)</code></pre>
 
-  <p>
-    With <code>threshold_factor = 0.30</code>, the decision boundary
-    sits 30% of the way up the dynamic range &mdash; well clear of band
-    noise, well below saturation. Frames above threshold are marked
-    &ldquo;active&rdquo;. Active runs are merged across short gaps
-    (<code>merge_gap_s = 0.5 s</code> by default), and runs shorter
-    than <code>min_region_s = 0.3 s</code> are rejected as transient
-    static spikes. Each surviving run is padded symmetrically by
-    <code>pad_s = 0.15 s</code> so leading and trailing dits are not
-    clipped.
-  </p>
+    <p>
+      The default <code>threshold_factor</code> is <code>0.30</code>.
+      Active frames form candidate regions.
+      The detector merges gaps shorter than <code>0.5 s</code>.
+      It rejects regions shorter than <code>0.3 s</code>.
+      It adds <code>0.15 s</code> of padding at each region boundary.
+    </p>
 
-  <p>
-    A later synthetic impairment sweep added one more guard that belongs
-    in the baseline: before a detected run is decoded, it must show
-    narrowband CW-like prominence. The implementation compares Goertzel
-    power at the selected pitch against the run&rsquo;s broadband frame
-    energy and rejects runs below
-    <code>min_tonal_prominence_ratio = 8.0</code>. This prevents pure
-    background static from being promoted into fake regions simply
-    because a percentile threshold can always split random noise into
-    &ldquo;above&rdquo; and &ldquo;below&rdquo; frames.
-  </p>
+    <p>
+      A tonal-prominence test rejects broadband noise.
+      It compares Goertzel power at the selected pitch with broadband frame energy.
+      The default <code>min_tonal_prominence_ratio</code> is <code>8.0</code>.
+    </p>
 
-  <h3>3.2 Per-region decode</h3>
+    <h3>2.2 Region decode</h3>
 
-  <p>
-    For each detected region, the audio slice is handed to the
-    <code>ditdah</code> baseline decoder with no carry-over state. The
-    decoder estimates pitch and dot length fresh, runs its own k-means
-    classification, and emits a transcript fragment. Because each
-    region is short and homogeneous (one operator, one burst, one
-    speed), the baseline decoder &mdash; which was always strong on
-    short clean clips &mdash; performs near-perfectly.
-  </p>
+    <p>
+      The decoder sends each region to the <code>ditdah</code> baseline decoder.
+      Each decode operation starts without state from an earlier region.
+      It calculates a new pitch, dot length, classification, and transcript fragment.
+    </p>
 
-  <h3>3.3 The streaming wrapper</h3>
+    <h3>2.3 Streaming wrapper</h3>
 
-  <p>
-    <code>region_streamer.rs</code> wraps the batch detector for true
-    streaming use. It maintains a rolling sample buffer; on every
-    <code>try_commit()</code> call it re-runs detection over the
-    current buffer and reports any region whose end time is followed
-    by at least <code>stable_latency_s = 0.6 s</code> of trailing
-    static. That trailing-static window is the commit gate &mdash; it
-    guarantees that no further morse from the same burst can still be
-    arriving when we lock in the region&rsquo;s text.
-  </p>
+    <p>
+      <code>RegionStreamer</code> in <code>region_streamer.rs</code> keeps a rolling sample buffer.
+      Each <code>try_commit()</code> call runs region detection on that buffer.
+      The decoder commits a region after the stable noise interval.
+      The default <code>stable_latency_s</code> is <code>0.6 s</code>.
+    </p>
 
-  <pre><code>// Append-only commit, deduplicated across decode cycles.
-for region in detected:
-    if region.start &le; last_committed_end:
-        continue                    // already committed
+    <pre><code>for region in detected:
+    if region.start &lt;= last_committed_end:
+        continue
     if region.end &gt; head - stable_latency:
-        break                       // not stable yet
+        break
     transcript.append(region.text)
     last_committed_end = region.end</code></pre>
 
-  <p>
-    For long-running live capture, <code>trim_committed()</code> drops
-    the buffer back to a configurable lookback (default 6 s past the
-    last committed region), and <code>reset()</code> clears all state
-    in response to the operator&rsquo;s <code>Ctrl+Alt+W</code> relock
-    request, all without restarting the decoder process.
-  </p>
-
-  <h2>4. Integration with the V3 Visualizer</h2>
-
-  <p>
-    A key design constraint was that the visualizer must keep working.
-    Operators rely on the live waveform, the lock indicator, the
-    pitch readout, and the rolling WPM gauge to know whether the
-    decoder is healthy. The V3 envelope path produces all of those as a
-    side effect of its frame-level processing; the region streamer
-    produces none of them.
-  </p>
-
-  <p>
-    The integration therefore runs both decoders in parallel. The new
-    <code>--region-transcript</code> flag on
-    <code>stream-live-v3</code> instantiates a <code>RegionStreamer</code>
-    alongside the existing <code>LiveEnvelopeStreamer</code>. Audio
-    chunks are fed to both. The envelope streamer continues to emit
-    NDJSON <code>viz</code> frames on every decode cycle, exactly as
-    before. The region streamer&rsquo;s
-    <code>try_commit()</code> result overrides only one field on the
-    emitted <code>text</code> / <code>appended</code> / <code>end</code>
-    events: the cumulative <code>transcript</code> string.
-  </p>
-
-  <figure>
-    <svg viewBox="0 0 760 240" xmlns="http://www.w3.org/2000/svg">
-      <!-- Audio source -->
-      <rect x="20" y="100" width="120" height="40" fill="#fff" stroke="#102a54" stroke-width="1.5"/>
-      <text x="80" y="125" font-size="12" text-anchor="middle" fill="#102a54">Audio chunks</text>
-      <text x="80" y="155" font-size="10" text-anchor="middle" fill="#555">(mic / file replay)</text>
-
-      <!-- Fanout -->
-      <line x1="140" y1="120" x2="220" y2="60"  stroke="#102a54" stroke-width="1.5"/>
-      <line x1="140" y1="120" x2="220" y2="180" stroke="#102a54" stroke-width="1.5"/>
-
-      <!-- Envelope path -->
-      <rect x="220" y="40" width="200" height="60" fill="#fff" stroke="#102a54" stroke-width="1.5"/>
-      <text x="320" y="60" font-size="12" text-anchor="middle" fill="#102a54">LiveEnvelopeStreamer</text>
-      <text x="320" y="78" font-size="10" text-anchor="middle" fill="#555">Goertzel + hysteresis</text>
-      <text x="320" y="92" font-size="10" text-anchor="middle" fill="#555">k-means dot/dah, viz frames</text>
-
-      <!-- Region path -->
-      <rect x="220" y="160" width="200" height="60" fill="#fff" stroke="#b21f1f" stroke-width="1.5"/>
-      <text x="320" y="180" font-size="12" text-anchor="middle" fill="#b21f1f">RegionStreamer</text>
-      <text x="320" y="198" font-size="10" text-anchor="middle" fill="#555">burst detection +</text>
-      <text x="320" y="212" font-size="10" text-anchor="middle" fill="#555">per-region ditdah decode</text>
-
-      <!-- Merge -->
-      <line x1="420" y1="70"  x2="500" y2="120" stroke="#102a54" stroke-width="1.5"/>
-      <line x1="420" y1="190" x2="500" y2="120" stroke="#b21f1f" stroke-width="1.5"/>
-
-      <!-- Output -->
-      <rect x="500" y="80" width="240" height="80" fill="#fff" stroke="#102a54" stroke-width="1.5"/>
-      <text x="620" y="105" font-size="12" text-anchor="middle" fill="#102a54">NDJSON event stream</text>
-      <text x="620" y="125" font-size="10" text-anchor="middle" fill="#555">viz frames &larr; envelope</text>
-      <text x="620" y="142" font-size="10" text-anchor="middle" fill="#b21f1f">transcript &larr; region</text>
-    </svg>
-    <figcaption>
-      <strong>Figure 2.</strong> Dual-path integration. Audio is fanned
-      out to both decoders. The envelope path retains full ownership
-      of the visualizer&rsquo;s real-time frames; the region path owns
-      only the cumulative transcript field. Both UIs (production
-      logger F7 capture and the experimental visualizer) consume the
-      merged NDJSON stream unchanged.
-    </figcaption>
-  </figure>
-
-  <p>
-    Both UI surfaces &mdash; the production logger&rsquo;s
-    <code>CwDecoderProcessSampleSource</code> and the experimental
-    visualizer&rsquo;s <code>CwDecoderProcess</code> &mdash; spawn the
-    decoder with <code>--region-transcript</code> by default. Operators
-    do not see a new mode switch; they simply get a transcript that
-    matches what they actually heard.
-  </p>
-
-  <h2>5. Results</h2>
-
-  <p>
-    On the target reference recording, the architecture meets the
-    success criterion exactly:
-  </p>
-
-  <table>
-    <thead>
-      <tr><th>Path</th><th>Output transcript</th><th>vs. truth</th></tr>
-    </thead>
-    <tbody>
-      <tr class="match">
-        <td>truth.txt</td>
-        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
-        <td>&mdash;</td>
-      </tr>
-      <tr class="match">
-        <td><code>stream-region</code> (batch)</td>
-        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
-        <td>0 char diff</td>
-      </tr>
-      <tr class="match">
-        <td><code>stream-live-v3 --region-transcript</code></td>
-        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
-        <td>0 char diff</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <p>
-    A cross-validation run over additional samples confirms that the
-    streaming wrapper reproduces the batch reference on real CW audio:
-  </p>
-
-  <table>
-    <thead>
-      <tr><th>Sample</th><th>Description</th><th>Match</th></tr>
-    </thead>
-    <tbody>
-      <tr class="match">
-        <td><code>radio-20260502-105714.mp3</code></td>
-        <td>4 bursts, mixed WPM, real radio</td>
-        <td>yes</td>
-      </tr>
-      <tr class="match">
-        <td><code>cw_30wpm_abbrev_clean.wav</code></td>
-        <td>continuous, clean 30 WPM</td>
-        <td>yes</td>
-      </tr>
-      <tr class="match">
-        <td><code>cw_30wpm_abbrev_weak.wav</code></td>
-        <td>continuous, weak 30 WPM</td>
-        <td>yes</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <p>
-    A synthetic impairment suite now exercises the baseline beyond the
-    reference MP3. It generates deterministic CW with quiet static gaps,
-    additive white noise, QSB amplitude fading, an offset continuous-tone
-    QRM carrier, and a combined noise/QSB/QRM exchange. The suite also
-    includes a noise-only stream that previously produced ghost text;
-    after the tonal-prominence guard, it remains empty.
-  </p>
-
-  <table>
-    <thead>
-      <tr><th>Synthetic condition</th><th>Expected behavior</th><th>Result</th></tr>
-    </thead>
-    <tbody>
-      <tr class="match">
-        <td>clean four-burst reference shape</td>
-        <td><code>IHU NVCHU 7QP W7N 7QP W7N</code>, four regions</td>
-        <td>pass</td>
-      </tr>
-      <tr class="match">
-        <td>quiet static between bursts</td>
-        <td>same exact copy, no extra regions</td>
-        <td>pass</td>
-      </tr>
-      <tr class="match">
-        <td>noise-only static stream</td>
-        <td>empty transcript</td>
-        <td>pass</td>
-      </tr>
-      <tr class="match">
-        <td>moderate white noise + QSB + offset QRM</td>
-        <td><code>CQ TEST KC7AVA 73</code></td>
-        <td>pass</td>
-      </tr>
-    </tbody>
-  </table>
-
-  <div class="callout">
-    <p><span class="label">Validation gates.</span>
-      The change clears <code>cargo&nbsp;fmt</code>,
-      <code>cargo&nbsp;clippy&nbsp;-D&nbsp;warnings</code>, the full
-      <code>cargo&nbsp;test</code> suite (129 passing, one pre-existing
-      environmental skip unrelated to this work),
-      <code>dotnet&nbsp;publish&nbsp;CwDecoderGui&nbsp;-c&nbsp;Release</code>,
-      and <code>dotnet&nbsp;build&nbsp;QsoRipper.Gui&nbsp;-c&nbsp;Release</code>.
+    <p>
+      <code>trim_committed()</code> limits memory use during long sessions.
+      It keeps six seconds of audio after the last committed region by default.
+      <code>reset()</code> clears the state after the operator requests a relock.
     </p>
-  </div>
+  </section>
 
-  <h2>6. Discussion</h2>
+  <section id="integration">
+    <h2>3. V3 visualizer integration</h2>
 
-  <h3>6.1 Latency</h3>
+    <p>
+      The V3 envelope path continues to supply waveform, lock, pitch, WPM, and classified-element data.
+      The region path supplies only transcript text.
+      Both paths process the same audio chunks.
+    </p>
 
-  <p>
-    The trailing-static commit gate trades latency for correctness. With
-    <code>stable_latency_s = 0.6 s</code>, a region&rsquo;s text appears
-    in the transcript roughly 0.6 s after the operator releases the key
-    at the end of a burst. For logging and post-QSO copy this is
-    negligible. For real-time pile-up triage it would be perceptible;
-    the parameter is exposed as <code>--region-stable-latency-s</code>
-    and can be reduced at the cost of occasional re-decode churn.
-  </p>
+    <div class="flow" aria-label="Dual decoder integration">
+      <div>
+        <strong>Audio source</strong>
+        Microphone input or file replay supplies audio chunks.
+      </div>
+      <div>
+        <strong>Envelope path</strong>
+        <code>LiveEnvelopeStreamer</code> supplies visual events.
+      </div>
+      <div>
+        <strong>Region path</strong>
+        <code>RegionStreamer</code> supplies committed text.
+      </div>
+      <div>
+        <strong>NDJSON output</strong>
+        The merged stream keeps the existing client contract.
+      </div>
+    </div>
 
-  <h3>6.2 Why batch and stream agree on real CW</h3>
+    <p>
+      The <code>--region-transcript</code> option enables the dual path in <code>stream-live-v3</code>.
+      The envelope path continues to emit <code>viz</code> events.
+      The region path controls the cumulative <code>transcript</code> field.
+    </p>
 
-  <p>
-    The streaming wrapper and the batch reference call the same
-    <code>decode_region_stream</code> over the same audio. The only
-    difference is that the streaming wrapper invokes it incrementally
-    on a growing buffer. As long as the noise-floor percentiles are
-    stable across cycles &mdash; which they are once a real CW signal is
-    present &mdash; the detected regions are identical and the per-region
-    decoder is deterministic. On clips with no real signal, the
-    percentiles drift with the buffer length and incremental commits
-    can capture transient noise spikes that the batch reference
-    smooths out.
-  </p>
+    <p>
+      <code>CwDecoderProcessSampleSource</code> uses this option in the production logger.
+      <code>CwDecoderProcess</code> uses it in the experimental visualizer.
+      The client event contract does not change.
+    </p>
+  </section>
 
-  <h3>6.3 Relation to the append-only event-stream foundation</h3>
+  <section id="results">
+    <h2>4. Results</h2>
 
-  <p>
-    The append-only event-stream decoder in
-    <code>append_decode.rs</code> is not deprecated. It remains the
-    source of truth for the visualizer&rsquo;s bar painting and for
-    the time-weighted <code>cw_decode_rx_wpm</code> aggregator that
-    feeds ADIF. The region-isolated path supplements that foundation
-    for the transcript field; the two are now both &ldquo;line in the
-    sand&rdquo; baselines, each governing its own concern.
-  </p>
+    <p>The batch path and live path match the reference transcript.</p>
 
-  <h2 id="future">7. Future Directions</h2>
+    <table>
+      <thead>
+        <tr><th>Path</th><th>Output transcript</th><th>Result</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Truth file</td>
+          <td class="exact"><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
+          <td>Reference</td>
+        </tr>
+        <tr>
+          <td><code>stream-region</code></td>
+          <td class="exact"><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
+          <td class="pass">Exact</td>
+        </tr>
+        <tr>
+          <td><code>stream-live-v3 --region-transcript</code></td>
+          <td class="exact"><code>IHU NVCHU 7QP W7N 7QP W7N</code></td>
+          <td class="pass">Exact</td>
+        </tr>
+      </tbody>
+    </table>
 
-  <p>
-    Several extensions are natural next steps:
-  </p>
+    <p>Additional real CW samples gave the same batch and stream results.</p>
 
-  <ul>
-    <li>
-      <span class="key">Content-stability gate.</span> Require a
-      candidate region to produce identical decoded text across
-      <i>N</i> consecutive <code>try_commit</code> cycles before
-      committing. This would converge the streaming and batch outputs
-      on noisy non-CW clips at the cost of one decode period of
-      additional latency. A prototype was implemented and reverted to
-      keep the current behavior surgical and faithful to the batch
-      reference; it is the obvious next iteration.
-    </li>
-    <li>
-      <span class="key">Adaptive trailing-static window.</span>
-      Slow CW (5&ndash;8 WPM) has intra-character gaps approaching the
-      current 0.6 s commit gate. An adaptive
-      <code>stable_latency_s = max(0.6, 4 &times; estimated_dot_period)</code>
-      would let the gate scale with the operator&rsquo;s speed without
-      manual tuning.
-    </li>
-    <li>
-      <span class="key">Multi-pitch region routing.</span> When two
-      stations share the passband at different pitches, the existing
-      <code>LiveMultiPitchStreamer</code> already separates them at the
-      envelope level. Routing per-pitch envelopes into per-pitch
-      <code>RegionStreamer</code> instances would let us produce two
-      simultaneous transcripts &mdash; useful for SO2R and contest
-      monitoring.
-    </li>
-    <li>
-      <span class="key">Confidence and provisional text.</span>
-      The current commit gate is binary: a region is either committed
-      or invisible. A provisional-text channel that surfaces in-flight
-      regions with a confidence band would let the GUI render copy as
-      it forms, without disturbing the committed transcript.
-    </li>
-    <li>
-      <span class="key">Integration into the engine-side
-      <code>CwDecodeService</code>.</span> The decoder presently runs
-      as a subprocess of each UI. Promoting it to a gRPC service in
-      <code>src/rust/qsoripper-server</code> would let multiple clients
-      (Avalonia GUI, web dashboard, future TUI) share a single decoder
-      instance and a single set of region commits.
-    </li>
-    <li>
-      <span class="key">Larger labeled corpus.</span> The strongest
-      protection against regression is a broad, real-world test set.
-      Expanding the existing <code>training-set-a</code> /
-      <code>training-set-b</code> with more multi-burst, mixed-speed,
-      mixed-conditions captures &mdash; each with an operator-supplied
-      truth file &mdash; is the cheapest way to keep raising the bar.
-    </li>
-  </ul>
+    <table>
+      <thead>
+        <tr><th>Sample</th><th>Condition</th><th>Match</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>radio-20260502-105714.mp3</code></td><td>Four mixed-speed bursts</td><td class="pass">Yes</td></tr>
+        <tr><td><code>cw_30wpm_abbrev_clean.wav</code></td><td>Clean continuous 30 WPM</td><td class="pass">Yes</td></tr>
+        <tr><td><code>cw_30wpm_abbrev_weak.wav</code></td><td>Weak continuous 30 WPM</td><td class="pass">Yes</td></tr>
+      </tbody>
+    </table>
 
-  <h2>8. Reproducing the Result</h2>
+    <p>
+      Deterministic synthetic tests cover static gaps, white noise, QSB, offset QRM, and combined impairments.
+      A noise-only stream produces an empty transcript after the tonal-prominence test.
+    </p>
 
-  <p>
-    The complete cross-validation can be reproduced from a clean
-    checkout in a few minutes:
-  </p>
+    <table>
+      <thead>
+        <tr><th>Condition</th><th>Expected result</th><th>Test</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Clean four-burst signal</td><td>Exact transcript and four regions</td><td class="pass">Pass</td></tr>
+        <tr><td>Static between bursts</td><td>Exact transcript without extra regions</td><td class="pass">Pass</td></tr>
+        <tr><td>Noise-only stream</td><td>Empty transcript</td><td class="pass">Pass</td></tr>
+        <tr><td>Noise, QSB, and offset QRM</td><td><code>CQ TEST KC7AVA 73</code></td><td class="pass">Pass</td></tr>
+      </tbody>
+    </table>
 
-  <pre><code>cd C:\Users\randy\Git\qsoripper
+    <div class="callout success">
+      <p>
+        <strong>Validation record.</strong>
+        The change passed Cargo formatting, Clippy, Rust tests, the CW GUI publish, and the QsoRipper GUI build.
+        The Rust test run had 129 passes and one unrelated environmental skip.
+      </p>
+    </div>
+  </section>
+
+  <section id="limits">
+    <h2>5. Limits and future work</h2>
+
+    <h3>5.1 Commit latency</h3>
+
+    <p>
+      The stable noise interval adds approximately <code>0.6 s</code> after the key release.
+      This delay is acceptable for logging and QSO review.
+      Fast pileup work can make the delay visible.
+      Operators can change it with <code>--region-stable-latency-s</code>.
+    </p>
+
+    <h3>5.2 Batch and stream differences</h3>
+
+    <p>
+      Batch and stream paths call the same <code>decode_region_stream</code> function.
+      The stream path calls it many times on a growing buffer.
+      Noise-only audio can change percentile values as the buffer grows.
+      The tonal-prominence test reduces this risk.
+    </p>
+
+    <h3>5.3 Future changes</h3>
+
+    <ul>
+      <li>Require stable candidate text across multiple decode cycles.</li>
+      <li>Adjust the stable noise interval from the estimated dot period.</li>
+      <li>Route separate pitch tracks to separate region decoders.</li>
+      <li>Supply provisional text without a change to the committed transcript.</li>
+      <li>Move decoding to the engine-side <code>CwDecodeService</code>.</li>
+      <li>Add more labeled recordings with mixed speeds and signal conditions.</li>
+    </ul>
+  </section>
+
+  <section id="reproduce">
+    <h2>6. Reproduce the result</h2>
+
+    <ol>
+      <li>Open PowerShell in the QsoRipper repository.</li>
+      <li>Build the CW decoder in release configuration.</li>
+      <li>Set the sample and truth-file paths.</li>
+      <li>Run the batch command.</li>
+      <li>Run the live-stream command.</li>
+      <li>Compare both transcript fields with <code>$truth</code>.</li>
+    </ol>
+
+    <pre><code>cd C:\Users\randy\Git\qsoripper
 cargo build --manifest-path experiments\cw-decoder\Cargo.toml --release
 
 $exe   = "experiments\cw-decoder\target\release\cw-decoder.exe"
@@ -781,85 +536,44 @@ $truth = (Get-Content "$base\radio-20260502-105714.truth.txt" -Raw).Trim()
     --decode-every-ms 250 |
     Select-String '"type":"end"' | Select-Object -Last 1
 
-# Live streaming path used by both UIs.
+# Live path used by both user interfaces.
 &amp; $exe stream-live-v3 --file $f --json --region-transcript `
     --decode-every-ms 250 |
     Select-String '"type":"end"' | Select-Object -Last 1
 
-# Both transcript fields should equal $truth:
-#   IHU NVCHU 7QP W7N 7QP W7N</code></pre>
+# Both transcript fields must equal $truth.
+# IHU NVCHU 7QP W7N 7QP W7N</code></pre>
+  </section>
 
-  <h2>9. Conclusion</h2>
+  <section>
+    <h2>7. Conclusion</h2>
 
-  <p>
-    Multi-burst, mixed-speed off-air CW is a different problem from
-    long single-speed practice files, and it benefits from a different
-    decomposition. By detecting each operator burst as a region,
-    decoding each region independently, and committing only after a
-    trailing-static window, we achieve 100% character-exact transcripts
-    on real-world QSO audio that previously defeated our envelope-only
-    foundation. The architecture preserves the rich visualizer event
-    stream, integrates cleanly into both UI surfaces, and is now the
-    documented baseline against which future CW decoding experiments
-    will be measured. Future work will refine the commit gate, extend
-    to multi-pitch and provisional output, and grow the labeled corpus
-    that protects this baseline from regression.
-  </p>
+    <p>
+      Mixed-speed CW needs isolation between operator bursts.
+      The region architecture removes state transfer between these bursts.
+      It preserves the existing visualizer path and client contract.
+      It gives an exact transcript for the reference recording.
+      Future tests must compare all changes with this baseline.
+    </p>
+  </section>
 
-  <h2>Acknowledgments</h2>
+  <section>
+    <h2>References</h2>
 
-  <p>
-    Thanks to the upstream <code>ditdah</code> baseline decoder for the
-    short-clip Morse decoding that each region relies on, and to the
-    QsoRipper agent toolchain (Claude, GitHub Copilot CLI) for
-    rubber-ducking the architecture and helping cross-validate it
-    against the labeled corpus.
-  </p>
-
-  <h2 class="refs-h">References</h2>
-
-  <div class="refs">
     <ol>
-      <li>
-        QsoRipper repository,
-        <code>experiments/cw-decoder/</code> &mdash; primary source for
-        the implementation discussed in this report.
-      </li>
-      <li>
-        QsoRipper PR&nbsp;#375, &ldquo;cw-decoder: region-based streaming
-        decoder (100% match on real-world QSO sample)&rdquo;, batch
-        path.
-      </li>
-      <li>
-        QsoRipper PR&nbsp;#376, &ldquo;cw-decoder: wire region-isolated
-        transcript into live streaming + GUIs&rdquo;.
-      </li>
-      <li>
-        ARRL, <i>The ARRL Handbook for Radio Communications</i>,
-        chapter on Morse code timing and PARIS-derived WPM.
-      </li>
-      <li>
-        Goertzel, G., &ldquo;An Algorithm for the Evaluation of Finite
-        Trigonometric Series&rdquo;, <i>American Mathematical Monthly</i>,
-        Vol.&nbsp;65, No.&nbsp;1, 1958, pp.&nbsp;34&ndash;35.
-      </li>
-      <li>
-        Lloyd, S. P., &ldquo;Least Squares Quantization in PCM&rdquo;,
-        <i>IEEE Transactions on Information Theory</i>,
-        Vol.&nbsp;28, No.&nbsp;2, 1982, pp.&nbsp;129&ndash;137 (the
-        k-means classifier underlying the dot/dah decision).
-      </li>
+      <li>QsoRipper source: <code>experiments/cw-decoder/</code>.</li>
+      <li>QsoRipper pull request 375: region-based batch decode.</li>
+      <li>QsoRipper pull request 376: live region transcript integration.</li>
+      <li>ARRL Handbook for Radio Communications: Morse timing and WPM.</li>
+      <li>G. Goertzel, “An Algorithm for the Evaluation of Finite Trigonometric Series,” 1958.</li>
+      <li>S. P. Lloyd, “Least Squares Quantization in PCM,” 1982.</li>
     </ol>
-  </div>
+  </section>
 
-  </div><!-- /columns -->
-
-  <div class="footer">
-    QsoRipper Technical Report &middot; <i>Region-Isolated Streaming for
-    Real-World CW Copy</i> &middot; rev. May 2026.
+  <footer>
+    QsoRipper technical report.
     Source: <code>experiments/cw-decoder/docs/cw-decoder-architecture.html</code>.
-  </div>
-
-</div>
+  </footer>
+</main>
 </body>
 </html>

--- a/experiments/cw-decoder/scripts/arrl_corpus/README.md
+++ b/experiments/cw-decoder/scripts/arrl_corpus/README.md
@@ -1,16 +1,19 @@
-# ARRL CW Corpus — Index-Driven Parallel Harvester
+# ARRL CW Corpus - Index-Driven Parallel Harvester
 
-Fetch, trim, align, and slice the ARRL Code Practice (W1AW bulletin) archive
-into a labeled CW training corpus. Designed to be **fast** and **resumable**:
-one HTTP request per speed builds the full session index, then download / trim
-/ align run in parallel across all available cores.
+Fetch the ARRL Code Practice archive.
+Then trim, align, and divide it into a labeled CW training corpus.
+The archive contains W1AW bulletins.
+The process is **fast** and **resumable**.
+One HTTP request for each speed builds the complete session index.
+Then download, trim, and align operations use all available cores.
 
 ## Pilot result
 
-Pilot run on 4 speeds × 50 newest sessions = 200 sessions completed in **6.2
-minutes wall time** on a Windows workstation (8 download workers, 8 align
-workers). 1576 chunks / ~17.8 hours of clean labeled CW produced. See
-`quality_report.md` and `../../../EXPERIMENT_REPORT.md`.
+The pilot used four speeds and the 50 newest sessions for each speed.
+It processed 200 sessions in **6.2 minutes** on a Windows workstation.
+The process used eight download workers and eight alignment workers.
+It produced 1,576 chunks and approximately 17.8 hours of clean labeled CW.
+See `quality_report.md` and `../../../EXPERIMENT_REPORT.md`.
 
 ## Prerequisites
 
@@ -38,7 +41,7 @@ Common flags:
 | `--limit-per-speed`   | `50`                 | Newest N sessions per speed |
 | `--workers`           | `8`                  | Concurrent HTTP downloads (per-host cap) |
 | `--align-workers`     | `os.cpu_count()`     | Process pool size for trim+align |
-| `--skip-stages`       | _empty_              | e.g. `0,1` to skip rebuild & redownload |
+| `--skip-stages`       | _empty_              | for example `0,1` to skip rebuild & redownload |
 
 Stage indices: `0=build_index 1=download 2=trim 3=align 4=manifest 5=report`.
 
@@ -47,13 +50,13 @@ Stage indices: `0=build_index 1=download 2=trim 3=align 4=manifest 5=report`.
 | Stage | Module | What it does | Output |
 |:-----:|:-------|:-------------|:-------|
 | 0 | `build_index.py`     | One GET per speed → parses anchor tags → emits `index.jsonl` of every (wpm,date,mp3,txt) tuple. **No date-probing.** | `data/cw-samples/arrl-archive/index.jsonl` |
-| 1 | `download_parallel.py` | aiohttp + `Semaphore(workers)`; validates content-type (rejects the ARRL CDN GIF error page); per-file `*.dl.json` sidecar. Polite. | `data/cw-samples/arrl-archive/{wpm}wpm/raw/{YYMMDD}.{mp3,txt}` |
-| 2 | `trim_parallel.py`   | ProcessPool; ffmpeg → 8 kHz mono → Goertzel @ 700 Hz → strip intro/outro silence. | `…/trimmed/{YYMMDD}.wav` + `.trim.json` |
-| 3 | `align_parallel.py`  | ProcessPool spawning N `cw-decoder.exe stream-region` subprocesses; Levenshtein-anchored alignment vs truth → sentence-bounded chunks; drops chunks with align CER > 0.05 and whole files with CER > 0.50. | `…/chunks/{YYMMDD}_{seq:04d}.wav` + `.chunks.jsonl` |
+| 1 | `download_parallel.py` | aiohttp + `Semaphore(workers)`. Validates content-type (rejects the ARRL CDN GIF error page). Per-file `*.dl.json` sidecar. Polite. | `data/cw-samples/arrl-archive/{wpm}wpm/raw/{YYMMDD}.{mp3,txt}` |
+| 2 | `trim_parallel.py`   | ProcessPool. Ffmpeg → 8 kHz mono → Goertzel @ 700 Hz → strip intro/outro silence. | `…/trimmed/{YYMMDD}.wav` + `.trim.json` |
+| 3 | `align_parallel.py`  | ProcessPool spawning N `cw-decoder.exe stream-region` subprocesses. Levenshtein-anchored alignment vs truth → sentence-bounded chunks. Drops chunks with align CER > 0.05 and whole files with CER > 0.50. | `…/chunks/{YYMMDD}_{seq:04d}.wav` + `.chunks.jsonl` |
 | 4 | `manifest.py`        | Aggregates all `*.chunks.jsonl` → master manifest + 20-row committed sample. | `…/manifest.jsonl`, `sample_manifest.jsonl` |
 | 5 | `report.py`          | Per-speed coverage, duration histogram, alignment score distribution, spot checks, pipeline timings. | `quality_report.md` |
 
-All stages are **idempotent** — re-running with the same args is a no-op for
+All stages are **idempotent** - re-running with the same args is a no-op for
 already-completed work (downloads check size, trim/align check sidecar / chunks
 JSONL).
 
@@ -78,31 +81,31 @@ JSONL).
 - `wav_path` is forward-slash relative to the repo root.
 - `alignment_score` is per-chunk Levenshtein-anchored CER between the truth
   text and the decoder's transcript at the same proportional position. Lower
-  is better; chunks > 0.05 are dropped before manifest writeout.
+  is better. Chunks > 0.05 are dropped before manifest writeout.
 - `duration_s` is the actual sliced WAV duration (mono int16, 8 kHz).
 
 ## Scaling guidance
 
 - **Wider speed coverage:** add `5,7.5,10,13,18,35,40` to `--speeds`. The
   current `cw-decoder` model has trouble locking at 15 WPM (whole-file CER
-  ~0.30 → 0 chunks retained); `20+ WPM` works cleanly. The ARRL archive index
-  parser handles all 11 official speeds; the URL slug for fractional speeds
-  is `7pt5` (e.g. `https://www.arrl.org/7pt5-wpm-code-archive`).
+  ~0.30 → 0 chunks retained). `20+ WPM` works cleanly. The ARRL archive index
+  parser handles all 11 official speeds. The URL slug for fractional speeds
+  is `7pt5` (for example `https://www.arrl.org/7pt5-wpm-code-archive`).
 - **Full archive:** drop `--limit-per-speed`. Each speed has ~285 sessions
-  going back to 2013–2014 (bi-weekly cadence). Total at 8 speeds with full
+  going back to 2013-2014 (bi-weekly cadence). Total at 8 speeds with full
   alignment ≈ ~3 000 sessions, ~470 audio hours, ~30 000+ chunks.
 - **Throughput:** download stage is bandwidth-bound at ~1.1 files/s/host
   (deliberately polite). Alignment stage is CPU-bound, ~1.2 sessions/s on 8
   cores. To go faster on a beefier box bump `--align-workers`. Do **not**
-  bump `--workers` past 8; ARRL is a non-profit hosting public files.
-- **Resumability:** kill at any point and re-run; finished work is skipped.
+  bump `--workers` past 8. ARRL is a non-profit hosting public files.
+- **Resumability:** kill at any point and re-run. Finished work is skipped.
   To force a refetch, delete the per-file `*.dl.json` sidecar (or the file
   itself).
 
 ## Why the index-driven approach
 
 The prior pipeline (`u/randy/cw-exp-arrl-corpus`) blindly probed every
-Mon/Wed/Fri date in 2024–2026 with a HEAD request, then a GET on hits. That
+Mon/Wed/Fri date in 2024-2026 with a HEAD request, then a GET on hits. That
 took 80+ minutes for **2 sessions**. ARRL bulletins are actually **bi-weekly**
 and every available file is listed in plain HTML on the per-speed archive
 page. One HTTP request per speed (≤11 total) replaces ~9 000 blind probes.

--- a/experiments/cw-decoder/scripts/arrl_corpus/quality_report.md
+++ b/experiments/cw-decoder/scripts/arrl_corpus/quality_report.md
@@ -1,4 +1,4 @@
-# ARRL CW Corpus — Quality Report (Index-Driven Pipeline)
+# ARRL CW Corpus - Quality Report (Index-Driven Pipeline)
 
 Auto-generated from `data/cw-samples/arrl-archive/manifest.jsonl` and the per-session `*.trim.json` sidecars by the index-driven parallel harvester.
 
@@ -53,7 +53,7 @@ Auto-generated from `data/cw-samples/arrl-archive/manifest.jsonl` and the per-se
 ## Per-Chunk Alignment Score Distribution
 
 - median=0.0146, p95=0.0312, max retained=0.0500
-- (drop threshold: 0.05; chunks above were filtered out by `align_parallel.py`)
+- (drop threshold: 0.05. Chunks above were filtered out by `align_parallel.py`)
 
 ## Spot Checks (8 random chunks)
 
@@ -75,16 +75,24 @@ Auto-generated from `data/cw-samples/arrl-archive/manifest.jsonl` and the per-se
 
 ## Known Limitations
 
-- **Studio-clean source.** ARRL bulletins are recorded directly from a code generator; no QSB, no QRM, no fading, single oscillator pitch (~700 Hz). A model trained only on this corpus will be brittle on real on-air audio. Use it as a pretraining seed and add on-the-fly augmentation (additive noise, SNR randomization, pitch shifts ±300 Hz, time-warp ±10 %, fading, QSB, key-clicks).
-- **Bulletin vocabulary.** Texts are pulled from QST articles, ARRL announcements and callsign drills. Ham vocabulary is well represented; conversational English / contest exchanges are not.
+- **Studio-clean source.** ARRL bulletins are recorded directly from a code generator. No QSB, no QRM, no fading, single oscillator pitch (~700 Hz). A model trained only on this corpus will be brittle on real on-air audio. Use it as a pretraining seed. Add noise, SNR changes, pitch shifts, time changes, fading, QSB, and key clicks during training.
+- **Bulletin vocabulary.** Texts are pulled from QST articles, ARRL announcements and callsign drills. Ham vocabulary is well represented. Conversational English / contest exchanges are not.
 - **One WPM per file.** Mixed-speed bursts (typical of real QSOs) are not represented.
-- **Uniform char-rate alignment.** We assume constant CW rate within a session; small tempo wobble or operator pauses can shift chunk boundaries by 0.3–0.8 s. The drop threshold (alignment CER > 0.05) catches the worst cases.
+- **Uniform character-rate alignment.** We assume a constant CW rate in each session.
+  Small tempo changes or operator pauses can move chunk boundaries by 0.3 to 0.8 seconds.
+  The drop threshold (`alignment CER > 0.05`) finds the worst cases.
 - **Bi-weekly cadence.** The ARRL archive has been bi-weekly (every 2 weeks) since at least 2014. The index parser pulls every available date in one HTTP request per speed, eliminating the prior pipeline's blind date probing.
 
 ## Recommended Use
 
 - **Pretraining only.** Use this corpus to bootstrap a CTC / transducer encoder.
-- **Always augment.** Suggested chain: random gain → additive band-limited noise to reach SNR ∈ [-3, +20] dB → ±300 Hz pitch shift → random 5–10 % time stretch → occasional QSB envelope (0.3–1.5 Hz). Keep the truth label unchanged.
+- **Always augment.** Use this suggested sequence:
+  random gain, band-limited noise, pitch shift, time stretch, and a QSB envelope.
+  Use an SNR from -3 through +20 dB.
+  Use a pitch shift of up to 300 Hz in each direction.
+  Use a time stretch from 5 through 10 percent.
+  Use a QSB rate from 0.3 through 1.5 Hz.
+  Keep the truth label unchanged.
 - **Validation set.** Reserve ≥ 1 full session per speed (hold out by date) so you never evaluate on a chunk whose neighbours were trained on.
 - **Mix with augmented synthetic.** Combine 70 % ARRL chunks with 30 % synthetic CW from `gen-rough-fist` / `gen-qso-suite` to add fist variability and prosigns.
 
@@ -94,5 +102,5 @@ ARRL archive coverage observed during pilot index build:
 
 - ~285 sessions per speed × 11 speeds available = ~3 100 candidate sessions.
 - Median trimmed length ~9 min ≈ ~470 hours of clean labeled CW at full coverage.
-- At pilot's chunks-per-session density, that's ~30 000–40 000 labeled chunks.
+- At the pilot chunks-per-session density, the result is approximately 30 000-40 000 labeled chunks.
 - Storage at 8 kHz int16: ~17 GB raw WAV. MP3 source ~35 GB.

--- a/experiments/cw-decoder/scripts/augment_arrl/README.md
+++ b/experiments/cw-decoder/scripts/augment_arrl/README.md
@@ -1,9 +1,10 @@
 # ARRL CW augmentation pipeline
 
-Generate a deterministic, multi-impairment augmentation of the pristine ARRL
-Code Practice corpus (1,576 chunks, 17.84 h, median CER 1.6 %) so downstream
-training experiments can target real-world HF channel conditions instead of
-the unrealistically clean ARRL recordings.
+Generate a repeatable augmentation of the original ARRL Code Practice corpus.
+The corpus contains 1,576 chunks and 17.84 hours of audio.
+Its median CER is 1.6 percent.
+The augmentation applies multiple impairments.
+Thus, training experiments can use realistic HF-channel conditions.
 
 ## Layout
 
@@ -29,7 +30,7 @@ seed_u32 = zlib.crc32(f"{chunk_id}|{augment_seed}".encode()) & 0xFFFFFFFF
 rng = numpy.random.default_rng(seed_u32)
 ```
 
-`chunk_id` is `"{wpm_dir}_{wav_stem}"` (e.g. `20wpm_230905_0000`) so the
+`chunk_id` is `"{wpm_dir}_{wav_stem}"` (for example `20wpm_230905_0000`) so the
 same stem in two different speed buckets yields independent variants.
 
 ## Quickstart
@@ -56,31 +57,31 @@ py -m augment_arrl.report
 
 ## Impairment summary
 
-Group A — timing / rate
+Group A - timing / rate
 
 - WPM scale (always, [0.7, 1.5])
-- Farnsworth ratio (20 %, [1.2, 3.0]) — gap-only stretch
+- Farnsworth ratio (20 %, [1.2, 3.0]) - gap-only stretch
 - WPM drift in chunk (always, ε∈[0, 0.10], f∈[0.01, 0.1] Hz)
-- Per-element LogNormal jitter (always; paddle 0.05, amateur 0.10, rough 0.20)
+- Per-element LogNormal jitter (always. Paddle 0.05, amateur 0.10, rough 0.20)
 
-Group B — frequency / pitch
+Group B - frequency / pitch
 
 - Pitch shift (always, ±50 Hz from 700 Hz carrier)
 - Pitch drift (30 %, ±20 Hz/min)
-- VFO chirp on key-down (30 %, ±5–10 Hz)
+- VFO chirp on key-down (30 %, ±5-10 Hz)
 
-Group C — HF channel
+Group C - HF channel
 
 - Watterson 2-tap (65 %, profiles `good` / `moderate` / `poor` per ITU-R F.1487)
 - QSB (55 %, f∈[0.1, 2.0] Hz, depth∈[0.2, 0.8])
 
-Group D — noise / interference
+Group D - noise / interference
 
 - AWGN (always, SNR ∈ {0, 5, 10, 15, 20, 30} dB)
 - Pink noise (45 %, configurable level)
-- Atmospheric impulses (1 %, Poisson 0.5–3 Hz)
+- Atmospheric impulses (1 %, Poisson 0.5-3 Hz)
 - QRM (30 %, partner chunk at Δpitch ∈ [-100, 100] Hz, S/QRM ∈ [-6, 6] dB)
-- Receiver birdies (5 %, 1–2 tones at ±50–200 Hz)
+- Receiver birdies (5 %, 1-2 tones at ±50-200 Hz)
 - AGC pumping (10 %, attack 10 ms / release 200 ms)
 
 ## Output layout

--- a/experiments/cw-decoder/scripts/kaggle_morse_v2/README.md
+++ b/experiments/cw-decoder/scripts/kaggle_morse_v2/README.md
@@ -1,8 +1,10 @@
-# Kaggle Morse Learning Machine Challenge v2 — external benchmark
+# Kaggle Morse Learning Machine Challenge v2 - external benchmark
 
-This pipeline ingests the Kaggle [Morse Learning Machine Challenge v2][kaggle]
-dataset and uses it as a **third external benchmark** alongside `training-set-a`
-(real OTA) and the adversarial synthetic suite (`bench_adversarial.py`).
+This pipeline reads the Kaggle [Morse Learning Machine Challenge v2][kaggle] dataset.
+It uses the dataset as a **third external benchmark**.
+The other benchmarks are `training-set-a` and `bench_adversarial.py`.
+`training-set-a` contains real OTA audio.
+`bench_adversarial.py` supplies the adversarial synthetic suite.
 
 [kaggle]: https://www.kaggle.com/competitions/morse-learning-machine-challenge-v2
 
@@ -13,31 +15,31 @@ Tracks GitHub issue **#424**.
 1. **External metric.** Public, third-party CER number scored on data we did not
    pick. Defends against silently overfitting `training-set-a`.
 2. **Distribution coverage.** Kaggle randomizes per-file SNR (−14 to +20 dB),
-   pitch (600–1200 Hz), and speed (12–80 WPM). Our current OTA bench tops out
-   around 40 WPM, so the high-WPM tail (50–80) stresses regions we never see.
+   pitch (600-1200 Hz), and speed (12-80 WPM). Our current OTA bench tops out
+   around 40 WPM, so the high-WPM tail (50-80) stresses regions we never see.
 3. **Augmenter cross-check.** The `augment_arrl` synthesizer aims at the same
-   randomization envelope. If augmented-corpus statistics don't bracket
+   randomization envelope. If augmented-corpus statistics do not include
    Kaggle's, the augmenter is mis-tuned.
 
 ## Dataset facts
 
 - 200 WAV files, mono, 32-bit float, 8 kHz
 - File naming: `cw001.wav` … `cw200.wav`
-- ~100 labeled (training); ~100 held out (validation, scored via leaderboard)
+- ~100 labeled (training). ~100 held out (validation, scored via leaderboard)
 - Per-file randomization: SNR ∈ [−14, +20] dB, pitch ∈ [600, 1200] Hz,
   speed ∈ [12, 80] WPM
 - Scoring metric: Levenshtein distance == our CER
 
 ## What this pipeline does
 
-1. **Download** — `download.py` invokes `kaggle competitions download` and
+1. **Download** - `download.py` invokes `kaggle competitions download` and
    extracts under `data/cw-samples/kaggle-morse-v2/` (gitignored).
-2. **Manifest** — `build_manifest.py` reads `SampleSubmission.csv` and the
+2. **Manifest** - `build_manifest.py` reads `SampleSubmission.csv` and the
    training labels, producing `manifest.jsonl` rows of `{id, wav, truth, split}`.
-3. **Bench** — `bench.py` runs `cw-decoder.exe stream-region --json --no-realtime`
-   on each WAV, computes per-file CER, buckets by *estimated* WPM and pitch
-   (extracted from the decoder's region trace), and writes a JSON report.
-4. **Submission** — `submit.py` generates a leaderboard-shaped CSV from the
+3. **Bench** - `bench.py` runs `cw-decoder.exe stream-region --json --no-realtime` on each WAV.
+   It calculates CER for each file. It groups results by estimated WPM and pitch.
+   It gets these values from the decoder region trace. Then it writes a JSON report.
+4. **Submission** - `submit.py` generates a leaderboard-shaped CSV from the
    held-out half and prints the path you upload to Kaggle.
 
 The harness pattern matches `bench_adversarial.py` (PR #417) for consistency.
@@ -59,7 +61,7 @@ Two paths are supported.
 3. **Accept the competition rules** (one-time, browser-only):
    <https://www.kaggle.com/competitions/morse-learning-machine-challenge-v2/rules> →
    click "I Understand and Accept". Without this step, every download endpoint
-   returns 403 Forbidden — Kaggle does not expose a programmatic
+   returns 403 Forbidden - Kaggle does not expose a programmatic
    rules-acceptance API.
 
 `download.py` reads `.env` automatically (no `python-dotenv` dependency) and
@@ -121,9 +123,10 @@ Measured impact on the 200-file held-out split:
 
 ## Smoke test (no Kaggle account needed)
 
-If you want to verify the harness without registering for Kaggle, the bench
-script accepts `--manifest <path>` so you can point at a synthetic mini-suite
-that uses the same WAV format + SNR/WPM/pitch envelope:
+You can verify the harness without a Kaggle account.
+Give `--manifest <path>` to the bench script.
+The path can identify a synthetic small suite.
+The suite must use the same WAV, SNR, WPM, and pitch format:
 
 ```powershell
 python experiments\cw-decoder\scripts\kaggle_morse_v2\generate_synthetic_minisuite.py
@@ -135,9 +138,9 @@ python experiments\cw-decoder\scripts\kaggle_morse_v2\bench.py `
 
 ## Output
 
-- `manifest.jsonl` — `{id, wav, truth, split, ...}` rows
-- `<out>.json` — per-file CER plus aggregate stats and SNR/WPM/pitch buckets
-- `<out>_submission.csv` — Kaggle-format predictions for the held-out split
+- `manifest.jsonl` - `{id, wav, truth, split, ...}` rows
+- `<out>.json` - per-file CER plus aggregate stats and SNR/WPM/pitch buckets
+- `<out>_submission.csv` - Kaggle-format predictions for the held-out split
 
 ## Limitations
 
@@ -145,4 +148,4 @@ python experiments\cw-decoder\scripts\kaggle_morse_v2\bench.py `
 - This is **not** real-world. Synthetic CW + AWGN, no Watterson, no QRM, no fist
   variation. Beating Kaggle is necessary but not sufficient for OTA performance.
 - SNR/WPM/pitch labels are per-synthesis-parameter and are not in the published
-  truth file; the bench buckets by *post-hoc decoder estimates*. Expect noise.
+  truth file. The bench buckets by *post-hoc decoder estimates*. Expect noise.

--- a/scripts/Start-CatHub.ps1
+++ b/scripts/Start-CatHub.ps1
@@ -24,11 +24,15 @@ function Find-CatHubExecutable {
     if (Test-Path -LiteralPath $bundled) {
         return $bundled
     }
+    $sibling = Join-Path (Split-Path -Parent $repoRoot) "cathub\target\release\$binaryName"
+    if (Test-Path -LiteralPath $sibling) {
+        return $sibling
+    }
     $command = Get-Command cathub -ErrorAction SilentlyContinue
     if ($command) {
         return $command.Source
     }
-    throw 'CatHub is not installed. Set CATHUB_EXECUTABLE, add cathub to PATH, or bundle it under artifacts\publish\cathub\Release.'
+    throw 'CatHub is not installed. Set CATHUB_EXECUTABLE, add cathub to PATH, build it in a sibling cathub checkout, or bundle it under artifacts\publish\cathub\Release.'
 }
 
 function Get-QsoRipperConfigPath {

--- a/src/rust/deny.toml
+++ b/src/rust/deny.toml
@@ -70,6 +70,11 @@ version = "=0.5.10"
 reason = "Used by tonic 0.12 transport; newer networking dependencies in the graph use socket2 0.6."
 
 [[bans.skip]]
+name = "syn"
+version = ">=2, <3"
+reason = "Proc-macro dependencies are migrating to syn 3, while tonic and ratatui transitives still require syn 2."
+
+[[bans.skip]]
 name = "tower"
 version = "=0.4.13"
 reason = "Used by tonic 0.12 transport; reqwest and newer Hyper/Axum dependencies use tower 0.5."

--- a/src/rust/qsoripper-launcher/src/catalog.rs
+++ b/src/rust/qsoripper-launcher/src/catalog.rs
@@ -48,13 +48,20 @@ pub(crate) struct ArtifactSpec {
     /// platform suffix is appended in [`ArtifactSpec::executable_path`]).
     pub executable_stem: &'static str,
     /// Optional environment variable containing an explicitly installed executable.
-    /// When present, resolution falls back to a bundled artifact and then `PATH`.
+    /// When present, resolution may fall back to external development and install locations.
     pub external_executable_env: Option<&'static str>,
+    /// Optional sibling source checkout whose Cargo output can be used during development.
+    pub sibling_source_checkout: Option<&'static str>,
 }
 
 impl ArtifactSpec {
     /// Resolve the full executable path under the published artifact root.
     pub(crate) fn executable_path(&self, root: &ArtifactRoot) -> PathBuf {
+        let mut file_name = self.executable_stem.to_owned();
+        if cfg!(windows) {
+            file_name.push_str(".exe");
+        }
+
         if let Some(variable) = self.external_executable_env {
             if let Some(path) = std::env::var_os(variable).map(PathBuf::from) {
                 if path.is_file() {
@@ -62,21 +69,35 @@ impl ArtifactSpec {
                 }
             }
         }
-        let mut p = root
+        let bundled = root
             .path()
             .join(self.publish_subdir)
-            .join(root.configuration());
-        let mut name = self.executable_stem.to_owned();
-        if cfg!(windows) {
-            name.push_str(".exe");
+            .join(root.configuration())
+            .join(&file_name);
+        if bundled.is_file() || self.external_executable_env.is_none() {
+            return bundled;
         }
-        p.push(name);
-        if self.external_executable_env.is_some() && !p.is_file() {
-            if let Some(installed) = find_on_path(p.file_name().unwrap_or_default()) {
+
+        if let (Some(repo_root), Some(checkout)) = (root.repo_root(), self.sibling_source_checkout)
+        {
+            if let Some(parent) = repo_root.parent() {
+                let source_build = parent
+                    .join(checkout)
+                    .join("target")
+                    .join(root.configuration().to_ascii_lowercase())
+                    .join(&file_name);
+                if source_build.is_file() {
+                    return source_build;
+                }
+            }
+        }
+
+        if self.external_executable_env.is_some() {
+            if let Some(installed) = find_on_path(file_name.as_ref()) {
                 return installed;
             }
         }
-        p
+        bundled
     }
 }
 
@@ -95,6 +116,7 @@ const fn bundled_artifact(
         publish_subdir,
         executable_stem,
         external_executable_env: None,
+        sibling_source_checkout: None,
     }
 }
 
@@ -121,6 +143,7 @@ pub(crate) fn catalog() -> Vec<ComponentSpec> {
                 publish_subdir: "cathub",
                 executable_stem: "cathub",
                 external_executable_env: Some("CATHUB_EXECUTABLE"),
+                sibling_source_checkout: Some("cathub"),
             },
         },
         ComponentSpec {
@@ -241,6 +264,40 @@ mod tests {
             spec.artifact.external_executable_env,
             Some("CATHUB_EXECUTABLE")
         );
+        assert_eq!(spec.artifact.sibling_source_checkout, Some("cathub"));
+    }
+
+    #[test]
+    fn cathub_resolves_from_a_built_sibling_checkout() {
+        let workspace =
+            std::env::temp_dir().join(format!("qsoripper-launcher-cathub-{}", std::process::id()));
+        let repo_root = workspace.join("qsoripper");
+        let executable_name = if cfg!(windows) {
+            "cathub.exe"
+        } else {
+            "cathub"
+        };
+        let sibling_executable = workspace
+            .join("cathub")
+            .join("target")
+            .join("release")
+            .join(executable_name);
+        std::fs::create_dir_all(sibling_executable.parent().expect("executable parent"))
+            .expect("create sibling target directory");
+        std::fs::write(&sibling_executable, []).expect("create sibling executable");
+
+        let root =
+            ArtifactRoot::from_repo_root(&repo_root, crate::discovery::Configuration::Release);
+        let spec = ArtifactSpec {
+            publish_subdir: "cathub",
+            executable_stem: "cathub",
+            external_executable_env: Some("QSORIPPER_TEST_CATHUB_EXECUTABLE"),
+            sibling_source_checkout: Some("cathub"),
+        };
+
+        assert_eq!(spec.executable_path(&root), sibling_executable);
+
+        std::fs::remove_dir_all(workspace).expect("remove sibling checkout fixture");
     }
 
     #[test]

--- a/src/rust/qsoripper-launcher/src/discovery.rs
+++ b/src/rust/qsoripper-launcher/src/discovery.rs
@@ -25,6 +25,7 @@ impl Configuration {
 pub(crate) struct ArtifactRoot {
     publish_root: PathBuf,
     configuration: &'static str,
+    repo_root: Option<PathBuf>,
 }
 
 impl ArtifactRoot {
@@ -33,12 +34,15 @@ impl ArtifactRoot {
         Self {
             publish_root,
             configuration: configuration.as_str(),
+            repo_root: None,
         }
     }
 
     /// Resolve `artifacts/publish/` relative to a repo root.
     pub(crate) fn from_repo_root(repo_root: &Path, configuration: Configuration) -> Self {
-        Self::new(repo_root.join("artifacts").join("publish"), configuration)
+        let mut root = Self::new(repo_root.join("artifacts").join("publish"), configuration);
+        root.repo_root = Some(repo_root.to_path_buf());
+        root
     }
 
     pub(crate) fn path(&self) -> &Path {
@@ -47,6 +51,10 @@ impl ArtifactRoot {
 
     pub(crate) fn configuration(&self) -> &str {
         self.configuration
+    }
+
+    pub(crate) fn repo_root(&self) -> Option<&Path> {
+        self.repo_root.as_deref()
     }
 }
 

--- a/tests/Docs.LookupParity.Tests.ps1
+++ b/tests/Docs.LookupParity.Tests.ps1
@@ -54,15 +54,15 @@ Describe 'LookupService doc/implementation parity' {
 
     Context 'docs/api/lookup-service.md status table reflects implementation' {
         It 'marks BatchLookup as Implemented' {
-            Assert-DocsLookupMatches $global:DocsLookupLookupDocContent '\|\s*`BatchLookup`\s*\|\s*✅\s*Implemented'
+            Assert-DocsLookupMatches $global:DocsLookupLookupDocContent '\|\s*`BatchLookup`\s*\|\s*Implemented'
         }
 
         It 'marks GetDxccEntity by dxcc_code as Implemented' {
-            Assert-DocsLookupMatches $global:DocsLookupLookupDocContent '\|\s*`GetDxccEntity`\s*\(by\s*`dxcc_code`\)\s*\|\s*✅\s*Implemented'
+            Assert-DocsLookupMatches $global:DocsLookupLookupDocContent '\|\s*`GetDxccEntity`\s*\(by\s*`dxcc_code`\)\s*\|\s*Implemented'
         }
 
         It 'marks GetDxccEntity by prefix as Unimplemented' {
-            Assert-DocsLookupMatches $global:DocsLookupLookupDocContent '\|\s*`GetDxccEntity`\s*\(by\s*`prefix`\)\s*\|\s*⚠️\s*Unimplemented'
+            Assert-DocsLookupMatches $global:DocsLookupLookupDocContent '\|\s*`GetDxccEntity`\s*\(by\s*`prefix`\)\s*\|\s*Unimplemented'
         }
     }
 


### PR DESCRIPTION
Updates QsoRipper documentation and reports to use ASD-STE100 Issue 9 guidance. Adds repository instructions and a documentation review checklist. Rewrites maintained documentation and the CW decoder report. Keeps technical identifiers, commands, paths, and protocol values exact.

Also lets the launcher find a release build from a sibling CatHub checkout. Adds launcher coverage for this path. Updates documentation parity tests so they verify status words without prohibited emoji markers.

Validation:

.\test.ps1 pester passed all 37 tests.

cargo fmt --manifest-path src\rust\Cargo.toml --all -- --check passed.

cargo test --manifest-path src\rust\Cargo.toml -p qsoripper-launcher passed all 46 tests.

cargo clippy --manifest-path src\rust\Cargo.toml --all-targets -- -D warnings passed.

Objective prose checks passed for contractions, Latin abbreviations, semicolons, and em dashes.

The full Rust workspace test reached one FFI integration failure. The returned qrz_logid was empty instead of qrz-123. This change does not modify FFI or QRZ behavior.