### PR TITLE
Restart engines when CatHub endpoint changes

### DIFF
--- a/src/rust/qsoripper-launcher/src/engine_runtime.rs
+++ b/src/rust/qsoripper-launcher/src/engine_runtime.rs
@@ -1,0 +1,92 @@
+//! Inspect an existing engine before the launcher reuses its listening port.
+
+use std::time::Duration;
+
+use qsoripper_core::proto::qsoripper::services::{
+    cw_service_client::CwServiceClient, GetCwKeyerStatusRequest,
+};
+use tokio::runtime::Runtime;
+use tonic::transport::{Channel, Endpoint};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CatHubEndpointInspection {
+    Compatible,
+    Incompatible { actual: Option<String> },
+    Unavailable(String),
+}
+
+pub(crate) fn inspect_cathub_endpoint(
+    runtime: &Runtime,
+    engine_endpoint: &str,
+    expected_endpoint: &str,
+) -> CatHubEndpointInspection {
+    match runtime.block_on(fetch_cathub_endpoint(engine_endpoint)) {
+        Ok(actual) if endpoint_matches(actual.as_deref(), expected_endpoint) => {
+            CatHubEndpointInspection::Compatible
+        }
+        Ok(actual) => CatHubEndpointInspection::Incompatible { actual },
+        Err(error) => CatHubEndpointInspection::Unavailable(error),
+    }
+}
+
+fn endpoint_matches(actual: Option<&str>, expected: &str) -> bool {
+    actual.is_some_and(|actual| normalize_endpoint(actual) == normalize_endpoint(expected))
+}
+
+fn normalize_endpoint(endpoint: &str) -> &str {
+    endpoint.trim_end_matches('/')
+}
+
+async fn fetch_cathub_endpoint(engine_endpoint: &str) -> Result<Option<String>, String> {
+    let channel = connect(engine_endpoint).await?;
+    let mut client = CwServiceClient::new(channel);
+    let response = tokio::time::timeout(
+        Duration::from_secs(3),
+        client.get_cw_keyer_status(GetCwKeyerStatusRequest {}),
+    )
+    .await
+    .map_err(|_| "timed out waiting for GetCwKeyerStatus".to_owned())?
+    .map_err(|status| format!("GetCwKeyerStatus failed: {}", status.message()))?;
+    response
+        .into_inner()
+        .status
+        .map(|status| status.broker_endpoint)
+        .ok_or_else(|| "engine returned no CW keyer status".to_owned())
+}
+
+async fn connect(endpoint: &str) -> Result<Channel, String> {
+    let endpoint = Endpoint::from_shared(endpoint.to_owned())
+        .map_err(|error| format!("invalid engine endpoint: {error}"))?
+        .connect_timeout(Duration::from_secs(2))
+        .timeout(Duration::from_secs(5));
+    endpoint
+        .connect()
+        .await
+        .map_err(|error| format!("engine connection failed: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_match_accepts_equivalent_trailing_slash() {
+        assert!(endpoint_matches(
+            Some("http://127.0.0.1:53772/"),
+            "http://127.0.0.1:53772"
+        ));
+    }
+
+    #[test]
+    fn endpoint_match_rejects_obsolete_dynamic_port() {
+        assert!(!endpoint_matches(
+            Some("http://127.0.0.1:50071"),
+            "http://127.0.0.1:53772"
+        ));
+    }
+
+    #[test]
+    fn endpoint_match_rejects_missing_broker_endpoint() {
+        assert!(!endpoint_matches(None, "http://127.0.0.1:53772"));
+    }
+}

--- a/src/rust/qsoripper-launcher/src/main.rs
+++ b/src/rust/qsoripper-launcher/src/main.rs
@@ -4,6 +4,7 @@ mod catalog;
 mod cathub_runtime;
 mod config;
 mod discovery;
+mod engine_runtime;
 mod model;
 mod plan;
 mod ports;

--- a/src/rust/qsoripper-launcher/src/plan.rs
+++ b/src/rust/qsoripper-launcher/src/plan.rs
@@ -436,4 +436,16 @@ mod tests {
             )]
         );
     }
+
+    #[test]
+    fn dotnet_engine_plan_injects_discovered_cathub_endpoint() {
+        let plan = engine_plan(ENGINE_DOTNET, Some("http://127.0.0.1:54322")).expect("plan");
+        assert_eq!(
+            plan.env,
+            vec![(
+                "QSORIPPER_CW_CATHUB_ENDPOINT".to_string(),
+                "http://127.0.0.1:54322".to_string()
+            )]
+        );
+    }
 }

--- a/src/rust/qsoripper-launcher/src/process.rs
+++ b/src/rust/qsoripper-launcher/src/process.rs
@@ -377,10 +377,6 @@ pub(crate) fn stop_pid(pid: u32) -> bool {
 /// before the binary on disk was last built (`built_secs`, seconds since the
 /// Unix epoch). A process running a different executable, or one started after
 /// the current build, is never considered stale.
-#[expect(
-    clippy::case_sensitive_file_extension_comparisons,
-    reason = "comparing a known side-lined suffix, not a real file extension; casing is normalized on Windows and intentionally exact on Unix"
-)]
 fn is_stale_published_copy(
     proc_exe: &Path,
     proc_start_secs: u64,
@@ -390,6 +386,16 @@ fn is_stale_published_copy(
     if proc_start_secs >= built_secs {
         return false;
     }
+    is_managed_published_copy(proc_exe, target_exe)
+}
+
+/// Decide whether a running process uses the published executable managed by
+/// this launcher. A side-lined locked copy also belongs to the launcher.
+#[expect(
+    clippy::case_sensitive_file_extension_comparisons,
+    reason = "comparing a known side-lined suffix, not a real file extension; casing is normalized on Windows and intentionally exact on Unix"
+)]
+fn is_managed_published_copy(proc_exe: &Path, target_exe: &Path) -> bool {
     let (Some(proc_parent), Some(target_parent)) = (proc_exe.parent(), target_exe.parent()) else {
         return false;
     };
@@ -455,6 +461,37 @@ pub(crate) fn reap_stale_published_copies(exe: &Path) -> usize {
             continue;
         };
         if !is_stale_published_copy(proc_exe, proc_handle.start_time(), exe, built_secs) {
+            continue;
+        }
+        let killed = proc_handle
+            .kill_with(Signal::Term)
+            .unwrap_or_else(|| proc_handle.kill());
+        if killed {
+            stopped += 1;
+        }
+    }
+    stopped
+}
+
+/// Stop processes that use the launcher's published engine executable.
+///
+/// A new launcher session cannot recover its previous in-memory registry. It
+/// uses this executable match to reclaim engines that it started earlier. A
+/// process from a different executable remains external and is not stopped.
+pub(crate) fn reap_managed_published_copies(exe: &Path) -> usize {
+    let mut sys = System::new();
+    sys.refresh_processes_specifics(
+        ProcessesToUpdate::All,
+        true,
+        ProcessRefreshKind::nothing().with_exe(UpdateKind::Always),
+    );
+
+    let mut stopped = 0usize;
+    for proc_handle in sys.processes().values() {
+        let Some(proc_exe) = proc_handle.exe() else {
+            continue;
+        };
+        if !is_managed_published_copy(proc_exe, exe) {
             continue;
         }
         let killed = proc_handle
@@ -569,6 +606,19 @@ mod tests {
         let target = PathBuf::from("/publish/Release/qsoripper-server.exe");
         // Started at t=100, binary built at t=200 -> stale.
         assert!(is_stale_published_copy(&target, 100, &target, 200));
+    }
+
+    #[test]
+    fn managed_copy_matches_same_exe_without_build_time_check() {
+        let target = PathBuf::from("/publish/Release/qsoripper-server.exe");
+        assert!(is_managed_published_copy(&target, &target));
+    }
+
+    #[test]
+    fn managed_copy_rejects_same_name_from_another_directory() {
+        let target = PathBuf::from("/publish/Release/qsoripper-server.exe");
+        let external = PathBuf::from("/debug/qsoripper-server.exe");
+        assert!(!is_managed_published_copy(&external, &target));
     }
 
     #[test]

--- a/src/rust/qsoripper-launcher/src/ui.rs
+++ b/src/rust/qsoripper-launcher/src/ui.rs
@@ -22,11 +22,13 @@ use crate::cathub_runtime::{
 };
 use crate::config;
 use crate::discovery::ArtifactRoot;
+use crate::engine_runtime::{inspect_cathub_endpoint, CatHubEndpointInspection};
 use crate::model::Selection;
 use crate::plan::{daemon_plan, engine_plan, ui_plan};
 use crate::ports::{is_port_listening, wait_for_port, wait_for_port_release};
 use crate::process::{
-    open_url, reap_stale_published_copies, spawn, stop_pid, verify_cathub_version, ProcessRegistry,
+    open_url, reap_managed_published_copies, reap_stale_published_copies, spawn, stop_pid,
+    verify_cathub_version, ProcessRegistry,
 };
 use crate::sync::{diff_rows, DialogState, DiffRow, Side, SyncDialog};
 
@@ -381,16 +383,7 @@ impl AppState {
         true
     }
 
-    /// Spawn selected daemons, then engines (waiting for readiness on each),
-    /// then every selected UI with its per-UI engine binding env vars.
-    fn launch_selected(&mut self) {
-        // Daemons first: the CAT hub must own the radio and expose its rigctld
-        // endpoint before any engine connects. Abort the launch if one fails.
-        if !self.launch_daemons() {
-            return;
-        }
-
-        // Engines next.
+    fn launch_engines(&mut self) -> bool {
         for engine_id in self.selection.engines.clone() {
             let Some(plan) = engine_plan(engine_id, self.cathub_endpoint.as_deref()) else {
                 continue;
@@ -398,16 +391,55 @@ impl AppState {
             let exe = plan.spec.artifact.executable_path(&self.artifact_root);
             let port = plan.spec.engine_port.unwrap_or(0);
             if port != 0 && is_port_listening(port, Duration::from_millis(200)) {
-                // Something owns the port. If it is a stale copy of our own
-                // published binary left by an earlier session/rebuild, reclaim
-                // the port so the restart spawns fresh code; otherwise respect
-                // a genuinely external owner.
-                if reap_stale_published_copies(&exe) > 0 {
+                if let Some(process) = self.registry.get(engine_id) {
+                    self.statuses
+                        .insert(engine_id, Status::running(process.pid));
+                    continue;
+                }
+
+                // The registry is in memory. A new launcher session reclaims
+                // an earlier published engine so it receives this CatHub
+                // instance's dynamic endpoint.
+                if reap_managed_published_copies(&exe) > 0 {
                     wait_for_port_release(port, Duration::from_secs(3));
                 }
                 if is_port_listening(port, Duration::from_millis(200)) {
-                    self.statuses
-                        .insert(engine_id, Status::listening_external());
+                    let Some(expected_endpoint) = self.cathub_endpoint.clone() else {
+                        self.statuses
+                            .insert(engine_id, Status::listening_external());
+                        continue;
+                    };
+                    let engine_endpoint = format!("http://127.0.0.1:{port}");
+                    let Some(runtime) = self.ensure_runtime() else {
+                        self.statuses.insert(
+                            engine_id,
+                            Status::failed("could not inspect external engine"),
+                        );
+                        return false;
+                    };
+                    match inspect_cathub_endpoint(runtime, &engine_endpoint, &expected_endpoint) {
+                        CatHubEndpointInspection::Compatible => {
+                            self.statuses
+                                .insert(engine_id, Status::listening_external());
+                        }
+                        CatHubEndpointInspection::Incompatible { actual } => {
+                            let actual = actual.as_deref().unwrap_or("<none>");
+                            let reason = format!(
+                                "external engine uses CatHub endpoint {actual}; expected {expected_endpoint}"
+                            );
+                            self.statuses.insert(engine_id, Status::failed(&reason));
+                            self.last_message = format!("Aborted launch: {reason}");
+                            return false;
+                        }
+                        CatHubEndpointInspection::Unavailable(error) => {
+                            let reason = format!(
+                                "could not verify external engine CatHub endpoint: {error}"
+                            );
+                            self.statuses.insert(engine_id, Status::failed(&reason));
+                            self.last_message = format!("Aborted launch: {reason}");
+                            return false;
+                        }
+                    }
                     continue;
                 }
             }
@@ -431,6 +463,17 @@ impl AppState {
                         .insert(engine_id, Status::failed(&e.to_string()));
                 }
             }
+        }
+        true
+    }
+
+    /// Spawn selected daemons, then engines (waiting for readiness on each),
+    /// then every selected UI with its per-UI engine binding env vars.
+    fn launch_selected(&mut self) {
+        // Daemons first: the CAT hub must own the radio and expose its rigctld
+        // endpoint before any engine connects. Abort the launch if one fails.
+        if !self.launch_daemons() || !self.launch_engines() {
+            return;
         }
 
         // UIs next.


### PR DESCRIPTION
Fixes #561.

The launcher previously treated every listening engine as external unless its executable was older than the current build. An engine from an earlier launcher session could therefore keep an obsolete dynamic CatHub WinKeyer endpoint.

This change reclaims engines that run from the launcher's published artifacts when a new launcher session starts. The replacement process receives the current CatHub endpoint. The launcher now queries a real external engine's CW status and reuses it only when its broker endpoint matches the current CatHub runtime endpoint. It stops the launch with a clear status when the endpoint is incompatible or cannot be verified.

The change adds endpoint compatibility tests, published process ownership tests, and Rust plus .NET launch-plan coverage.

Validation: .\build.ps1 check-rust passed. This includes formatting, workspace Clippy, tests with coverage above 80 percent, protobuf lint, and cargo deny.