### PR TITLE
Show complete QSO history in the GUI

### DIFF
--- a/src/dotnet/QsoRipper.Gui.Tests/CallsignCardViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/CallsignCardViewModelTests.cs
@@ -58,7 +58,7 @@ public sealed class CallsignCardViewModelTests
         public Task<SaveSetupResponse> SaveSetupAsync(SaveSetupRequest request, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) => throw new NotImplementedException();
-        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) => throw new NotImplementedException();
+        public Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) => throw new NotImplementedException();
         public Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default) => throw new NotImplementedException();
         public Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default) => throw new NotImplementedException();

--- a/src/dotnet/QsoRipper.Gui.Tests/FullQsoCardViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/FullQsoCardViewModelTests.cs
@@ -589,7 +589,7 @@ public sealed class FullQsoCardViewModelTests
         public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default) =>
             Task.FromResult(RecentQsos);
 
         public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default)

--- a/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelEngineReachabilityTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelEngineReachabilityTests.cs
@@ -92,7 +92,7 @@ public sealed class MainWindowViewModelEngineReachabilityTests
         public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default)
+        public Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default)
         {
             if (FailWithRpcException)
             {

--- a/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/MainWindowViewModelTests.cs
@@ -274,7 +274,7 @@ public sealed class MainWindowViewModelTests
         public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default) =>
             Task.FromResult(RecentQsos);
 
         public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) =>

--- a/src/dotnet/QsoRipper.Gui.Tests/MinimalEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/MinimalEngineClient.cs
@@ -19,7 +19,7 @@ internal sealed class MinimalEngineClient : IEngineClient
     public Task<SaveSetupResponse> SaveSetupAsync(SaveSetupRequest request, CancellationToken ct = default) => throw new NotImplementedException();
     public Task<GetSetupStatusResponse> GetSetupStatusAsync(CancellationToken ct = default) => throw new NotImplementedException();
     public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) => throw new NotImplementedException();
-    public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) => Task.FromResult<IReadOnlyList<QsoRecord>>([]);
+    public Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default) => Task.FromResult<IReadOnlyList<QsoRecord>>([]);
     public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) => throw new NotImplementedException();
     public Task<SyncWithQrzResponse> SyncWithQrzAsync(CancellationToken ct = default) => throw new NotImplementedException();
     public Task<GetSyncStatusResponse> GetSyncStatusAsync(CancellationToken ct = default) => throw new NotImplementedException();

--- a/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/QsoLoggerEnrichmentTests.cs
@@ -450,7 +450,7 @@ public sealed class QsoLoggerEnrichmentTests
         public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<QsoRecord>>([]);
 
         public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) =>
@@ -514,7 +514,7 @@ public sealed class QsoLoggerEnrichmentTests
         public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<QsoRecord>>([]);
 
         public Task<UpdateQsoResponse> UpdateQsoAsync(QsoRecord qso, bool syncToQrz = false, CancellationToken ct = default) =>

--- a/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/RecentQsoListViewModelTests.cs
@@ -70,7 +70,32 @@ public class RecentQsoListViewModelTests
         Assert.Equal("2 QSOs", viewModel.CountStatusText);
         Assert.Equal("No filter", viewModel.FilterStatusText);
         Assert.Equal("Sync local", viewModel.TopSyncIndicatorText);
-        Assert.Equal(200, engine.LastRecentQsoLimit);
+        Assert.Equal(1, engine.ListQsosCallCount);
+    }
+
+    [Fact]
+    public async Task RefreshAsyncLoadsMoreThanPreviousRowLimit()
+    {
+        var engine = new FakeEngineClient
+        {
+            RecentQsos = Enumerable.Range(1, 250)
+                .Select(index => CreateQso(
+                    $"qso-{index}",
+                    $"K7{index:000}",
+                    Band._20M,
+                    Mode.Cw,
+                    14_025_000,
+                    "CN87",
+                    $"QSO {index}"))
+                .ToArray()
+        };
+
+        var viewModel = new RecentQsoListViewModel(engine);
+
+        await viewModel.RefreshAsync();
+
+        Assert.Equal(250, viewModel.VisibleItems.Count);
+        Assert.Equal("250 QSOs", viewModel.CountStatusText);
     }
 
     [Fact]
@@ -387,7 +412,7 @@ public class RecentQsoListViewModelTests
 
         public List<QsoRecord> UpdatedQsos { get; } = [];
 
-        public int? LastRecentQsoLimit { get; private set; }
+        public int ListQsosCallCount { get; private set; }
 
         public Task<GetSetupWizardStateResponse> GetWizardStateAsync(CancellationToken ct = default) =>
             throw new NotImplementedException();
@@ -407,9 +432,9 @@ public class RecentQsoListViewModelTests
         public Task<TestQrzLogbookCredentialsResponse> TestQrzLogbookCredentialsAsync(string apiKey, CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default)
+        public Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default)
         {
-            LastRecentQsoLimit = limit;
+            ListQsosCallCount++;
             if (RefreshException is not null)
             {
                 throw RefreshException;

--- a/src/dotnet/QsoRipper.Gui.Tests/SwitchableEngineClientTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/SwitchableEngineClientTests.cs
@@ -26,7 +26,7 @@ public sealed class SwitchableEngineClientTests
             "http://engine-a",
             endpoint => clients[endpoint]);
 
-        var initialQsos = await switchable.ListRecentQsosAsync();
+        var initialQsos = await switchable.ListQsosAsync();
         Assert.Equal("rust", Assert.Single(initialQsos).LocalId);
 
         var result = await switchable.SwitchAsync(dotnetProfile, "http://engine-b");
@@ -34,7 +34,7 @@ public sealed class SwitchableEngineClientTests
         Assert.True(result.Success);
         Assert.Equal(dotnetProfile.ProfileId, switchable.CurrentProfile.ProfileId);
         Assert.Equal("http://engine-b", switchable.CurrentEndpoint);
-        var switchedQsos = await switchable.ListRecentQsosAsync();
+        var switchedQsos = await switchable.ListQsosAsync();
         Assert.Equal("dotnet", Assert.Single(switchedQsos).LocalId);
         Assert.Equal(0, first.DisposeCount);
         Assert.Equal(0, second.DisposeCount);
@@ -62,7 +62,7 @@ public sealed class SwitchableEngineClientTests
         Assert.False(result.Success);
         Assert.Equal(rustProfile.ProfileId, switchable.CurrentProfile.ProfileId);
         Assert.Equal("http://engine-a", switchable.CurrentEndpoint);
-        var currentQsos = await switchable.ListRecentQsosAsync();
+        var currentQsos = await switchable.ListQsosAsync();
         Assert.Equal("rust", Assert.Single(currentQsos).LocalId);
         Assert.Equal(1, failedCandidate.DisposeCount);
     }
@@ -98,7 +98,7 @@ public sealed class SwitchableEngineClientTests
             CancellationToken ct = default) =>
             throw new NotImplementedException();
 
-        public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) =>
+        public Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default) =>
             Task.FromResult<IReadOnlyList<QsoRecord>>([new QsoRecord { LocalId = localId }]);
 
         public Task<UpdateQsoResponse> UpdateQsoAsync(

--- a/src/dotnet/QsoRipper.Gui.Tests/UxFixtureEngineClientTests.cs
+++ b/src/dotnet/QsoRipper.Gui.Tests/UxFixtureEngineClientTests.cs
@@ -109,7 +109,7 @@ public class UxFixtureEngineClientTests
 
         var response = await client.SyncWithQrzAsync();
         var syncStatus = await client.GetSyncStatusAsync();
-        var records = await client.ListRecentQsosAsync();
+        var records = await client.ListQsosAsync();
 
         Assert.Equal(1u, response.UploadedRecords);
         Assert.Equal(0u, syncStatus.PendingUpload);

--- a/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Inspection/UxFixtureEngineClient.cs
@@ -274,12 +274,11 @@ internal sealed class UxFixtureEngineClient : IEngineClient
             });
     }
 
-    public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default)
+    public Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default)
     {
         lock (_gate)
         {
             var records = _recentQsos
-                .Take(limit)
                 .Select(record => record.Clone())
                 .ToArray();
             return Task.FromResult((IReadOnlyList<QsoRecord>)records);

--- a/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/EngineGrpcService.cs
@@ -87,15 +87,12 @@ internal sealed class EngineGrpcService : IEngineClient, IDisposable
             cancellationToken: ct);
     }
 
-    public async Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default)
+    public async Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default)
     {
-        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(limit);
-
-        var recentQsos = new List<QsoRecord>(limit);
+        var qsos = new List<QsoRecord>();
         using var call = _logbookClient.ListQsos(
             new ListQsosRequest
             {
-                Limit = (uint)limit,
                 Sort = QsoSortOrder.NewestFirst
             },
             cancellationToken: ct);
@@ -104,11 +101,11 @@ internal sealed class EngineGrpcService : IEngineClient, IDisposable
         {
             if (response.Qso is not null)
             {
-                recentQsos.Add(response.Qso);
+                qsos.Add(response.Qso);
             }
         }
 
-        return recentQsos;
+        return qsos;
     }
 
     public async Task<UpdateQsoResponse> UpdateQsoAsync(

--- a/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/IEngineClient.cs
@@ -29,7 +29,7 @@ internal interface IEngineClient
         string apiKey,
         CancellationToken ct = default);
 
-    Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default);
+    Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default);
 
     Task<UpdateQsoResponse> UpdateQsoAsync(
         QsoRecord qso,

--- a/src/dotnet/QsoRipper.Gui/Services/SwitchableEngineClient.cs
+++ b/src/dotnet/QsoRipper.Gui/Services/SwitchableEngineClient.cs
@@ -180,8 +180,8 @@ internal sealed class SwitchableEngineClient : IEngineClient, IDisposable
         CancellationToken ct = default) =>
         SnapshotClient().TestQrzLogbookCredentialsAsync(apiKey, ct);
 
-    public Task<IReadOnlyList<QsoRecord>> ListRecentQsosAsync(int limit = 200, CancellationToken ct = default) =>
-        SnapshotClient().ListRecentQsosAsync(limit, ct);
+    public Task<IReadOnlyList<QsoRecord>> ListQsosAsync(CancellationToken ct = default) =>
+        SnapshotClient().ListQsosAsync(ct);
 
     public Task<UpdateQsoResponse> UpdateQsoAsync(
         QsoRecord qso,

--- a/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/MainWindowViewModel.cs
@@ -311,7 +311,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
             GuiPerformanceTrace.Write(nameof(CheckFirstRunAsync) + ".start");
             await ApplyPreferredEngineSelectionAsync();
             GuiPerformanceTrace.Write(nameof(CheckFirstRunAsync) + ".afterPreferredEngine");
-            StatusMessage = "Loading recent QSOs...";
+            StatusMessage = "Loading QSOs...";
             var recentQsoRefreshTask = RecentQsos.RefreshAsync();
             var status = (await _engine.GetSetupStatusAsync()).Status;
             GuiPerformanceTrace.Write(
@@ -1755,7 +1755,7 @@ internal sealed partial class MainWindowViewModel : ObservableObject, IDisposabl
     private async Task ActivateDashboardAsync(bool focusSearch, Task? recentQsoRefreshTask = null)
     {
         GuiPerformanceTrace.Write(nameof(ActivateDashboardAsync) + ".start");
-        StatusMessage = "Loading recent QSOs...";
+        StatusMessage = "Loading QSOs...";
         recentQsoRefreshTask ??= RecentQsos.RefreshAsync();
         await recentQsoRefreshTask;
         GuiPerformanceTrace.Write(nameof(ActivateDashboardAsync) + ".afterRecentQsosRefresh");

--- a/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
+++ b/src/dotnet/QsoRipper.Gui/ViewModels/RecentQsoListViewModel.cs
@@ -13,7 +13,6 @@ namespace QsoRipper.Gui.ViewModels;
 
 internal sealed partial class RecentQsoListViewModel : ObservableObject
 {
-    private const int DefaultLimit = 200;
     private const double DefaultGridFontSize = 12;
     private const double MinGridFontSize = 10;
     private const double MaxGridFontSize = 18;
@@ -57,7 +56,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         {
             if (!HasLoaded)
             {
-                return "Recent QSOs will appear here after setup completes.";
+                return "QSOs will appear here after setup completes.";
             }
 
             if (!string.IsNullOrWhiteSpace(ErrorMessage) && _allItems.Count == 0)
@@ -67,7 +66,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
 
             if (_parsedSearchQuery.HasTokens)
             {
-                return "No recent QSOs match the current search.";
+                return "No QSOs match the current search.";
             }
 
             return "No QSOs have been logged yet.";
@@ -193,8 +192,8 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         try
         {
             var selectedLocalId = SelectedQso?.LocalId;
-            var qsos = await _engine.ListRecentQsosAsync(DefaultLimit);
-            GuiPerformanceTrace.Write(nameof(RefreshAsync) + ".afterListRecentQsos", $"count={qsos.Count}");
+            var qsos = await _engine.ListQsosAsync();
+            GuiPerformanceTrace.Write(nameof(RefreshAsync) + ".afterListQsos", $"count={qsos.Count}");
             var items = new RecentQsoItemViewModel[qsos.Count];
             var format = TimestampFormat;
             for (var index = 0; index < qsos.Count; index++)
@@ -215,7 +214,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         {
             HasLoaded = true;
             ErrorMessage = string.IsNullOrWhiteSpace(ex.Status.Detail)
-                ? $"Recent QSOs could not be loaded ({ex.StatusCode})."
+                ? $"QSOs could not be loaded ({ex.StatusCode})."
                 : ex.Status.Detail;
             RefreshView();
         }
@@ -609,7 +608,7 @@ internal sealed partial class RecentQsoListViewModel : ObservableObject
         RecentQsoSortColumn.State => "state",
         RecentQsoSortColumn.County => "county",
         RecentQsoSortColumn.Sync => "sync",
-        _ => "recent QSOs"
+        _ => "QSOs"
     };
 
     private void ApplySortDescriptions(RecentQsoSortColumn column, bool ascending)

--- a/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
+++ b/src/dotnet/QsoRipper.Gui/Views/MainWindow.axaml
@@ -158,7 +158,7 @@
       <MenuItem Header="_View">
         <MenuItem Header="_Find" InputGesture="Ctrl+F"
                   Command="{Binding FocusSearchCommand}" />
-        <MenuItem Header="_Refresh Recent QSOs" InputGesture="F5"
+        <MenuItem Header="_Refresh QSOs" InputGesture="F5"
                   Command="{Binding RecentQsos.RefreshCommand}" />
         <MenuItem Header="Zoom _In" InputGesture="Ctrl++"
                   Command="{Binding RecentQsos.ZoomInCommand}" />
@@ -929,7 +929,7 @@
                   IsVisible="{Binding IsSortChooserOpen}">
             <ScrollViewer MaxHeight="480" VerticalScrollBarVisibility="Auto">
             <StackPanel Spacing="6">
-              <TextBlock Text="Sort recent QSOs"
+              <TextBlock Text="Sort QSOs"
                          FontSize="12.5"
                          FontWeight="SemiBold" />
               <Button Content="1  UTC"


### PR DESCRIPTION
The GUI requested only the newest 200 QSO records. Older records were therefore absent from the table and could not appear in search or sort results.

This change removes the client-side 200-record limit and streams the complete QSO list from the engine. It renames the internal client method and updates visible text from “Recent QSOs” to “QSOs.”

The GUI tests include a new 250-record case that verifies records beyond the previous limit remain visible.

Validation: the complete QsoRipper.Gui.Tests project passed with 190 tests.