### PR TITLE
Fix FFI LoTW ownership assertion

### DIFF
--- a/src/rust/qsoripper-ffi/tests/integration.rs
+++ b/src/rust/qsoripper-ffi/tests/integration.rs
@@ -220,8 +220,8 @@ fn log_list_get_delete_round_trip() {
     assert_eq!(buf_as_str(&detail.worked_operator_callsign), "W1AW/OP");
     assert_eq!(buf_as_str(&detail.qsl_sent_status), "Y");
     assert_eq!(buf_as_str(&detail.qsl_sent_date), "2025-01-16");
-    assert_eq!(buf_as_str(&detail.lotw_sent), "N");
-    // The server owns QRZ linkage and station context on the public LogQso path.
+    // The server owns LoTW state, QRZ linkage, and station context on the public LogQso path.
+    assert!(buf_as_str(&detail.lotw_sent).is_empty());
     assert!(buf_as_str(&detail.qrz_log_id).is_empty());
     assert!(!buf_as_str(&detail.station_callsign).is_empty());
     assert_eq!(


### PR DESCRIPTION
Updates the FFI round-trip test to match the public LogQso ownership contract.

The engine now owns LoTW confirmation state and removes caller-supplied values during new QSO creation. The integration test still expected its supplied LoTW sent value to persist, which caused the Rust test failure after the LoTW ownership change.

The test now verifies that the returned LoTW sent field is empty. The targeted test, the complete qsoripper-ffi test suite, Rust formatting, and Clippy all pass.