### PR TITLE
Fix flaky Rust tests

### DIFF
--- a/src/rust/qsoripper-core/src/contest_calendar/catalog.rs
+++ b/src/rust/qsoripper-core/src/contest_calendar/catalog.rs
@@ -232,7 +232,7 @@ fn parse_mode(value: &str) -> Option<Mode> {
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
-    use std::{fs, path::PathBuf, time::SystemTime};
+    use std::fs;
 
     use super::*;
 
@@ -254,7 +254,7 @@ mod tests {
         )
         .expect("write catalog");
 
-        let catalog = ContestDetailsCatalog::load(path.clone()).expect("catalog");
+        let catalog = ContestDetailsCatalog::load(&path).expect("catalog");
         let contest = ContestCalendarEntry {
             contest_id: "contest".to_string(),
             name: "Real Time Contest".to_string(),
@@ -276,7 +276,6 @@ mod tests {
             Some("https://example.test/rules")
         );
         assert_eq!(enriched.details_status, ContestDetailsStatus::Full as i32);
-        fs::remove_file(path).expect("remove catalog");
     }
 
     #[test]
@@ -293,7 +292,7 @@ mod tests {
         )
         .expect("write catalog");
 
-        let catalog = ContestDetailsCatalog::load(path.clone()).expect("catalog");
+        let catalog = ContestDetailsCatalog::load(&path).expect("catalog");
         let contest = ContestCalendarEntry {
             contest_id: "contest".to_string(),
             details_status: ContestDetailsStatus::Partial as i32,
@@ -306,16 +305,14 @@ mod tests {
             enriched.details_status,
             ContestDetailsStatus::MetadataOnly as i32
         );
-        fs::remove_file(path).expect("remove catalog");
     }
 
-    fn temp_catalog_path() -> PathBuf {
-        std::env::temp_dir().join(format!(
-            "qsoripper-contest-catalog-{:?}.json",
-            SystemTime::now()
-                .duration_since(SystemTime::UNIX_EPOCH)
-                .expect("time")
-                .as_nanos()
-        ))
+    fn temp_catalog_path() -> tempfile::TempPath {
+        tempfile::Builder::new()
+            .prefix("qsoripper-contest-catalog-")
+            .suffix(".json")
+            .tempfile()
+            .expect("create temp catalog")
+            .into_temp_path()
     }
 }

--- a/src/rust/qsoripper-tui/src/app.rs
+++ b/src/rust/qsoripper-tui/src/app.rs
@@ -1,6 +1,6 @@
 //! Top-level application state shared across the main event loop and UI renderer.
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use qsoripper_core::proto::qsoripper::domain::QsoRecord;
 
@@ -303,15 +303,7 @@ impl App {
         if !self.qso_timer_active {
             return None;
         }
-        let secs = self.qso_started_at.elapsed().as_secs();
-        let h = secs / 3600;
-        let m = (secs % 3600) / 60;
-        let s = secs % 60;
-        Some(if h > 0 {
-            format!("{h}:{m:02}:{s:02}")
-        } else {
-            format!("{m}:{s:02}")
-        })
+        Some(format_qso_duration(self.qso_started_at.elapsed()))
     }
 
     /// Set a success status message, replacing any current message.
@@ -347,6 +339,18 @@ impl App {
                 self.status_message = None;
             }
         }
+    }
+}
+
+fn format_qso_duration(duration: Duration) -> String {
+    let secs = duration.as_secs();
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    if h > 0 {
+        format!("{h}:{m:02}:{s:02}")
+    } else {
+        format!("{m}:{s:02}")
     }
 }
 
@@ -497,12 +501,9 @@ mod tests {
     }
 
     #[test]
-    fn qso_duration_str_formats_hours() {
-        let mut app = App::new("http://localhost:50051".to_string());
-        app.qso_timer_active = true;
-        app.qso_started_at = Instant::now() - Duration::from_secs(3661);
-        let dur = app.qso_duration_str().unwrap();
-        assert!(dur.starts_with('1'), "expected H:MM:SS, got: {dur}");
+    fn format_qso_duration_formats_minutes_and_hours() {
+        assert_eq!(format_qso_duration(Duration::from_secs(61)), "1:01");
+        assert_eq!(format_qso_duration(Duration::from_secs(3661)), "1:01:01");
     }
 
     #[test]


### PR DESCRIPTION
Fix two Rust test failures. Catalog tests now use unique temporary files. TUI duration formatting tests no longer require more than one hour of system uptime. The Rust test script passes with 905 tests.