### PR TITLE
Adopt CatHub protocol v0.2

### DIFF
--- a/config/cathub-dependency.json
+++ b/config/cathub-dependency.json
@@ -1,9 +1,9 @@
 {
   "repository": "https://github.com/treitforge/cathub",
-  "version": "0.1.1",
-  "protocolVersion": "0.1.1",
-  "supportedVersion": ">=0.1.0 <0.2.0",
-  "wirePackage": "qsoripper.services",
+  "version": "0.2.0",
+  "protocolVersion": "0.2.0",
+  "supportedVersion": ">=0.2.0 <0.3.0",
+  "wirePackage": "cathub.services",
   "rustPackage": "cathub-protocol",
   "dotnetPackage": "CatHub.Protocol"
 }

--- a/docs/integrations/cathub-setup.md
+++ b/docs/integrations/cathub-setup.md
@@ -14,15 +14,15 @@ QsoRipper needs the CatHub executable, not the `cathub-protocol` Rust crate or t
 `CatHub.Protocol` NuGet package. Those packages are for applications that develop against
 CatHub's typed WinKeyer API.
 
-Download the CatHub 0.1.2 Windows or Linux archive and adjacent SHA-256 checksum from the
-[GitHub release](https://github.com/treitforge/cathub/releases/tag/v0.1.2). Verify the
+Download the CatHub 0.2.0 Windows or Linux archive and adjacent SHA-256 checksum from the
+[GitHub release](https://github.com/treitforge/cathub/releases/tag/v0.2.0). Verify the
 checksum, extract the executable, and either add its directory to `PATH` or set
 `CATHUB_EXECUTABLE`.
 
 If Rust 1.88 or newer is installed, install the same release from crates.io:
 
 ```powershell
-cargo install cathub --version 0.1.2
+cargo install cathub --version 0.2.0
 ```
 
 Cargo downloads `cathub-protocol` automatically while building the daemon. The protocol
@@ -42,12 +42,10 @@ QsoRipper resolves the executable in this order:
 1. The path in `CATHUB_EXECUTABLE`.
 2. A binary bundled at `artifacts\publish\cathub\Release\cathub.exe` on Windows, or the
    equivalent platform path.
-3. A source build in a sibling CatHub checkout at `..\cathub\target\release\cathub.exe`,
-   or the equivalent platform path.
-4. `cathub` on `PATH`.
+3. `cathub` on `PATH`.
 
 QsoRipper does not download, install, or update CatHub during startup.
-The current supported executable range is `>=0.1.2 <0.2.0`. The launcher checks
+The current supported executable range is `>=0.2.0 <0.3.0`. The launcher checks
 `cathub --version` and reports an incompatible version separately from a spawn failure.
 
 ## Configuration modes
@@ -157,12 +155,11 @@ keyer and broker. Enable transmission only during an attended hardware test.
 
 ## Protocol compatibility
 
-CatHub 0.1 retains the existing `qsoripper.services` WinKeyer broker wire-package identifier.
-The identifier is part of the wire contract and does not make CatHub part of QsoRipper. The
-authoritative contract lives in the CatHub repository.
+CatHub 0.2 uses the CatHub-owned `cathub.services` WinKeyer broker wire-package identifier.
+The authoritative contract lives in the CatHub repository.
 
-The Rust engine consumes `cathub-protocol` 0.1.1. The .NET engine consumes
-`CatHub.Protocol` 0.1.1. CatHub owns these packages and the source protocol files.
+The Rust engine consumes `cathub-protocol` 0.2.0. The .NET engine consumes
+`CatHub.Protocol` 0.2.0. CatHub owns these packages and the source protocol files.
 
 QsoRipper records the dependency pin in `config\cathub-dependency.json`.
 

--- a/scripts/Start-CatHub.ps1
+++ b/scripts/Start-CatHub.ps1
@@ -24,15 +24,11 @@ function Find-CatHubExecutable {
     if (Test-Path -LiteralPath $bundled) {
         return $bundled
     }
-    $sibling = Join-Path (Split-Path -Parent $repoRoot) "cathub\target\release\$binaryName"
-    if (Test-Path -LiteralPath $sibling) {
-        return $sibling
-    }
     $command = Get-Command cathub -ErrorAction SilentlyContinue
     if ($command) {
         return $command.Source
     }
-    throw 'CatHub is not installed. Set CATHUB_EXECUTABLE, add cathub to PATH, build it in a sibling cathub checkout, or bundle it under artifacts\publish\cathub\Release.'
+    throw 'CatHub is not installed. Set CATHUB_EXECUTABLE, add cathub to PATH, or bundle it under artifacts\publish\cathub\Release.'
 }
 
 function Get-QsoRipperConfigPath {

--- a/src/dotnet/Directory.Packages.props
+++ b/src/dotnet/Directory.Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="CatHub.Protocol" Version="0.1.1" />
+    <PackageVersion Include="CatHub.Protocol" Version="0.2.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Google.Protobuf" Version="3.34.1" />

--- a/src/dotnet/QsoRipper.Engine.DotNet/CwKeying.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/CwKeying.cs
@@ -1,9 +1,9 @@
 using System.Globalization;
 using System.IO.Ports;
 using System.Text;
+using CatHub.Protocol;
 using Grpc.Core;
 using Grpc.Net.Client;
-using CatHub.Protocol;
 using QsoRipper.Domain;
 using QsoRipper.Services;
 

--- a/src/dotnet/QsoRipper.Engine.DotNet/CwKeying.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/CwKeying.cs
@@ -3,6 +3,7 @@ using System.IO.Ports;
 using System.Text;
 using Grpc.Core;
 using Grpc.Net.Client;
+using CatHub.Protocol;
 using QsoRipper.Domain;
 using QsoRipper.Services;
 

--- a/src/rust/qsoripper-core/Cargo.toml
+++ b/src/rust/qsoripper-core/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-cathub-protocol = "=0.1.1"
+cathub-protocol = "=0.2.0"
 prost = { workspace = true }
 prost-types = { workspace = true }
 tonic = { workspace = true }

--- a/src/rust/qsoripper-launcher/src/catalog.rs
+++ b/src/rust/qsoripper-launcher/src/catalog.rs
@@ -50,8 +50,6 @@ pub(crate) struct ArtifactSpec {
     /// Optional environment variable containing an explicitly installed executable.
     /// When present, resolution may fall back to external development and install locations.
     pub external_executable_env: Option<&'static str>,
-    /// Optional sibling source checkout whose Cargo output can be used during development.
-    pub sibling_source_checkout: Option<&'static str>,
 }
 
 impl ArtifactSpec {
@@ -78,20 +76,6 @@ impl ArtifactSpec {
             return bundled;
         }
 
-        if let (Some(repo_root), Some(checkout)) = (root.repo_root(), self.sibling_source_checkout)
-        {
-            if let Some(parent) = repo_root.parent() {
-                let source_build = parent
-                    .join(checkout)
-                    .join("target")
-                    .join(root.configuration().to_ascii_lowercase())
-                    .join(&file_name);
-                if source_build.is_file() {
-                    return source_build;
-                }
-            }
-        }
-
         if self.external_executable_env.is_some() {
             if let Some(installed) = find_on_path(file_name.as_ref()) {
                 return installed;
@@ -116,7 +100,6 @@ const fn bundled_artifact(
         publish_subdir,
         executable_stem,
         external_executable_env: None,
-        sibling_source_checkout: None,
     }
 }
 
@@ -143,7 +126,6 @@ pub(crate) fn catalog() -> Vec<ComponentSpec> {
                 publish_subdir: "cathub",
                 executable_stem: "cathub",
                 external_executable_env: Some("CATHUB_EXECUTABLE"),
-                sibling_source_checkout: Some("cathub"),
             },
         },
         ComponentSpec {
@@ -264,40 +246,6 @@ mod tests {
             spec.artifact.external_executable_env,
             Some("CATHUB_EXECUTABLE")
         );
-        assert_eq!(spec.artifact.sibling_source_checkout, Some("cathub"));
-    }
-
-    #[test]
-    fn cathub_resolves_from_a_built_sibling_checkout() {
-        let workspace =
-            std::env::temp_dir().join(format!("qsoripper-launcher-cathub-{}", std::process::id()));
-        let repo_root = workspace.join("qsoripper");
-        let executable_name = if cfg!(windows) {
-            "cathub.exe"
-        } else {
-            "cathub"
-        };
-        let sibling_executable = workspace
-            .join("cathub")
-            .join("target")
-            .join("release")
-            .join(executable_name);
-        std::fs::create_dir_all(sibling_executable.parent().expect("executable parent"))
-            .expect("create sibling target directory");
-        std::fs::write(&sibling_executable, []).expect("create sibling executable");
-
-        let root =
-            ArtifactRoot::from_repo_root(&repo_root, crate::discovery::Configuration::Release);
-        let spec = ArtifactSpec {
-            publish_subdir: "cathub",
-            executable_stem: "cathub",
-            external_executable_env: Some("QSORIPPER_TEST_CATHUB_EXECUTABLE"),
-            sibling_source_checkout: Some("cathub"),
-        };
-
-        assert_eq!(spec.executable_path(&root), sibling_executable);
-
-        std::fs::remove_dir_all(workspace).expect("remove sibling checkout fixture");
     }
 
     #[test]

--- a/src/rust/qsoripper-launcher/src/discovery.rs
+++ b/src/rust/qsoripper-launcher/src/discovery.rs
@@ -25,7 +25,6 @@ impl Configuration {
 pub(crate) struct ArtifactRoot {
     publish_root: PathBuf,
     configuration: &'static str,
-    repo_root: Option<PathBuf>,
 }
 
 impl ArtifactRoot {
@@ -34,15 +33,12 @@ impl ArtifactRoot {
         Self {
             publish_root,
             configuration: configuration.as_str(),
-            repo_root: None,
         }
     }
 
     /// Resolve `artifacts/publish/` relative to a repo root.
     pub(crate) fn from_repo_root(repo_root: &Path, configuration: Configuration) -> Self {
-        let mut root = Self::new(repo_root.join("artifacts").join("publish"), configuration);
-        root.repo_root = Some(repo_root.to_path_buf());
-        root
+        Self::new(repo_root.join("artifacts").join("publish"), configuration)
     }
 
     pub(crate) fn path(&self) -> &Path {
@@ -51,10 +47,6 @@ impl ArtifactRoot {
 
     pub(crate) fn configuration(&self) -> &str {
         self.configuration
-    }
-
-    pub(crate) fn repo_root(&self) -> Option<&Path> {
-        self.repo_root.as_deref()
     }
 }
 

--- a/src/rust/qsoripper-launcher/src/process.rs
+++ b/src/rust/qsoripper-launcher/src/process.rs
@@ -12,9 +12,9 @@ use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, Signal, System, Update
 
 use crate::catalog::{ComponentId, ComponentSpec};
 
-const MINIMUM_CATHUB_VERSION: (u32, u32, u32) = (0, 1, 2);
-const MAXIMUM_CATHUB_VERSION: (u32, u32, u32) = (0, 2, 0);
-const SUPPORTED_CATHUB_RANGE: &str = ">=0.1.2 <0.2.0";
+const MINIMUM_CATHUB_VERSION: (u32, u32, u32) = (0, 2, 0);
+const MAXIMUM_CATHUB_VERSION: (u32, u32, u32) = (0, 3, 0);
+const SUPPORTED_CATHUB_RANGE: &str = ">=0.2.0 <0.3.0";
 
 /// A child the launcher started, tracked by OS PID so it survives the launcher
 /// exiting and so a later "stop" can find it again.
@@ -557,10 +557,10 @@ mod tests {
     fn accepts_only_supported_cathub_version_series() {
         assert!(!is_supported_cathub_version("0.1"));
         assert!(!is_supported_cathub_version("0.1.0"));
-        assert!(is_supported_cathub_version("0.1.2"));
-        assert!(is_supported_cathub_version("0.1.12"));
+        assert!(is_supported_cathub_version("0.2.0"));
+        assert!(is_supported_cathub_version("0.2.12"));
         assert!(!is_supported_cathub_version("0.0.9"));
-        assert!(!is_supported_cathub_version("0.2.0"));
+        assert!(!is_supported_cathub_version("0.3.0"));
         assert!(!is_supported_cathub_version("0.10.0"));
     }
 


### PR DESCRIPTION
## Summary

- Adopt CatHub Protocol 0.2.0 and its `cathub.services` WinKeyer wire namespace.
- Update .NET and Rust package pins plus the supported CatHub executable range.
- Remove legacy sibling-source checkout discovery from the launcher.
- Retain intentional standalone CatHub integration through explicit executable configuration, bundled binaries, `PATH`, opaque `[cat_hub]` configuration, Hamlib NET, and optional WinKeyer brokering.

## Why

CatHub is independently released. QSORipper should consume its published interfaces without assuming a sibling source checkout or owning CatHub protocol identity.

## Impact

Merge after the CatHub 0.2.0 protocol packages are published. Run `cargo update -p cathub-protocol --precise 0.2.0` in `src\rust` to refresh the Rust lockfile once the crates.io release is available.

## Validation

- Built `QsoRipper.Engine.DotNet` against a locally packed `CatHub.Protocol 0.2.0`.
- Ran Rust formatting checks.
- Validated CatHub dry-run against the managed QSORipper configuration.