### PR TITLE
Add QRZ enrichment backfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -648,6 +648,8 @@ Run it directly from source with:
 cd src/dotnet
 dotnet run --project QsoRipper.Cli -- status
 dotnet run --project QsoRipper.Cli -- --endpoint http://localhost:50051 status
+dotnet run --project QsoRipper.Cli -- enrich --preview
+dotnet run --project QsoRipper.Cli -- enrich --apply --after 2026-08-01T00:00:00Z
 ```
 
 Or publish the Native AOT build and run the produced executable:
@@ -658,7 +660,7 @@ Or publish the Native AOT build and run the produced executable:
 ```
 
 The CLI generates client stubs from the shared proto contracts during the build.
-It includes commands for status, lookup, and local gRPC logbook operations.
+It includes commands for status, lookup, local logbook operations, and QSO enrichment backfill.
 
 ## Documentation
 

--- a/docs/api/logbook-service.md
+++ b/docs/api/logbook-service.md
@@ -1,6 +1,7 @@
 # LogbookService Reference
 
-The `LogbookService` is the core QSO lifecycle interface. It covers local QSO CRUD and ADIF import/export today, with QRZ sync reserved for a later slice.
+The `LogbookService` is the core QSO lifecycle interface.
+It covers local QSO storage, callsign enrichment, external sync, and ADIF transfer.
 
 Proto definition: [`proto/services/logbook_service.proto`](../../proto/services/logbook_service.proto)
 
@@ -17,6 +18,7 @@ Service envelopes and support types live in their own files under `proto/service
 | `DeleteQso` | Implemented | Deletes from local storage. QRZ delete still reports unimplemented when requested |
 | `GetQso` | Implemented | Loads a single local QSO by `local_id` |
 | `ListQsos` | Implemented | Streams locally stored QSOs with filters, sorting, limit, and offset |
+| `BackfillQsoEnrichment` | Implemented | Fills missing QSO enrichment fields through QRZ XML callsign lookup |
 | `SyncWithQrz` | Planned | Contract defined. Returns `UNIMPLEMENTED` |
 | `GetSyncStatus` | Implemented | Returns live local counts from storage. QRZ fields remain zero or absent until the engine implements sync. |
 | `ImportAdif` | Implemented | Streams ADIF in, imports after client close, reports duplicates/fallback warnings |
@@ -193,6 +195,44 @@ rpc ListQsos(ListQsosRequest) returns (stream ListQsosResponse)
 
 **Notable status codes:**
 - `OK` - zero or more `ListQsosResponse` envelopes streamed back.
+
+---
+
+### BackfillQsoEnrichment
+
+Fill missing enrichment fields on active local QSOs.
+
+```
+rpc BackfillQsoEnrichment(BackfillQsoEnrichmentRequest) returns (stream BackfillQsoEnrichmentResponse)
+```
+
+Preview mode is the default.
+Apply mode uses atomic semantic compare-and-update writes; protobuf map wire order
+does not affect concurrent-edit detection.
+The engine keeps concurrent operator changes.
+The engine does not change QRZ Logbook fields or sync state.
+
+The request supports optional inclusive `after` and `before` UTC filters.
+Both values must be valid protobuf timestamps, and `after` must not be later than
+`before`; violations return `INVALID_ARGUMENT`.
+The response contains cumulative scan, lookup, change, conflict, and storage counts.
+The final response has `complete=true`.
+Cancellation stops new work but waits for an active, independently bounded shared
+provider lookup before releasing the one-run lease.
+The CLI returns failure for a stream without a terminal complete response or for a
+summary with lookup/storage errors; not-found records are normal success results.
+
+The CLI command is:
+
+```powershell
+qsoripper-cli enrich --preview
+qsoripper-cli enrich --apply --after 2026-08-01T00:00:00Z
+```
+
+**Notable status codes:**
+
+- `RESOURCE_EXHAUSTED` - another backfill is active.
+- `INVALID_ARGUMENT` - the mode or time range is invalid.
 
 ---
 

--- a/docs/architecture/engine-specification.md
+++ b/docs/architecture/engine-specification.md
@@ -144,6 +144,7 @@ The primary QSO CRUD and sync surface. This is the most critical service in the 
 | `PurgeDeletedQsos` | `PurgeDeletedQsosRequest` | `PurgeDeletedQsosResponse` | Unary |
 | `GetQso` | `GetQsoRequest` | `GetQsoResponse` | Unary |
 | `ListQsos` | `ListQsosRequest` | `stream ListQsosResponse` | Server-streaming |
+| `BackfillQsoEnrichment` | `BackfillQsoEnrichmentRequest` | `stream BackfillQsoEnrichmentResponse` | Server-streaming |
 | `SyncWithQrz` | `SyncWithQrzRequest` | `stream SyncWithQrzResponse` | Server-streaming |
 | `SyncWithLotw` | `SyncWithLotwRequest` | `stream SyncWithLotwResponse` | Server-streaming |
 | `GetSyncStatus` | `GetSyncStatusRequest` | `GetSyncStatusResponse` | Unary |
@@ -280,6 +281,67 @@ Streams QSO records matching optional filter criteria.
 
 **Error semantics:**
 - `INVALID_ARGUMENT` - malformed filter values.
+
+#### BackfillQsoEnrichment
+
+Fills missing QSO fields with QRZ XML callsign data.
+
+**Behavior:**
+
+1. Select active QSO rows by `local_id`.
+2. Apply the optional inclusive `after` and `before` UTC filters.
+3. Exclude soft-deleted rows.
+4. Normalize each exact callsign with the lookup coordinator rules.
+5. Keep slash callsigns as separate keys.
+6. Perform one lookup for each unique key through `LookupCoordinator`.
+7. Process lookups with conservative bounded concurrency.
+8. Fill only fields that are absent, empty, or whitespace-only.
+9. Keep each existing nonblank field unchanged.
+10. In preview mode, count changes without storage writes.
+11. In apply mode, use an atomic semantic compare-and-update operation. Protobuf
+    wire bytes are not a valid comparison key because map entry order is not stable.
+12. If the row changed after the scan, skip the write and count a concurrent edit.
+
+The operation supports these QSO fields:
+
+- `worked_operator_name`
+- `worked_grid`
+- `worked_country`
+- `worked_dxcc`
+- `worked_state`
+- `worked_county`
+- `worked_cq_zone`
+- `worked_itu_zone`
+- `worked_continent`
+- `worked_latitude`
+- `worked_longitude`
+
+The operation does not create QSO rows.
+It does not call the QRZ Logbook API.
+It does not change `qrz_logid` or `sync_status`.
+Repeated apply operations are idempotent.
+
+`BACKFILL_QSO_ENRICHMENT_MODE_UNSPECIFIED` uses preview behavior.
+Only one backfill can run in one engine process.
+A second request returns `RESOURCE_EXHAUSTED`.
+Client cancellation stops new lookup and write work.
+If a provider lookup is already active, the backfill waits for that independently
+bounded shared operation to finish before releasing its one-run lease.
+Each lookup waiter can cancel its own wait without cancelling shared provider work
+for other callers.
+
+`after` and `before` must be valid protobuf timestamps: seconds must be in
+`[-62135596800, 253402300799]` and nanos must be in `[0, 999999999]`.
+The engine returns `INVALID_ARGUMENT` for invalid timestamps or when `after` is
+later than `before`.
+
+The response values are cumulative.
+`candidates` counts active rows with missing target fields and a nonblank worked callsign.
+`found`, `not_found`, and `errors` count unique callsigns.
+`changed`, `unchanged`, `concurrent_edits`, and `storage_errors` count QSO rows.
+The server sends a terminal response with `complete=true`.
+CLI clients treat a stream without that terminal response, or a completed summary
+with lookup or storage errors, as failure. Not-found lookups remain successful.
 
 #### SyncWithQrz
 

--- a/proto/services/backfill_qso_enrichment_mode.proto
+++ b/proto/services/backfill_qso_enrichment_mode.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+// Controls whether enrichment changes are simulated or stored.
+enum BackfillQsoEnrichmentMode {
+  BACKFILL_QSO_ENRICHMENT_MODE_UNSPECIFIED = 0;
+  BACKFILL_QSO_ENRICHMENT_MODE_PREVIEW = 1;
+  BACKFILL_QSO_ENRICHMENT_MODE_APPLY = 2;
+}

--- a/proto/services/backfill_qso_enrichment_request.proto
+++ b/proto/services/backfill_qso_enrichment_request.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+import "google/protobuf/timestamp.proto";
+import "services/backfill_qso_enrichment_mode.proto";
+
+// Selects active QSO records for callsign enrichment backfill.
+message BackfillQsoEnrichmentRequest {
+  // Unspecified mode uses preview behavior.
+  BackfillQsoEnrichmentMode mode = 1;
+  // Include QSOs at or after this UTC time.
+  optional google.protobuf.Timestamp after = 2;
+  // Include QSOs at or before this UTC time.
+  optional google.protobuf.Timestamp before = 3;
+}

--- a/proto/services/backfill_qso_enrichment_response.proto
+++ b/proto/services/backfill_qso_enrichment_response.proto
@@ -6,16 +6,16 @@ option csharp_namespace = "QsoRipper.Services";
 
 // Reports cumulative callsign enrichment backfill progress.
 message BackfillQsoEnrichmentResponse {
-  uint64 scanned = 1;
-  uint64 candidates = 2;
-  uint64 unique_callsigns = 3;
-  uint64 found = 4;
-  uint64 not_found = 5;
-  uint64 errors = 6;
-  uint64 changed = 7;
-  uint64 unchanged = 8;
-  uint64 concurrent_edits = 9;
-  uint64 storage_errors = 10;
+  uint32 scanned = 1;
+  uint32 candidates = 2;
+  uint32 unique_callsigns = 3;
+  uint32 found = 4;
+  uint32 not_found = 5;
+  uint32 errors = 6;
+  uint32 changed = 7;
+  uint32 unchanged = 8;
+  uint32 concurrent_edits = 9;
+  uint32 storage_errors = 10;
   bool complete = 11;
   optional string current_callsign = 12;
 }

--- a/proto/services/backfill_qso_enrichment_response.proto
+++ b/proto/services/backfill_qso_enrichment_response.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package qsoripper.services;
+
+option csharp_namespace = "QsoRipper.Services";
+
+// Reports cumulative callsign enrichment backfill progress.
+message BackfillQsoEnrichmentResponse {
+  uint64 scanned = 1;
+  uint64 candidates = 2;
+  uint64 unique_callsigns = 3;
+  uint64 found = 4;
+  uint64 not_found = 5;
+  uint64 errors = 6;
+  uint64 changed = 7;
+  uint64 unchanged = 8;
+  uint64 concurrent_edits = 9;
+  uint64 storage_errors = 10;
+  bool complete = 11;
+  optional string current_callsign = 12;
+}

--- a/proto/services/logbook_service.proto
+++ b/proto/services/logbook_service.proto
@@ -6,6 +6,8 @@ option csharp_namespace = "QsoRipper.Services";
 
 import "services/delete_qso_request.proto";
 import "services/delete_qso_response.proto";
+import "services/backfill_qso_enrichment_request.proto";
+import "services/backfill_qso_enrichment_response.proto";
 import "services/export_adif_request.proto";
 import "services/export_adif_response.proto";
 import "services/get_qso_request.proto";
@@ -37,6 +39,7 @@ import "services/update_qso_response.proto";
 //   DeleteQso     — implemented for local storage; QRZ delete supported when delete_from_qrz=true
 //   GetQso        — implemented for local storage
 //   ListQsos      — implemented for local storage
+//   BackfillQsoEnrichment - implemented with QRZ XML lookup data (both engines)
 //   SyncWithQrz   — implemented (both engines)
 //   GetSyncStatus — implemented for local storage counts
 //   ImportAdif    — implemented for local ADIF migration import with duplicate/warning reporting
@@ -95,6 +98,9 @@ service LogbookService {
   // All filter fields are optional; omitting all filters returns all QSOs (subject to limit/offset).
   // Clients should consume incrementally rather than buffering the full stream.
   rpc ListQsos(ListQsosRequest) returns (stream ListQsosResponse);
+
+  // Fill missing QSO enrichment fields from QRZ XML callsign data.
+  rpc BackfillQsoEnrichment(BackfillQsoEnrichmentRequest) returns (stream BackfillQsoEnrichmentResponse);
 
   // --- QRZ Sync ---
 

--- a/src/dotnet/QsoRipper.Cli.Tests/CliCancellationCoverageTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/CliCancellationCoverageTests.cs
@@ -10,6 +10,7 @@ public sealed class CliCancellationCoverageTests
     [InlineData(typeof(ImportAdifCommand))]
     [InlineData(typeof(ExportAdifCommand))]
     [InlineData(typeof(ListQsosCommand))]
+    [InlineData(typeof(EnrichCommand))]
     [InlineData(typeof(SyncCommand))]
     [InlineData(typeof(StreamLookupCommand))]
     public void RunAsync_methods_accept_cancellation_token(Type commandType)

--- a/src/dotnet/QsoRipper.Cli.Tests/EnrichCommandTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/EnrichCommandTests.cs
@@ -53,9 +53,9 @@ public sealed class EnrichCommandTests
     }
 
     [Theory]
-    [InlineData(1ul, 0ul)]
-    [InlineData(0ul, 1ul)]
-    public async Task Consume_returns_failure_for_reported_errors(ulong lookupErrors, ulong storageErrors)
+    [InlineData(1u, 0u)]
+    [InlineData(0u, 1u)]
+    public async Task Consume_returns_failure_for_reported_errors(uint lookupErrors, uint storageErrors)
     {
         var responses = new TestStreamReader(
             new BackfillQsoEnrichmentResponse

--- a/src/dotnet/QsoRipper.Cli.Tests/EnrichCommandTests.cs
+++ b/src/dotnet/QsoRipper.Cli.Tests/EnrichCommandTests.cs
@@ -1,0 +1,109 @@
+using Grpc.Core;
+using QsoRipper.Cli.Commands;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli.Tests;
+
+#pragma warning disable CA1707
+public sealed class EnrichCommandTests
+{
+    [Fact]
+    public void Parse_defaults_to_preview()
+    {
+        Assert.True(EnrichCommand.TryParseArgs([], out var request, out var error));
+        Assert.Null(error);
+        Assert.Equal(BackfillQsoEnrichmentMode.Preview, request.Mode);
+    }
+
+    [Fact]
+    public void Parse_accepts_apply_and_utc_filters()
+    {
+        Assert.True(EnrichCommand.TryParseArgs(
+            ["--apply", "--after", "2026-08-01T00:00:00Z", "--before", "2026-08-31T23:59:59Z"],
+            out var request,
+            out var error));
+        Assert.Null(error);
+        Assert.Equal(BackfillQsoEnrichmentMode.Apply, request.Mode);
+        Assert.NotNull(request.After);
+        Assert.NotNull(request.Before);
+    }
+
+    [Theory]
+    [InlineData("--preview", "--apply")]
+    [InlineData("--after", "2026-08-01T00:00:00-07:00")]
+    [InlineData("--after", "not-a-time")]
+    public void Parse_rejects_invalid_options(string first, string second)
+    {
+        Assert.False(EnrichCommand.TryParseArgs([first, second], out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public async Task Consume_returns_failure_when_stream_has_no_complete_response()
+    {
+        var responses = new TestStreamReader(
+            new BackfillQsoEnrichmentResponse { Scanned = 1 });
+
+        var exitCode = await EnrichCommand.ConsumeResponsesAsync(
+            responses,
+            jsonOutput: true,
+            CancellationToken.None);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Theory]
+    [InlineData(1ul, 0ul)]
+    [InlineData(0ul, 1ul)]
+    public async Task Consume_returns_failure_for_reported_errors(ulong lookupErrors, ulong storageErrors)
+    {
+        var responses = new TestStreamReader(
+            new BackfillQsoEnrichmentResponse
+            {
+                Complete = true,
+                Errors = lookupErrors,
+                StorageErrors = storageErrors,
+            });
+
+        var exitCode = await EnrichCommand.ConsumeResponsesAsync(
+            responses,
+            jsonOutput: true,
+            CancellationToken.None);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task Consume_allows_completed_not_found_results()
+    {
+        var responses = new TestStreamReader(
+            new BackfillQsoEnrichmentResponse
+            {
+                Complete = true,
+                NotFound = 2,
+            });
+
+        var exitCode = await EnrichCommand.ConsumeResponsesAsync(
+            responses,
+            jsonOutput: true,
+            CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    private sealed class TestStreamReader(params BackfillQsoEnrichmentResponse[] responses)
+        : IAsyncStreamReader<BackfillQsoEnrichmentResponse>
+    {
+        private int _index = -1;
+
+        public BackfillQsoEnrichmentResponse Current => responses[_index];
+
+        public Task<bool> MoveNext(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            _index++;
+            return Task.FromResult(_index < responses.Length);
+        }
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Cli/CliHelpText.cs
+++ b/src/dotnet/QsoRipper.Cli/CliHelpText.cs
@@ -13,6 +13,7 @@ internal static class CliHelpText
               log <call> <band> <mode>         Log a QSO (e.g., log W1AW 20m FT8)
               get <local-id>                   Get a QSO by ID
               list [filters]                   List QSOs (--callsign, --band, --mode, --limit)
+              enrich [--preview | --apply]     Backfill missing QSO data from QRZ XML
               update <local-id> [fields]       Update a QSO (--grid, --freq, --enrich, etc.)
               delete <local-id>                Soft-delete a QSO (recoverable via restore)
               restore <local-id>               Restore a soft-deleted QSO
@@ -125,6 +126,22 @@ internal static class CliHelpText
                   update abc123 --grid CN87 --freq 14074
                   update abc123 --at "2026-04-12T01:51:00Z"
                   update abc123 --enrich
+                """,
+            "enrich" => """
+                Usage: enrich [--preview | --apply] [options]
+
+                Fill missing QSO enrichment fields from QRZ XML callsign data.
+                Preview is the default. Existing local values are not changed or cleared.
+
+                  --preview            Show the changes without storing them
+                  --apply              Store the missing enrichment values
+                  --after <utc>        Include QSOs at or after an ISO 8601 UTC time
+                  --before <utc>       Include QSOs at or before an ISO 8601 UTC time
+
+                Examples:
+                  enrich
+                  enrich --apply
+                  enrich --preview --after 2026-08-01T00:00:00Z
                 """,
             "delete" => """
                 Usage: delete <local-id>

--- a/src/dotnet/QsoRipper.Cli/Commands/EnrichCommand.cs
+++ b/src/dotnet/QsoRipper.Cli/Commands/EnrichCommand.cs
@@ -1,0 +1,157 @@
+using System.Globalization;
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using Grpc.Net.Client;
+using QsoRipper.Services;
+
+namespace QsoRipper.Cli.Commands;
+
+internal static class EnrichCommand
+{
+    public static async Task<int> RunAsync(
+        GrpcChannel channel,
+        string[] args,
+        bool jsonOutput = false,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryParseArgs(args, out var request, out var error))
+        {
+            Console.Error.WriteLine(error);
+            return 1;
+        }
+
+        var client = new LogbookService.LogbookServiceClient(channel);
+        using var call = client.BackfillQsoEnrichment(request, cancellationToken: cancellationToken);
+        return await ConsumeResponsesAsync(call.ResponseStream, jsonOutput, cancellationToken);
+    }
+
+    internal static async Task<int> ConsumeResponsesAsync(
+        IAsyncStreamReader<BackfillQsoEnrichmentResponse> responseStream,
+        bool jsonOutput,
+        CancellationToken cancellationToken)
+    {
+        BackfillQsoEnrichmentResponse? final = null;
+
+        while (await responseStream.MoveNext(cancellationToken))
+        {
+            var progress = responseStream.Current;
+            final = progress;
+            if (!jsonOutput && !progress.Complete)
+            {
+                var current = progress.HasCurrentCallsign ? $" Current: {progress.CurrentCallsign}." : "";
+                Console.WriteLine(
+                    $"Scanned {progress.Scanned}. Candidates {progress.Candidates}. Callsigns {progress.UniqueCallsigns}.{current}");
+            }
+        }
+
+        if (final is null || !final.Complete)
+        {
+            Console.Error.WriteLine("The engine closed the backfill stream without a complete summary.");
+            return 1;
+        }
+
+        if (jsonOutput)
+        {
+            JsonOutput.Print(final);
+        }
+        else
+        {
+            Console.WriteLine(
+                $"Complete. Found {final.Found}, not found {final.NotFound}, errors {final.Errors}. " +
+                $"Changed {final.Changed}, unchanged {final.Unchanged}, concurrent edits {final.ConcurrentEdits}, " +
+                $"storage errors {final.StorageErrors}.");
+        }
+
+        return final.Errors == 0 && final.StorageErrors == 0 ? 0 : 1;
+    }
+
+    internal static bool TryParseArgs(
+        string[] args,
+        out BackfillQsoEnrichmentRequest request,
+        out string? error)
+    {
+        request = new BackfillQsoEnrichmentRequest
+        {
+            Mode = BackfillQsoEnrichmentMode.Preview,
+        };
+        error = null;
+        var modeSpecified = false;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--preview":
+                    if (modeSpecified && request.Mode != BackfillQsoEnrichmentMode.Preview)
+                    {
+                        error = "--preview and --apply cannot be combined.";
+                        return false;
+                    }
+                    request.Mode = BackfillQsoEnrichmentMode.Preview;
+                    modeSpecified = true;
+                    break;
+                case "--apply":
+                    if (modeSpecified && request.Mode != BackfillQsoEnrichmentMode.Apply)
+                    {
+                        error = "--preview and --apply cannot be combined.";
+                        return false;
+                    }
+                    request.Mode = BackfillQsoEnrichmentMode.Apply;
+                    modeSpecified = true;
+                    break;
+                case "--after" when index < args.Length - 1:
+                    if (!TryParseUtc(args[++index], out var after))
+                    {
+                        error = "Invalid --after value. Use ISO 8601 UTC syntax, such as 2026-08-01T00:00:00Z.";
+                        return false;
+                    }
+                    request.After = after;
+                    break;
+                case "--after":
+                    error = "Missing value for --after.";
+                    return false;
+                case "--before" when index < args.Length - 1:
+                    if (!TryParseUtc(args[++index], out var before))
+                    {
+                        error = "Invalid --before value. Use ISO 8601 UTC syntax, such as 2026-08-31T23:59:59Z.";
+                        return false;
+                    }
+                    request.Before = before;
+                    break;
+                case "--before":
+                    error = "Missing value for --before.";
+                    return false;
+                default:
+                    error = $"Unknown option: {args[index]}";
+                    return false;
+            }
+        }
+
+        if (request.After is not null
+            && request.Before is not null
+            && request.After.ToDateTimeOffset() > request.Before.ToDateTimeOffset())
+        {
+            error = "--after must not be later than --before.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryParseUtc(string value, out Timestamp timestamp)
+    {
+        if (DateTimeOffset.TryParse(
+                value,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.RoundtripKind,
+                out var parsed)
+            && parsed.Offset == TimeSpan.Zero)
+        {
+            timestamp = Timestamp.FromDateTimeOffset(parsed);
+            return true;
+        }
+
+        timestamp = null!;
+        return false;
+    }
+}

--- a/src/dotnet/QsoRipper.Cli/Program.cs
+++ b/src/dotnet/QsoRipper.Cli/Program.cs
@@ -56,6 +56,7 @@ try
             "log" => await LogQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.RemainingArgs),
             "get" => await GetQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.JsonOutput),
             "list" => await ListQsosCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput, cancellationSource.Token),
+            "enrich" => await EnrichCommand.RunAsync(channel, arguments.RemainingArgs, arguments.JsonOutput, cancellationSource.Token),
             "update" => await UpdateQsoCommand.RunAsync(channel, arguments.Callsign!, arguments.RemainingArgs),
             "delete" => await DeleteQsoCommand.RunAsync(channel, arguments.Callsign!),
             "restore" => await RestoreQsoCommand.RunAsync(channel, arguments.Callsign!),

--- a/src/dotnet/QsoRipper.Engine.DotNet.Tests/EnrichmentBackfillTests.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet.Tests/EnrichmentBackfillTests.cs
@@ -1,0 +1,276 @@
+using Google.Protobuf.WellKnownTypes;
+using Grpc.Core;
+using QsoRipper.Domain;
+using QsoRipper.Engine.DotNet;
+using QsoRipper.Engine.Lookup;
+using QsoRipper.Engine.Storage.Memory;
+using QsoRipper.Services;
+
+namespace QsoRipper.Engine.DotNet.Tests;
+
+#pragma warning disable CA1707
+public sealed class EnrichmentBackfillTests : IDisposable
+{
+    private readonly string _configPath = Path.Combine(
+        Path.GetTempPath(),
+        "qsoripper-backfill-tests",
+        $"{Guid.NewGuid():N}.toml");
+
+    [Fact]
+    public async Task Preview_deduplicates_callsigns_and_does_not_write()
+    {
+        var storage = new MemoryStorage();
+        await storage.Logbook.InsertQsoAsync(CreateQso("one", " w1aw "));
+        await storage.Logbook.InsertQsoAsync(CreateQso("two", "W1AW"));
+        await storage.Logbook.InsertQsoAsync(CreateQso("portable", "W1AW/P"));
+        var coordinator = new FakeLookupCoordinator(FoundRecord());
+        var state = new ManagedEngineState(_configPath, storage, coordinator);
+
+        var updates = await CollectAsync(state, new BackfillQsoEnrichmentRequest());
+
+        var summary = Assert.Single(updates, static update => update.Complete);
+        Assert.Equal(3ul, summary.Scanned);
+        Assert.Equal(3ul, summary.Candidates);
+        Assert.Equal(2ul, summary.UniqueCallsigns);
+        Assert.Equal(2ul, summary.Found);
+        Assert.Equal(3ul, summary.Changed);
+        Assert.Equal(2, coordinator.LookupCount);
+        Assert.False((await storage.Logbook.GetQsoAsync("one"))!.HasWorkedGrid);
+    }
+
+    [Fact]
+    public async Task Apply_fills_blank_fields_without_overwrite_or_sync_changes_and_excludes_deleted()
+    {
+        var storage = new MemoryStorage();
+        var active = CreateQso("active", "W1AW");
+        active.WorkedGrid = " ";
+        active.WorkedCountry = "Keep Country";
+        active.SyncStatus = SyncStatus.Synced;
+        active.QrzLogid = "qrz-123";
+        await storage.Logbook.InsertQsoAsync(active);
+
+        var deleted = CreateQso("deleted", "K1ABC");
+        deleted.DeletedAt = Timestamp.FromDateTimeOffset(DateTimeOffset.UtcNow);
+        await storage.Logbook.InsertQsoAsync(deleted);
+
+        var state = new ManagedEngineState(
+            _configPath,
+            storage,
+            new FakeLookupCoordinator(FoundRecord()));
+
+        var updates = await CollectAsync(state, new BackfillQsoEnrichmentRequest
+        {
+            Mode = BackfillQsoEnrichmentMode.Apply,
+        });
+
+        var summary = updates[^1];
+        Assert.True(summary.Complete);
+        Assert.Equal(1ul, summary.Scanned);
+        Assert.Equal(1ul, summary.Changed);
+        var saved = (await storage.Logbook.GetQsoAsync("active"))!;
+        Assert.Equal("FN31", saved.WorkedGrid);
+        Assert.Equal("Keep Country", saved.WorkedCountry);
+        Assert.Equal(SyncStatus.Synced, saved.SyncStatus);
+        Assert.Equal("qrz-123", saved.QrzLogid);
+        Assert.False((await storage.Logbook.GetQsoAsync("deleted"))!.HasWorkedGrid);
+    }
+
+    [Fact]
+    public async Task Apply_counts_a_concurrent_operator_edit_and_preserves_it()
+    {
+        var storage = new MemoryStorage();
+        await storage.Logbook.InsertQsoAsync(CreateQso("active", "W1AW"));
+        var coordinator = new FakeLookupCoordinator(
+            FoundRecord(),
+            async () =>
+            {
+                var edited = (await storage.Logbook.GetQsoAsync("active"))!;
+                edited.Notes = "operator edit";
+                await storage.Logbook.UpdateQsoAsync(edited);
+            });
+        var state = new ManagedEngineState(_configPath, storage, coordinator);
+
+        var updates = await CollectAsync(state, new BackfillQsoEnrichmentRequest
+        {
+            Mode = BackfillQsoEnrichmentMode.Apply,
+        });
+
+        Assert.Equal(1ul, updates[^1].ConcurrentEdits);
+        var saved = (await storage.Logbook.GetQsoAsync("active"))!;
+        Assert.Equal("operator edit", saved.Notes);
+        Assert.False(saved.HasWorkedGrid);
+    }
+
+    [Fact]
+    public void Only_one_backfill_can_hold_the_engine_lease()
+    {
+        var state = new ManagedEngineState(
+            _configPath,
+            new MemoryStorage(),
+            new FakeLookupCoordinator(FoundRecord()));
+
+        Assert.True(state.TryBeginEnrichmentBackfill(out var first));
+        Assert.False(state.TryBeginEnrichmentBackfill(out _));
+        first!.Dispose();
+        Assert.True(state.TryBeginEnrichmentBackfill(out var second));
+        second!.Dispose();
+    }
+
+    [Fact]
+    public async Task Cancellation_waits_for_the_active_lookup_before_the_run_finishes()
+    {
+        var storage = new MemoryStorage();
+        await storage.Logbook.InsertQsoAsync(CreateQso("active", "W1AW"));
+        var lookupStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseLookup = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var state = new ManagedEngineState(
+            _configPath,
+            storage,
+            new FakeLookupCoordinator(
+                FoundRecord(),
+                async () =>
+                {
+                    lookupStarted.SetResult();
+                    await releaseLookup.Task;
+                }));
+        using var cancellation = new CancellationTokenSource();
+        await using var updates = state
+            .RunEnrichmentBackfillAsync(
+                new BackfillQsoEnrichmentRequest { Mode = BackfillQsoEnrichmentMode.Apply },
+                cancellation.Token)
+            .GetAsyncEnumerator();
+
+        Assert.True(await updates.MoveNextAsync());
+        var activeMove = updates.MoveNextAsync().AsTask();
+        await lookupStarted.Task;
+        cancellation.Cancel();
+
+        Assert.False(activeMove.IsCompleted);
+        releaseLookup.SetResult();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => activeMove);
+    }
+
+    [Theory]
+    [InlineData(0L, -1)]
+    [InlineData(0L, 1_000_000_000)]
+    [InlineData(253_402_300_800L, 0)]
+    public void Request_validation_rejects_invalid_timestamps(long seconds, int nanos)
+    {
+        var error = Assert.Throws<RpcException>(() =>
+            ManagedLogbookGrpcService.ValidateEnrichmentBackfillRequest(
+                new BackfillQsoEnrichmentRequest
+                {
+                    After = new Timestamp { Seconds = seconds, Nanos = nanos },
+                }));
+
+        Assert.Equal(StatusCode.InvalidArgument, error.StatusCode);
+    }
+
+    [Fact]
+    public void Request_validation_rejects_reversed_range()
+    {
+        var error = Assert.Throws<RpcException>(() =>
+            ManagedLogbookGrpcService.ValidateEnrichmentBackfillRequest(
+                new BackfillQsoEnrichmentRequest
+                {
+                    After = new Timestamp { Seconds = 10, Nanos = 1 },
+                    Before = new Timestamp { Seconds = 10, Nanos = 0 },
+                }));
+
+        Assert.Equal(StatusCode.InvalidArgument, error.StatusCode);
+    }
+
+    public void Dispose()
+    {
+        var directory = Path.GetDirectoryName(_configPath);
+        if (directory is not null && Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static async Task<List<BackfillQsoEnrichmentResponse>> CollectAsync(
+        ManagedEngineState state,
+        BackfillQsoEnrichmentRequest request)
+    {
+        var updates = new List<BackfillQsoEnrichmentResponse>();
+        await foreach (var update in state.RunEnrichmentBackfillAsync(request, CancellationToken.None))
+        {
+            updates.Add(update);
+        }
+        return updates;
+    }
+
+    private static QsoRecord CreateQso(string id, string callsign)
+    {
+        return new QsoRecord
+        {
+            LocalId = id,
+            StationCallsign = "K7RND",
+            WorkedCallsign = callsign,
+            UtcTimestamp = Timestamp.FromDateTimeOffset(DateTimeOffset.Parse(
+                "2026-08-15T12:00:00Z",
+                System.Globalization.CultureInfo.InvariantCulture)),
+            Band = Band._20M,
+            Mode = Mode.Cw,
+        };
+    }
+
+    private static CallsignRecord FoundRecord()
+    {
+        return new CallsignRecord
+        {
+            Callsign = "W1AW",
+            FirstName = "Ada",
+            LastName = "Lovelace",
+            GridSquare = "FN31",
+            Country = "United States",
+            DxccEntityId = 291,
+            State = "CT",
+            County = "Hartford",
+            CqZone = 5,
+            ItuZone = 8,
+            DxccContinent = "NA",
+            Latitude = 41.7,
+            Longitude = -72.7,
+        };
+    }
+
+    private sealed class FakeLookupCoordinator(
+        CallsignRecord record,
+        Func<Task>? beforeResult = null) : ILookupCoordinator
+    {
+        public int LookupCount { get; private set; }
+
+        public async Task<LookupResult> LookupAsync(
+            string callsign,
+            bool skipCache = false,
+            CancellationToken ct = default)
+        {
+            LookupCount++;
+            if (beforeResult is not null)
+            {
+                await beforeResult().WaitAsync(ct);
+            }
+            return new LookupResult
+            {
+                State = LookupState.Found,
+                QueriedCallsign = callsign,
+                Record = record.Clone(),
+            };
+        }
+
+        public Task<LookupResult> GetCachedAsync(string callsign)
+        {
+            return LookupAsync(callsign);
+        }
+
+        public async Task<LookupResult[]> StreamLookupAsync(
+            string callsign,
+            CancellationToken ct = default)
+        {
+            return [await LookupAsync(callsign, ct: ct)];
+        }
+    }
+}
+#pragma warning restore CA1707

--- a/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/GrpcServices.cs
@@ -5,6 +5,7 @@ using QsoRipper.Domain;
 using QsoRipper.Engine.DotNet.Lotw;
 using QsoRipper.Engine.Lookup;
 using QsoRipper.Services;
+using Timestamp = Google.Protobuf.WellKnownTypes.Timestamp;
 
 namespace QsoRipper.Engine.DotNet;
 
@@ -404,6 +405,70 @@ internal sealed class ManagedLogbookGrpcService(ManagedEngineState state)
         foreach (var qso in qsos)
         {
             await responseStream.WriteAsync(new ListQsosResponse { Qso = qso });
+        }
+    }
+
+    public override async Task BackfillQsoEnrichment(
+        BackfillQsoEnrichmentRequest request,
+        IServerStreamWriter<BackfillQsoEnrichmentResponse> responseStream,
+        ServerCallContext context)
+    {
+        ValidateEnrichmentBackfillRequest(request);
+        if (!state.TryBeginEnrichmentBackfill(out var lease))
+        {
+            throw new RpcException(new Status(
+                StatusCode.ResourceExhausted,
+                "A QSO enrichment backfill is active."));
+        }
+
+        using (lease)
+        {
+            await foreach (var progress in state
+                .RunEnrichmentBackfillAsync(request, context.CancellationToken)
+                .ConfigureAwait(false))
+            {
+                await responseStream.WriteAsync(progress, context.CancellationToken);
+            }
+        }
+    }
+
+    internal static void ValidateEnrichmentBackfillRequest(BackfillQsoEnrichmentRequest request)
+    {
+        if (!System.Enum.IsDefined(request.Mode))
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, "Invalid backfill mode."));
+        }
+        try
+        {
+            ValidateTimestamp(request.After, "after");
+            ValidateTimestamp(request.Before, "before");
+            _ = request.After?.ToDateTimeOffset();
+            _ = request.Before?.ToDateTimeOffset();
+            if (request.After is not null
+                && request.Before is not null
+                && (request.After.Seconds > request.Before.Seconds
+                    || (request.After.Seconds == request.Before.Seconds
+                        && request.After.Nanos > request.Before.Nanos)))
+            {
+                throw new RpcException(new Status(
+                    StatusCode.InvalidArgument,
+                    "Backfill after must not be later than before."));
+            }
+        }
+        catch (Exception ex) when (ex is ArgumentOutOfRangeException or InvalidOperationException)
+        {
+            throw new RpcException(new Status(StatusCode.InvalidArgument, ex.Message));
+        }
+    }
+
+    private static void ValidateTimestamp(Timestamp? timestamp, string name)
+    {
+        if (timestamp is not null
+            && (timestamp.Seconds is < -62_135_596_800 or > 253_402_300_799
+                || timestamp.Nanos is < 0 or > 999_999_999))
+        {
+            throw new InvalidOperationException(
+                $"Backfill {name} must be a valid protobuf Timestamp.");
         }
     }
 

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEngineState.cs
@@ -101,7 +101,7 @@ internal sealed class QrzSyncUnavailableException : InvalidOperationException
     }
 }
 
-internal sealed class ManagedEngineState
+internal sealed partial class ManagedEngineState
 {
     private const string PersistenceStepDescription = "The managed .NET engine keeps its logbook in memory. No persistence input is required during setup.";
     private const string PersistenceStepDescriptionSqlite = "The managed .NET engine stores its logbook in a local SQLite database backed by shared setup.";

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEnrichmentBackfill.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEnrichmentBackfill.cs
@@ -1,0 +1,250 @@
+using System.Runtime.CompilerServices;
+using QsoRipper.Domain;
+using QsoRipper.Engine.Lookup;
+using QsoRipper.Engine.Storage;
+using QsoRipper.Services;
+
+namespace QsoRipper.Engine.DotNet;
+
+internal sealed partial class ManagedEngineState
+{
+    private int _enrichmentBackfillActive;
+
+    internal bool TryBeginEnrichmentBackfill(out IDisposable? lease)
+    {
+        if (Interlocked.CompareExchange(ref _enrichmentBackfillActive, 1, 0) != 0)
+        {
+            lease = null;
+            return false;
+        }
+
+        lease = new BackfillLease(this);
+        return true;
+    }
+
+    internal async IAsyncEnumerable<BackfillQsoEnrichmentResponse> RunEnrichmentBackfillAsync(
+        BackfillQsoEnrichmentRequest request,
+        [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        ILookupCoordinator coordinator;
+        lock (_gate)
+        {
+            coordinator = _lookupCoordinator;
+        }
+
+        var progress = new BackfillQsoEnrichmentResponse();
+        IReadOnlyList<QsoRecord>? records = null;
+        try
+        {
+            records = await _storage.Logbook.ListQsosAsync(new QsoListQuery
+            {
+                After = request.After?.ToDateTimeOffset(),
+                Before = request.Before?.ToDateTimeOffset(),
+                Sort = Engine.Storage.QsoSortOrder.OldestFirst,
+                DeletedFilter = Engine.Storage.DeletedRecordsFilter.ActiveOnly,
+            }).ConfigureAwait(false);
+        }
+        catch (StorageException)
+        {
+            progress.StorageErrors = 1;
+            progress.Complete = true;
+        }
+        if (records is null)
+        {
+            yield return progress;
+            yield break;
+        }
+
+        progress.Scanned = (ulong)records.Count;
+        var grouped = new SortedDictionary<string, List<QsoRecord>>(StringComparer.Ordinal);
+        foreach (var record in records)
+        {
+            if (!NeedsEnrichment(record))
+            {
+                continue;
+            }
+
+            if (string.IsNullOrWhiteSpace(record.WorkedCallsign))
+            {
+                continue;
+            }
+
+            progress.Candidates++;
+            var callsign = CallsignNormalizer.Normalize(record.WorkedCallsign);
+            if (!grouped.TryGetValue(callsign, out var group))
+            {
+                group = [];
+                grouped.Add(callsign, group);
+            }
+            group.Add(record);
+        }
+        progress.UniqueCallsigns = (ulong)grouped.Count;
+        yield return progress.Clone();
+
+        var apply = request.Mode == BackfillQsoEnrichmentMode.Apply;
+        foreach (var pair in grouped)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var lookupTask = coordinator.LookupAsync(pair.Key, ct: CancellationToken.None);
+            LookupResult lookup;
+            try
+            {
+                lookup = await lookupTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                _ = await lookupTask.ConfigureAwait(false);
+                throw;
+            }
+
+            if (lookup.State == LookupState.Found && lookup.Record is not null)
+            {
+                progress.Found++;
+                foreach (var record in pair.Value)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var replacement = record.Clone();
+                    if (!MergeMissingEnrichment(replacement, lookup.Record))
+                    {
+                        progress.Unchanged++;
+                        continue;
+                    }
+
+                    if (!apply)
+                    {
+                        progress.Changed++;
+                        continue;
+                    }
+
+                    try
+                    {
+                        if (await _storage.Logbook
+                            .UpdateQsoIfUnchangedAsync(record, replacement)
+                            .ConfigureAwait(false))
+                        {
+                            progress.Changed++;
+                        }
+                        else
+                        {
+                            progress.ConcurrentEdits++;
+                        }
+                    }
+                    catch (StorageException)
+                    {
+                        progress.StorageErrors++;
+                    }
+                }
+            }
+            else if (lookup.State == LookupState.NotFound)
+            {
+                progress.NotFound++;
+                progress.Unchanged += (ulong)pair.Value.Count;
+            }
+            else
+            {
+                progress.Errors++;
+                progress.Unchanged += (ulong)pair.Value.Count;
+            }
+
+            progress.CurrentCallsign = pair.Key;
+            yield return progress.Clone();
+        }
+
+        progress.ClearCurrentCallsign();
+        progress.Complete = true;
+        yield return progress;
+    }
+
+    private static bool NeedsEnrichment(QsoRecord qso)
+    {
+        return IsMissing(qso.HasWorkedOperatorName, qso.WorkedOperatorName)
+            || IsMissing(qso.HasWorkedGrid, qso.WorkedGrid)
+            || IsMissing(qso.HasWorkedCountry, qso.WorkedCountry)
+            || !qso.HasWorkedDxcc
+            || IsMissing(qso.HasWorkedState, qso.WorkedState)
+            || IsMissing(qso.HasWorkedCounty, qso.WorkedCounty)
+            || !qso.HasWorkedCqZone
+            || !qso.HasWorkedItuZone
+            || IsMissing(qso.HasWorkedContinent, qso.WorkedContinent)
+            || !qso.HasWorkedLatitude
+            || !qso.HasWorkedLongitude;
+    }
+
+    private static bool MergeMissingEnrichment(QsoRecord qso, CallsignRecord record)
+    {
+        var changed = false;
+        var fullName = !string.IsNullOrWhiteSpace(record.FormattedName)
+            ? record.FormattedName
+            : $"{record.FirstName} {record.LastName}".Trim();
+
+        changed |= FillString(qso.HasWorkedOperatorName, qso.WorkedOperatorName, fullName, value => qso.WorkedOperatorName = value);
+        changed |= FillString(qso.HasWorkedGrid, qso.WorkedGrid, record.GridSquare, value => qso.WorkedGrid = value);
+        var country = !string.IsNullOrWhiteSpace(record.DxccCountryName)
+            ? record.DxccCountryName
+            : record.Country;
+        changed |= FillString(qso.HasWorkedCountry, qso.WorkedCountry, country, value => qso.WorkedCountry = value);
+        changed |= FillUInt32(qso.HasWorkedDxcc, record.DxccEntityId == 0 ? null : record.DxccEntityId, value => qso.WorkedDxcc = value);
+        changed |= FillString(qso.HasWorkedState, qso.WorkedState, record.State, value => qso.WorkedState = value);
+        changed |= FillString(qso.HasWorkedCounty, qso.WorkedCounty, record.County, value => qso.WorkedCounty = value);
+        changed |= FillUInt32(qso.HasWorkedCqZone, record.HasCqZone ? record.CqZone : null, value => qso.WorkedCqZone = value);
+        changed |= FillUInt32(qso.HasWorkedItuZone, record.HasItuZone ? record.ItuZone : null, value => qso.WorkedItuZone = value);
+        changed |= FillString(qso.HasWorkedContinent, qso.WorkedContinent, record.DxccContinent, value => qso.WorkedContinent = value);
+        changed |= FillDouble(qso.HasWorkedLatitude, record.HasLatitude ? record.Latitude : null, value => qso.WorkedLatitude = value);
+        changed |= FillDouble(qso.HasWorkedLongitude, record.HasLongitude ? record.Longitude : null, value => qso.WorkedLongitude = value);
+        return changed;
+    }
+
+    private static bool IsMissing(bool hasValue, string value)
+    {
+        return !hasValue || string.IsNullOrWhiteSpace(value);
+    }
+
+    private static bool FillString(bool hasTarget, string target, string? source, Action<string> assign)
+    {
+        if (!IsMissing(hasTarget, target) || string.IsNullOrWhiteSpace(source))
+        {
+            return false;
+        }
+
+        assign(source.Trim());
+        return true;
+    }
+
+    private static bool FillUInt32(bool hasTarget, uint? source, Action<uint> assign)
+    {
+        if (hasTarget || source is null)
+        {
+            return false;
+        }
+
+        assign(source.Value);
+        return true;
+    }
+
+    private static bool FillDouble(bool hasTarget, double? source, Action<double> assign)
+    {
+        if (hasTarget || source is null)
+        {
+            return false;
+        }
+
+        assign(source.Value);
+        return true;
+    }
+
+    private sealed class BackfillLease(ManagedEngineState owner) : IDisposable
+    {
+        private ManagedEngineState? _owner = owner;
+
+        public void Dispose()
+        {
+            var activeOwner = Interlocked.Exchange(ref _owner, null);
+            if (activeOwner is not null)
+            {
+                Interlocked.Exchange(ref activeOwner._enrichmentBackfillActive, 0);
+            }
+        }
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.DotNet/ManagedEnrichmentBackfill.cs
+++ b/src/dotnet/QsoRipper.Engine.DotNet/ManagedEnrichmentBackfill.cs
@@ -57,7 +57,7 @@ internal sealed partial class ManagedEngineState
             yield break;
         }
 
-        progress.Scanned = (ulong)records.Count;
+        progress.Scanned = (uint)records.Count;
         var grouped = new SortedDictionary<string, List<QsoRecord>>(StringComparer.Ordinal);
         foreach (var record in records)
         {
@@ -80,7 +80,7 @@ internal sealed partial class ManagedEngineState
             }
             group.Add(record);
         }
-        progress.UniqueCallsigns = (ulong)grouped.Count;
+        progress.UniqueCallsigns = (uint)grouped.Count;
         yield return progress.Clone();
 
         var apply = request.Mode == BackfillQsoEnrichmentMode.Apply;
@@ -140,12 +140,12 @@ internal sealed partial class ManagedEngineState
             else if (lookup.State == LookupState.NotFound)
             {
                 progress.NotFound++;
-                progress.Unchanged += (ulong)pair.Value.Count;
+                progress.Unchanged += (uint)pair.Value.Count;
             }
             else
             {
                 progress.Errors++;
-                progress.Unchanged += (ulong)pair.Value.Count;
+                progress.Unchanged += (uint)pair.Value.Count;
             }
 
             progress.CurrentCallsign = pair.Key;

--- a/src/dotnet/QsoRipper.Engine.Lookup.Abstractions/CallsignNormalizer.cs
+++ b/src/dotnet/QsoRipper.Engine.Lookup.Abstractions/CallsignNormalizer.cs
@@ -1,0 +1,12 @@
+namespace QsoRipper.Engine.Lookup;
+
+/// <summary>Creates exact callsign keys for lookup and cache operations.</summary>
+public static class CallsignNormalizer
+{
+    /// <summary>Trim and uppercase a callsign while preserving slash components.</summary>
+    public static string Normalize(string callsign)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(callsign);
+        return callsign.Trim().ToUpperInvariant();
+    }
+}

--- a/src/dotnet/QsoRipper.Engine.Lookup.Abstractions/LookupCoordinator.cs
+++ b/src/dotnet/QsoRipper.Engine.Lookup.Abstractions/LookupCoordinator.cs
@@ -19,9 +19,11 @@ public sealed class LookupCoordinator : ILookupCoordinator
     private readonly ILogbookStore? _logbookStore;
     private readonly TimeSpan _positiveTtl;
     private readonly TimeSpan _negativeTtl;
+    private readonly TimeSpan _providerTimeout;
 
     private readonly ConcurrentDictionary<string, CacheEntry> _cache = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<string, Task<ProviderLookupResult>> _inFlight = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<string, Lazy<Task<ProviderLookupResult>>> _inFlight =
+        new(StringComparer.Ordinal);
 
     /// <summary>Create a coordinator with configurable TTLs and optional snapshot persistence.</summary>
     public LookupCoordinator(
@@ -29,19 +31,27 @@ public sealed class LookupCoordinator : ILookupCoordinator
         ILookupSnapshotStore? snapshotStore = null,
         TimeSpan? positiveTtl = null,
         TimeSpan? negativeTtl = null,
-        ILogbookStore? logbookStore = null)
+        ILogbookStore? logbookStore = null,
+        TimeSpan? providerTimeout = null)
     {
         _provider = provider ?? throw new ArgumentNullException(nameof(provider));
         _snapshotStore = snapshotStore;
         _logbookStore = logbookStore;
         _positiveTtl = positiveTtl ?? TimeSpan.FromMinutes(15);
         _negativeTtl = negativeTtl ?? TimeSpan.FromMinutes(2);
+        _providerTimeout = providerTimeout ?? TimeSpan.FromSeconds(30);
+        if (_providerTimeout <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(providerTimeout),
+                "Provider timeout must be greater than zero.");
+        }
     }
 
     /// <inheritdoc/>
     public async Task<LookupResult> LookupAsync(string callsign, bool skipCache = false, CancellationToken ct = default)
     {
-        var normalized = NormalizeCallsign(callsign);
+        var normalized = CallsignNormalizer.Normalize(callsign);
 
         if (!skipCache)
         {
@@ -59,6 +69,7 @@ public sealed class LookupCoordinator : ILookupCoordinator
 
         var sw = Stopwatch.StartNew();
         var providerResult = await RunProviderLookupWithFallback(normalized, baseCallsign, ct).ConfigureAwait(false);
+        ct.ThrowIfCancellationRequested();
         var latencyMs = (uint)Math.Min(sw.ElapsedMilliseconds, uint.MaxValue);
 
         var result = await ProviderResultToLookup(providerResult, normalized, latencyMs, ct).ConfigureAwait(false);
@@ -69,7 +80,7 @@ public sealed class LookupCoordinator : ILookupCoordinator
     /// <inheritdoc/>
     public async Task<LookupResult> GetCachedAsync(string callsign)
     {
-        var normalized = NormalizeCallsign(callsign);
+        var normalized = CallsignNormalizer.Normalize(callsign);
         var cached = GetFreshCacheEntry(normalized);
         LookupResult result;
         if (cached is not null)
@@ -109,7 +120,7 @@ public sealed class LookupCoordinator : ILookupCoordinator
         bool skipCache = false,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
-        var normalized = NormalizeCallsign(callsign);
+        var normalized = CallsignNormalizer.Normalize(callsign);
         yield return new LookupResult
         {
             State = LookupState.Loading,
@@ -142,6 +153,7 @@ public sealed class LookupCoordinator : ILookupCoordinator
 
         var sw = Stopwatch.StartNew();
         var providerResult = await RunProviderLookupWithFallback(normalized, baseCallsign, ct).ConfigureAwait(false);
+        ct.ThrowIfCancellationRequested();
         var latencyMs = (uint)Math.Min(sw.ElapsedMilliseconds, uint.MaxValue);
 
         var finalResult = await ProviderResultToLookup(providerResult, normalized, latencyMs, ct).ConfigureAwait(false);
@@ -166,21 +178,53 @@ public sealed class LookupCoordinator : ILookupCoordinator
 
     private async Task<ProviderLookupResult> RunProviderLookupDeduped(string normalizedCallsign, CancellationToken ct)
     {
-        // Use GetOrAdd to ensure only one in-flight request per callsign.
-        // The first caller creates the task; subsequent callers await the same task.
-        var task = _inFlight.GetOrAdd(normalizedCallsign, key =>
-            Task.Run(() => _provider.LookupAsync(key, ct), CancellationToken.None));
+        // Provider work has its own lifetime and timeout. Each caller only
+        // cancels its wait, so one waiter cannot cancel another waiter.
+        var shared = _inFlight.GetOrAdd(
+            normalizedCallsign,
+            key => new Lazy<Task<ProviderLookupResult>>(
+                () => RunBoundedProviderLookupAsync(key),
+                LazyThreadSafetyMode.ExecutionAndPublication));
+        var task = shared.Value;
+        ScheduleRemovalOnCompletion(normalizedCallsign, shared, task);
 
+        return await task.WaitAsync(ct).ConfigureAwait(false);
+    }
+
+    private async Task<ProviderLookupResult> RunBoundedProviderLookupAsync(string normalizedCallsign)
+    {
+        using var timeout = new CancellationTokenSource(_providerTimeout);
         try
         {
-            return await task.ConfigureAwait(false);
+            return await _provider.LookupAsync(normalizedCallsign, timeout.Token).ConfigureAwait(false);
         }
-        finally
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested)
         {
-            // Remove the in-flight entry once the task completes.
-            // Only remove if the stored task is still our task (avoid removing a newer one).
-            _inFlight.TryRemove(new KeyValuePair<string, Task<ProviderLookupResult>>(normalizedCallsign, task));
+            return new ProviderLookupResult
+            {
+                State = ProviderLookupState.NetworkError,
+                ErrorMessage = $"Provider lookup timed out after {_providerTimeout.TotalSeconds:g} seconds.",
+            };
         }
+    }
+
+    private void ScheduleRemovalOnCompletion(
+        string normalizedCallsign,
+        Lazy<Task<ProviderLookupResult>> shared,
+        Task<ProviderLookupResult> task)
+    {
+        _ = task.ContinueWith(
+            completed =>
+            {
+                _ = completed.Exception;
+                _inFlight.TryRemove(
+                    new KeyValuePair<string, Lazy<Task<ProviderLookupResult>>>(
+                        normalizedCallsign,
+                        shared));
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private async Task<LookupResult> ProviderResultToLookup(
@@ -294,12 +338,6 @@ public sealed class LookupCoordinator : ILookupCoordinator
         };
 
         await _snapshotStore.UpsertAsync(snapshot).ConfigureAwait(false);
-    }
-
-    internal static string NormalizeCallsign(string callsign)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(callsign);
-        return callsign.Trim().ToUpperInvariant();
     }
 
     private async Task PopulateHistoryAsync(LookupResult result, string normalizedCallsign)

--- a/src/dotnet/QsoRipper.Engine.Lookup.Tests/LookupCoordinatorTests.cs
+++ b/src/dotnet/QsoRipper.Engine.Lookup.Tests/LookupCoordinatorTests.cs
@@ -305,6 +305,37 @@ public sealed class LookupCoordinatorTests
     }
 
     [Fact]
+    public async Task Lookup_CancellationOnlyCancelsThatWaiter()
+    {
+        var provider = new BlockingProvider();
+        var coordinator = new LookupCoordinator(provider);
+        using var cancellation = new CancellationTokenSource();
+
+        var first = coordinator.LookupAsync("W1AW", skipCache: true, cancellation.Token);
+        var second = coordinator.LookupAsync("W1AW", skipCache: true);
+        cancellation.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => first);
+        provider.Complete(FoundResult("W1AW"));
+        var result = await second;
+
+        Assert.Equal(LookupState.Found, result.State);
+    }
+
+    [Fact]
+    public async Task Lookup_SharedProviderWorkHasAnIndependentTimeout()
+    {
+        var coordinator = new LookupCoordinator(
+            new BlockingProvider(),
+            providerTimeout: TimeSpan.FromMilliseconds(20));
+
+        var result = await coordinator.LookupAsync("W1AW", skipCache: true);
+
+        Assert.Equal(LookupState.Error, result.State);
+        Assert.Contains("timed out", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task Lookup_ProviderError_ReturnsErrorState()
     {
         var provider = new FakeProvider();

--- a/src/rust/qsoripper-core/src/application/enrichment_backfill.rs
+++ b/src/rust/qsoripper-core/src/application/enrichment_backfill.rs
@@ -15,25 +15,25 @@ use crate::{
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct EnrichmentBackfillProgress {
     /// Active QSO rows read from storage.
-    pub scanned: u64,
+    pub scanned: u32,
     /// Rows that have at least one missing enrichment field.
-    pub candidates: u64,
+    pub candidates: u32,
     /// Distinct normalized callsigns selected for lookup.
-    pub unique_callsigns: u64,
+    pub unique_callsigns: u32,
     /// Callsigns that returned a record.
-    pub found: u64,
+    pub found: u32,
     /// Callsigns that the provider did not find.
-    pub not_found: u64,
+    pub not_found: u32,
     /// Callsigns that failed lookup.
-    pub errors: u64,
+    pub errors: u32,
     /// Rows that would change or changed successfully.
-    pub changed: u64,
+    pub changed: u32,
     /// Candidate rows that received no values.
-    pub unchanged: u64,
+    pub unchanged: u32,
     /// Rows skipped because their persisted snapshot changed.
-    pub concurrent_edits: u64,
+    pub concurrent_edits: u32,
     /// Storage operations that failed.
-    pub storage_errors: u64,
+    pub storage_errors: u32,
     /// Whether this is the terminal progress update.
     pub complete: bool,
     /// Callsign processed by the latest progress update.
@@ -59,7 +59,7 @@ pub async fn run_enrichment_backfill(
         return;
     };
 
-    progress.scanned = records.len() as u64;
+    progress.scanned = u32::try_from(records.len()).unwrap_or(u32::MAX);
     let mut grouped = BTreeMap::<String, Vec<QsoRecord>>::new();
     for record in records {
         if !needs_enrichment(&record) {
@@ -77,7 +77,7 @@ pub async fn run_enrichment_backfill(
             .or_default()
             .push(record);
     }
-    progress.unique_callsigns = grouped.len() as u64;
+    progress.unique_callsigns = u32::try_from(grouped.len()).unwrap_or(u32::MAX);
 
     if progress_sender.send(progress.clone()).await.is_err() {
         return;
@@ -118,16 +118,22 @@ pub async fn run_enrichment_backfill(
                     }
                 } else {
                     progress.errors += 1;
-                    progress.unchanged += records.len() as u64;
+                    progress.unchanged = progress
+                        .unchanged
+                        .saturating_add(u32::try_from(records.len()).unwrap_or(u32::MAX));
                 }
             }
             LookupState::NotFound => {
                 progress.not_found += 1;
-                progress.unchanged += records.len() as u64;
+                progress.unchanged = progress
+                    .unchanged
+                    .saturating_add(u32::try_from(records.len()).unwrap_or(u32::MAX));
             }
             _ => {
                 progress.errors += 1;
-                progress.unchanged += records.len() as u64;
+                progress.unchanged = progress
+                    .unchanged
+                    .saturating_add(u32::try_from(records.len()).unwrap_or(u32::MAX));
             }
         }
 

--- a/src/rust/qsoripper-core/src/application/enrichment_backfill.rs
+++ b/src/rust/qsoripper-core/src/application/enrichment_backfill.rs
@@ -1,0 +1,271 @@
+//! QSO callsign enrichment backfill workflow.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use tokio::sync::mpsc;
+
+use crate::{
+    domain::lookup::normalize_callsign,
+    lookup::LookupCoordinator,
+    proto::qsoripper::domain::{CallsignRecord, LookupState, QsoRecord},
+    storage::{LogbookStore, QsoListQuery},
+};
+
+/// Cumulative progress for one backfill operation.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct EnrichmentBackfillProgress {
+    /// Active QSO rows read from storage.
+    pub scanned: u64,
+    /// Rows that have at least one missing enrichment field.
+    pub candidates: u64,
+    /// Distinct normalized callsigns selected for lookup.
+    pub unique_callsigns: u64,
+    /// Callsigns that returned a record.
+    pub found: u64,
+    /// Callsigns that the provider did not find.
+    pub not_found: u64,
+    /// Callsigns that failed lookup.
+    pub errors: u64,
+    /// Rows that would change or changed successfully.
+    pub changed: u64,
+    /// Candidate rows that received no values.
+    pub unchanged: u64,
+    /// Rows skipped because their persisted snapshot changed.
+    pub concurrent_edits: u64,
+    /// Storage operations that failed.
+    pub storage_errors: u64,
+    /// Whether this is the terminal progress update.
+    pub complete: bool,
+    /// Callsign processed by the latest progress update.
+    pub current_callsign: Option<String>,
+}
+
+/// Backfill missing enrichment fields on active QSO records.
+///
+/// Lookups run one at a time so this maintenance operation does not occupy the
+/// interactive lookup concurrency budget.
+pub async fn run_enrichment_backfill(
+    store: &dyn LogbookStore,
+    coordinator: &Arc<LookupCoordinator>,
+    query: &QsoListQuery,
+    apply: bool,
+    progress_sender: &mpsc::Sender<EnrichmentBackfillProgress>,
+) {
+    let mut progress = EnrichmentBackfillProgress::default();
+    let Ok(records) = store.list_qsos(query).await else {
+        progress.storage_errors = 1;
+        progress.complete = true;
+        let _ = progress_sender.send(progress).await;
+        return;
+    };
+
+    progress.scanned = records.len() as u64;
+    let mut grouped = BTreeMap::<String, Vec<QsoRecord>>::new();
+    for record in records {
+        if !needs_enrichment(&record) {
+            continue;
+        }
+
+        let callsign = record.worked_callsign.trim();
+        if callsign.is_empty() {
+            continue;
+        }
+
+        progress.candidates += 1;
+        grouped
+            .entry(normalize_callsign(callsign))
+            .or_default()
+            .push(record);
+    }
+    progress.unique_callsigns = grouped.len() as u64;
+
+    if progress_sender.send(progress.clone()).await.is_err() {
+        return;
+    }
+
+    for (callsign, records) in grouped {
+        let lookup_task = coordinator.lookup(&callsign, false);
+        tokio::pin!(lookup_task);
+        let lookup = tokio::select! {
+            () = progress_sender.closed() => {
+                let _ = lookup_task.await;
+                return;
+            },
+            result = &mut lookup_task => result,
+        };
+        match LookupState::try_from(lookup.state).unwrap_or(LookupState::Error) {
+            LookupState::Found => {
+                if let Some(callsign_record) = lookup.record.as_ref() {
+                    progress.found += 1;
+                    for record in records {
+                        if progress_sender.is_closed() {
+                            return;
+                        }
+                        let mut replacement = record.clone();
+                        if merge_missing_enrichment(&mut replacement, callsign_record) {
+                            if apply {
+                                match store.update_qso_if_unchanged(&record, &replacement).await {
+                                    Ok(true) => progress.changed += 1,
+                                    Ok(false) => progress.concurrent_edits += 1,
+                                    Err(_) => progress.storage_errors += 1,
+                                }
+                            } else {
+                                progress.changed += 1;
+                            }
+                        } else {
+                            progress.unchanged += 1;
+                        }
+                    }
+                } else {
+                    progress.errors += 1;
+                    progress.unchanged += records.len() as u64;
+                }
+            }
+            LookupState::NotFound => {
+                progress.not_found += 1;
+                progress.unchanged += records.len() as u64;
+            }
+            _ => {
+                progress.errors += 1;
+                progress.unchanged += records.len() as u64;
+            }
+        }
+
+        progress.current_callsign = Some(callsign.clone());
+        if progress_sender.send(progress.clone()).await.is_err() {
+            return;
+        }
+    }
+
+    progress.complete = true;
+    progress.current_callsign = None;
+    let _ = progress_sender.send(progress).await;
+}
+
+fn needs_enrichment(qso: &QsoRecord) -> bool {
+    string_is_missing(qso.worked_operator_name.as_deref())
+        || string_is_missing(qso.worked_grid.as_deref())
+        || string_is_missing(qso.worked_country.as_deref())
+        || qso.worked_dxcc.is_none()
+        || string_is_missing(qso.worked_state.as_deref())
+        || string_is_missing(qso.worked_county.as_deref())
+        || qso.worked_cq_zone.is_none()
+        || qso.worked_itu_zone.is_none()
+        || string_is_missing(qso.worked_continent.as_deref())
+        || qso.worked_latitude.is_none()
+        || qso.worked_longitude.is_none()
+}
+
+fn merge_missing_enrichment(qso: &mut QsoRecord, record: &CallsignRecord) -> bool {
+    let mut changed = false;
+    let name = record
+        .formatted_name
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(str::to_owned)
+        .or_else(|| {
+            let value = format!("{} {}", record.first_name, record.last_name);
+            (!value.trim().is_empty()).then(|| value.trim().to_string())
+        });
+
+    changed |= fill_string(&mut qso.worked_operator_name, name.as_deref());
+    changed |= fill_string(&mut qso.worked_grid, record.grid_square.as_deref());
+    changed |= fill_string(
+        &mut qso.worked_country,
+        record
+            .dxcc_country_name
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .or(record.country.as_deref()),
+    );
+    changed |= fill_u32(
+        &mut qso.worked_dxcc,
+        (record.dxcc_entity_id != 0).then_some(record.dxcc_entity_id),
+    );
+    changed |= fill_string(&mut qso.worked_state, record.state.as_deref());
+    changed |= fill_string(&mut qso.worked_county, record.county.as_deref());
+    changed |= fill_u32(&mut qso.worked_cq_zone, record.cq_zone);
+    changed |= fill_u32(&mut qso.worked_itu_zone, record.itu_zone);
+    changed |= fill_string(&mut qso.worked_continent, record.dxcc_continent.as_deref());
+    changed |= fill_f64(&mut qso.worked_latitude, record.latitude);
+    changed |= fill_f64(&mut qso.worked_longitude, record.longitude);
+    changed
+}
+
+fn string_is_missing(value: Option<&str>) -> bool {
+    value.is_none_or(|value| value.trim().is_empty())
+}
+
+fn fill_string(target: &mut Option<String>, source: Option<&str>) -> bool {
+    if !string_is_missing(target.as_deref()) {
+        return false;
+    }
+    let Some(source) = source.map(str::trim).filter(|value| !value.is_empty()) else {
+        return false;
+    };
+    *target = Some(source.to_string());
+    true
+}
+
+fn fill_u32(target: &mut Option<u32>, source: Option<u32>) -> bool {
+    if target.is_some() || source.is_none() {
+        return false;
+    }
+    *target = source;
+    true
+}
+
+fn fill_f64(target: &mut Option<f64>, source: Option<f64>) -> bool {
+    if target.is_some() || source.is_none() {
+        return false;
+    }
+    *target = source;
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{merge_missing_enrichment, needs_enrichment};
+    use crate::proto::qsoripper::domain::{CallsignRecord, QsoRecord, SyncStatus};
+
+    #[test]
+    fn merge_fills_blank_fields_without_overwriting_values_or_sync_metadata() {
+        let mut qso = QsoRecord {
+            worked_operator_name: Some(" \t".into()),
+            worked_grid: Some("CN87".into()),
+            worked_country: Some(String::new()),
+            worked_dxcc: Some(291),
+            worked_state: Some("WA".into()),
+            sync_status: SyncStatus::Synced as i32,
+            qrz_logid: Some("123".into()),
+            ..Default::default()
+        };
+        let source = CallsignRecord {
+            first_name: "Ada".into(),
+            last_name: "Lovelace".into(),
+            grid_square: Some("FN31".into()),
+            dxcc_country_name: Some("  ".into()),
+            country: Some("United States".into()),
+            dxcc_entity_id: 110,
+            state: Some("CT".into()),
+            county: Some("Hartford".into()),
+            cq_zone: Some(5),
+            itu_zone: Some(8),
+            dxcc_continent: Some("NA".into()),
+            latitude: Some(41.7),
+            longitude: Some(-72.7),
+            ..Default::default()
+        };
+
+        assert!(merge_missing_enrichment(&mut qso, &source));
+        assert_eq!(qso.worked_operator_name.as_deref(), Some("Ada Lovelace"));
+        assert_eq!(qso.worked_grid.as_deref(), Some("CN87"));
+        assert_eq!(qso.worked_country.as_deref(), Some("United States"));
+        assert_eq!(qso.worked_country.as_deref(), Some("United States"));
+        assert_eq!(qso.worked_dxcc, Some(291));
+        assert_eq!(qso.worked_state.as_deref(), Some("WA"));
+        assert_eq!(qso.sync_status, SyncStatus::Synced as i32);
+        assert_eq!(qso.qrz_logid.as_deref(), Some("123"));
+        assert!(!needs_enrichment(&qso));
+    }
+}

--- a/src/rust/qsoripper-core/src/application/mod.rs
+++ b/src/rust/qsoripper-core/src/application/mod.rs
@@ -1,3 +1,4 @@
 //! Application services that coordinate engine workflows above storage ports.
 
+pub mod enrichment_backfill;
 pub mod logbook;

--- a/src/rust/qsoripper-core/src/storage/ports.rs
+++ b/src/rust/qsoripper-core/src/storage/ports.rs
@@ -27,9 +27,11 @@ pub trait LogbookStore: Send + Sync {
     /// Update an existing QSO. Returns `true` when a row was updated.
     async fn update_qso(&self, qso: &QsoRecord) -> Result<bool, StorageError>;
 
-    /// Replace a QSO only when its persisted protobuf payload still matches
-    /// `expected`. Production stores must make the comparison and update
-    /// atomic so a sync snapshot cannot overwrite a concurrent operator edit.
+    /// Replace a QSO only when its persisted record is semantically equal to
+    /// `expected`. Implementations must not compare protobuf wire bytes because
+    /// map serialization order is not stable. Production stores must make the
+    /// semantic comparison and update atomic so a stale snapshot cannot
+    /// overwrite a concurrent operator edit.
     async fn update_qso_if_unchanged(
         &self,
         expected: &QsoRecord,

--- a/src/rust/qsoripper-server/src/main.rs
+++ b/src/rust/qsoripper-server/src/main.rs
@@ -15,11 +15,15 @@ use std::{
     io,
     net::SocketAddr,
     path::PathBuf,
+    pin::Pin,
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use qsoripper_core::adif::{parse_adi_qsos, serialize_adi_qsos};
+use qsoripper_core::application::enrichment_backfill::{
+    run_enrichment_backfill, EnrichmentBackfillProgress,
+};
 use qsoripper_core::application::logbook::LogbookError;
 use qsoripper_core::cw::{CwController, CwError, CwKeyerConfig};
 use qsoripper_core::lookup::QRZ_USER_AGENT_ENV_VAR;
@@ -30,7 +34,10 @@ use qsoripper_core::storage::{
 use qsoripper_storage_memory::MemoryStorage;
 use qsoripper_storage_sqlite::SqliteStorageBuilder;
 use tokio::sync::Mutex;
-use tokio_stream::wrappers::{ReceiverStream, TcpListenerStream};
+use tokio_stream::{
+    wrappers::{ReceiverStream, TcpListenerStream},
+    Stream, StreamExt,
+};
 use tonic::transport::Server;
 use tonic::{Request, Response, Status};
 
@@ -51,10 +58,11 @@ use qsoripper_core::proto::qsoripper::services::{
     space_weather_service_server::{SpaceWeatherService, SpaceWeatherServiceServer},
     station_profile_service_server::StationProfileServiceServer,
     AbortCwRequest, AbortCwResponse, AdifChunk, ApplyRuntimeConfigRequest,
-    ApplyRuntimeConfigResponse, BatchLookupRequest, BatchLookupResponse, ComputeGreatCircleRequest,
-    ComputeGreatCircleResponse, CwSendState, DeleteQsoRequest, DeleteQsoResponse,
-    DeletedRecordsFilter as ProtoDeletedRecordsFilter, EngineInfo, ExportAdifRequest,
-    ExportAdifResponse, GetActiveContestsRequest, GetActiveContestsResponse,
+    ApplyRuntimeConfigResponse, BackfillQsoEnrichmentMode, BackfillQsoEnrichmentRequest,
+    BackfillQsoEnrichmentResponse, BatchLookupRequest, BatchLookupResponse,
+    ComputeGreatCircleRequest, ComputeGreatCircleResponse, CwSendState, DeleteQsoRequest,
+    DeleteQsoResponse, DeletedRecordsFilter as ProtoDeletedRecordsFilter, EngineInfo,
+    ExportAdifRequest, ExportAdifResponse, GetActiveContestsRequest, GetActiveContestsResponse,
     GetCachedCallsignRequest, GetCachedCallsignResponse, GetCurrentSpaceWeatherRequest,
     GetCurrentSpaceWeatherResponse, GetCwKeyerStatusRequest, GetCwKeyerStatusResponse,
     GetDxccEntityRequest, GetDxccEntityResponse, GetEngineInfoRequest, GetEngineInfoResponse,
@@ -369,6 +377,7 @@ struct DeveloperLogbookService {
     sync_scheduler: Arc<sync_scheduler::SyncScheduler>,
     qrz_upload_lock: Arc<Mutex<()>>,
     lotw_upload_lock: Arc<Mutex<()>>,
+    enrichment_backfill_lock: Arc<Mutex<()>>,
 }
 
 impl DeveloperLogbookService {
@@ -383,6 +392,7 @@ impl DeveloperLogbookService {
             sync_scheduler,
             qrz_upload_lock,
             lotw_upload_lock,
+            enrichment_backfill_lock: Arc::new(Mutex::new(())),
         }
     }
 
@@ -517,6 +527,8 @@ impl DeveloperLogbookService {
 #[tonic::async_trait]
 impl LogbookService for DeveloperLogbookService {
     type ListQsosStream = ReceiverStream<Result<ListQsosResponse, Status>>;
+    type BackfillQsoEnrichmentStream =
+        Pin<Box<dyn Stream<Item = Result<BackfillQsoEnrichmentResponse, Status>> + Send>>;
     type SyncWithQrzStream = ReceiverStream<Result<SyncWithQrzResponse, Status>>;
     type SyncWithLotwStream = ReceiverStream<Result<SyncWithLotwResponse, Status>>;
     type ExportAdifStream = ReceiverStream<Result<ExportAdifResponse, Status>>;
@@ -738,6 +750,65 @@ impl LogbookService for DeveloperLogbookService {
         }
 
         Ok(Response::new(ReceiverStream::new(receiver)))
+    }
+
+    async fn backfill_qso_enrichment(
+        &self,
+        request: Request<BackfillQsoEnrichmentRequest>,
+    ) -> Result<Response<Self::BackfillQsoEnrichmentStream>, Status> {
+        let request = request.into_inner();
+        let mode = BackfillQsoEnrichmentMode::try_from(request.mode)
+            .map_err(|_| Status::invalid_argument("Invalid backfill mode."))?;
+        if !is_valid_backfill_timestamp(request.after.as_ref()) {
+            return Err(Status::invalid_argument(
+                "Backfill after must be a valid protobuf Timestamp.",
+            ));
+        }
+        if !is_valid_backfill_timestamp(request.before.as_ref()) {
+            return Err(Status::invalid_argument(
+                "Backfill before must be a valid protobuf Timestamp.",
+            ));
+        }
+        if matches!(
+            (&request.after, &request.before),
+            (Some(after), Some(before))
+                if (after.seconds, after.nanos) > (before.seconds, before.nanos)
+        ) {
+            return Err(Status::invalid_argument(
+                "Backfill after must not be later than before.",
+            ));
+        }
+        let guard = self
+            .enrichment_backfill_lock
+            .clone()
+            .try_lock_owned()
+            .map_err(|_| Status::resource_exhausted("A QSO enrichment backfill is active."))?;
+        let apply = mode == BackfillQsoEnrichmentMode::Apply;
+        let query = QsoListQuery {
+            after: request.after,
+            before: request.before,
+            sort: QsoSortOrder::OldestFirst,
+            deleted_filter: DeletedRecordsFilter::ActiveOnly,
+            ..QsoListQuery::default()
+        };
+        let (engine, coordinator) = self.runtime_config.enrichment_backfill_context().await;
+        let (progress_tx, progress_rx) = tokio::sync::mpsc::channel(8);
+
+        tokio::spawn(async move {
+            let _guard = guard;
+            run_enrichment_backfill(
+                engine.logbook_store(),
+                &coordinator,
+                &query,
+                apply,
+                &progress_tx,
+            )
+            .await;
+        });
+        let stream =
+            ReceiverStream::new(progress_rx).map(|progress| Ok(backfill_response(progress)));
+
+        Ok(Response::new(Box::pin(stream)))
     }
 
     async fn sync_with_qrz(
@@ -1853,6 +1924,37 @@ fn qso_list_query_from_request(request: &ListQsosRequest) -> Result<QsoListQuery
     })
 }
 
+fn is_valid_backfill_timestamp(timestamp: Option<&Timestamp>) -> bool {
+    const MIN_SECONDS: i64 = -62_135_596_800;
+    const MAX_SECONDS: i64 = 253_402_300_799;
+
+    if let Some(timestamp) = timestamp {
+        if !(MIN_SECONDS..=MAX_SECONDS).contains(&timestamp.seconds)
+            || !(0..1_000_000_000).contains(&timestamp.nanos)
+        {
+            return false;
+        }
+    }
+    true
+}
+
+fn backfill_response(progress: EnrichmentBackfillProgress) -> BackfillQsoEnrichmentResponse {
+    BackfillQsoEnrichmentResponse {
+        scanned: progress.scanned,
+        candidates: progress.candidates,
+        unique_callsigns: progress.unique_callsigns,
+        found: progress.found,
+        not_found: progress.not_found,
+        errors: progress.errors,
+        changed: progress.changed,
+        unchanged: progress.unchanged,
+        concurrent_edits: progress.concurrent_edits,
+        storage_errors: progress.storage_errors,
+        complete: progress.complete,
+        current_callsign: progress.current_callsign,
+    }
+}
+
 const ADIF_CHUNK_SIZE: usize = 16 * 1024;
 
 fn export_qso_list_query_from_request(request: &ExportAdifRequest) -> QsoListQuery {
@@ -1912,12 +2014,12 @@ mod tests {
         logbook_service_server::{LogbookService, LogbookServiceServer},
         lookup_service_server::LookupService,
         space_weather_service_server::SpaceWeatherService,
-        AdifChunk, BatchLookupRequest, ComputeGreatCircleRequest, DeleteQsoRequest,
-        ExportAdifRequest, GetCachedCallsignRequest, GetCurrentSpaceWeatherRequest,
-        GetDxccEntityRequest, GetQsoRequest, GetSyncStatusRequest, ImportAdifRequest,
-        ImportAdifResponse, ListQsosRequest, LogQsoRequest, LookupRequest, QsoSortOrder,
-        RefreshSpaceWeatherRequest, RestoreQsoRequest, StreamLookupRequest, SyncWithLotwRequest,
-        UpdateQsoRequest,
+        AdifChunk, BackfillQsoEnrichmentRequest, BatchLookupRequest, ComputeGreatCircleRequest,
+        DeleteQsoRequest, ExportAdifRequest, GetCachedCallsignRequest,
+        GetCurrentSpaceWeatherRequest, GetDxccEntityRequest, GetQsoRequest, GetSyncStatusRequest,
+        ImportAdifRequest, ImportAdifResponse, ListQsosRequest, LogQsoRequest, LookupRequest,
+        QsoSortOrder, RefreshSpaceWeatherRequest, RestoreQsoRequest, StreamLookupRequest,
+        SyncWithLotwRequest, UpdateQsoRequest,
     };
     use tokio_stream::StreamExt;
     use tonic::transport::Channel;
@@ -2003,6 +2105,78 @@ mod tests {
 
     fn test_runtime_config() -> Arc<RuntimeConfigManager> {
         Arc::new(RuntimeConfigManager::new(BTreeMap::new()).expect("runtime config"))
+    }
+
+    #[tokio::test]
+    async fn second_enrichment_backfill_returns_resource_exhausted() {
+        let service = test_logbook_service(test_runtime_config());
+        let _guard = service.enrichment_backfill_lock.lock().await;
+
+        let error = LogbookService::backfill_qso_enrichment(
+            &service,
+            Request::new(BackfillQsoEnrichmentRequest::default()),
+        )
+        .await
+        .err()
+        .expect("second backfill must fail");
+
+        assert_eq!(error.code(), Code::ResourceExhausted);
+    }
+
+    #[tokio::test]
+    async fn enrichment_backfill_rejects_invalid_timestamp_components() {
+        let service = test_logbook_service(test_runtime_config());
+        for timestamp in [
+            Timestamp {
+                seconds: 0,
+                nanos: -1,
+            },
+            Timestamp {
+                seconds: 0,
+                nanos: 1_000_000_000,
+            },
+            Timestamp {
+                seconds: 253_402_300_800,
+                nanos: 0,
+            },
+        ] {
+            let error = LogbookService::backfill_qso_enrichment(
+                &service,
+                Request::new(BackfillQsoEnrichmentRequest {
+                    after: Some(timestamp),
+                    ..Default::default()
+                }),
+            )
+            .await
+            .err()
+            .expect("invalid timestamp must fail");
+
+            assert_eq!(error.code(), Code::InvalidArgument);
+        }
+    }
+
+    #[tokio::test]
+    async fn enrichment_backfill_rejects_reversed_timestamp_range() {
+        let service = test_logbook_service(test_runtime_config());
+        let error = LogbookService::backfill_qso_enrichment(
+            &service,
+            Request::new(BackfillQsoEnrichmentRequest {
+                after: Some(Timestamp {
+                    seconds: 10,
+                    nanos: 1,
+                }),
+                before: Some(Timestamp {
+                    seconds: 10,
+                    nanos: 0,
+                }),
+                ..Default::default()
+            }),
+        )
+        .await
+        .err()
+        .expect("reversed range must fail");
+
+        assert_eq!(error.code(), Code::InvalidArgument);
     }
 
     fn test_runtime_config_with_logbook(

--- a/src/rust/qsoripper-server/src/runtime_config.rs
+++ b/src/rust/qsoripper-server/src/runtime_config.rs
@@ -216,6 +216,16 @@ impl RuntimeConfigManager {
         self.bindings.read().await.lookup_coordinator.clone()
     }
 
+    pub(crate) async fn enrichment_backfill_context(
+        &self,
+    ) -> (LogbookEngine, Arc<LookupCoordinator>) {
+        let bindings = self.bindings.read().await;
+        (
+            bindings.logbook_engine.clone(),
+            bindings.lookup_coordinator.clone(),
+        )
+    }
+
     pub(crate) async fn contest_calendar_monitor(&self) -> Arc<ContestCalendarMonitor> {
         self.bindings.read().await.contest_calendar_monitor.clone()
     }

--- a/src/rust/qsoripper-storage-memory/tests/enrichment_backfill.rs
+++ b/src/rust/qsoripper-storage-memory/tests/enrichment_backfill.rs
@@ -1,0 +1,269 @@
+//! QSO enrichment backfill tests with a fake callsign provider.
+
+#![allow(clippy::expect_used)]
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc,
+};
+use std::time::Duration;
+
+use prost_types::Timestamp;
+use qsoripper_core::application::enrichment_backfill::run_enrichment_backfill;
+use qsoripper_core::lookup::{
+    CallsignProvider, LookupCoordinator, LookupCoordinatorConfig, ProviderLookup,
+    ProviderLookupError,
+};
+use qsoripper_core::proto::qsoripper::domain::{Band, CallsignRecord, Mode, QsoRecord, SyncStatus};
+use qsoripper_core::storage::{DeletedRecordsFilter, LogbookStore, QsoListQuery, QsoSortOrder};
+use qsoripper_storage_memory::MemoryStorage;
+
+#[derive(Clone)]
+struct FakeProvider {
+    calls: Arc<AtomicUsize>,
+    record: CallsignRecord,
+    edit_store: Option<Arc<MemoryStorage>>,
+    delay: Duration,
+}
+
+#[tonic::async_trait]
+impl CallsignProvider for FakeProvider {
+    async fn lookup_callsign(
+        &self,
+        _callsign: &str,
+    ) -> Result<ProviderLookup, ProviderLookupError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(self.delay).await;
+        if let Some(store) = &self.edit_store {
+            let mut edited = store
+                .get_qso("active")
+                .await
+                .expect("read concurrent row")
+                .expect("concurrent row exists");
+            edited.notes = Some("operator edit".into());
+            store
+                .update_qso(&edited)
+                .await
+                .expect("write concurrent row");
+        }
+        Ok(ProviderLookup::found(self.record.clone(), Vec::new()))
+    }
+}
+
+#[tokio::test]
+async fn preview_deduplicates_and_apply_fills_only_missing_active_fields() {
+    let store = Arc::new(MemoryStorage::new());
+    let mut first = qso("one", " w1aw ");
+    first.worked_grid = Some(" \t".into());
+    first.worked_country = Some("Keep Country".into());
+    first.sync_status = SyncStatus::Synced as i32;
+    first.qrz_logid = Some("qrz-123".into());
+    store.insert_qso(&first).await.expect("insert first");
+    store
+        .insert_qso(&qso("two", "W1AW"))
+        .await
+        .expect("insert second");
+    store
+        .insert_qso(&qso("portable", "W1AW/P"))
+        .await
+        .expect("insert portable");
+    let mut deleted = qso("deleted", "K1ABC");
+    deleted.deleted_at = Some(Timestamp {
+        seconds: 1_786_157_400,
+        nanos: 0,
+    });
+    store.insert_qso(&deleted).await.expect("insert deleted");
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let coordinator = Arc::new(LookupCoordinator::new(
+        Arc::new(FakeProvider {
+            calls: Arc::clone(&calls),
+            record: callsign_record(),
+            edit_store: None,
+            delay: Duration::ZERO,
+        }),
+        LookupCoordinatorConfig::new(Duration::from_secs(300), Duration::from_secs(60)),
+    ));
+    let query = active_query();
+
+    let preview = execute(&store, &coordinator, &query, false).await;
+    assert!(preview.complete);
+    assert_eq!(preview.scanned, 3);
+    assert_eq!(preview.candidates, 3);
+    assert_eq!(preview.unique_callsigns, 2);
+    assert_eq!(preview.changed, 3);
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+    assert_eq!(
+        store
+            .get_qso("one")
+            .await
+            .expect("read first")
+            .expect("first exists")
+            .worked_grid
+            .as_deref(),
+        Some(" \t")
+    );
+
+    let applied = execute(&store, &coordinator, &query, true).await;
+    assert_eq!(applied.changed, 3);
+    let saved = store
+        .get_qso("one")
+        .await
+        .expect("read first")
+        .expect("first exists");
+    assert_eq!(saved.worked_grid.as_deref(), Some("FN31"));
+    assert_eq!(saved.worked_country.as_deref(), Some("Keep Country"));
+    assert_eq!(saved.sync_status, SyncStatus::Synced as i32);
+    assert_eq!(saved.qrz_logid.as_deref(), Some("qrz-123"));
+    assert!(store
+        .get_qso("deleted")
+        .await
+        .expect("read deleted")
+        .expect("deleted exists")
+        .worked_grid
+        .is_none());
+
+    let repeated = execute(&store, &coordinator, &query, true).await;
+    assert_eq!(repeated.candidates, 0);
+    assert_eq!(repeated.changed, 0);
+}
+
+#[tokio::test]
+async fn apply_counts_concurrent_edit_and_preserves_operator_change() {
+    let store = Arc::new(MemoryStorage::new());
+    store
+        .insert_qso(&qso("active", "W1AW"))
+        .await
+        .expect("insert active");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let coordinator = Arc::new(LookupCoordinator::new(
+        Arc::new(FakeProvider {
+            calls: Arc::clone(&calls),
+            record: callsign_record(),
+            edit_store: Some(Arc::clone(&store)),
+            delay: Duration::ZERO,
+        }),
+        LookupCoordinatorConfig::default(),
+    ));
+
+    let summary = execute(&store, &coordinator, &active_query(), true).await;
+
+    assert_eq!(summary.concurrent_edits, 1);
+    let saved = store
+        .get_qso("active")
+        .await
+        .expect("read active")
+        .expect("active exists");
+    assert_eq!(saved.notes.as_deref(), Some("operator edit"));
+    assert!(saved.worked_grid.is_none());
+}
+
+#[tokio::test]
+async fn client_disconnect_stops_scheduling_but_waits_for_the_active_lookup() {
+    let store = Arc::new(MemoryStorage::new());
+    store
+        .insert_qso(&qso("active", "W1AW"))
+        .await
+        .expect("insert active");
+    let calls = Arc::new(AtomicUsize::new(0));
+    let coordinator = Arc::new(LookupCoordinator::new(
+        Arc::new(FakeProvider {
+            calls: Arc::clone(&calls),
+            record: callsign_record(),
+            edit_store: None,
+            delay: Duration::from_millis(200),
+        }),
+        LookupCoordinatorConfig::default(),
+    ));
+    let (sender, mut receiver) = tokio::sync::mpsc::channel(1);
+    let mut run = tokio::spawn({
+        let store = Arc::clone(&store);
+        let coordinator = Arc::clone(&coordinator);
+        async move {
+            run_enrichment_backfill(store.as_ref(), &coordinator, &active_query(), true, &sender)
+                .await;
+        }
+    });
+
+    receiver.recv().await.expect("initial progress");
+    while calls.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+    drop(receiver);
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(25), &mut run)
+            .await
+            .is_err(),
+        "backfill must retain its active provider operation"
+    );
+    tokio::time::timeout(Duration::from_secs(1), run)
+        .await
+        .expect("backfill stops after active lookup")
+        .expect("backfill task completes");
+    assert!(store
+        .get_qso("active")
+        .await
+        .expect("read active")
+        .expect("active exists")
+        .worked_grid
+        .is_none());
+}
+
+async fn execute(
+    store: &MemoryStorage,
+    coordinator: &Arc<LookupCoordinator>,
+    query: &QsoListQuery,
+    apply: bool,
+) -> qsoripper_core::application::enrichment_backfill::EnrichmentBackfillProgress {
+    let (sender, mut receiver) = tokio::sync::mpsc::channel(16);
+    run_enrichment_backfill(store, coordinator, query, apply, &sender).await;
+    drop(sender);
+    let mut final_progress = None;
+    while let Some(progress) = receiver.recv().await {
+        final_progress = Some(progress);
+    }
+    final_progress.expect("terminal progress")
+}
+
+fn active_query() -> QsoListQuery {
+    QsoListQuery {
+        sort: QsoSortOrder::OldestFirst,
+        deleted_filter: DeletedRecordsFilter::ActiveOnly,
+        ..QsoListQuery::default()
+    }
+}
+
+fn qso(local_id: &str, callsign: &str) -> QsoRecord {
+    QsoRecord {
+        local_id: local_id.into(),
+        station_callsign: "K7RND".into(),
+        worked_callsign: callsign.into(),
+        utc_timestamp: Some(Timestamp {
+            seconds: 1_786_157_400,
+            nanos: 0,
+        }),
+        band: Band::Band20m as i32,
+        mode: Mode::Cw as i32,
+        ..Default::default()
+    }
+}
+
+fn callsign_record() -> CallsignRecord {
+    CallsignRecord {
+        callsign: "W1AW".into(),
+        first_name: "Ada".into(),
+        last_name: "Lovelace".into(),
+        grid_square: Some("FN31".into()),
+        country: Some("United States".into()),
+        dxcc_entity_id: 291,
+        state: Some("CT".into()),
+        county: Some("Hartford".into()),
+        cq_zone: Some(5),
+        itu_zone: Some(8),
+        dxcc_continent: Some("NA".into()),
+        latitude: Some(41.7),
+        longitude: Some(-72.7),
+        ..Default::default()
+    }
+}

--- a/src/rust/qsoripper-storage-sqlite/src/lib.rs
+++ b/src/rust/qsoripper-storage-sqlite/src/lib.rs
@@ -616,48 +616,38 @@ fn update_qso_record_if_unchanged(
     expected: &QsoRecord,
     replacement: &QsoRecord,
 ) -> Result<bool, StorageError> {
-    let encoded = encode_message(replacement);
-    let expected_encoded = encode_message(expected);
-    let rows = execute_statement(
-        connection,
-        "UPDATE qsos
-         SET qrz_logid = ?,
-             qrz_bookid = ?,
-             station_callsign = ?,
-             worked_callsign = ?,
-             utc_timestamp_ms = ?,
-             band = ?,
-             mode = ?,
-             contest_id = ?,
-             created_at_ms = ?,
-             updated_at_ms = ?,
-             sync_status = ?,
-             record = ?,
-             deleted_at_ms = ?,
-             pending_remote_delete = ?
-         WHERE local_id = ? AND record = ?",
-        &[
-            Value::from(replacement.qrz_logid.as_deref()),
-            Value::from(replacement.qrz_bookid.as_deref()),
-            Value::from(replacement.station_callsign.as_str()),
-            Value::from(replacement.worked_callsign.as_str()),
-            Value::from(timestamp_to_millis(replacement.utc_timestamp.as_ref())),
-            Value::Integer(i64::from(replacement.band)),
-            Value::Integer(i64::from(replacement.mode)),
-            Value::from(replacement.contest_id.as_deref()),
-            Value::from(timestamp_to_millis(replacement.created_at.as_ref())),
-            Value::from(timestamp_to_millis(replacement.updated_at.as_ref())),
-            Value::Integer(i64::from(replacement.sync_status)),
-            Value::Binary(encoded),
-            Value::from(timestamp_to_millis(replacement.deleted_at.as_ref())),
-            Value::Integer(i64::from(replacement.pending_remote_delete)),
-            Value::from(replacement.local_id.as_str()),
-            Value::Binary(expected_encoded),
-        ],
-    )
-    .map_err(map_sqlite_error)?;
+    execute_statement(connection, "BEGIN IMMEDIATE", &[]).map_err(map_sqlite_error)?;
+    let result = (|| {
+        let payload = query_optional::<Vec<u8>>(
+            connection,
+            "SELECT record FROM qsos WHERE local_id = ?",
+            &[Value::from(expected.local_id.as_str())],
+            0,
+        )
+        .map_err(map_sqlite_error)?;
+        let Some(payload) = payload else {
+            return Ok(false);
+        };
+        if decode_qso(&payload)? != *expected {
+            return Ok(false);
+        }
 
-    Ok(rows > 0)
+        update_qso_record(connection, replacement)
+    })();
+
+    match result {
+        Ok(updated) => match execute_statement(connection, "COMMIT", &[]) {
+            Ok(_) => Ok(updated),
+            Err(error) => {
+                let _ = execute_statement(connection, "ROLLBACK", &[]);
+                Err(map_sqlite_error(error))
+            }
+        },
+        Err(error) => {
+            let _ = execute_statement(connection, "ROLLBACK", &[]);
+            Err(error)
+        }
+    }
 }
 
 fn encode_message<T: Message>(message: &T) -> Vec<u8> {
@@ -748,7 +738,7 @@ fn millis_to_timestamp(millis: Option<i64>) -> Option<prost_types::Timestamp> {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::panic, clippy::indexing_slicing)]
 mod tests {
-    use super::SqliteStorageBuilder;
+    use super::{encode_message, SqliteStorageBuilder};
     use prost_types::Timestamp;
     use qsoripper_core::application::logbook::LogbookEngine;
     use qsoripper_core::domain::qso::QsoRecordBuilder;
@@ -833,7 +823,7 @@ mod tests {
     #[tokio::test]
     async fn sqlite_storage_conditional_update_rejects_stale_snapshot() {
         let storage = SqliteStorageBuilder::new().in_memory().build().unwrap();
-        let original = QsoRecordBuilder::new("W1AW", "K7CAS")
+        let mut original = QsoRecordBuilder::new("W1AW", "K7CAS")
             .band(Band::Band20m)
             .mode(Mode::Ft8)
             .timestamp(Timestamp {
@@ -841,6 +831,9 @@ mod tests {
                 nanos: 0,
             })
             .build();
+        original.extra_fields.insert("APP_A".into(), "one".into());
+        original.extra_fields.insert("APP_B".into(), "two".into());
+        original.extra_fields.insert("APP_C".into(), "three".into());
         let logbook = storage.logbook();
         logbook.insert_qso(&original).await.unwrap();
         let mut current = original.clone();
@@ -855,6 +848,55 @@ mod tests {
             .unwrap());
         let saved = logbook.get_qso(&original.local_id).await.unwrap().unwrap();
         assert_eq!(saved.notes.as_deref(), Some("operator edit"));
+    }
+
+    #[tokio::test]
+    async fn sqlite_storage_conditional_update_compares_map_fields_semantically() {
+        let storage = SqliteStorageBuilder::new().in_memory().build().unwrap();
+        let mut persisted = QsoRecordBuilder::new("W1AW", "K7MAP")
+            .band(Band::Band20m)
+            .mode(Mode::Ft8)
+            .timestamp(Timestamp {
+                seconds: 1_700_000_000,
+                nanos: 0,
+            })
+            .build();
+        for index in 0..16 {
+            persisted
+                .extra_fields
+                .insert(format!("APP_FIELD_{index}"), format!("value-{index}"));
+        }
+        let logbook = storage.logbook();
+        logbook.insert_qso(&persisted).await.unwrap();
+
+        let mut expected = persisted.clone();
+        for _ in 0..100 {
+            expected.extra_fields = persisted
+                .extra_fields
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect();
+            if encode_message(&expected) != encode_message(&persisted) {
+                break;
+            }
+        }
+        assert_eq!(expected, persisted);
+        assert_ne!(
+            encode_message(&expected),
+            encode_message(&persisted),
+            "test requires different protobuf map encodings"
+        );
+
+        let mut replacement = expected.clone();
+        replacement.worked_grid = Some("FN31".into());
+        assert!(logbook
+            .update_qso_if_unchanged(&expected, &replacement)
+            .await
+            .unwrap());
+
+        let saved = logbook.get_qso(&persisted.local_id).await.unwrap().unwrap();
+        assert_eq!(saved.worked_grid.as_deref(), Some("FN31"));
+        assert_eq!(saved.extra_fields, persisted.extra_fields);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Adds engine-level QRZ XML enrichment backfill with matching Rust and .NET implementations.

The new streaming RPC scans active QSO records, deduplicates callsign lookups, and fills only blank name, grid, country, DXCC, state, county, zone, continent, latitude, and longitude fields. It never creates QSOs, overwrites local values, changes QRZ linkage or sync status, or modifies soft-deleted records. Atomic updates skip records changed during the run.

The CLI command `enrich` previews by default. Use `enrich --apply` to save changes. Optional `--after` and `--before` filters accept ISO 8601 UTC timestamps.

The implementation includes cancellation, one-run protection, bounded provider work, progress summaries, contract documentation, and regression coverage for both engines and storage backends.