### PR TITLE
Persist QRZ credentials in platform secret stores

### DIFF
--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -414,7 +414,10 @@ They must also cancel stale UI requests.
 They must use this shared lookup service for callsign enrichment.
 They must not duplicate QRZ XML logic in the UI.
 
-Credentials supplied through setup remain process-session secrets and are never serialized. For restart availability, operators provide secrets through the documented environment variables or a secure configuration provider. See §6.3.
+Credentials supplied through setup remain available after an engine restart.
+The engine stores them in the platform credential store.
+The engine never stores them in the shared TOML file.
+See §6.3.
 
 **Slash-call fallback:** A callsign can contain a `/` modifier, such as `W1AW/7`.
 If the full lookup fails, remove the modifier.
@@ -817,9 +820,15 @@ Persists setup configuration and station profile.
 
 **Behavior:**
 1. Validate all provided fields.
-2. Persist non-secret configuration and station/storage settings to the config path. Install QRZ passwords and API keys only in process memory. Never serialize them.
-3. Apply the configuration to the running engine (activate the station profile, enable integrations).
-4. Mark setup as complete.
+2. Persist supplied QRZ passwords and API keys in the platform credential store. Never serialize them.
+3. If credential storage fails, return `FAILED_PRECONDITION`. Do not report that setup saved the supplied secret.
+4. Persist non-secret configuration and station/storage settings to the config path.
+5. Apply the configuration to the running engine (activate the station profile, enable integrations).
+6. Mark setup as complete.
+
+An omitted QRZ secret keeps the stored secret unchanged.
+A nonempty QRZ secret replaces the stored secret.
+The engine must use the credential identifiers in §6.3.
 
 **WSJT-X ingest (`wsjtx_ingest`) management:**
 - The optional `wsjtx_ingest` field (`WsjtxIngestSettings`) lets setup clients manage the
@@ -1664,17 +1673,37 @@ The engine must start and function even when external integrations are unavailab
 
 - The engine stores configuration in a shared TOML file at `QSORIPPER_CONFIG_PATH`.
 - The `SaveSetup` RPC writes only non-secret configuration to this path.
-- On startup, the engine loads persisted configuration and overlays environment variable overrides (env vars take precedence).
+- On startup, the engine loads persisted configuration, secure secrets, and environment variable overrides.
 - Runtime config mutations (via `DeveloperControlService`) are ephemeral and do not persist across restarts unless explicitly saved.
 - The persisted/default conflict policy is `LAST_WRITE_WINS`. When a present setup request explicitly supplies the proto zero value, engines normalize it to the safe `FLAG_FOR_REVIEW` policy before persistence.
 
 #### Secret handling
 
 - The engine MUST NOT serialize QRZ passwords, API keys, session keys, or other credentials to the shared TOML file.
-- Secrets supplied by `SaveSetup` or `DeveloperControlService` are process-session values. Restart-persistent secrets come from environment variables or a platform secure configuration provider.
+- `SaveSetup` MUST store supplied QRZ secrets in the platform credential store.
+- `DeveloperControlService` secret mutations are process-session values.
+- The secret precedence is runtime override, environment variable, platform credential store, and then unset.
+- Environment variables support managed deployments and headless systems.
+- Desktop setup uses the platform credential store:
+  - Windows uses a generic Windows Credential Manager record.
+  - macOS uses a generic Keychain password record.
+  - Linux uses the Secret Service API and the default collection.
+- All conformant engines MUST use these logical identifiers:
+  - Package: `com.treitforge.qsoripper`
+  - Service: `qrz`
+  - QRZ XML password account: `xml-password`
+  - QRZ logbook API key account: `logbook-api-key`
+- Platform records MUST map the logical identifiers as follows:
+  - Windows target: `<package>.<service>/<account>`
+  - macOS service: `<package>.<service>`, with the logical account as the Keychain account
+  - Linux schema: `<package>`, with `service=<service>` and `username=<account>`
+- Engines MUST read records that another conformant engine writes.
+- The engine MUST continue without QRZ integration when the platform credential store is unavailable.
+- A `SaveSetup` request that supplies a secret MUST fail if the engine cannot store that secret.
 - Status and runtime configuration responses expose only configured/unconfigured state and redacted display text. Logs and error details never contain secret values or sensitive request payloads.
 - A legacy configuration can contain plaintext QRZ secrets.
-  An engine MAY use these values for the current process.
+  The engine MUST try to move these values to the platform credential store.
+  The engine MAY use these values for the current process if the move fails.
   It MUST immediately rewrite its owned tables without the plaintext fields.
   This migration is idempotent.
 

--- a/src/dotnet/Directory.Packages.props
+++ b/src/dotnet/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Grpc.AspNetCore" Version="2.76.0" />
     <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.80.0" />
+    <PackageVersion Include="keyring-dotnet" Version="1.2.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.6" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageVersion Include="System.IO.Ports" Version="10.0.0" />

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/ManagedEngineStateTests.cs
@@ -310,6 +310,48 @@ public sealed class ManagedEngineStateTests : IDisposable
     }
 
     [Fact]
+    public void Secure_qrz_secrets_survive_engine_state_reload()
+    {
+        var configPath = Path.Combine(_tempDirectory, "config.toml");
+        var secretStore = new FakeQrzSecretStore();
+        var state = CreateStateWithSecretStore(configPath, secretStore);
+
+        state.SaveSetup(new SaveSetupRequest
+        {
+            QrzXmlUsername = "k7rnd",
+            QrzXmlPassword = "xml-secret",
+            QrzLogbookApiKey = "logbook-secret",
+        });
+
+        var reloaded = CreateStateWithSecretStore(configPath, secretStore);
+        var status = reloaded.GetSetupStatus();
+        var persistedConfig = File.ReadAllText(configPath);
+
+        Assert.Equal("k7rnd", status.QrzXmlUsername);
+        Assert.True(status.HasQrzXmlPassword);
+        Assert.True(status.HasQrzLogbookApiKey);
+        Assert.DoesNotContain("xml-secret", persistedConfig, StringComparison.Ordinal);
+        Assert.DoesNotContain("logbook-secret", persistedConfig, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Save_setup_reports_failed_precondition_when_secret_storage_fails()
+    {
+        var secretStore = new FakeQrzSecretStore { FailWrites = true };
+        var state = CreateStateWithSecretStore(
+            Path.Combine(_tempDirectory, "config.toml"),
+            secretStore);
+        var service = new ManagedSetupGrpcService(state);
+
+        var exception = await Assert.ThrowsAsync<RpcException>(() => service.SaveSetup(
+            new SaveSetupRequest { QrzXmlPassword = "xml-secret" },
+            new TestServerCallContext()));
+
+        Assert.Equal(StatusCode.FailedPrecondition, exception.StatusCode);
+        Assert.DoesNotContain("xml-secret", exception.Status.Detail, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Save_setup_preserves_unknown_shared_config_tables()
     {
         // The unified config.toml is shared with the CAT hub daemon ([cat_hub]) and launcher
@@ -2000,6 +2042,24 @@ public sealed class ManagedEngineStateTests : IDisposable
         return new ManagedEngineState(Path.Combine(_tempDirectory, "config.toml"), new MemoryStorage());
     }
 
+    private static ManagedEngineState CreateStateWithSecretStore(
+        string configPath,
+        IQrzSecretStore secretStore)
+    {
+        return new ManagedEngineState(
+            configPath,
+            new MemoryStorage(),
+            lookupCoordinator: null,
+            contestCalendarMonitor: null,
+            rigControlMonitor: null,
+            spaceWeatherMonitor: null,
+            syncEngine: null,
+            currentPersistenceLocation: null,
+            loadedPersistedSetup: null,
+            qrzCredentialTester: null,
+            qrzSecretStore: secretStore);
+    }
+
     private ManagedEngineState CreateStateWithSync()
     {
         var storage = new MemoryStorage();
@@ -2099,6 +2159,26 @@ public sealed class ManagedEngineStateTests : IDisposable
                 LogbookOwner = "K7RND",
                 QsoCount = 42,
             });
+        }
+    }
+
+    private sealed class FakeQrzSecretStore : IQrzSecretStore
+    {
+        private readonly Dictionary<QrzSecret, string> _values = [];
+
+        public bool FailWrites { get; init; }
+
+        public string? Get(QrzSecret secret) =>
+            _values.TryGetValue(secret, out var value) ? value : null;
+
+        public void Set(QrzSecret secret, string value)
+        {
+            if (FailWrites)
+            {
+                throw new QrzSecretStoreException("The platform credential store is unavailable.");
+            }
+
+            _values[secret] = value;
         }
     }
 

--- a/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
@@ -77,6 +77,10 @@ internal sealed class ManagedSetupGrpcService(ManagedEngineState state)
         {
             return Task.FromResult(state.SaveSetup(request));
         }
+        catch (QrzSecretStoreException ex)
+        {
+            throw new RpcException(new Status(StatusCode.FailedPrecondition, ex.Message));
+        }
         catch (InvalidOperationException ex)
         {
             throw new RpcException(new Status(StatusCode.InvalidArgument, ex.Message));

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -126,6 +126,7 @@ internal sealed class ManagedEngineState
     private readonly RigControlMonitor? _rigControlMonitor;
     private readonly SpaceWeatherMonitor? _spaceWeatherMonitor;
     private readonly IQrzCredentialTester _qrzCredentialTester;
+    private readonly IQrzSecretStore _qrzSecretStore;
     private readonly string _configPath;
     private readonly SharedPersistedSetupConfig _persistedSetup;
     private readonly string? _currentPersistenceLocation;
@@ -187,7 +188,7 @@ internal sealed class ManagedEngineState
     {
     }
 
-    public ManagedEngineState(string configPath, IEngineStorage storage, ILookupCoordinator? lookupCoordinator, ContestCalendarMonitor? contestCalendarMonitor, RigControlMonitor? rigControlMonitor, SpaceWeatherMonitor? spaceWeatherMonitor, QrzSyncEngine? syncEngine, string? currentPersistenceLocation, LoadedSharedSetupConfig? loadedPersistedSetup, IQrzCredentialTester? qrzCredentialTester = null)
+    public ManagedEngineState(string configPath, IEngineStorage storage, ILookupCoordinator? lookupCoordinator, ContestCalendarMonitor? contestCalendarMonitor, RigControlMonitor? rigControlMonitor, SpaceWeatherMonitor? spaceWeatherMonitor, QrzSyncEngine? syncEngine, string? currentPersistenceLocation, LoadedSharedSetupConfig? loadedPersistedSetup, IQrzCredentialTester? qrzCredentialTester = null, IQrzSecretStore? qrzSecretStore = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(configPath);
         ArgumentNullException.ThrowIfNull(storage);
@@ -199,6 +200,7 @@ internal sealed class ManagedEngineState
         _rigControlMonitor = rigControlMonitor;
         _spaceWeatherMonitor = spaceWeatherMonitor;
         _qrzCredentialTester = qrzCredentialTester ?? new QrzCredentialTester();
+        _qrzSecretStore = qrzSecretStore ?? new NullQrzSecretStore();
         _ownsSyncEngine = syncEngine is null;
         _syncEngine = syncEngine;
         var loadedSetup = loadedPersistedSetup ?? SharedSetupConfigPersistence.Load(_configPath);
@@ -209,11 +211,17 @@ internal sealed class ManagedEngineState
                 : null);
         _qrzXmlUsername = NormalizeOptional(Environment.GetEnvironmentVariable(QrzXmlUsernameKey))
             ?? NormalizeOptional(_persistedSetup.QrzXmlUsername);
+        var legacyQrzXmlPassword = NormalizeOptional(_persistedSetup.QrzXmlPassword);
+        var legacyQrzLogbookApiKey = NormalizeOptional(_persistedSetup.QrzLogbookApiKey);
+        MigrateLegacySecret(QrzSecret.XmlPassword, legacyQrzXmlPassword);
+        MigrateLegacySecret(QrzSecret.LogbookApiKey, legacyQrzLogbookApiKey);
         _qrzXmlPassword = NormalizeOptional(Environment.GetEnvironmentVariable(QrzXmlPasswordKey))
-            ?? NormalizeOptional(_persistedSetup.QrzXmlPassword);
+            ?? legacyQrzXmlPassword
+            ?? ReadStoredSecret(QrzSecret.XmlPassword);
         _hasQrzXmlPassword = _qrzXmlPassword is not null;
         _qrzLogbookApiKey = NormalizeOptional(Environment.GetEnvironmentVariable(QrzLogbookApiKeyKey))
-            ?? NormalizeOptional(_persistedSetup.QrzLogbookApiKey);
+            ?? legacyQrzLogbookApiKey
+            ?? ReadStoredSecret(QrzSecret.LogbookApiKey);
         _hasQrzLogbookApiKey = _qrzLogbookApiKey is not null;
         var hadPersistedSecrets = !string.IsNullOrWhiteSpace(_persistedSetup.QrzXmlPassword)
             || !string.IsNullOrWhiteSpace(_persistedSetup.QrzLogbookApiKey);
@@ -363,6 +371,11 @@ internal sealed class ManagedEngineState
 
         lock (_gate)
         {
+            var requestedQrzXmlPassword = NormalizeOptional(request.QrzXmlPassword);
+            var requestedQrzLogbookApiKey = NormalizeOptional(request.QrzLogbookApiKey);
+            PersistRequestedSecret(QrzSecret.XmlPassword, requestedQrzXmlPassword);
+            PersistRequestedSecret(QrzSecret.LogbookApiKey, requestedQrzLogbookApiKey);
+
             var normalizedWsjtxIngest = request.WsjtxIngest is null
                 ? null
                 : NormalizeWsjtxIngest(request.WsjtxIngest);
@@ -383,17 +396,17 @@ internal sealed class ManagedEngineState
                 RebuildLookupCoordinatorNoLock();
             }
 
-            if (!string.IsNullOrWhiteSpace(request.QrzXmlPassword))
+            if (requestedQrzXmlPassword is not null)
             {
-                _qrzXmlPassword = request.QrzXmlPassword.Trim();
+                _qrzXmlPassword = requestedQrzXmlPassword;
                 _hasQrzXmlPassword = true;
                 _runtimeOverrides.Remove(QrzXmlPasswordKey);
                 RebuildLookupCoordinatorNoLock();
             }
 
-            if (!string.IsNullOrWhiteSpace(request.QrzLogbookApiKey))
+            if (requestedQrzLogbookApiKey is not null)
             {
-                _qrzLogbookApiKey = request.QrzLogbookApiKey.Trim();
+                _qrzLogbookApiKey = requestedQrzLogbookApiKey;
                 _hasQrzLogbookApiKey = true;
                 _runtimeOverrides.Remove(QrzLogbookApiKeyKey);
                 if (_ownsSyncEngine)
@@ -2317,6 +2330,58 @@ internal sealed class ManagedEngineState
         }
 
         return normalized;
+    }
+
+    private string? ReadStoredSecret(QrzSecret secret)
+    {
+        try
+        {
+            return NormalizeOptional(_qrzSecretStore.Get(secret));
+        }
+        catch (QrzSecretStoreException)
+        {
+            return null;
+        }
+    }
+
+    private void MigrateLegacySecret(QrzSecret secret, string? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _qrzSecretStore.Set(secret, value);
+        }
+        catch (QrzSecretStoreException)
+        {
+            // Keep the legacy value active for this process. The TOML rewrite still removes it.
+        }
+    }
+
+    private void PersistRequestedSecret(QrzSecret secret, string? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+
+        try
+        {
+            _qrzSecretStore.Set(secret, value);
+        }
+        catch (QrzSecretStoreException)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            throw new QrzSecretStoreException(
+                "The platform credential store did not save the QRZ secret.",
+                exception);
+        }
     }
 
     private static string? NormalizeOptional(string? value)

--- a/src/dotnet/QsoRipper.Engine.DotNet/Program.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/Program.cs
@@ -2,8 +2,6 @@ using System.Net;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using QsoRipper.Engine.ContestCalendar;
 using QsoRipper.Engine.DotNet;
-using QsoRipper.Engine.Lookup;
-using QsoRipper.Engine.Lookup.Qrz;
 using QsoRipper.Engine.RigControl;
 using QsoRipper.Engine.SpaceWeather;
 using QsoRipper.Engine.Storage;
@@ -25,8 +23,7 @@ builder.Services.AddSingleton(_ =>
 var resolvedStorage = CreateStorage(persistedSetup.Config);
 builder.Services.AddSingleton(resolvedStorage.Storage);
 
-var lookupCoordinator = CreateLookupCoordinator(resolvedStorage.Storage, persistedSetup.Config);
-builder.Services.AddSingleton(lookupCoordinator);
+var qrzSecretStore = new PlatformQrzSecretStore();
 
 var contestCalendarMonitor = CreateContestCalendarMonitor();
 var rigControlMonitor = CreateRigControlMonitor();
@@ -35,13 +32,15 @@ var spaceWeatherMonitor = CreateSpaceWeatherMonitor();
 builder.Services.AddSingleton(provider => new ManagedEngineState(
     options.ConfigPath,
     provider.GetRequiredService<IEngineStorage>(),
-    provider.GetRequiredService<ILookupCoordinator>(),
+    null,
     contestCalendarMonitor,
     rigControlMonitor,
     spaceWeatherMonitor,
     null,
     resolvedStorage.PersistenceLocation,
-    persistedSetup));
+    persistedSetup,
+    null,
+    qrzSecretStore));
 
 builder.Services.AddHostedService(provider =>
     new QsoRipper.Engine.DotNet.Wsjtx.WsjtxIngestSupervisor(provider.GetRequiredService<ManagedEngineState>()));
@@ -94,44 +93,6 @@ static ResolvedStorageSettings CreateStorage(SharedPersistedSetupConfig persiste
     }
 
     return new ResolvedStorageSettings(new MemoryStorage(), null);
-}
-
-static ILookupCoordinator CreateLookupCoordinator(IEngineStorage storage, SharedPersistedSetupConfig persistedSetup)
-{
-    var username = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_XML_USERNAME")?.Trim();
-    var password = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_XML_PASSWORD")?.Trim();
-    var userAgent = Environment.GetEnvironmentVariable("QSORIPPER_QRZ_USER_AGENT")?.Trim();
-
-    if (string.IsNullOrWhiteSpace(username))
-    {
-        username = persistedSetup.QrzXmlUsername?.Trim();
-    }
-
-    if (string.IsNullOrWhiteSpace(password))
-    {
-        password = persistedSetup.QrzXmlPassword?.Trim();
-    }
-
-    if (string.IsNullOrWhiteSpace(userAgent))
-    {
-        userAgent = persistedSetup.QrzXmlUserAgent?.Trim();
-    }
-
-    ICallsignProvider provider;
-    if (!string.IsNullOrWhiteSpace(username) && !string.IsNullOrWhiteSpace(password))
-    {
-        // HttpClient is intentionally not disposed — it is a singleton owned by the provider for the app lifetime.
-#pragma warning disable CA2000 // Dispose objects before losing scope
-        var httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(8) };
-#pragma warning restore CA2000
-        provider = new QrzXmlProvider(httpClient, username, password, userAgent: userAgent);
-    }
-    else
-    {
-        provider = new DisabledCallsignProvider();
-    }
-
-    return new LookupCoordinator(provider, storage.LookupSnapshots, logbookStore: storage.Logbook);
 }
 
 static ContestCalendarMonitor? CreateContestCalendarMonitor()

--- a/src/dotnet/QsoRipper.Engine.DotNet/QrzSecretStore.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/QrzSecretStore.cs
@@ -1,0 +1,86 @@
+using KeySharp;
+
+namespace QsoRipper.Engine.DotNet;
+
+internal enum QrzSecret
+{
+    XmlPassword,
+    LogbookApiKey,
+}
+
+internal interface IQrzSecretStore
+{
+    string? Get(QrzSecret secret);
+
+    void Set(QrzSecret secret, string value);
+}
+
+internal sealed class NullQrzSecretStore : IQrzSecretStore
+{
+    public string? Get(QrzSecret secret) => null;
+
+    public void Set(QrzSecret secret, string value)
+    {
+    }
+}
+
+internal sealed class PlatformQrzSecretStore : IQrzSecretStore
+{
+    private const string Package = "com.treitforge.qsoripper";
+    private const string Service = "qrz";
+
+    public string? Get(QrzSecret secret)
+    {
+        try
+        {
+            return Keyring.GetPassword(Package, Service, GetAccount(secret));
+        }
+        catch (KeyringException exception) when (exception.Type == ErrorType.NotFound)
+        {
+            return null;
+        }
+        catch (Exception exception)
+        {
+            throw new QrzSecretStoreException("The platform credential store is unavailable.", exception);
+        }
+    }
+
+    public void Set(QrzSecret secret, string value)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(value);
+
+        try
+        {
+            Keyring.SetPassword(Package, Service, GetAccount(secret), value);
+        }
+        catch (Exception exception)
+        {
+            throw new QrzSecretStoreException("The platform credential store did not save the QRZ secret.", exception);
+        }
+    }
+
+    private static string GetAccount(QrzSecret secret) =>
+        secret switch
+        {
+            QrzSecret.XmlPassword => "xml-password",
+            QrzSecret.LogbookApiKey => "logbook-api-key",
+            _ => throw new ArgumentOutOfRangeException(nameof(secret)),
+        };
+}
+
+internal sealed class QrzSecretStoreException : InvalidOperationException
+{
+    public QrzSecretStoreException()
+    {
+    }
+
+    public QrzSecretStoreException(string message)
+        : base(message)
+    {
+    }
+
+    public QrzSecretStoreException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.DotNet/QsoRipper.Engine.DotNet.csproj
+++ b/src/dotnet/QsoRipper.Engine.DotNet/QsoRipper.Engine.DotNet.csproj
@@ -13,6 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="keyring-dotnet" />
     <PackageReference Include="System.IO.Ports" />
     <PackageReference Include="Tomlyn" />
   </ItemGroup>

--- a/src/dotnet/QsoRipper.Gui.Tests/SettingsViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/SettingsViewModelTests.cs
@@ -61,6 +61,27 @@ public class SettingsViewModelTests
     }
 
     [Fact]
+    public async Task LoadAsyncShowsSecureQrzSecretStateWithoutLoadingSecretValues()
+    {
+        var client = new UxFixtureEngineClient(
+            new UxCaptureFixture
+            {
+                QrzXmlUsername = "k7rnd",
+                HasQrzXmlPassword = true,
+                HasQrzLogbookApiKey = true,
+            });
+        var viewModel = new SettingsViewModel(client);
+
+        await viewModel.LoadAsync();
+
+        Assert.Equal("k7rnd", viewModel.QrzXmlUsername);
+        Assert.True(viewModel.HasConfiguredQrzXmlPassword);
+        Assert.True(viewModel.HasConfiguredQrzLogbookApiKey);
+        Assert.Equal(string.Empty, viewModel.QrzXmlPassword);
+        Assert.Equal(string.Empty, viewModel.QrzLogbookApiKey);
+    }
+
+    [Fact]
     public async Task SaveCommandIncludesPersistencePathValueWhenRequired()
     {
         var client = new UxFixtureEngineClient(new UxCaptureFixture());

--- a/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/SettingsViewModel.cs
@@ -69,6 +69,9 @@ internal sealed partial class SettingsViewModel : ObservableObject
     private string _qrzXmlPassword = string.Empty;
 
     [ObservableProperty]
+    private bool _hasConfiguredQrzXmlPassword;
+
+    [ObservableProperty]
     private bool _isTestingQrzXml;
 
     [ObservableProperty]
@@ -80,6 +83,9 @@ internal sealed partial class SettingsViewModel : ObservableObject
     // QRZ Logbook
     [ObservableProperty]
     private string _qrzLogbookApiKey = string.Empty;
+
+    [ObservableProperty]
+    private bool _hasConfiguredQrzLogbookApiKey;
 
     [ObservableProperty]
     private bool _isTestingLogbook;
@@ -559,6 +565,8 @@ internal sealed partial class SettingsViewModel : ObservableObject
     private void ApplyStatus(SetupStatus status)
     {
         QrzXmlUsername = status.QrzXmlUsername ?? string.Empty;
+        HasConfiguredQrzXmlPassword = status.HasQrzXmlPassword;
+        HasConfiguredQrzLogbookApiKey = status.HasQrzLogbookApiKey;
         PersistenceSectionTitle = string.IsNullOrWhiteSpace(status.PersistenceLabel)
             ? "Storage"
             : status.PersistenceLabel;
@@ -602,8 +610,7 @@ internal sealed partial class SettingsViewModel : ObservableObject
             RigControlStaleThresholdMs = string.Empty;
         }
 
-        // Password and API key are never returned by the engine for security;
-        // leave them empty so the user can re-enter if they want to change them.
+        // The engine returns only saved state. The input stays empty until the user replaces a secret.
         ApplyWsjtxIngest(status.WsjtxIngest);
     }
 

--- a/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/SettingsView.axaml
@@ -378,10 +378,10 @@
                     Spacing="16">
           <TextBlock Classes="settingsSectionHeader" Text="QRZ XML Lookup" />
           <TextBlock Classes="settingsSectionHint"
-                     Text="Used for callsign lookups. Leave blank to disable." />
+                     Text="Used for callsign lookups. Blank secret fields keep saved values." />
 
           <Grid ColumnDefinitions="120,*"
-                RowDefinitions="Auto,Auto"
+                RowDefinitions="Auto,Auto,Auto"
                 ColumnSpacing="12"
                 RowSpacing="6">
             <TextBlock Grid.Row="0" Grid.Column="0" Text="Username:" VerticalAlignment="Center" />
@@ -397,6 +397,11 @@
                      Text="{Binding QrzXmlPassword, Mode=TwoWay}"
                      PasswordChar="•"
                      PlaceholderText="Enter to update" />
+            <TextBlock Grid.Row="2"
+                       Grid.Column="1"
+                       Classes="settingsSectionHint"
+                       Text="Credential is configured. Enter a value to replace it."
+                       IsVisible="{Binding HasConfiguredQrzXmlPassword}" />
           </Grid>
 
           <StackPanel Orientation="Horizontal"
@@ -424,7 +429,9 @@
                      Text="API key for bidirectional sync with logbook.qrz.com." />
 
           <Grid ColumnDefinitions="120,*"
-                ColumnSpacing="12">
+                RowDefinitions="Auto,Auto"
+                ColumnSpacing="12"
+                RowSpacing="4">
             <TextBlock Grid.Column="0" Text="API Key:" VerticalAlignment="Center" />
             <TextBox x:Name="SettingsQrzLogbookApiKeyBox"
                      AutomationProperties.AutomationId="SettingsQrzLogbookApiKeyBox"
@@ -432,6 +439,11 @@
                      Text="{Binding QrzLogbookApiKey, Mode=TwoWay}"
                      PasswordChar="•"
                      PlaceholderText="Enter to update" />
+            <TextBlock Grid.Row="1"
+                       Grid.Column="1"
+                       Classes="settingsSectionHint"
+                       Text="Credential is configured. Enter a value to replace it."
+                       IsVisible="{Binding HasConfiguredQrzLogbookApiKey}" />
           </Grid>
 
           <StackPanel Orientation="Horizontal"

--- a/src/rust/deny.toml
+++ b/src/rust/deny.toml
@@ -80,9 +80,24 @@ version = "=0.4.13"
 reason = "Used by tonic 0.12 transport; reqwest and newer Hyper/Axum dependencies use tower 0.5."
 
 [[bans.skip]]
+name = "toml_datetime"
+version = "=1.1.1+spec-1.1.0"
+reason = "Required by the Secret Service zbus macros. QsoRipper setup still uses toml 0.8."
+
+[[bans.skip]]
+name = "toml_edit"
+version = "=0.25.13+spec-1.1.0"
+reason = "Required by the Secret Service zbus macros. QsoRipper setup still uses toml_edit 0.22."
+
+[[bans.skip]]
 name = "unicode-width"
 version = "=0.1.14"
 reason = "Required by unicode-truncate via ratatui; ratatui also uses unicode-width 0.2.x directly."
+
+[[bans.skip]]
+name = "winnow"
+version = "=1.0.4"
+reason = "Required by the Secret Service zbus stack. QsoRipper setup still uses winnow 0.7."
 
 [[bans.skip]]
 name = "windows-sys"

--- a/src/rust/qsoripper-server/Cargo.toml
+++ b/src/rust/qsoripper-server/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 chrono = "0.4"
 dotenvy = "0.15"
+keyring = "4.1.5"
 qsoripper-core = { path = "../qsoripper-core", version = "0.1.0" }
 qsoripper-storage-memory = { path = "../qsoripper-storage-memory", version = "0.1.0" }
 qsoripper-storage-sqlite = { path = "../qsoripper-storage-sqlite", version = "0.1.0" }

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -1,5 +1,6 @@
 //! Runnable tonic gRPC host for the `QsoRipper` Rust engine.
 
+mod qrz_secret_store;
 mod repair;
 mod runtime_config;
 mod setup;

--- a/src/rust/qsoripper-server/src/qrz_secret_store.rs
+++ b/src/rust/qsoripper-server/src/qrz_secret_store.rs
@@ -1,0 +1,110 @@
+#[cfg(not(test))]
+const PACKAGE: &str = "com.treitforge.qsoripper";
+#[cfg(not(test))]
+const SERVICE: &str = "qrz";
+#[cfg(all(not(test), target_os = "macos"))]
+const FULL_SERVICE: &str = "com.treitforge.qsoripper.qrz";
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) enum QrzSecret {
+    XmlPassword,
+    LogbookApiKey,
+}
+
+impl QrzSecret {
+    fn account(self) -> &'static str {
+        match self {
+            Self::XmlPassword => "xml-password",
+            Self::LogbookApiKey => "logbook-api-key",
+        }
+    }
+}
+
+pub(crate) trait QrzSecretStore: Send + Sync {
+    fn get(&self, secret: QrzSecret) -> Result<Option<String>, String>;
+    fn set(&self, secret: QrzSecret, value: &str) -> Result<(), String>;
+}
+
+#[cfg(not(test))]
+pub(crate) struct PlatformQrzSecretStore;
+
+#[cfg(not(test))]
+impl PlatformQrzSecretStore {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+
+    fn entry(secret: QrzSecret) -> Result<keyring::Entry, String> {
+        let account = secret.account();
+
+        #[cfg(target_os = "windows")]
+        let entry = keyring::Entry::new(&format!("{SERVICE}/{account}"), PACKAGE);
+
+        #[cfg(target_os = "macos")]
+        let entry = keyring::Entry::new(FULL_SERVICE, account);
+
+        #[cfg(all(unix, not(target_os = "macos")))]
+        let entry = keyring::Entry::new(SERVICE, account);
+
+        #[cfg(not(any(target_os = "windows", target_os = "macos", unix)))]
+        return Err("The platform credential store is not supported.".to_string());
+
+        entry.map_err(|error| format!("Platform credential store is unavailable: {error}"))
+    }
+}
+
+#[cfg(not(test))]
+impl QrzSecretStore for PlatformQrzSecretStore {
+    fn get(&self, secret: QrzSecret) -> Result<Option<String>, String> {
+        match Self::entry(secret)?.get_password() {
+            Ok(value) => Ok(Some(value)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(error) => Err(format!(
+                "Failed to read the platform credential store: {error}"
+            )),
+        }
+    }
+
+    fn set(&self, secret: QrzSecret, value: &str) -> Result<(), String> {
+        let entry = Self::entry(secret)?;
+        entry
+            .set_password(value)
+            .map_err(|error| format!("Failed to write the platform credential store: {error}"))?;
+
+        #[cfg(all(unix, not(target_os = "macos")))]
+        entry
+            .inner
+            .update_attributes(&std::collections::HashMap::from([("xdg:schema", PACKAGE)]))
+            .map_err(|error| {
+                format!("Failed to set the platform credential store schema: {error}")
+            })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct MemoryQrzSecretStore {
+    values: std::sync::RwLock<std::collections::HashMap<&'static str, String>>,
+}
+
+#[cfg(test)]
+impl QrzSecretStore for MemoryQrzSecretStore {
+    fn get(&self, secret: QrzSecret) -> Result<Option<String>, String> {
+        let values = self
+            .values
+            .read()
+            .map_err(|_| "Memory credential store read failed.".to_string())?;
+        Ok(values.get(secret.account()).cloned())
+    }
+
+    fn set(&self, secret: QrzSecret, value: &str) -> Result<(), String> {
+        let mut values = self
+            .values
+            .write()
+            .map_err(|_| "Memory credential store write failed.".to_string())?;
+        values.insert(secret.account(), value.to_string());
+        Ok(())
+    }
+}

--- a/src/rust/qsoripper-server/src/setup.rs
+++ b/src/rust/qsoripper-server/src/setup.rs
@@ -41,6 +41,9 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, RwLock};
 use tonic::{Request, Response, Status};
 
+#[cfg(not(test))]
+use crate::qrz_secret_store::PlatformQrzSecretStore;
+use crate::qrz_secret_store::{QrzSecret, QrzSecretStore};
 use crate::runtime_config::{
     RuntimeConfigManager, DEFAULT_QRZ_LOGBOOK_BASE_URL, QRZ_LOGBOOK_API_KEY_ENV_VAR,
     QRZ_LOGBOOK_BASE_URL_ENV_VAR, SQLITE_PATH_ENV_VAR, STORAGE_BACKEND_ENV_VAR,
@@ -62,6 +65,7 @@ const PERSISTENCE_PATH_KEY: &str = "persistence.path";
 const PERSISTENCE_STEP_DESCRIPTION: &str =
     "Choose where QsoRipper stores the local logbook used by this engine.";
 const PERSISTENCE_STEP_LABEL: &str = "Log storage";
+const SECRET_STORE_ERROR_PREFIX: &str = "QRZ secret storage failed.";
 
 #[derive(Clone)]
 pub(crate) struct SetupControlSurface {
@@ -130,7 +134,13 @@ impl SetupService for SetupControlSurface {
             .state
             .save_setup(request.into_inner(), &self.runtime_config)
             .await
-            .map_err(Status::invalid_argument)?;
+            .map_err(|message| {
+                if message.starts_with(SECRET_STORE_ERROR_PREFIX) {
+                    Status::failed_precondition(message)
+                } else {
+                    Status::invalid_argument(message)
+                }
+            })?;
         let status = self.attach_wsjtx_status(status).await;
         Ok(Response::new(SaveSetupResponse {
             status: Some(status),
@@ -292,15 +302,43 @@ pub(crate) struct SetupState {
     config_path: PathBuf,
     suggested_log_file_path: PathBuf,
     persisted_config: RwLock<Option<PersistedSetupConfig>>,
+    secret_store: Arc<dyn QrzSecretStore>,
 }
 
 impl SetupState {
     pub(crate) fn load(config_path: PathBuf) -> Result<Self, String> {
-        let persisted_config = load_persisted_config(&config_path)?;
+        #[cfg(not(test))]
+        let secret_store: Arc<dyn QrzSecretStore> = Arc::new(PlatformQrzSecretStore::new());
+        #[cfg(test)]
+        let secret_store: Arc<dyn QrzSecretStore> =
+            Arc::new(crate::qrz_secret_store::MemoryQrzSecretStore::default());
+
+        Self::load_with_secret_store(config_path, secret_store)
+    }
+
+    fn load_with_secret_store(
+        config_path: PathBuf,
+        secret_store: Arc<dyn QrzSecretStore>,
+    ) -> Result<Self, String> {
+        let mut persisted_config = load_persisted_config(&config_path)?;
+        if let Some(config) = persisted_config.as_mut() {
+            migrate_or_hydrate_secret(
+                &secret_store,
+                QrzSecret::XmlPassword,
+                &mut config.qrz_xml.password,
+            );
+            migrate_or_hydrate_secret(
+                &secret_store,
+                QrzSecret::LogbookApiKey,
+                &mut config.qrz_logbook.api_key,
+            );
+        }
+
         Ok(Self {
             suggested_log_file_path: suggested_log_file_path(&config_path),
             config_path,
             persisted_config: RwLock::new(persisted_config),
+            secret_store,
         })
     }
 
@@ -345,15 +383,36 @@ impl SetupState {
         runtime_config: &RuntimeConfigManager,
     ) -> Result<SetupStatus, String> {
         let existing_config = self.persisted_config.read().await.clone();
-        let config = PersistedSetupConfig::from_request(
+        let mut config = PersistedSetupConfig::from_request(
             existing_config.as_ref(),
             &request,
             self.suggested_log_file_path.as_path(),
         )?;
+        hydrate_secret(
+            &self.secret_store,
+            QrzSecret::XmlPassword,
+            &mut config.qrz_xml.password,
+        );
+        hydrate_secret(
+            &self.secret_store,
+            QrzSecret::LogbookApiKey,
+            &mut config.qrz_logbook.api_key,
+        );
         let runtime_values = config.to_runtime_values();
         runtime_config
             .preview_config_file_values(runtime_values.clone())
             .await?;
+
+        persist_requested_secret(
+            &self.secret_store,
+            QrzSecret::XmlPassword,
+            request.qrz_xml_password.as_deref(),
+        )?;
+        persist_requested_secret(
+            &self.secret_store,
+            QrzSecret::LogbookApiKey,
+            request.qrz_logbook_api_key.as_deref(),
+        )?;
 
         let wsjtx_ingest_update = request.wsjtx_ingest.as_ref().map(|_| &config.wsjtx_ingest);
         write_persisted_config(self.config_path.as_path(), &config, wsjtx_ingest_update)?;
@@ -552,6 +611,44 @@ impl SetupState {
             .await?;
         Ok(result)
     }
+}
+
+fn migrate_or_hydrate_secret(
+    secret_store: &Arc<dyn QrzSecretStore>,
+    secret: QrzSecret,
+    value: &mut Option<String>,
+) {
+    if let Some(legacy_value) = value.as_deref() {
+        let _ = secret_store.set(secret, legacy_value);
+    } else {
+        hydrate_secret(secret_store, secret, value);
+    }
+}
+
+fn hydrate_secret(
+    secret_store: &Arc<dyn QrzSecretStore>,
+    secret: QrzSecret,
+    value: &mut Option<String>,
+) {
+    if value.is_none() {
+        if let Ok(stored_value) = secret_store.get(secret) {
+            *value = stored_value;
+        }
+    }
+}
+
+fn persist_requested_secret(
+    secret_store: &Arc<dyn QrzSecretStore>,
+    secret: QrzSecret,
+    requested_value: Option<&str>,
+) -> Result<(), String> {
+    let Some(value) = normalize_optional_string(requested_value) else {
+        return Ok(());
+    };
+
+    secret_store
+        .set(secret, &value)
+        .map_err(|error| format!("{SECRET_STORE_ERROR_PREFIX} {error}"))
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
@@ -2169,6 +2266,7 @@ mod tests {
         RIGCTLD_ENABLED_ENV_VAR, RIGCTLD_HOST_ENV_VAR, RIGCTLD_PORT_ENV_VAR,
         RIGCTLD_READ_TIMEOUT_MS_ENV_VAR, RIGCTLD_STALE_THRESHOLD_MS_ENV_VAR,
     };
+    use crate::qrz_secret_store::MemoryQrzSecretStore;
     use crate::runtime_config::RuntimeConfigManager;
     use qsoripper_core::proto::qsoripper::domain::{ConflictPolicy, StationProfile, SyncConfig};
     use qsoripper_core::proto::qsoripper::services::{
@@ -3623,6 +3721,52 @@ file_path = "{}"
         drop(service);
         drop(runtime_config);
         drop(setup_state);
+
+        let config_directory = config_path.parent().expect("config directory");
+        let _ = fs::remove_dir_all(config_directory);
+    }
+
+    #[tokio::test]
+    async fn secure_qrz_secrets_survive_engine_state_reload() {
+        let config_path = unique_config_path();
+        let log_file_path = absolute_log_file_path(&config_path, "secure-secret-reload.db");
+        let secret_store = Arc::new(MemoryQrzSecretStore::default());
+        let setup_state = Arc::new(
+            SetupState::load_with_secret_store(config_path.clone(), secret_store.clone())
+                .expect("setup state"),
+        );
+        let runtime_config = Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime"));
+        let service = SetupControlSurface::new(setup_state.clone(), runtime_config);
+
+        SetupService::save_setup(
+            &service,
+            Request::new(SaveSetupRequest {
+                log_file_path: Some(log_file_path),
+                station_profile: Some(StationProfile {
+                    station_callsign: "k7rnd".to_string(),
+                    ..StationProfile::default()
+                }),
+                qrz_xml_username: Some("k7rnd".to_string()),
+                qrz_xml_password: Some("xml-secret".to_string()),
+                qrz_logbook_api_key: Some("logbook-secret".to_string()),
+                ..Default::default()
+            }),
+        )
+        .await
+        .expect("save setup");
+
+        drop(service);
+        drop(setup_state);
+
+        let reloaded =
+            SetupState::load_with_secret_store(config_path.clone(), secret_store).expect("reload");
+        let status = reloaded.status().await;
+        assert!(status.has_qrz_xml_password);
+        assert!(status.has_qrz_logbook_api_key);
+
+        let saved_toml = fs::read_to_string(&config_path).expect("read config");
+        assert!(!saved_toml.contains("xml-secret"));
+        assert!(!saved_toml.contains("logbook-secret"));
 
         let config_directory = config_path.parent().expect("config directory");
         let _ = fs::remove_dir_all(config_directory);


### PR DESCRIPTION
QRZ credentials were only held in process memory after setup. An engine restart, reboot, or rebuild required the operator to enter them again.

This change stores QRZ XML passwords and logbook API keys in the platform credential store. Windows uses Credential Manager. macOS uses Keychain. Linux uses Secret Service. The Rust and .NET engines use the same logical credential identifiers.

Runtime overrides and environment variables keep their documented precedence. The engine migrates legacy plaintext secrets and removes them from the shared TOML file. Credential read failures disable QRZ integration without blocking local logging. Credential write failures return FAILED_PRECONDITION.

The Settings view now shows whether each credential is configured. Empty secret fields preserve stored values and never load secret text into the UI.

The engine specification now defines persistence, precedence, platform mapping, migration, and error behavior.

Validation completed with the Release build, Rust formatting, Clippy, Rust tests, dependency audit, .NET engine tests, GUI tests, and the full .NET solution build.