### PR TITLE
Update CatHub integration to 0.2.0

### DIFF
--- a/config/cathub-dependency.json
+++ b/config/cathub-dependency.json
@@ -1,9 +1,9 @@
 {
   "repository": "https://github.com/treitforge/cathub",
-  "version": "0.1.1",
-  "protocolVersion": "0.1.1",
-  "supportedVersion": ">=0.1.0 <0.2.0",
-  "wirePackage": "qsoripper.services",
+  "version": "0.2.0",
+  "protocolVersion": "0.2.0",
+  "supportedVersion": ">=0.2.0 <0.3.0",
+  "wirePackage": "cathub.services",
   "rustPackage": "cathub-protocol",
   "dotnetPackage": "CatHub.Protocol"
 }

--- a/docs/integrations/cathub-setup.md
+++ b/docs/integrations/cathub-setup.md
@@ -14,15 +14,15 @@ QsoRipper needs the CatHub executable, not the `cathub-protocol` Rust crate or t
 `CatHub.Protocol` NuGet package. Those packages are for applications that develop against
 CatHub's typed WinKeyer API.
 
-Download the CatHub 0.1.2 Windows or Linux archive and adjacent SHA-256 checksum from the
-[GitHub release](https://github.com/treitforge/cathub/releases/tag/v0.1.2). Verify the
+Download the CatHub 0.2.0 Windows or Linux archive and adjacent SHA-256 checksum from the
+[GitHub release](https://github.com/treitforge/cathub/releases/tag/v0.2.0). Verify the
 checksum, extract the executable, and either add its directory to `PATH` or set
 `CATHUB_EXECUTABLE`.
 
 If Rust 1.88 or newer is installed, install the same release from crates.io:
 
 ```powershell
-cargo install cathub --version 0.1.2
+cargo install cathub --version 0.2.0
 ```
 
 Cargo downloads `cathub-protocol` automatically while building the daemon. The protocol
@@ -47,7 +47,7 @@ QsoRipper resolves the executable in this order:
 4. `cathub` on `PATH`.
 
 QsoRipper does not download, install, or update CatHub during startup.
-The current supported executable range is `>=0.1.2 <0.2.0`. The launcher checks
+The current supported executable range is `>=0.2.0 <0.3.0`. The launcher checks
 `cathub --version` and reports an incompatible version separately from a spawn failure.
 
 ## Configuration modes
@@ -157,12 +157,11 @@ keyer and broker. Enable transmission only during an attended hardware test.
 
 ## Protocol compatibility
 
-CatHub 0.1 retains the existing `qsoripper.services` WinKeyer broker wire-package identifier.
-The identifier is part of the wire contract and does not make CatHub part of QsoRipper. The
-authoritative contract lives in the CatHub repository.
+CatHub 0.2 uses the `cathub.services` WinKeyer broker wire-package identifier.
+The authoritative contract lives in the CatHub repository.
 
-The Rust engine consumes `cathub-protocol` 0.1.1. The .NET engine consumes
-`CatHub.Protocol` 0.1.1. CatHub owns these packages and the source protocol files.
+The Rust engine consumes `cathub-protocol` 0.2.0. The .NET engine consumes
+`CatHub.Protocol` 0.2.0. CatHub owns these packages and the source protocol files.
 
 QsoRipper records the dependency pin in `config\cathub-dependency.json`.
 

--- a/src/dotnet/Directory.Packages.props
+++ b/src/dotnet/Directory.Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="Avalonia.Desktop" Version="12.0.1" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.0.1" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="CatHub.Protocol" Version="0.1.1" />
+    <PackageVersion Include="CatHub.Protocol" Version="0.2.0" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="Google.Protobuf" Version="3.34.1" />

--- a/src/dotnet/QsoRipper.Engine.DotNet/CwKeying.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/CwKeying.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.IO.Ports;
 using System.Text;
+using CatHub.Protocol;
 using Grpc.Core;
 using Grpc.Net.Client;
 using QsoRipper.Domain;

--- a/src/rust/qsoripper-core/Cargo.toml
+++ b/src/rust/qsoripper-core/Cargo.toml
@@ -8,7 +8,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-cathub-protocol = "=0.1.1"
+cathub-protocol = "=0.2.0"
 prost = { workspace = true }
 prost-types = { workspace = true }
 tonic = { workspace = true }

--- a/src/rust/qsoripper-launcher/src/process.rs
+++ b/src/rust/qsoripper-launcher/src/process.rs
@@ -12,9 +12,9 @@ use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, Signal, System, Update
 
 use crate::catalog::{ComponentId, ComponentSpec};
 
-const MINIMUM_CATHUB_VERSION: (u32, u32, u32) = (0, 1, 2);
-const MAXIMUM_CATHUB_VERSION: (u32, u32, u32) = (0, 2, 0);
-const SUPPORTED_CATHUB_RANGE: &str = ">=0.1.2 <0.2.0";
+const MINIMUM_CATHUB_VERSION: (u32, u32, u32) = (0, 2, 0);
+const MAXIMUM_CATHUB_VERSION: (u32, u32, u32) = (0, 3, 0);
+const SUPPORTED_CATHUB_RANGE: &str = ">=0.2.0 <0.3.0";
 
 /// A child the launcher started, tracked by OS PID so it survives the launcher
 /// exiting and so a later "stop" can find it again.
@@ -557,10 +557,11 @@ mod tests {
     fn accepts_only_supported_cathub_version_series() {
         assert!(!is_supported_cathub_version("0.1"));
         assert!(!is_supported_cathub_version("0.1.0"));
-        assert!(is_supported_cathub_version("0.1.2"));
-        assert!(is_supported_cathub_version("0.1.12"));
+        assert!(!is_supported_cathub_version("0.1.2"));
+        assert!(is_supported_cathub_version("0.2.0"));
+        assert!(is_supported_cathub_version("0.2.12"));
         assert!(!is_supported_cathub_version("0.0.9"));
-        assert!(!is_supported_cathub_version("0.2.0"));
+        assert!(!is_supported_cathub_version("0.3.0"));
         assert!(!is_supported_cathub_version("0.10.0"));
     }
 


### PR DESCRIPTION
Updates QsoRipper to the released CatHub 0.2.0 executable and protocol contract. Aligns launcher compatibility, Rust and .NET package versions, wire namespace metadata, and setup documentation.